### PR TITLE
Add CircleCI build and test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,9 @@ jobs:
             corepack prepare pnpm@latest --activate
 
       # Install dependencies
-      - node/install-packages:
-          pkg-manager: pnpm
+      - run:
+          name: Install Dependencies
+          command: pnpm install
 
       # Run build
       - run:


### PR DESCRIPTION
This PR adds a circleCI config yml so that we build and test on circleCI

## Testing steps
1. Note the CIrcleCI checks below
2. Take a look at the CircleCI run