### PR TITLE
refactor: store resources in weakmap

### DIFF
--- a/packages/core/src/client/getClientStore.ts
+++ b/packages/core/src/client/getClientStore.ts
@@ -1,6 +1,6 @@
 import {createClient} from '@sanity/client'
 
-import {storesKey} from '../instance/sanityInstance'
+import {getOrCreateResource} from '../instance/sanityInstance'
 import type {SanityInstance} from '../instance/types'
 import {type ClientStore, createClientStore} from './clientStore'
 
@@ -8,14 +8,7 @@ export const DEFAULT_API_VERSION = 'v2024-11-12'
 
 /** @internal */
 export const getClientStore = (instance: SanityInstance): ClientStore => {
-  if (!instance[storesKey]) {
-    // Initialize stores if somehow not present
-    instance[storesKey] = {}
-  }
-
-  const stores = instance[storesKey]
-
-  if (!stores.clientStore) {
+  const clientStore = getOrCreateResource(instance, 'clientStore', () => {
     const {projectId, dataset, token} = instance.config
     const client = createClient({
       projectId,
@@ -24,8 +17,8 @@ export const getClientStore = (instance: SanityInstance): ClientStore => {
       useCdn: false,
       apiVersion: DEFAULT_API_VERSION,
     })
-    stores.clientStore = createClientStore(client)
-  }
+    return createClientStore(client)
+  })
 
-  return stores.clientStore
+  return clientStore
 }

--- a/packages/core/src/instance/sanityInstance.ts
+++ b/packages/core/src/instance/sanityInstance.ts
@@ -1,7 +1,5 @@
 import type {SanityInstance} from './types'
 
-export const storesKey = Symbol('stores')
-
 /** @public */
 export interface SanityConfig {
   projectId: string
@@ -10,12 +8,48 @@ export interface SanityConfig {
 }
 
 /**
- * Returns a new instance of dependecies required for SanitySDK.
+ * Returns a new instance of dependencies required for SanitySDK.
  * @public
  */
 export const createSanityInstance = (config: SanityConfig): SanityInstance => {
+  const randomId = Array.from({length: 8}, () =>
+    Math.floor(Math.random() * 16)
+      .toString(16)
+      .padStart(2, '0'),
+  ).join('')
+
   return {
     config,
-    [storesKey]: {},
+    instanceId: Symbol(['SanityInstance', randomId].join('.')) as SanityInstance['instanceId'],
   }
+}
+
+// TODO: we may want to implement a similar mechanism to
+// https://github.com/sanity-io/sanity/pull/7160
+// because this storage mechanism requires this singleton be the same across
+// various imports of the SDK
+// NOTE: this was intended to be a weakmap but symbols cannot be used in those
+const resourceStorage = new Map<symbol, Map<string, unknown>>()
+
+function getResource(instance: SanityInstance, key: string) {
+  const instanceMap = resourceStorage.get(instance.instanceId)
+  return instanceMap?.get(key)
+}
+
+function setResource(instance: SanityInstance, key: string, value: unknown) {
+  let instanceMap = resourceStorage.get(instance.instanceId)
+  if (!instanceMap) {
+    instanceMap = new Map()
+    resourceStorage.set(instance.instanceId, instanceMap)
+  }
+  instanceMap.set(key, value)
+}
+
+export function getOrCreateResource<T>(instance: SanityInstance, key: string, creator: () => T): T {
+  const cached = getResource(instance, key)
+  if (cached) return cached as T
+
+  const resource = creator()
+  setResource(instance, key, resource)
+  return resource
 }

--- a/packages/core/src/instance/types.ts
+++ b/packages/core/src/instance/types.ts
@@ -1,6 +1,5 @@
 import type {ClientStore} from '../client/clientStore'
 import type {SchemaStore} from '../schema/schemaStore'
-import {storesKey} from './sanityInstance'
 
 /** @public */
 export interface InternalStores {
@@ -10,11 +9,14 @@ export interface InternalStores {
 
 /** @public */
 export interface SanityInstance {
+  /**
+   * The following is used to look up resources associated with this instance.
+   */
+  readonly instanceId: unique symbol
+
   config: {
     projectId: string
     dataset: string
     token?: string
   }
-  // a symbol to ensure it can't be accessed from outside the package
-  [storesKey]: InternalStores
 }


### PR DESCRIPTION
### Description

This PR attempts to address the comment left here: https://github.com/sanity-io/sdk/pull/40#pullrequestreview-2430236291

This refactors the `SanityInstance` to store lazily created resources in a map instead of adding them to a hidden key in the instance.

### What to review

There are a few issues with this PR that I'd like some ideas to improve:
- Originally, we discussed using a weakmap as the resource cache and a symbol for the `instanceId` key but when trying to implement this, I learned that symbols cannot be used in weakmap in the current spec (however there is a [stage3 proposal](https://github.com/tc39/proposal-symbols-as-weakmap-keys) to allow this). I used a map instead for now.
- Since the map is a singleton instance, I expect us to have similar issues to react context. I want to do another pass that introduces a similar mechanism to https://github.com/sanity-io/sanity/pull/7160.
- This PR stores everything in one Map with a nested Map as the values to the main Map. The nested map is keyed by strings defined by us which could be better. I'm wondering if it would be better to have multiple cache maps instead of one. Then the map itself can be passed into the `getOrCreateResource` function.
- Overall naming and organization could use improvement.

### Testing

Additionally testing is needed but this may be good enough for now.

### Fun gif


![Elmo shrug](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmNmY2Y1c2NrcGRvb3A0MzE1eTR6cmVxZmc5N2g5cnFnNmlnM2d1cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jPAdK8Nfzzwt2/giphy.gif)
