### PR TITLE
fix: correct auth state subscription

### DIFF
--- a/packages/core/src/auth/authStore.ts
+++ b/packages/core/src/auth/authStore.ts
@@ -67,7 +67,10 @@ export const getAuthStore = (instance: SanityInstance): AuthStore => {
   const authState: AuthStateSlice = {
     getState: () => internalAuthStore.getState().authState,
     getInitialState: () => internalAuthStore.getInitialState().authState,
-    subscribe: internalAuthStore.subscribe.bind(internalAuthStore, (state) => state.authState),
+    subscribe: (listener) =>
+      internalAuthStore.subscribe((current, prev) => {
+        listener(current.authState, prev.authState)
+      }),
   }
 
   const tokenState: AuthTokenSlice = {


### PR DESCRIPTION
### Description

Ran into a small bug with the new auth store implementation. I think the previous implementation did not relay the subscription to the internal auth store correctly.

### What to review

Does this make sense?

### Testing

Ran into this while testing the auth boundary. PR for that soon.

### Fun gif

![wednesday](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGt2bTc2dmtyYTBhanBpZng0b2F0Nm5tbjJ4emZwdW52YWRkdTBweiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iibH5ymW6LFvSIVyUc/giphy.gif)
