### PR TITLE
chore(auth): use stamped tokens

### DIFF
--- a/packages/core/src/auth/fetchLoginUrls.ts
+++ b/packages/core/src/auth/fetchLoginUrls.ts
@@ -55,6 +55,8 @@ export const fetchLoginUrls = createAction(authStore, ({state, instance}) => {
       const hashParams = new URLSearchParams(origin.hash.slice(1))
       hashParams.delete('sid')
       origin.hash = hashParams.toString()
+      origin.searchParams.delete('sid')
+      origin.searchParams.delete('url')
 
       // similarly, the origin may be populated with an `error` query param if
       // the auth provider redirects back to the application. this should also
@@ -63,6 +65,7 @@ export const fetchLoginUrls = createAction(authStore, ({state, instance}) => {
 
       url.searchParams.set('origin', origin.toString())
       url.searchParams.set('withSid', 'true')
+      url.searchParams.set('type', 'stampedToken')
       if (authScope === 'project') {
         url.searchParams.set('projectId', projectId)
       }

--- a/packages/core/src/auth/handleCallback.ts
+++ b/packages/core/src/auth/handleCallback.ts
@@ -51,6 +51,8 @@ export const handleCallback = createAction(authStore, ({state, instance}) => {
 
       const loc = new URL(locationHref)
       loc.hash = ''
+      loc.searchParams.delete('sid')
+      loc.searchParams.delete('url')
       return loc.toString()
     } catch (error) {
       state.set('exchangeSessionForTokenError', {authState: {type: AuthStateType.ERROR, error}})

--- a/packages/core/src/auth/utils.ts
+++ b/packages/core/src/auth/utils.ts
@@ -9,7 +9,11 @@ export function getAuthCode(callbackUrl: string | undefined, locationHref: strin
     ? loc.pathname.toLowerCase().startsWith(callbackLocation.pathname.toLowerCase())
     : true
 
-  const authCode = new URLSearchParams(loc.hash.slice(1)).get(AUTH_CODE_PARAM)
+  // for stamped tokens, the authCode is not in the hash, it is in the query params
+  const authCode =
+    new URLSearchParams(loc.hash.slice(1)).get(AUTH_CODE_PARAM) ||
+    new URLSearchParams(loc.search).get(AUTH_CODE_PARAM)
+
   return authCode && callbackLocationMatches ? authCode : null
 }
 


### PR DESCRIPTION
### Description

This PR changes the SDK to request stamped tokens. These tokens are shorter lived and have the ability to be refreshed. Another PR will address the refreshing of the token.


### What to review

Verify that a stamped token is requested

### Testing

Log into kitchensink app and ensure that your token ends with `-st*`

### Fun gif
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZnOW9zcTNvb3oxdnY0em84MXg2ODVhN3BsOHN3ZDJ0ejhuMmVmcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2JHVUriDGEtWOx0c/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
