### PR TITLE
chore: fix typedoc generation

### DIFF
--- a/packages/core/src/instance/types.d.ts
+++ b/packages/core/src/instance/types.d.ts
@@ -18,7 +18,7 @@ export interface SanityInstance {
   readonly identity: SdkIdentity
 
   config: {
-    /** @todo refactor - if we are binding clients to the identity, we can't have the token changing without those clients getting updated */
+    /** TODO: refactor - if we are binding clients to the identity, we can't have the token changing without those clients getting updated */
     token?: string
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@sanity/pkg-utils/tsconfig/strictest.json",
   "include": ["./packages/**/*.ts", "./packages/**/*.tsx"],
-  "exclude": ["./node_modules"]
+  "exclude": ["./node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
### Description

This PR is a followup to #44 that fixes TypeDoc that was attempting to get run for test files in the storybook app. It excludes these test files.

### What to review

Check that the docs build and deploy on this PR

### Testing

Check that the docs build and deploy on this PR

### Fun gif
![ignore](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2Znd3prMGNsd2l1dTBzNDd3aHo1YXhtNzZ5end3b2swMHVyaHA1ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/11nthj7FPS2o3S/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
