### PR TITLE
fix: initialize client with configured `apiHost`

### DIFF
--- a/packages/core/src/client/clientStore.test.ts
+++ b/packages/core/src/client/clientStore.test.ts
@@ -41,6 +41,16 @@ describe('clientStore', () => {
       expect(state.defaultClient.config().token).toBe('foo')
     })
 
+    it('creates initial state with apiHost', () => {
+      const instance = createSanityInstance({
+        ...config,
+        auth: {apiHost: 'https://api.sanity.work'},
+      })
+      const store = getOrCreateResource(instance, clientStore)
+      const state = store.state.get()
+      expect(state.defaultClient.config().apiHost).toBe('https://api.sanity.work')
+    })
+
     it('initializes clients Map with default client', () => {
       const instance = createSanityInstance(config)
       const store = getOrCreateResource(instance, clientStore)

--- a/packages/core/src/client/clientStore.ts
+++ b/packages/core/src/client/clientStore.ts
@@ -26,6 +26,7 @@ export const clientStore: Resource<ClientState> = createResource({
       token: config?.auth?.token,
       useCdn: false,
       apiVersion: DEFAULT_API_VERSION,
+      ...(config?.auth?.apiHost ? {apiHost: config.auth.apiHost} : {}),
     })
 
     const clients = new Map<string, SanityClient>()


### PR DESCRIPTION
### Description

This updates the client store so it's initialized with any custom defined `apiHost`. Currently, hooks like `useDocuments` will continue to use the default `api.sanity.io` even if you've configured otherwise.

### What to review

- In the kitchen sink example, point to a project on staging and specify `apiHost: https://api.sanity.work`
- Navigate to project auth > document list
- Observe that requests point to the above api host

### Testing

Added a simple test

### Fun gif

![cwC88pk27GcKETPNV38aXiKa1wyWIU8InF13kInd2YE](https://github.com/user-attachments/assets/331ce6bb-9184-413d-ac4f-a30fd5551dea)


