### PR TITLE
chore: add eslint to lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "ts:check": "tsc --noEmit"
   },
   "lint-staged": {
-    "*": [
-      "prettier --write --cache --ignore-unknown"
+    "!(*.{ts,tsx})": "prettier --write",
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
     ]
   },
   "prettier": "@sanity/prettier-config",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,8 +53,10 @@
     "ts:check": "tsc --noEmit"
   },
   "lint-staged": {
-    "*": [
-      "prettier --write --cache --ignore-unknown"
+    "!(*.{ts,tsx})": "prettier --write",
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
     ]
   },
   "browserslist": "extends @sanity/browserslist-config",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -74,8 +74,10 @@
     "ts:check": "tsc --noEmit"
   },
   "lint-staged": {
-    "*": [
-      "prettier --write --cache --ignore-unknown"
+    "!(*.{ts,tsx})": "prettier --write",
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
     ]
   },
   "browserslist": "extends @sanity/browserslist-config",


### PR DESCRIPTION
### Description

eslint was missing from our `lint-staged` commands. This PR adds it in for typescript files.

### What to review

Check that eslint was added where needed.

### Testing

1. Pull down this branch
2. Make a linting error in a file and stage that file
3. run `npx lint-staged`
4. The command should fail with the linting error.


### Fun gif

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjc1dTA3cTV2dGhlNjN2a2lpNmh0ZWNtaDMxZWdkZXN0aWFnYXk0cyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/DakhsXLRBMtEw41ryv/giphy-downsized.gif)

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
