### PR TITLE
fix(storybook): fixes build dependencies for storybook

### DIFF
--- a/apps/storybook/turbo.json
+++ b/apps/storybook/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@sanity/sdk#build", "@sanity/sdk-react#build"],
       "outputs": ["storybook-static/**"]
     }
   }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

The storybook app does not explicitly depend on the sdk and the react-sdk packages instead it crosses boundaries so you can colocate the stories with code which causes turbo to not build up a proper dependency for the app. This causes it to run the build in parallel with the sdk adn react causing it to fail sometimes since it does not get completed in time. This change adds an explicit dependency between the storybook app and the dependent packages so they complete first before the sb build runs

#### before
![turbo-graph](https://github.com/user-attachments/assets/1d813d07-aac7-441d-8cc5-79cbf11c53a8)

#### after 
![turbo-graph-after](https://github.com/user-attachments/assets/a8cf9b3a-af4f-4ae6-8641-7407fd677568)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

`npx turbo run build --graph --dry | dot -Tpng -oturbo-graph.png && open turbo-graph.png` to test the graph and the build passes

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

N/A

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->

![web developer GIF](https://media4.giphy.com/media/YFkpsHWCsNUUo/giphy.gif)