### PR TITLE
feat: `createStore` prototype

### DIFF
--- a/packages/core/src/store/createStore.ts
+++ b/packages/core/src/store/createStore.ts
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {devtools} from 'zustand/middleware'
+import {createStore as createZustandStore, type StoreApi} from 'zustand/vanilla'
+import type {SanityInstance} from '../instance/types'
+
+/**
+ * Creates a (vanilla) zustand store with the given initial state and actions.
+ * Only the actions will be returned - actions should be created to interact with it.
+ *
+ * @thoughtLevel 4
+ * The rationale for this is to encapsulate the internal state so only the store knows about it,
+ * making refactoring easier and more predictable. While this seems like good practice, I am unsure
+ * if it might get in our way once we start wanting to subscribe to finer piece of state or similar.
+ * I will leave it for now, and we can see if it becomes a problem.
+ *
+ * @param initialState - Initial state of the store
+ * @param actions - The actions available on the store
+ * @param options - Options for the store
+ * @returns The actions available on the store
+ * @internal
+ */
+export function createStore<S, A extends StoreActionMap<S>>(
+  initialState: S,
+  actions: A,
+  {name, instance}: StoreOptions,
+): CurriedActions<S, A> {
+  const uniqueName = `${name}-${instance.identity.id}`
+  const store = createZustandStore<S>()(devtools(() => ({...initialState}), {name: uniqueName}))
+  const context = {store, instance}
+  return createCurriedActions(actions, context)
+}
+
+/**
+ * Context passed to store actions as first argument.
+ *
+ * @internal
+ */
+export interface StoreActionContext<S> {
+  /**
+   * The store API, from zustand. Contains `getState()`, `setState()`, and `subscribe()`.
+   */
+  store: StoreApi<S>
+
+  /**
+   * The Sanity SDK instance associated with the store. Often used
+   */
+  instance: SanityInstance
+}
+
+/**
+ * An action that can be performed on a store.
+ *
+ * @param context - Store context. Contains the store API (`getState()`, `setState()`, `subscribe()`), as well as the SDK instance associated with it.
+ * @internal
+ */
+export type StoreAction<S> = (context: StoreActionContext<S>, ...args: any[]) => any
+
+/**
+ * A map of actions that can be performed on a store.
+ *
+ * @internal
+ */
+export type StoreActionMap<S> = Record<string, StoreAction<S>>
+
+/**
+ * Options for creating a store.
+ *
+ * @internal
+ */
+export interface StoreOptions {
+  /**
+   * Name used for debugging
+   */
+  name: string
+
+  /**
+   * The Sanity SDK instance associated with the store
+   */
+  instance: SanityInstance
+}
+
+function createCurriedActions<S, A extends StoreActionMap<S>>(
+  actions: A,
+  store: StoreActionContext<S>,
+): CurriedActions<S, A> {
+  const curried: CurriedActions<S, A> = {} as CurriedActions<S, A>
+  return Object.entries(actions).reduce((acc, [key, action]) => {
+    const curriedAction = (...args: RestParameters<typeof action>) => action(store, ...args)
+    return {...acc, [key]: curriedAction}
+  }, curried)
+}
+
+type RestParameters<T extends (...args: any[]) => any> = T extends (
+  first: any,
+  ...rest: infer R
+) => any
+  ? R
+  : never
+
+type ActionReturn<T extends (...args: any[]) => any> = ReturnType<T>
+
+type CurriedActions<S, A extends StoreActionMap<S>> = {
+  [K in keyof A]: A[K] extends StoreAction<S>
+    ? (...args: RestParameters<A[K]>) => ActionReturn<A[K]>
+    : never
+}


### PR DESCRIPTION
### Description

This may be premature optimization, but I don't really like the way the zustand stores mix the actions and state - so I wanted to play with some alternatives. This PR introduces a `createStore` method for the SDK specifically, that takes a slightly different approach than what is documented in the zustand docs. This may be a terrible idea, so we'll see.

My current philosophy/thought process is that the internal state of the store should not be something that other SDK pieces (and definitely not end-users) care about. It makes the structure of the state "locked", as you cannot easily change the state structure without also finding all code paths that might depend on it. If we instead only expose "actions" (getters, setters, subscribers), we can have more control of things.

So the `createStore` method in this iteration takes:
- an initial state. This is the _internal_ state.
- An object of "actions", key being the action name, value being the function that runs the action. The first argument to the function is an object containing methods to interact with the store (get, set, subscribe) and the instance of which the store was created for. This allows the action functions to be stateless and reused across instances. Additionally it should make it easier to test them, since you can easily inject state and see the output  of them.
- A name for the store and an instance to bind the store to. The binding is not implemented yet, but should be a quick refactor of the `getOrCreateResource` step, I _think_.

Note: I'd be happy to not refactor existing stores to this pattern right away - we could try it out on certain stores and see if it is ergonomic or if it becomes tedious when we start adding actions.

### What to review

- Does this all make sense? Are there decisions you do not agree with?

### Testing

No tests yet, want to hear your thoughts first.

### Fun gif

![Gimme dat store](https://i.giphy.com/7bSRnrNc1X6yEEeemq.webp)
