### PR TITLE
fix: styled is not a function in Remix apps

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -110,8 +110,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0",
-    "styled-components": "^6.1.13"
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "packageManager": "pnpm@9.15.2",
   "engines": {

--- a/packages/react/src/components/auth/Login.tsx
+++ b/packages/react/src/components/auth/Login.tsx
@@ -1,13 +1,8 @@
 import {Button, Flex, Heading, Spinner} from '@sanity/ui'
 import {type JSX, Suspense} from 'react'
-import styled from 'styled-components'
 
 import {useLoginUrls} from '../../hooks/auth/useLoginUrls'
 import {LoginLayout, type LoginLayoutProps} from './LoginLayout'
-
-const FallbackRoot = styled(Flex)`
-  height: 123px;
-`
 
 /**
  * Login component that displays available authentication providers.
@@ -25,9 +20,9 @@ export function Login({header, footer}: LoginLayoutProps): JSX.Element {
 
         <Suspense
           fallback={
-            <FallbackRoot align="center" justify="center">
+            <Flex align="center" justify="center" style={{height: '123px'}}>
               <Spinner />
-            </FallbackRoot>
+            </Flex>
           }
         >
           <Providers />

--- a/packages/react/src/components/auth/LoginCallback.tsx
+++ b/packages/react/src/components/auth/LoginCallback.tsx
@@ -1,14 +1,10 @@
 import {Flex, Spinner, Text} from '@sanity/ui'
 import {useEffect} from 'react'
-import styled from 'styled-components'
 
 import {useHandleCallback} from '../../hooks/auth/useHandleCallback'
 import {LoginLayout, type LoginLayoutProps} from './LoginLayout'
 
-const StyledFlex = styled(Flex)`
-  margin: auto;
-`
-
+/**
 /**
  * Component shown during auth callback processing that handles login completion.
  * Automatically processes the auth callback when mounted and updates the URL
@@ -32,10 +28,10 @@ export function LoginCallback({header, footer}: LoginLayoutProps): React.ReactNo
 
   return (
     <LoginLayout header={header} footer={footer}>
-      <StyledFlex direction="column" justify="center" align="center" gap={4}>
+      <Flex direction="column" justify="center" align="center" gap={4} style={{margin: 'auto'}}>
         <Text size={1}>Logging you in…</Text>
         <Spinner size={4} />
-      </StyledFlex>
+      </Flex>
     </LoginLayout>
   )
 }

--- a/packages/react/src/components/auth/LoginError.tsx
+++ b/packages/react/src/components/auth/LoginError.tsx
@@ -1,7 +1,6 @@
 import {Button, Flex, Text} from '@sanity/ui'
 import {useCallback} from 'react'
 import {type FallbackProps} from 'react-error-boundary'
-import styled from 'styled-components'
 
 import {useLogOut} from '../../hooks/auth/useLogOut'
 import {AuthError} from './AuthError'
@@ -11,10 +10,6 @@ import {LoginLayout, type LoginLayoutProps} from './LoginLayout'
  * @alpha
  */
 export type LoginErrorProps = FallbackProps & LoginLayoutProps
-
-const StyledFlex = styled(Flex)`
-  margin: auto;
-`
 
 /**
  * Displays authentication error details and provides retry functionality.
@@ -38,7 +33,7 @@ export function LoginError({
 
   return (
     <LoginLayout header={header} footer={footer}>
-      <StyledFlex direction="column" gap={4}>
+      <Flex direction="column" gap={4} style={{margin: 'auto'}}>
         <Flex direction="column" gap={3}>
           <Text as="h2" align="center" weight="bold" size={3}>
             Authentication Error
@@ -48,7 +43,7 @@ export function LoginError({
           </Text>
         </Flex>
         <Button text="Retry" tone="primary" onClick={handleRetry} />
-      </StyledFlex>
+      </Flex>
     </LoginLayout>
   )
 }

--- a/packages/react/src/components/auth/LoginFooter.tsx
+++ b/packages/react/src/components/auth/LoginFooter.tsx
@@ -1,7 +1,6 @@
 import {SanityLogo} from '@sanity/logos'
 import {Flex, Text} from '@sanity/ui'
 import {Fragment} from 'react'
-import styled from 'styled-components'
 
 const LINKS = [
   {
@@ -26,12 +25,6 @@ const LINKS = [
   },
 ]
 
-const StyledText = styled(Text)`
-  a {
-    color: inherit;
-  }
-`
-
 /**
  * Default footer component for login screens showing Sanity branding and legal
  * links.
@@ -48,11 +41,16 @@ export function LoginFooter(): React.ReactNode {
       <Flex align="center" gap={2}>
         {LINKS.map((link, index) => (
           <Fragment key={link.title}>
-            <StyledText muted size={1}>
-              <a href={link.url} target="_blank" rel="noopener noreferrer">
+            <Text muted size={1}>
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{color: 'inherit'}}
+              >
                 {link.title}
               </a>
-            </StyledText>
+            </Text>
 
             {index < LINKS.length - 1 && (
               <Text size={1} muted>

--- a/packages/react/src/components/auth/LoginLayout.tsx
+++ b/packages/react/src/components/auth/LoginLayout.tsx
@@ -1,5 +1,4 @@
 import {Card, Flex} from '@sanity/ui'
-import styled from 'styled-components'
 
 import {LoginFooter} from './LoginFooter'
 
@@ -16,23 +15,6 @@ export interface LoginLayoutProps {
   /** Main content rendered in card body */
   children?: React.ReactNode
 }
-
-const Root = styled.div`
-  width: 100%;
-  display: flex;
-`
-
-const Container = styled(Flex)`
-  width: 320px;
-  margin: auto;
-  display: flex;
-`
-
-const StyledCard = styled(Card)``
-
-const ChildrenFlex = styled(Flex)`
-  min-height: 154px;
-`
 
 /**
  * Layout component for login-related screens providing consistent styling and structure.
@@ -74,9 +56,9 @@ export function LoginLayout({
   header,
 }: LoginLayoutProps): React.ReactNode {
   return (
-    <Root>
-      <Container direction="column" gap={4}>
-        <StyledCard border radius={2} paddingY={4}>
+    <div style={{width: '100%', display: 'flex'}}>
+      <Flex direction="column" gap={4} style={{width: '320px', margin: 'auto', display: 'flex'}}>
+        <Card border radius={2} paddingY={4}>
           <Flex direction="column" gap={4}>
             {header && (
               <Card borderBottom paddingX={4} paddingBottom={3}>
@@ -85,15 +67,15 @@ export function LoginLayout({
             )}
 
             {children && (
-              <ChildrenFlex paddingX={4} direction="column">
+              <Flex paddingX={4} direction="column" style={{minHeight: '154px'}}>
                 {children}
-              </ChildrenFlex>
+              </Flex>
             )}
           </Flex>
-        </StyledCard>
+        </Card>
 
         {footer}
-      </Container>
-    </Root>
+      </Flex>
+    </div>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,9 +325,6 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
-      styled-components:
-        specifier: ^6.1.13
-        version: 6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@repo/config-eslint':
         specifier: workspace:*


### PR DESCRIPTION
### Description

This PR fixes the incompatibility of styled-components with Remix by removing styled-components. Note, we will eventually be shipping only headless components, so this should be the first step in removing these fully styled components. For now, I will keep some inline styles in place.

### What to review
Check that styled-components is removed, but the currently pages are still rendered well enough to test.



### Fun gif
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHVoYzBhZ3drdXRtYW5pYXFzaW40Y2w3NHY1eGtpczQ1bmFtMWp0NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/k1SuVPEuA89S8/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
