### PR TITLE
fix: update typedoc to use package mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "all": "turbo run build && turbo run lint && turbo run test:coverage && pnpm build:docs",
     "build": "turbo run build --filter='./packages/*' --filter='./apps/*'",
-    "build:docs": "typedoc --options ./typedoc.json --tsconfig tsconfig.tsdoc.json",
+    "build:docs": "turbo run docs && typedoc",
     "build:packages": "turbo run build --filter='./packages/*' --filter='!./packages/@repo/*'",
     "dev:kitchensink": "turbo run dev --filter=@sanity/kitchensink-react",
     "dev:storybook": "turbo run dev --filter={@sanity/storybook,@sanity/sdk,@sanity/sdk-react} --parallel",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,7 @@
     "build": "pkg build --strict --clean --check",
     "clean": "rimraf dist",
     "dev": "pkg watch",
+    "docs": "typedoc --out docs --tsconfig ../../tsconfig.tsdoc.json",
     "format": "prettier --write --cache --ignore-unknown .",
     "lint": "eslint .",
     "prepublishOnly": "pnpm run build",

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["./src/_exports/*"],
+  /**
+   * Path to the project's README file
+   * Will be included as the documentation homepage
+   */
+  "readme": "README.md"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,6 +63,7 @@
     "build": "pkg build --strict --clean --check",
     "clean": "rimraf dist",
     "dev": "pkg watch",
+    "docs": "typedoc --out docs --tsconfig ../../tsconfig.tsdoc.json",
     "format": "prettier --write --cache --ignore-unknown .",
     "lint": "eslint .",
     "prepublishOnly": "pnpm run build",

--- a/packages/react/src/_exports/components.ts
+++ b/packages/react/src/_exports/components.ts
@@ -1,4 +1,5 @@
 export {AuthBoundary, type AuthBoundaryProps} from '../components/auth/AuthBoundary'
+export {AuthError} from '../components/auth/AuthError'
 export {Login} from '../components/auth/Login'
 export {LoginCallback} from '../components/auth/LoginCallback'
 export {LoginError, type LoginErrorProps} from '../components/auth/LoginError'

--- a/packages/react/typedoc.json
+++ b/packages/react/typedoc.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["./src/_exports/*"],
+  /**
+   * Path to the project's README file
+   * Will be included as the documentation homepage
+   */
+  "readme": "README.md"
+}

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "includeVersion": true,
+  /**
+   * Documentation visibility filters
+   * Excludes internal implementation details from public documentation
+   */
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "excludeExternals": true,
+  "excludeInternal": true
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,27 +12,7 @@
    * Source files to include in documentation generation
    * Includes core SDK exports and React components/hooks
    */
-  "entryPoints": [
-    "packages/core/src/_exports/index.ts",
-    "packages/react/src/_exports/components.ts",
-    "packages/react/src/_exports/hooks.ts"
-  ],
-
-  /**
-   * Path to the project's README file
-   * Will be included as the documentation homepage
-   */
-  "readme": "README.md",
-  /**
-   * Output directory for generated documentation
-   */
-  "out": "docs",
-  /**
-   * Documentation visibility filters
-   * Excludes internal implementation details from public documentation
-   */
-  "excludePrivate": true,
-  "excludeProtected": true,
-  "excludeExternals": true,
-  "excludeInternal": true
+  "entryPoints": ["packages/*"],
+  "entryPointStrategy": "packages",
+  "includeVersion": false
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Updates typedoc to run in package mode so it works on showing the docs as packages with proper version. It also allows for proper linking between packages.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

See the sdk-docs preview and see if it makes sense

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->

![Im Ready Doc Brown GIF by Back to the Future Trilogy](https://media3.giphy.com/media/0DYipdNqJ5n4GYATKL/giphy.gif)