### PR TITLE
fix: package access and version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/core": "0.0.0-alpha.1",
-  "packages/react": "0.0.0-alpha.1"
+  "packages/core": "0.0.0-alpha.0",
+  "packages/react": "0.0.0-alpha.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sdk-root",
   "version": "0.0.0",
+  "private": true,
   "description": "Sanity SDK for Content OS",
   "keywords": [],
   "homepage": "https://github.com/sanity-io/sdk#readme",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/sdk",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.0",
   "private": true,
   "description": "Sanity SDK for Content OS",
   "keywords": [],
@@ -37,6 +37,7 @@
     "dev": "pkg watch",
     "format": "prettier --write --cache --ignore-unknown .",
     "lint": "eslint .",
+    "prepublishOnly": "pnpm run build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
@@ -71,5 +72,8 @@
   "packageManager": "pnpm@9.14.4",
   "engines": {
     "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "restricted"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/sdk-react",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.0",
   "private": true,
   "description": "Sanity SDK React toolkit for Content OS",
   "keywords": [],
@@ -57,6 +57,7 @@
     "dev": "pkg watch",
     "format": "prettier --write --cache --ignore-unknown .",
     "lint": "eslint .",
+    "prepublishOnly": "pnpm run build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
@@ -103,5 +104,8 @@
   "packageManager": "pnpm@9.14.4",
   "engines": {
     "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "restricted"
   }
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- Makes the root package.json private
- Sets the access to restricted (note it will still fail because the packages are private, that is intentional for now)
- Starts the version at `0` so it starts at `0.0.0-alpha.1` because starting at 2 is weird

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Mostly check if changes logically makes sense but we will test after merge