### PR TITLE
feat(core): use separate client for auth and refresh client store with token

### DIFF
--- a/packages/core/src/auth/tradeTokenForSession.ts
+++ b/packages/core/src/auth/tradeTokenForSession.ts
@@ -1,11 +1,11 @@
-import {getClient} from '../client/getClient'
-import type {SanityInstance} from '../instance/types'
+import {createClient} from '@sanity/client'
+
+const AUTH_API_VERSION = 'v2024-12-03'
 
 /**
  * Exchanges a temporary authentication token for a permanent session token
  * @public
  * @param {string} sessionId - Temporary session ID received from auth provider
- * @param {SanityInstance} sanityInstance - Configuration instance for the Sanity client
  * @returns {Promise<string | undefined>} Resolves to:
  *   - A long-lived session token if exchange is successful
  *   - undefined if sessionId is empty or exchange fails
@@ -16,14 +16,23 @@ import type {SanityInstance} from '../instance/types'
  * // Returns: 'permanent_token_xyz'
  * ```
  */
-export const tradeTokenForSession = async (
-  sessionId: string,
-  sanityInstance: SanityInstance,
-): Promise<string | undefined> => {
-  const client = getClient({apiVersion: 'v2024-11-22'}, sanityInstance)
+export const tradeTokenForSession = async (sessionId: string): Promise<string | undefined> => {
   if (!sessionId) {
     return
   }
+
+  /*
+   * To authenticate, we don't want to call a "project" endpoint
+   * (so, not like "https://{projectId}.api.sanity.io/etc/etc").
+   * We want to get to "api.sanity.io" directly, so we use a client with no project.
+   */
+  const client = createClient({
+    useCdn: false,
+    apiVersion: AUTH_API_VERSION,
+    withCredentials: false,
+    useProjectHostname: false,
+    ignoreBrowserTokenWarning: true,
+  })
 
   const {token} = await client.request<{token: string}>({
     method: 'GET',

--- a/packages/react/src/components/Login/LoginLinks.test.tsx
+++ b/packages/react/src/components/Login/LoginLinks.test.tsx
@@ -79,7 +79,7 @@ describe('LoginLinks', () => {
     // Wait for the token message to appear
     const tokenMessage = await screen.findByText('You are logged in with token: mock-token')
     expect(tokenMessage).toBeInTheDocument()
-    expect(tradeTokenForSession).toHaveBeenCalledWith('mock-sid-token', mockSanityInstance)
+    expect(tradeTokenForSession).toHaveBeenCalledWith('mock-sid-token')
   })
 
   describe('token handling', () => {

--- a/packages/react/src/components/Login/LoginLinks.tsx
+++ b/packages/react/src/components/Login/LoginLinks.tsx
@@ -36,7 +36,7 @@ export const LoginLinks = ({sanityInstance}: {sanityInstance: SanityInstance}): 
     const sidToken = getSidUrlSearch(window.location)
     if (sidToken) {
       setIsLoading(true)
-      tradeTokenForSession(sidToken, sanityInstance)
+      tradeTokenForSession(sidToken)
         .then((tokenResponse) => {
           setToken(tokenResponse ?? null)
         })


### PR DESCRIPTION
### Description

Refactors the authentication token exchange process making the `tradeTokenForSession` function create its own client instance with specific authentication configurations. This is to keep consistency in the client store and clean up the configuration for a `SanityProvider` in a subsequent PR.

### What to review
- Review the modified test cases to ensure they align with the new implementation
- Validate that the authentication flow still works as expected in the React components

### Testing
Existing tests should be sufficient.

### Fun gif

![Authentication dance](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGQ2bnFqa3ZtenozZmZpdGhlNHR0aGtvenJrNXN0dHVuNWYyM2U4OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/8pjGQCZIRIN2NJC1tI/giphy.webp))