### PR TITLE
feat(react): add initial SanityProvider

### DIFF
--- a/apps/kitchensink-react/src/App.tsx
+++ b/apps/kitchensink-react/src/App.tsx
@@ -1,31 +1,22 @@
-import {createSanityInstance, LOGGED_IN_STATES} from '@sanity/sdk'
-import {LoginLinks} from '@sanity/sdk-react/components'
-import {useCurrentUser, useLoggedInState} from '@sanity/sdk-react/hooks'
-import {Avatar, Container, Heading, ThemeProvider} from '@sanity/ui'
+import {SanityProvider} from '@sanity/sdk-react/components'
+import {Container, Heading, ThemeProvider} from '@sanity/ui'
 import {buildTheme} from '@sanity/ui/theme'
+import { AuthPlayground } from './AuthPlayground'
 
 const theme = buildTheme({})
 
 export function App(): JSX.Element {
-  const sanityInstance = createSanityInstance()
-  const currentUser = useCurrentUser(sanityInstance)
-  const loggedInState = useLoggedInState(sanityInstance)
-
+  const config = {projectId: 'ppsg7ml5', dataset: 'test'}
   return (
     <ThemeProvider theme={theme}>
+      <SanityProvider config={config}>
       <Container width={0}>
         <Heading as="h1" size={5} style={{marginBottom: 24}}>
           React Kitchensink
         </Heading>
-        {loggedInState === LOGGED_IN_STATES.LOGGED_IN ? (
-          <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
-            <Avatar src={currentUser?.profileImage} color="blue" />{' '}
-            <span>Welcome {currentUser?.name}</span>
-          </div>
-        ) : (
-          <LoginLinks sanityInstance={sanityInstance} />
-        )}
-      </Container>
+        <AuthPlayground />
+        </Container>
+      </SanityProvider>
     </ThemeProvider>
   )
 }

--- a/apps/kitchensink-react/src/AuthPlayground.tsx
+++ b/apps/kitchensink-react/src/AuthPlayground.tsx
@@ -1,0 +1,22 @@
+import { useCurrentUser, useLoggedInState, useSanityInstance } from "@sanity/sdk-react/hooks"
+import { LOGGED_IN_STATES } from "@sanity/sdk"
+import { Avatar } from "@sanity/ui"
+import { LoginLinks } from "@sanity/sdk-react/components"
+
+export function AuthPlayground(): JSX.Element {
+  const sanityInstance = useSanityInstance()
+  const currentUser = useCurrentUser(sanityInstance)
+  const loggedInState = useLoggedInState(sanityInstance)
+  return (
+    <>
+      {loggedInState === LOGGED_IN_STATES.LOGGED_IN ? (
+        <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+          <Avatar src={currentUser?.profileImage} color="blue" />{' '}
+          <span>Welcome {currentUser?.name}</span>
+        </div>
+      ) : (
+        <LoginLinks />
+      )}
+    </>
+  )
+}

--- a/packages/react/src/_exports/components.ts
+++ b/packages/react/src/_exports/components.ts
@@ -3,6 +3,8 @@
  * @module @sanity/sdk-react/components
  */
 
+export {SanityProvider} from '../components/context/SanityProvider'
+export type {SanityProviderProps} from '../components/context/SanityProvider'
 export {
   type DocumentListItemProps,
   type DocumentListProps,

--- a/packages/react/src/_exports/hooks.ts
+++ b/packages/react/src/_exports/hooks.ts
@@ -5,4 +5,5 @@
 
 export {useCurrentUser} from '../hooks/auth/useCurrentUser'
 export {useLoggedInState} from '../hooks/auth/useLoggedInState'
+export {useSanityInstance} from '../hooks/context/useSanityInstance'
 export {type AuthProvider, useLoginLinks} from '../hooks/auth/useLoginLinks'

--- a/packages/react/src/components/Login/LoginLinks.tsx
+++ b/packages/react/src/components/Login/LoginLinks.tsx
@@ -1,15 +1,15 @@
-import {type SanityInstance, tradeTokenForSession} from '@sanity/sdk'
+import {tradeTokenForSession} from '@sanity/sdk'
 import {getSidUrlSearch} from '@sanity/sdk'
 import {Button, Card, Container, Flex, Heading, Stack} from '@sanity/ui'
 import {type ReactElement, useEffect, useState} from 'react'
 
 import {useLoginLinks} from '../../hooks/auth/useLoginLinks'
+import {useSanityInstance} from '../../hooks/context/useSanityInstance'
 
 /**
  * Component that handles Sanity authentication flow and renders login provider options
  * @public
  * @param {Object} props - Component props
- * @param {SanityInstance} props.sanityInstance - Sanity configuration instance
  * @returns {ReactElement} Rendered component
  * @remarks
  * The component handles three states:
@@ -22,7 +22,8 @@ import {useLoginLinks} from '../../hooks/auth/useLoginLinks'
  * return <LoginLinks sanityInstance={config} />
  * ```
  */
-export const LoginLinks = ({sanityInstance}: {sanityInstance: SanityInstance}): ReactElement => {
+export const LoginLinks = (): ReactElement => {
+  const sanityInstance = useSanityInstance()
   const authProviders = useLoginLinks()
 
   const [token, setToken] = useState<string | null>(null)

--- a/packages/react/src/components/context/SanityProvider.test.tsx
+++ b/packages/react/src/components/context/SanityProvider.test.tsx
@@ -1,0 +1,52 @@
+import {render} from '@testing-library/react'
+import React from 'react'
+import {describe, expect, it, vi} from 'vitest'
+import {createSanityInstance} from '@sanity/sdk'
+import {SanityProvider} from './SanityProvider'
+import {useSanityInstance} from '../../hooks/context/useSanityInstance'
+
+vi.mock('@sanity/sdk', () => ({
+  createSanityInstance: vi.fn(() => ({
+    identity: {
+      projectId: 'test-project',
+    },
+  })),
+}))
+
+describe('SanityProvider', () => {
+  const config = {projectId: 'test-project', dataset: 'production'}
+
+  it('provides instance to nested components', () => {
+    const TestComponent = () => {
+      const instance = useSanityInstance()
+      return <div data-testid="test">{JSON.stringify(instance)}</div>
+    }
+
+    const {getByTestId} = render(
+      <SanityProvider config={config}>
+        <TestComponent />
+      </SanityProvider>,
+    )
+
+    expect(getByTestId('test')).toHaveTextContent('{"projectId":"test-project"')
+    expect(createSanityInstance).toHaveBeenCalledWith(config)
+  })
+
+  it('creates new instance with updated config', () => {
+    const newConfig = {projectId: 'new-project', dataset: 'staging'}
+
+    const {rerender} = render(
+      <SanityProvider config={config}>
+        <div />
+      </SanityProvider>,
+    )
+
+    rerender(
+      <SanityProvider config={newConfig}>
+        <div />
+      </SanityProvider>,
+    )
+
+    expect(createSanityInstance).toHaveBeenCalledWith(newConfig)
+  })
+})

--- a/packages/react/src/components/context/SanityProvider.tsx
+++ b/packages/react/src/components/context/SanityProvider.tsx
@@ -1,0 +1,42 @@
+import {createSanityInstance, type SanityConfig, type SanityInstance} from '@sanity/sdk'
+import {createContext, type ReactElement} from 'react'
+
+/**
+ * @public
+ */
+export interface SanityProviderProps {
+  children: React.ReactNode
+  config: SanityConfig
+}
+type Instance = {
+  sanityInstance: SanityInstance
+}
+
+export const SanityInstanceContext = createContext<Instance | null>(null)
+
+/**
+ * Top-level context provider that provides a Sanity configuration instance.
+ * This must wrap any Sanity SDK React component.
+ * @public
+ * @param {config} props.config - Sanity project and dataset configuration
+ * @returns {ReactElement} Rendered component
+ * @example
+ * ```tsx
+ * import {ExampleComponent, SanityProvider} from @sanity/sdk-react'
+ * const config = { projectId: 'your-project-id', dataset: 'production' }
+ * return (
+ * <SanityProvider config={config}>
+ *  <ExampleComponent />
+ * </SanityProvider>
+ * )
+ * ```
+ */
+export const SanityProvider = ({children, config}: SanityProviderProps): ReactElement => {
+  const sanityInstance = createSanityInstance(config)
+
+  return (
+    <SanityInstanceContext.Provider value={{sanityInstance}}>
+      {children}
+    </SanityInstanceContext.Provider>
+  )
+}

--- a/packages/react/src/hooks/context/useSanityInstance.test.tsx
+++ b/packages/react/src/hooks/context/useSanityInstance.test.tsx
@@ -1,0 +1,33 @@
+import {renderHook} from '@testing-library/react'
+import React from 'react'
+import {describe, expect, it, vi} from 'vitest'
+import {createSanityInstance} from '@sanity/sdk'
+import {SanityProvider} from '../../components/context/SanityProvider'
+import {useSanityInstance} from './useSanityInstance'
+
+vi.mock('@sanity/sdk', () => ({
+  createSanityInstance: vi.fn(() => ({
+    mockInstance: true,
+  })),
+}))
+
+describe('useSanityInstance', () => {
+  const config = {projectId: 'test-project', dataset: 'production'}
+
+  it('returns sanity instance when used within provider', () => {
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <SanityProvider config={config}>{children}</SanityProvider>
+    )
+
+    const {result} = renderHook(() => useSanityInstance(), {wrapper})
+
+    expect(result.current).toEqual({mockInstance: true})
+    expect(createSanityInstance).toHaveBeenCalledWith(config)
+  })
+
+  it('throws error when used outside provider', () => {
+    expect(() => {
+      renderHook(() => useSanityInstance())
+    }).toThrow('useSanityInstance must be called from within the SanityProvider')
+  })
+})

--- a/packages/react/src/hooks/context/useSanityInstance.ts
+++ b/packages/react/src/hooks/context/useSanityInstance.ts
@@ -1,0 +1,24 @@
+import type {SanityInstance} from '@sanity/sdk'
+import {useContext} from 'react'
+
+import {SanityInstanceContext} from '../../components/context/SanityProvider'
+
+/**
+ * Hook that provides the current Sanity instance from the context.
+ * This must be called from within a `SanityProvider` component.
+ * @public
+ * @returns {SanityInstance} the current Sanity instance
+ * @example
+ * ```tsx
+ * const instance = useSanityInstance()
+ * ```
+ */
+export const useSanityInstance = (): SanityInstance => {
+  const context = useContext(SanityInstanceContext)
+
+  if (!context) throw new Error('useSanityInstance must be called from within the SanityProvider')
+
+  const {sanityInstance} = context
+
+  return sanityInstance
+}


### PR DESCRIPTION
### Description

Introduces a new `SanityProvider` component and `useSanityInstance` hook to manage Sanity configuration through React Context.

### What to review

- New `SanityProvider` component implementation
- `useSanityInstance` hook usage and error handling
- Updated `LoginLinks` component to use the new context
- Modified tests to accommodate the new context-based approach
- Example usage in the kitchensink app

### Testing
Added some pretty simple tests but let me know if we want something more extensive.

### Fun gif

![React Context](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXh1dDhwaXl6aHdncGR0bTV0dzY3aTF4dmhlZnd0dTE4NzVqZmpxeCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/r04KFpXcU9GgoXjyUt/giphy.webp)