### PR TITLE
chore(deps): add missing eslint-config packages to renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,13 @@
     {
       "description": "Group eslint related deps in a single PR, as they often have to update together",
       "groupName": "eslint-tooling",
-      "matchPackageNames": ["@eslint/*", "eslint", "eslint-plugin-*", "typescript-eslint"]
+      "matchPackageNames": [
+        "@eslint/*",
+        "eslint",
+        "eslint-plugin-*",
+        "eslint-config-*",
+        "typescript-eslint"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

The renovate group was missing `eslin-config-*` packages this PR adds that so the grouping is correct