### PR TITLE
docs: add categories to typedoc docs

### DIFF
--- a/packages/core/src/document/patchOperations.ts
+++ b/packages/core/src/document/patchOperations.ts
@@ -17,6 +17,7 @@ type SingleValuePath = Exclude<PathSegment, IndexTuple>[]
  * A minimal set of metadata for a given document, comprising the document's ID and type.
  * Used by most document-related hooks (such as {@link usePreview}, {@link useDocument}, and {@link useEditDocument})
  * to reference a particular document without fetching the entire document upfront.
+ * @category Types
  */
 export interface DocumentHandle<TDocument extends SanityDocumentLike = SanityDocumentLike> {
   _id: string

--- a/packages/core/tsdoc.json
+++ b/packages/core/tsdoc.json
@@ -10,6 +10,11 @@
       "tagName": "@todo",
       "syntaxKind": "block",
       "allowMultiple": true
+    },
+    {
+      "tagName": "@category",
+      "syntaxKind": "block",
+      "allowMultiple": true
     }
   ],
   "supportForTags": {
@@ -28,6 +33,7 @@
     "@remarks": true,
     "@throws": true,
     "@defaultValue": true,
-    "@todo": true
+    "@todo": true,
+    "@category": true
   }
 }

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -1,4 +1,5 @@
 {
+  "name": "sdk",
   "extends": ["../../typedoc.base.json"],
   "entryPoints": ["./src/_exports/*"],
   /**

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -135,16 +135,6 @@ export default App
 }
 ```
 
-## Available Hooks
-
-- `useAuthState` - Get current authentication state
-- `useCurrentUser` - Access the currently authenticated user
-- `useAuthToken` - Access the authentication token
-- `useLoginUrls` - Get OAuth login URLs
-- `useLogOut` - Handle user logout
-- `useSanityInstance` - Access the Sanity client instance
-- and more...
-
 ## TypeScript Support
 
 This package includes TypeScript definitions. You can import types like:

--- a/packages/react/src/_exports/index.ts
+++ b/packages/react/src/_exports/index.ts
@@ -1,6 +1,6 @@
 /**
  * An example function that will be removed.
- * @public
+ * @internal
  */
 export function main(): void {
   //

--- a/packages/react/src/context/SanityProvider.tsx
+++ b/packages/react/src/context/SanityProvider.tsx
@@ -2,7 +2,7 @@ import {type SanityInstance} from '@sanity/sdk'
 import {createContext, type ReactElement} from 'react'
 
 /**
- * @public
+ * @internal
  */
 export interface SanityProviderProps {
   children: React.ReactNode
@@ -12,10 +12,12 @@ export interface SanityProviderProps {
 export const SanityInstanceContext = createContext<SanityInstance | null>(null)
 
 /**
+ * @internal
+ *
  * Top-level context provider that provides access to the Sanity configuration instance.
  * This must wrap any components making use of the Sanity SDK React hooks.
+ *
  * @remarks In most cases, SanityApp should be used rather than SanityProvider directly; SanityApp bundles both SanityProvider and an authentication layer.
- * @internal
  * @param props - Sanity project and dataset configuration
  * @returns Rendered component
  * @example

--- a/packages/react/src/hooks/auth/useCurrentUser.tsx
+++ b/packages/react/src/hooks/auth/useCurrentUser.tsx
@@ -10,6 +10,7 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
  * Provides the currently authenticated user’s profile information (their name, email, roles, etc).
  * If no users are currently logged in, the hook returns null.
  *
+ * @category Authentication
  * @returns The current user data, or `null` if not authenticated
  *
  * @example Rendering a basic user profile

--- a/packages/react/src/hooks/client/useClient.ts
+++ b/packages/react/src/hooks/client/useClient.ts
@@ -12,6 +12,7 @@ import {useSanityInstance} from '../context/useSanityInstance'
  * The hook uses `useSyncExternalStore` to safely subscribe to changes
  * and ensure consistency between server and client rendering.
  *
+ * @category Platform
  * @returns A Sanity client
  *
  * @example

--- a/packages/react/src/hooks/document/useApplyActions.ts
+++ b/packages/react/src/hooks/document/useApplyActions.ts
@@ -14,8 +14,8 @@ import {createCallbackHook} from '../helpers/createCallbackHook'
  *
  * Provides a callback for applying one or more actions to a document.
  *
+ * @category Documents
  * @returns A function that takes one more more {@link DocumentAction}s and returns a promise that resolves to an {@link ActionsResult}.
- *
  * @example Publish or unpublish a document
  * ```
  * import { publishDocument, unpublishDocument } from '@sanity/sdk'

--- a/packages/react/src/hooks/document/useDocument.ts
+++ b/packages/react/src/hooks/document/useDocument.ts
@@ -12,8 +12,10 @@ import {useSanityInstance} from '../context/useSanityInstance'
 
 /**
  * @beta
+ *
  * ## useDocument(doc, path)
  * Read and subscribe to nested values in a document
+ * @category Documents
  * @param doc - The document to read state from
  * @param path - The path to the nested value to read from
  * @returns The value at the specified path

--- a/packages/react/src/hooks/document/useDocumentEvent.ts
+++ b/packages/react/src/hooks/document/useDocumentEvent.ts
@@ -10,8 +10,8 @@ import {useSanityInstance} from '../context/useSanityInstance'
  * Subscribes an event handler to events in your application’s document store, such as document
  * creation, deletion, and updates.
  *
+ * @category Documents
  * @param handler - The event handler to register.
- *
  * @example
  * ```
  * import {useDocumentEvent} from '@sanity/sdk-react'

--- a/packages/react/src/hooks/document/useDocumentSyncStatus.ts
+++ b/packages/react/src/hooks/document/useDocumentSyncStatus.ts
@@ -5,6 +5,8 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
 type UseDocumentSyncStatus = {
   /**
    * Exposes the document’s sync status between local and remote document states.
+   *
+   * @category Documents
    * @param doc - The document handle to get sync status for
    * @returns `true` if local changes are synced with remote, `false` if the changes are not synced, and `undefined` if the document is not found
    * @example Disable a Save button when there are no changes to sync

--- a/packages/react/src/hooks/document/useEditDocument.ts
+++ b/packages/react/src/hooks/document/useEditDocument.ts
@@ -23,6 +23,8 @@ type Updater<TValue> = TValue | ((nextValue: TValue) => TValue)
  *
  * ## useEditDocument(doc, path)
  * Edit a nested value within a document
+ *
+ * @category Documents
  * @param doc - The document to be edited; either as a document handle or the document’s ID a string
  * @param path - The path to the nested value to be edited
  * @returns A function to update the nested value. Accepts either a new value, or an updater function that exposes the previous value and returns a new value.

--- a/packages/react/src/hooks/documentCollection/useDocuments.ts
+++ b/packages/react/src/hooks/documentCollection/useDocuments.ts
@@ -6,6 +6,7 @@ import {useSanityInstance} from '../context/useSanityInstance'
 /**
  * @public
  * A live collection of {@link DocumentHandle}s, along with metadata about the collection and a function for loading more of them.
+ * @category Types
  */
 export interface DocumentHandleCollection {
   /** Retrieve more documents matching the provided options */
@@ -40,6 +41,7 @@ const STABLE_EMPTY = {
  * {@link DocumentHandle}s are used by many other hooks (such as {@link usePreview}, {@link useDocument}, and {@link useEditDocument})
  * to work with documents in various ways without the entire document needing to be fetched upfront.
  *
+ * @category Documents
  * @param options - Options for narrowing and sorting the document collection
  * @returns The collection of document handles matching the provided options (if any), as well as properties describing the collection and a function to load more.
  *

--- a/packages/react/src/hooks/preview/usePreview.tsx
+++ b/packages/react/src/hooks/preview/usePreview.tsx
@@ -5,7 +5,8 @@ import {distinctUntilChanged, EMPTY, Observable, startWith, switchMap} from 'rxj
 import {useSanityInstance} from '../context/useSanityInstance'
 
 /**
- * @alpha
+ * @beta
+ * @category Types
  */
 export interface UsePreviewOptions {
   document: DocumentHandle
@@ -13,7 +14,8 @@ export interface UsePreviewOptions {
 }
 
 /**
- * @alpha
+ * @beta
+ * @category Types
  */
 export interface UsePreviewResults {
   /** The results of resolving the document’s preview values */
@@ -23,13 +25,14 @@ export interface UsePreviewResults {
 }
 
 /**
- * @alpha
+ * @beta
  *
  * Returns the preview values of a document (specified via a `DocumentHandle`),
  * including the document’s `title`, `subtitle`, `media`, and `status`. These values are live and will update in realtime.
  * To reduce unnecessary network requests for resolving the preview values, an optional `ref` can be passed to the hook so that preview
  * resolution will only occur if the `ref` is intersecting the current viewport.
  *
+ * @category Documents
  * @param options - The document handle for the document you want to resolve preview values for, and an optional ref
  * @returns The preview values for the given document and a boolean to indicate whether the resolution is pending
  *

--- a/packages/react/tsdoc.json
+++ b/packages/react/tsdoc.json
@@ -10,6 +10,11 @@
       "tagName": "@todo",
       "syntaxKind": "block",
       "allowMultiple": true
+    },
+    {
+      "tagName": "@category",
+      "syntaxKind": "block",
+      "allowMultiple": true
     }
   ],
   "supportForTags": {
@@ -28,6 +33,7 @@
     "@remarks": true,
     "@throws": true,
     "@defaultValue": true,
-    "@todo": true
+    "@todo": true,
+    "@category": true
   }
 }

--- a/packages/react/typedoc.json
+++ b/packages/react/typedoc.json
@@ -1,6 +1,8 @@
 {
+  "name": "sdk-react",
   "extends": ["../../typedoc.base.json"],
   "entryPoints": ["./src/_exports/*"],
+  "exclude": ["./src/_exports/index.ts", "./src/_exports/context.ts"],
   /**
    * Path to the project's README file
    * Will be included as the documentation homepage

--- a/typedoc.json
+++ b/typedoc.json
@@ -13,6 +13,12 @@
    * Includes core SDK exports and React hooks/context
    */
   "entryPoints": ["packages/*"],
+  "exclude": ["packages/react-internal"],
   "entryPointStrategy": "packages",
-  "includeVersion": false
+  "includeVersion": false,
+  "navigation": {
+    "includeCategories": true,
+    "includeFolders": false
+  },
+  "categorizeByGroup": false
 }


### PR DESCRIPTION
## Description

React SDK members are now grouped into categories on the Typedoc docs.

### Before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/dd92485c-6d4a-4809-9c04-2c5640e5b947" />

### After
<img width="300" alt="image" src="https://github.com/user-attachments/assets/bdb2d48c-2f06-4cb6-b5d1-abeca8ab9bf6" />

### Notes
- I can't figure out how to get rid of the automatic 'Other' category — Typedoc docs and issues haven't revealed much here 🤔 

## What to review

- Check that modified Typedoc configs make sense
- Do the categories I've made make sense?
  - I created a category specifically for Types as that seemed cleaner and made it easier to find hooks; does this make sense?
- [Take a look at the preview deployment](https://sdk-docs-git-docs-docs-categories.sanity.dev/) and see what you think!

## Testing

N/A

## Fun gif

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExc3V0OGN6cHE5eGpjZDI5ZWw0ejV4Mnc4YXBsbjY1ZDUxaHVtdjM0MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o6Zt6h1dkdLR6uMlq/giphy.gif)
