### PR TITLE
feat: authenticate embedded apps using a sanityAuthCode param

### DIFF
--- a/packages/core/src/auth/authStore.ts
+++ b/packages/core/src/auth/authStore.ts
@@ -5,10 +5,17 @@ import {createResource, type Resource} from '../resources/createResource'
 import {createStateSourceAction} from '../resources/createStateSourceAction'
 import {subscribeToStateAndFetchCurrentUser} from './subscribeToStateAndFetchCurrentUser'
 import {subscribeToStorageEventsAndSetToken} from './subscribeToStorageEventsAndSetToken'
-import {getAuthCode, getDefaultLocation, getDefaultStorage, getTokenFromStorage} from './utils'
+import {
+  getAuthCode,
+  getDefaultLocation,
+  getDefaultStorage,
+  getSanityAuthCode,
+  getTokenFromStorage,
+} from './utils'
 
 export const DEFAULT_BASE = 'http://localhost'
 export const AUTH_CODE_PARAM = 'sid'
+export const SANITY_AUTH_CODE_PARAM = 'sanityAuthCode'
 export const DEFAULT_API_VERSION = '2021-06-07'
 export const REQUEST_TAG_PREFIX = 'sdk.auth'
 
@@ -191,6 +198,8 @@ export const authStore = createResource<AuthStoreState>({
 
     if (providedToken) {
       authState = {type: AuthStateType.LOGGED_IN, token: providedToken, currentUser: null}
+    } else if (getSanityAuthCode(initialLocationHref)) {
+      authState = {type: AuthStateType.LOGGING_IN, isExchangingToken: false}
     } else if (getAuthCode(callbackUrl, initialLocationHref)) {
       authState = {type: AuthStateType.LOGGING_IN, isExchangingToken: false}
     } else if (token) {

--- a/packages/core/src/auth/handleCallback.ts
+++ b/packages/core/src/auth/handleCallback.ts
@@ -1,6 +1,6 @@
 import {createAction} from '../resources/createAction'
 import {AuthStateType, DEFAULT_API_VERSION, getAuthStore, REQUEST_TAG_PREFIX} from './authStore'
-import {getAuthCode, getDefaultLocation} from './utils'
+import {getAuthCode, getDefaultLocation, getSanityAuthCode} from './utils'
 
 /**
  * @public
@@ -19,7 +19,7 @@ export const handleCallback = createAction(getAuthStore, ({state, instance}) => 
     if (authState.type === AuthStateType.LOGGING_IN && authState.isExchangingToken) return false
 
     // If there is no matching `authCode` then we can't handle the callback
-    const authCode = getAuthCode(callbackUrl, locationHref)
+    const authCode = getSanityAuthCode(locationHref) || getAuthCode(callbackUrl, locationHref)
     if (!authCode) return false
 
     // Otherwise, start the exchange

--- a/packages/core/src/auth/utils.test.ts
+++ b/packages/core/src/auth/utils.test.ts
@@ -1,11 +1,12 @@
 import {EMPTY, NEVER} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {AUTH_CODE_PARAM, DEFAULT_BASE} from './authStore'
+import {AUTH_CODE_PARAM, DEFAULT_BASE, SANITY_AUTH_CODE_PARAM} from './authStore'
 import {
   getAuthCode,
   getDefaultLocation,
   getDefaultStorage,
+  getSanityAuthCode,
   getStorageEvents,
   getTokenFromStorage,
 } from './utils'
@@ -199,5 +200,26 @@ describe('getDefaultLocation', () => {
 
     const result = getDefaultLocation()
     expect(result).toBe(DEFAULT_BASE)
+  })
+})
+
+describe('getSanityAuthCode', () => {
+  it('returns auth code when present in search params', () => {
+    const testCode = 'test123'
+    const testUrl = `http://example.com?${SANITY_AUTH_CODE_PARAM}=${testCode}`
+    const result = getSanityAuthCode(testUrl)
+    expect(result).toBe(testCode)
+  })
+
+  it('returns null when auth code is not present', () => {
+    const testUrl = 'http://example.com?other=value'
+    const result = getSanityAuthCode(testUrl)
+    expect(result).toBe(null)
+  })
+
+  it('handles empty search params', () => {
+    const testUrl = 'http://example.com'
+    const result = getSanityAuthCode(testUrl)
+    expect(result).toBe(null)
   })
 })

--- a/packages/core/src/auth/utils.ts
+++ b/packages/core/src/auth/utils.ts
@@ -1,6 +1,6 @@
 import {EMPTY, fromEvent, Observable} from 'rxjs'
 
-import {AUTH_CODE_PARAM, DEFAULT_BASE} from './authStore'
+import {AUTH_CODE_PARAM, DEFAULT_BASE, SANITY_AUTH_CODE_PARAM} from './authStore'
 
 export function getAuthCode(callbackUrl: string | undefined, locationHref: string): string | null {
   const loc = new URL(locationHref, DEFAULT_BASE)
@@ -11,6 +11,16 @@ export function getAuthCode(callbackUrl: string | undefined, locationHref: strin
 
   const authCode = new URLSearchParams(loc.hash.slice(1)).get(AUTH_CODE_PARAM)
   return authCode && callbackLocationMatches ? authCode : null
+}
+
+/**
+ * Retrieves the sanity auth code from the location search params. This is used when the COSUi loads the app with a token in the URL.
+ */
+export function getSanityAuthCode(locationHref: string): string | null {
+  const loc = new URL(locationHref, DEFAULT_BASE)
+
+  const authToken = new URLSearchParams(loc.search).get(SANITY_AUTH_CODE_PARAM)
+  return authToken
 }
 
 /**


### PR DESCRIPTION
### Description

This PR allows an app user to be authenticated using a `?sanityAuthCode=xxxx` search param when the app is loaded. This works much like an `sid` hash coming back from an oauth call. Details and a diagram can be seen in Notion: https://www.notion.so/sanityio/Ops-UI-FE-Authentication-13778d055b94801f8278c38580bd89f9?pvs=4#13778d055b94807b9ba6f45266ff29ab

### What to review

Ensure that th enew authentication flow matches the expected implementation in the diagram in Notion.

### Testing

1. load the app with a valid sanityAuthToken in the search params
2. you should be logged in

### Fun gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbmtuNGZ3bjB0NHRueWN6dzY4c3FjaWJ2aXluZWtnMWc3M3Bsc2c5eSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/H0RhfgV2LIEZa/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
