### PR TITLE
chore: usePreview fixes

### DIFF
--- a/apps/kitchensink-react/src/DocumentCollection/DocumentPreview.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentPreview.tsx
@@ -1,6 +1,6 @@
 import {DocumentHandle} from '@sanity/sdk'
 import {usePreview} from '@sanity/sdk-react/hooks'
-import {Suspense, useState} from 'react'
+import {Suspense, useRef} from 'react'
 import {ErrorBoundary} from 'react-error-boundary'
 
 import {DocumentPreviewLayout} from '../components/DocumentPreviewLayout/DocumentPreviewLayout'
@@ -24,7 +24,7 @@ export function DocumentPreview(props: DocumentPreviewProps): React.ReactNode {
 }
 
 function DocumentPreviewResolved({document}: DocumentPreviewProps): React.ReactNode {
-  const [ref, setRef] = useState<HTMLElement | null>(null)
+  const ref = useRef(null)
   const {
     results: {title, subtitle, media, status},
   } = usePreview({document, ref})
@@ -47,7 +47,7 @@ function DocumentPreviewResolved({document}: DocumentPreviewProps): React.ReactN
 
   return (
     <DocumentPreviewLayout
-      ref={setRef}
+      ref={ref}
       title={title}
       subtitle={subtitle}
       docType={document._type}

--- a/packages/react/src/hooks/preview/usePreview.test.tsx
+++ b/packages/react/src/hooks/preview/usePreview.test.tsx
@@ -1,6 +1,6 @@
 import {type DocumentHandle, getPreviewState, type PreviewValue, resolvePreview} from '@sanity/sdk'
 import {act, render, screen} from '@testing-library/react'
-import {Suspense, useState} from 'react'
+import {Suspense, useRef} from 'react'
 import {type Mock} from 'vitest'
 
 import {usePreview} from './usePreview'
@@ -44,11 +44,11 @@ const mockDocument: DocumentHandle = {
 }
 
 function TestComponent({document}: {document: DocumentHandle}) {
-  const [ref, setRef] = useState<HTMLElement | null>(null)
+  const ref = useRef(null)
   const {results, isPending} = usePreview({document, ref})
 
   return (
-    <div ref={setRef}>
+    <div ref={ref}>
       <h1>{results?.title}</h1>
       <p>{results?.subtitle}</p>
       {isPending && <div>Pending...</div>}


### PR DESCRIPTION
### Description

Fixes an issue with passing refs for intersection observers in usePreview, and updates usePreview documentation to demonstrate use of Suspense

### What to review

- Code is gud
- Doc is gud

### Testing

- They pass!

### Fun gif

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExajE4cmx4bG44Z25ka2gxZDNnNzJlZnBoeWQ0dXkxZHB3bGV1ZXFzayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BcJbdfFSsJPwK4O66J/giphy.gif)
