### PR TITLE
fix(deps): allow renovate to lookup private packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>sanity-io/renovate-config", ":dependencyDashboardApproval"],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
+  "hostRules": [
+    {
+      "matchHost": "registry.npmjs.org",
+      "token": "{{ secrets.SANITY_NPM_TOKEN }}"
+    }
+  ],
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
### Description

Added NPM token authentication to Renovate configuration to enable private package access through the `SANITY_NPM_TOKEN` secret.

### What to review

- Verify the host rule configuration for registry.npmjs.org
- Confirm the secret reference syntax for `SANITY_NPM_TOKEN`
- Check that the token integration aligns with existing Renovate presets

### Testing

Configuration changes can be verified by monitoring Renovate's behavior with private package updates in subsequent runs.

### Fun gif

![Cat typing on computer](https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif)