### PR TITLE
feat(auth): fetch current user after token is present

### DIFF
--- a/packages/react/src/hooks/auth/useAuthState.test.tsx
+++ b/packages/react/src/hooks/auth/useAuthState.test.tsx
@@ -40,7 +40,7 @@ describe('useAuthState', () => {
   })
 
   it('should update when auth state changes', async () => {
-    let currentState: AuthState = {type: 'logged-in', token: '123'}
+    let currentState: AuthState = {type: 'logged-in', token: '123', currentUser: null}
     const subscribers: {next: (state: AuthState) => void}[] = []
 
     const mockAuthStore = {


### PR DESCRIPTION
### Description

This adds user fetching back into the auth store. The previous thought process was that fetching the current user would be a concern from something like a user store but after more thought, I think we aligned on leaving this in the auth store as we could use error results from fetching the current user 

### What to review

Review the implementation and tests. This may need an additional pass to handle error states but we can iterate on that later. I added a TODO for that case.

### Testing

Added unit tests and kept up coverage.

### Fun gif


![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaDVyanBqeGdnd21ocW9hc2ZjcXlqNXhhY216bWEyODkxbjR5YWNteiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/9gkwDaCB4pmoOe73x2/giphy.gif)

