### PR TITLE
fix(ci): fix the typo in release please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,29 +34,30 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          release-type: node
           token: ${{ steps.generate-token.outputs.token }}
 
       # Publish to NPM on new releases
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.release_created || github.event.inputs.publish == 'true' }}
       - uses: pnpm/action-setup@v4
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.release_created || github.event.inputs.publish == 'true' }}}
       - uses: actions/setup-node@v4
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.release_created || github.event.inputs.publish == 'true' }}
         with:
           cache: pnpm
           node-version: lts/*
       - name: install deps & build
         run: pnpm install --ignore-scripts && pnpm build --filter=!./apps/*
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.release_created || github.event.inputs.publish == 'true' }}
       - name: Set publishing config
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.release_created || github.event.inputs.publish == 'true' }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
       # Release Please has already incremented versions and published tags, so we just
       # need to publish all unpublished versions to NPM here
       - run: pnpm -r publish
-        if: ${{ steps.release.outputs.releases_created || github.event.inputs.publish == 'true' }}
+        if: ${{ steps.release.outputs.release_created || github.event.inputs.publish == 'true' }}
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Had a typo in the configuration, example [here](https://github.com/googleapis/release-please-action?tab=readme-ov-file#automating-publication-to-npm) although next-sanity uses the [other way](https://github.com/sanity-io/next-sanity/blob/main/.github/workflows/release-please.yml#L41) but that doesn't look correct 🤔 

but can confirm asset-utils uses it correctly and it should be skipping the steps see [here](https://arc.net/l/quote/spxrmmqe)
 
### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
![first time GIF](https://media0.giphy.com/media/uUIFcDYRbvJTtxaFNa/giphy.gif)