### PR TITLE
test: fix act warning in useClient test

### DIFF
--- a/packages/react/src/hooks/client/useClient.test.tsx
+++ b/packages/react/src/hooks/client/useClient.test.tsx
@@ -1,8 +1,9 @@
 import {type SanityClient} from '@sanity/client'
-import {renderHook} from '../../../test/test-utils'
+import {act} from '@testing-library/react'
 import type {Subscribable, Subscriber} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {renderHook} from '../../../test/test-utils'
 import {useClient} from './useClient'
 
 vi.mock(import('@sanity/sdk'), async (importOriginal) => {
@@ -81,12 +82,12 @@ describe('useClient', () => {
     vi.mocked(getClient).mockReturnValue(authenticatedClient)
 
     // Simulate the client update that would happen after auth change
-    clientSubscriber!.next(authenticatedClient)
+    await act(async () => {
+      clientSubscriber!.next(authenticatedClient)
+    })
 
     // Verify the client was updated with the new token
-    await vi.waitFor(() => {
-      expect(result.current.config().token).toBe('auth-token')
-    })
+    expect(result.current.config().token).toBe('auth-token')
   })
 
   it('should unsubscribe on unmount', () => {


### PR DESCRIPTION
### Description
Fixes this warning

![CleanShot 2024-12-11 at 09 31 32@2x](https://github.com/user-attachments/assets/194b2d0c-8e6b-425a-9bd6-c817f5625c57)

### What to review

check that the warning is not in the test output,


### Fun gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXNvMXJmcGFtdmU5MGVucjh6a3FnejM4MnB1N2RjZjk5ZGU1Nm02eSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/U5hvUeqw10e0U/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
