### PR TITLE
fix(core): emit current token state on subscribe

### DIFF
--- a/packages/core/src/client/actions/getClient.test.ts
+++ b/packages/core/src/client/actions/getClient.test.ts
@@ -1,55 +1,58 @@
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {config} from '../../../test/fixtures'
+import {getAuthStore} from '../../auth/authStore'
 import {createSanityInstance} from '../../instance/sanityInstance'
+import type {SanityInstance} from '../../instance/types'
 import {getClient} from './getClient'
 
-let tokenCallback: ((token: string | null, prevToken: string | null) => void) | undefined
+type TokenState = ReturnType<typeof getAuthStore>['tokenState']
 
 vi.mock('../../auth/authStore', () => ({
-  getAuthStore: vi.fn(() => {
-    return {
-      tokenState: {
-        subscribe: vi.fn((callback) => {
-          tokenCallback = callback
-        }),
-      },
-    }
+  getAuthStore: vi.fn().mockReturnValue({
+    tokenState: {getState: vi.fn(), subscribe: vi.fn()},
   }),
 }))
 
 describe('getClient', () => {
   const apiVersion = '2024-01-01'
+  let instance: SanityInstance
+
+  let getState: Mock<TokenState['getState']>
+  let subscribe: Mock<TokenState['subscribe']>
 
   beforeEach(() => {
-    tokenCallback = undefined
     vi.clearAllMocks()
+    instance = createSanityInstance(config)
+
+    const {tokenState} = getAuthStore(instance)
+    getState = vi.mocked(tokenState.getState)
+    subscribe = vi.mocked(tokenState.subscribe)
   })
 
   it('throws error when apiVersion is missing', () => {
-    const instance = createSanityInstance(config)
     expect(() => getClient(instance, {})).toThrow('Missing required `apiVersion` option')
   })
 
   it('creates new client with correct apiVersion', () => {
-    const instance = createSanityInstance(config)
     const result = getClient(instance, {apiVersion})
     expect(result.config().apiVersion).toBe(apiVersion)
   })
 
   it('reuses existing client for same apiVersion', () => {
-    const instance = createSanityInstance(config)
     const result1 = getClient(instance, {apiVersion})
     const result2 = getClient(instance, {apiVersion})
     expect(result1).toBe(result2)
   })
 
   it('preserves client identity after token update', async () => {
-    const instance = createSanityInstance(config)
-
     const client1 = getClient(instance, {apiVersion})
 
-    tokenCallback?.('new-token', null)
+    expect(subscribe).toHaveBeenCalledTimes(1)
+    const [subscriber] = subscribe.mock.calls[0]
+
+    getState.mockReturnValue('new-token')
+    subscriber('new-token', null)
 
     const client2 = getClient(instance, {apiVersion})
 

--- a/packages/core/src/client/actions/subscribeToAuthEvents.test.ts
+++ b/packages/core/src/client/actions/subscribeToAuthEvents.test.ts
@@ -1,42 +1,62 @@
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
-import {createSanityInstance} from '../../instance/sanityInstance'
 import {config} from '../../../test/fixtures'
+import {getAuthStore} from '../../auth/authStore'
+import {createSanityInstance} from '../../instance/sanityInstance'
+import type {SanityInstance} from '../../instance/types'
+import {getOrCreateResource} from '../../resources/createResource'
+import {clientStore} from '../clientStore'
 import {getClient} from './getClient'
-import {subscribeToAuthEvents} from './subscribeToAuthEvents'
 
-let tokenCallback: ((token: string | null, prevToken: string | null) => void) | undefined
+type TokenState = ReturnType<typeof getAuthStore>['tokenState']
 
 vi.mock('../../auth/authStore', () => ({
-  getAuthStore: vi.fn(() => {
-    return {
-      tokenState: {
-        subscribe: vi.fn((callback) => {
-          tokenCallback = callback
-        }),
-      },
-    }
+  getAuthStore: vi.fn().mockReturnValue({
+    tokenState: {
+      getState: vi.fn(),
+      subscribe: vi.fn().mockReturnValue(
+        // unsubscribe function
+        vi.fn(),
+      ),
+    },
   }),
 }))
 
 describe('subscribeToAuthEvents', () => {
   const apiVersion = '2024-01-01'
   const apiVersion2 = '2024-02-01'
+
+  let instance: SanityInstance
+  let getTokenState: Mock<TokenState['getState']>
+  let tokenSubscribe: Mock<TokenState['subscribe']>
+  let tokenUnsubscribe: Mock<ReturnType<TokenState['subscribe']>>
+
   beforeEach(() => {
-    tokenCallback = undefined
+    instance = createSanityInstance(config)
+
+    // @ts-expect-error no params required since mocking
+    const {tokenState} = getAuthStore()
+    getTokenState = vi.mocked(tokenState.getState)
+    tokenSubscribe = vi.mocked(tokenState.subscribe)
+    tokenUnsubscribe = vi.mocked(tokenSubscribe(() => {}))
+
     vi.clearAllMocks()
+
+    // ensure state is initialized for this resource
+    getOrCreateResource(instance, clientStore)
   })
 
   it('updates all clients in the store when token changes', () => {
-    const instance = createSanityInstance(config)
-
     const client1 = getClient(instance, {apiVersion})
     const client2 = getClient(instance, {apiVersion: apiVersion2})
 
     expect(client1.config().token).toBeUndefined()
     expect(client2.config().token).toBeUndefined()
 
-    tokenCallback?.('new-token', null)
+    getTokenState.mockReturnValue('new-token')
+    expect(tokenSubscribe).toHaveBeenCalledTimes(1)
+    const [subscriber] = tokenSubscribe.mock.calls[0]
+    subscriber(getTokenState(), null)
 
     // Verify all clients were updated
     const updatedClient1 = getClient(instance, {apiVersion})
@@ -47,7 +67,10 @@ describe('subscribeToAuthEvents', () => {
   })
 
   it('clears the token when token is null', () => {
-    const instance = createSanityInstance({...config, auth: {token: 'old-token'}})
+    getTokenState.mockReturnValue('old-token')
+    expect(tokenSubscribe).toHaveBeenCalledTimes(1)
+    const [subscriber] = tokenSubscribe.mock.calls[0]
+    subscriber(getTokenState(), null)
 
     // Verify all clients were updated
     const client1 = getClient(instance, {apiVersion})
@@ -56,7 +79,9 @@ describe('subscribeToAuthEvents', () => {
     expect(client1.config().token).toBe('old-token')
     expect(client2.config().token).toBe('old-token')
 
-    tokenCallback?.(null, 'old-token')
+    getTokenState.mockReturnValue(null)
+    expect(tokenSubscribe).toHaveBeenCalledTimes(1)
+    subscriber(getTokenState(), 'old-token')
 
     // Verify all clients were updated
     const clearedClient1 = getClient(instance, {apiVersion})
@@ -66,15 +91,12 @@ describe('subscribeToAuthEvents', () => {
     expect(clearedClient2.config().token).toBeUndefined()
   })
 
-  it('should properly clean up subscription when unsubscribed', () => {
-    const instance = createSanityInstance(config)
-    const subscription = subscribeToAuthEvents(instance)
+  it('should properly clean up subscription when disposed', () => {
+    expect(tokenSubscribe).toHaveBeenCalledTimes(1)
+    expect(tokenUnsubscribe).not.toHaveBeenCalled()
 
-    subscription.unsubscribe()
+    instance.dispose()
 
-    // because we're unsubscribed, this should not trigger any updates
-    tokenCallback?.('another-token', null)
-    const client = getClient(instance, {apiVersion})
-    expect(client.config().token).toBeUndefined()
+    expect(tokenUnsubscribe).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/client/actions/subscribeToAuthEvents.ts
+++ b/packages/core/src/client/actions/subscribeToAuthEvents.ts
@@ -32,8 +32,9 @@ export const subscribeToAuthEvents = createAction(
       const authStore = getAuthStore(instance)
 
       const observableAuthStore = new Observable<string | null>((observer) => {
-        return authStore.tokenState.subscribe((token) => {
-          observer.next(token)
+        observer.next(authStore.tokenState.getState())
+        return authStore.tokenState.subscribe(() => {
+          observer.next(authStore.tokenState.getState())
         })
       })
 


### PR DESCRIPTION
### Description

The following fixes a bug where auth tokens were not being propagated on the first change.

Left is before, right is after. Notice how the document list can only show published documents.

https://github.com/user-attachments/assets/cb0eae5c-e027-45e7-9268-e78021603be5

### What to review

Did I miss anything?

### Testing

Test were updated!

### Fun gif

![happy friday](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExM2k0eXlqYnZjc3kyNXI1bXh5dW9nNmt6M204MWhmNjQ5dnloNmFraSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/577FZKjAUwyNN0f7ye/giphy.gif)
