### PR TITLE
refactor(react): pass created instance to provider

### DIFF
--- a/apps/kitchensink-react/src/App.tsx
+++ b/apps/kitchensink-react/src/App.tsx
@@ -1,3 +1,4 @@
+import {createSanityInstance} from '@sanity/sdk'
 import {SanityProvider} from '@sanity/sdk-react/components'
 import {Container, Heading, ThemeProvider} from '@sanity/ui'
 import {buildTheme} from '@sanity/ui/theme'
@@ -5,12 +6,12 @@ import {buildTheme} from '@sanity/ui/theme'
 import {AuthPlayground} from './AuthPlayground'
 
 const theme = buildTheme({})
+const sanityInstance = createSanityInstance({projectId: 'ppsg7ml5', dataset: 'test'})
 
 export function App(): JSX.Element {
-  const config = {projectId: 'ppsg7ml5', dataset: 'test'}
   return (
     <ThemeProvider theme={theme}>
-      <SanityProvider config={config}>
+      <SanityProvider sanityInstance={sanityInstance}>
         <Container width={0}>
           <Heading as="h1" size={5} style={{marginBottom: 24}}>
             React Kitchensink

--- a/packages/react/src/components/Login/LoginLinks.test.tsx
+++ b/packages/react/src/components/Login/LoginLinks.test.tsx
@@ -8,6 +8,7 @@ import {useAuthState} from '../../hooks/auth/useAuthState'
 import {useLoginUrls} from '../../hooks/auth/useLoginUrls'
 import {SanityProvider} from '../context/SanityProvider'
 import {LoginLinks} from './LoginLinks'
+import {createSanityInstance} from '@sanity/sdk'
 
 // Mock the hooks and SDK functions
 vi.mock('../../hooks/auth/useLoginUrls', () => ({
@@ -24,12 +25,16 @@ vi.mock('../../hooks/auth/useLoginUrls', () => ({
     },
   ]),
 }))
-vi.mock('@sanity/sdk', () => ({
-  createSanityInstance: vi.fn(),
-  tradeTokenForSession: vi.fn(),
-  getSidUrlHash: vi.fn().mockReturnValue(null),
-  getSidUrlSearch: vi.fn(),
-}))
+vi.mock('@sanity/sdk', async () => {
+  const actual = await vi.importActual('@sanity/sdk')
+
+  return {
+    ...actual,
+    tradeTokenForSession: vi.fn(),
+    getSidUrlHash: vi.fn().mockReturnValue(null),
+    getSidUrlSearch: vi.fn(),
+  }
+})
 
 vi.mock('../../hooks/auth/useAuthState', () => ({
   useAuthState: vi.fn(() => 'logged-out'),
@@ -46,11 +51,11 @@ describe('LoginLinks', () => {
     vi.clearAllMocks()
   })
 
+  const sanityInstance = createSanityInstance({projectId: 'test-project-id', dataset: 'production'})
   const renderWithWrappers = (ui: React.ReactElement) => {
-    const config = {projectId: 'test-project-id', dataset: 'production'}
     return render(
       <ThemeProvider theme={theme}>
-        <SanityProvider config={config}>{ui}</SanityProvider>
+        <SanityProvider sanityInstance={sanityInstance}>{ui}</SanityProvider>
       </ThemeProvider>,
     )
   }

--- a/packages/react/src/components/context/SanityProvider.test.tsx
+++ b/packages/react/src/components/context/SanityProvider.test.tsx
@@ -1,52 +1,25 @@
 import {createSanityInstance} from '@sanity/sdk'
 import {render} from '@testing-library/react'
-import {describe, expect, it, vi} from 'vitest'
+import {describe, expect, it} from 'vitest'
 
 import {useSanityInstance} from '../../hooks/context/useSanityInstance'
 import {SanityProvider} from './SanityProvider'
 
-vi.mock('@sanity/sdk', () => ({
-  createSanityInstance: vi.fn(() => ({
-    identity: {
-      projectId: 'test-project',
-    },
-  })),
-}))
-
 describe('SanityProvider', () => {
-  const config = {projectId: 'test-project', dataset: 'production'}
+  const sanityInstance = createSanityInstance({projectId: 'test-project', dataset: 'production'})
 
   it('provides instance to nested components', () => {
     const TestComponent = () => {
       const instance = useSanityInstance()
-      return <div data-testid="test">{JSON.stringify(instance)}</div>
+      return <div data-testid="test">{instance.identity.projectId}</div>
     }
 
     const {getByTestId} = render(
-      <SanityProvider config={config}>
+      <SanityProvider sanityInstance={sanityInstance}>
         <TestComponent />
       </SanityProvider>,
     )
 
-    expect(getByTestId('test')).toHaveTextContent('{"projectId":"test-project"')
-    expect(createSanityInstance).toHaveBeenCalledWith(config)
-  })
-
-  it('creates new instance with updated config', () => {
-    const newConfig = {projectId: 'new-project', dataset: 'staging'}
-
-    const {rerender} = render(
-      <SanityProvider config={config}>
-        <div />
-      </SanityProvider>,
-    )
-
-    rerender(
-      <SanityProvider config={newConfig}>
-        <div />
-      </SanityProvider>,
-    )
-
-    expect(createSanityInstance).toHaveBeenCalledWith(newConfig)
+    expect(getByTestId('test')).toHaveTextContent('test-project')
   })
 })

--- a/packages/react/src/components/context/SanityProvider.tsx
+++ b/packages/react/src/components/context/SanityProvider.tsx
@@ -1,4 +1,4 @@
-import {createSanityInstance, type SanityConfig, type SanityInstance} from '@sanity/sdk'
+import {type SanityInstance} from '@sanity/sdk'
 import {createContext, type ReactElement} from 'react'
 
 /**
@@ -6,13 +6,10 @@ import {createContext, type ReactElement} from 'react'
  */
 export interface SanityProviderProps {
   children: React.ReactNode
-  config: SanityConfig
-}
-type Instance = {
   sanityInstance: SanityInstance
 }
 
-export const SanityInstanceContext = createContext<Instance | null>(null)
+export const SanityInstanceContext = createContext<SanityInstance | null>(null)
 
 /**
  * Top-level context provider that provides a Sanity configuration instance.
@@ -22,20 +19,23 @@ export const SanityInstanceContext = createContext<Instance | null>(null)
  * @returns Rendered component
  * @example
  * ```tsx
- * import {ExampleComponent, SanityProvider} from @sanity/sdk-react'
- * const config = { projectId: 'your-project-id', dataset: 'production' }
- * return (
- * <SanityProvider config={config}>
- *  <ExampleComponent />
- * </SanityProvider>
- * )
+ * import {createSanityInstance} from '@sanity/sdk'
+ * import {ExampleComponent, SanityProvider} from '@sanity/sdk-react'
+ *
+ * const sanityInstance = createSanityInstance({projectId: 'your-project-id', dataset: 'production'})
+ *
+ * export default function MyApp() {
+ *   return (
+ *     <SanityProvider sanityInstance={sanityInstance}>
+ *      <ExampleComponent />
+ *     </SanityProvider>
+ *   )
+ * }
  * ```
  */
-export const SanityProvider = ({children, config}: SanityProviderProps): ReactElement => {
-  const sanityInstance = createSanityInstance(config)
-
+export const SanityProvider = ({children, sanityInstance}: SanityProviderProps): ReactElement => {
   return (
-    <SanityInstanceContext.Provider value={{sanityInstance}}>
+    <SanityInstanceContext.Provider value={sanityInstance}>
       {children}
     </SanityInstanceContext.Provider>
   )

--- a/packages/react/src/hooks/auth/useAuthState.test.tsx
+++ b/packages/react/src/hooks/auth/useAuthState.test.tsx
@@ -1,4 +1,4 @@
-import {type AuthState, type AuthStore, getAuthStore} from '@sanity/sdk'
+import {type AuthState, type AuthStore, createSanityInstance, getAuthStore} from '@sanity/sdk'
 import {renderHook} from '@testing-library/react'
 import {describe, expect, it, vi} from 'vitest'
 
@@ -29,9 +29,10 @@ describe('useAuthState', () => {
     vi.mocked(getAuthStore).mockReturnValue(mockAuthStore as AuthStore)
 
     // Wrap hook in SanityProvider and render
+    const sanityInstance = createSanityInstance({projectId: 'test', dataset: 'test'})
     const {result} = renderHook(() => useAuthState(), {
       wrapper: ({children}) => (
-        <SanityProvider config={{projectId: 'test', dataset: 'test'}}>{children}</SanityProvider>
+        <SanityProvider sanityInstance={sanityInstance}>{children}</SanityProvider>
       ),
     })
 
@@ -63,9 +64,10 @@ describe('useAuthState', () => {
 
     vi.mocked(getAuthStore).mockReturnValue(mockAuthStore as unknown as AuthStore)
 
+    const sanityInstance = createSanityInstance({projectId: 'test', dataset: 'test'})
     const {result, rerender} = renderHook(() => useAuthState(), {
       wrapper: ({children}) => (
-        <SanityProvider config={{projectId: 'test', dataset: 'test'}}>{children}</SanityProvider>
+        <SanityProvider sanityInstance={sanityInstance}>{children}</SanityProvider>
       ),
     })
 

--- a/packages/react/src/hooks/auth/useHandleCallback.test.tsx
+++ b/packages/react/src/hooks/auth/useHandleCallback.test.tsx
@@ -1,4 +1,4 @@
-import {type AuthStore, getAuthStore} from '@sanity/sdk'
+import {type AuthStore, createSanityInstance, getAuthStore} from '@sanity/sdk'
 import {renderHook} from '@testing-library/react'
 import {describe, expect, it, vi} from 'vitest'
 
@@ -37,8 +37,9 @@ describe('useHandleCallback', () => {
     }
     vi.mocked(getAuthStore).mockReturnValue(mockAuthStore as AuthStore)
 
+    const sanityInstance = createSanityInstance({projectId: 'test', dataset: 'test'})
     const wrapper = ({children}: {children: React.ReactNode}) => (
-      <SanityProvider config={{projectId: 'test', dataset: 'test'}}>{children}</SanityProvider>
+      <SanityProvider sanityInstance={sanityInstance}>{children}</SanityProvider>
     )
 
     renderHook(() => useHandleCallback(), {wrapper})
@@ -69,8 +70,9 @@ describe('useHandleCallback', () => {
     }
     vi.mocked(getAuthStore).mockReturnValue(mockAuthStore as AuthStore)
 
+    const sanityInstance = createSanityInstance({projectId: 'test', dataset: 'test'})
     const wrapper = ({children}: {children: React.ReactNode}) => (
-      <SanityProvider config={{projectId: 'test', dataset: 'test'}}>{children}</SanityProvider>
+      <SanityProvider sanityInstance={sanityInstance}>{children}</SanityProvider>
     )
 
     renderHook(() => useHandleCallback(), {wrapper})

--- a/packages/react/src/hooks/auth/useLoginUrls.test.tsx
+++ b/packages/react/src/hooks/auth/useLoginUrls.test.tsx
@@ -1,4 +1,4 @@
-import {type AuthStore, getAuthStore} from '@sanity/sdk'
+import {type AuthStore, createSanityInstance, getAuthStore} from '@sanity/sdk'
 import {renderHook, waitFor} from '@testing-library/react'
 import {describe, expect, it, vi} from 'vitest'
 
@@ -21,8 +21,9 @@ describe('useLoginUrls', () => {
     }
     vi.mocked(getAuthStore).mockReturnValue(mockAuthStore as AuthStore)
 
+    const sanityInstance = createSanityInstance({projectId: 'test', dataset: 'test'})
     const wrapper = ({children}: {children: React.ReactNode}) => (
-      <SanityProvider config={{projectId: 'test', dataset: 'test'}}>{children}</SanityProvider>
+      <SanityProvider sanityInstance={sanityInstance}>{children}</SanityProvider>
     )
 
     const {result} = renderHook(() => useLoginUrls(), {wrapper})
@@ -36,8 +37,9 @@ describe('useLoginUrls', () => {
     }
     vi.mocked(getAuthStore).mockReturnValue(mockAuthStore as AuthStore)
 
+    const sanityInstance = createSanityInstance({projectId: 'test', dataset: 'test'})
     const wrapper = ({children}: {children: React.ReactNode}) => (
-      <SanityProvider config={{projectId: 'test', dataset: 'test'}}>{children}</SanityProvider>
+      <SanityProvider sanityInstance={sanityInstance}>{children}</SanityProvider>
     )
 
     const {result} = renderHook(() => useLoginUrls(), {wrapper})

--- a/packages/react/src/hooks/context/useSanityInstance.test.tsx
+++ b/packages/react/src/hooks/context/useSanityInstance.test.tsx
@@ -6,24 +6,17 @@ import {describe, expect, it, vi} from 'vitest'
 import {SanityProvider} from '../../components/context/SanityProvider'
 import {useSanityInstance} from './useSanityInstance'
 
-vi.mock('@sanity/sdk', () => ({
-  createSanityInstance: vi.fn(() => ({
-    mockInstance: true,
-  })),
-}))
-
 describe('useSanityInstance', () => {
-  const config = {projectId: 'test-project', dataset: 'production'}
+  const sanityInstance = createSanityInstance({projectId: 'test-project', dataset: 'production'})
 
   it('returns sanity instance when used within provider', () => {
     const wrapper = ({children}: {children: React.ReactNode}) => (
-      <SanityProvider config={config}>{children}</SanityProvider>
+      <SanityProvider sanityInstance={sanityInstance}>{children}</SanityProvider>
     )
 
     const {result} = renderHook(() => useSanityInstance(), {wrapper})
 
-    expect(result.current).toEqual({mockInstance: true})
-    expect(createSanityInstance).toHaveBeenCalledWith(config)
+    expect(result.current).toBe(sanityInstance)
   })
 
   it('throws error when used outside provider', () => {

--- a/packages/react/src/hooks/context/useSanityInstance.ts
+++ b/packages/react/src/hooks/context/useSanityInstance.ts
@@ -14,11 +14,10 @@ import {SanityInstanceContext} from '../../components/context/SanityProvider'
  * ```
  */
 export const useSanityInstance = (): SanityInstance => {
-  const context = useContext(SanityInstanceContext)
-
-  if (!context) throw new Error('useSanityInstance must be called from within the SanityProvider')
-
-  const {sanityInstance} = context
+  const sanityInstance = useContext(SanityInstanceContext)
+  if (!sanityInstance) {
+    throw new Error('useSanityInstance must be called from within the SanityProvider')
+  }
 
   return sanityInstance
 }


### PR DESCRIPTION
### Description

This PR refactors the `SanityProvider` component to accept a pre-created Sanity instance rather than creating one internally. This change addresses an issue where using `SanityProvider` within a suspended component tree could cause infinite re-renders.

Key changes:
- Modified `SanityProvider` to accept `sanityInstance` prop instead of `config`
- Removed internal instance creation logic from the provider
- Updated all tests to use pre-created instances
- Simplified the context value to directly store the instance
- Updated example usage in documentation

This change is necessary because when `SanityProvider` is used in a component tree that suspends, the internal instance creation causes state updates that trigger re-renders, leading to an infinite loop. Even wrapping the instance creation in `useMemo` doesn't solve the issue since the instance needs to be completely stable and created outside of React's lifecycle.

Related issues:
- Fixes infinite re-render issue with Suspense
- Improves instance stability and predictability
- Better aligns with React's data flow patterns

### What to review

1. The new `SanityProvider` API design and its documentation
2. Test coverage for the refactored components
3. Usage patterns in the kitchensink app

### Testing

All existing tests have been updated to work with the new pattern. The changes are covered by:
- Unit tests for `SanityProvider`
- Integration tests for auth hooks
- Updated test scenarios in kitchensink app

The main behavioral change (Suspense compatibility) has been manually tested in the kitchensink app.

### Fun gif

![Cat trying to catch its own reflection](https://i.giphy.com/media/JuFwy0zPzd6jC/giphy.gif)