### PR TITLE
fix: make apiVersion required in getClient

### DIFF
--- a/packages/core/src/client/actions/getClient.test.ts
+++ b/packages/core/src/client/actions/getClient.test.ts
@@ -5,7 +5,7 @@ import {config} from '../../../test/fixtures'
 import {getTokenState} from '../../auth/authStore'
 import {createSanityInstance} from '../../instance/sanityInstance'
 import {type SanityInstance} from '../../instance/types'
-import {getClient} from './getClient'
+import {type ClientOptions, getClient} from './getClient'
 
 vi.mock('../../auth/authStore', async (importOriginal) => {
   const original = importOriginal<typeof import('../../auth/authStore')>()
@@ -33,7 +33,9 @@ describe('getClient', () => {
   })
 
   it('throws error when apiVersion is missing', () => {
-    expect(() => getClient(instance, {})).toThrow('Missing required `apiVersion` option')
+    expect(() => getClient(instance, {} as ClientOptions)).toThrow(
+      'Missing required `apiVersion` option',
+    )
   })
 
   it('creates new client with correct apiVersion', () => {

--- a/packages/core/src/client/actions/getClient.ts
+++ b/packages/core/src/client/actions/getClient.ts
@@ -8,7 +8,7 @@ import {clientStore} from '../clientStore'
  * @public
  */
 export interface ClientOptions {
-  apiVersion?: string
+  apiVersion: string
 }
 
 /**
@@ -17,7 +17,7 @@ export interface ClientOptions {
  * @public
  */
 export const getClient = createAction(clientStore, ({state}) => {
-  return (options: ClientOptions = {}): SanityClient => {
+  return (options: ClientOptions): SanityClient => {
     const {apiVersion} = options
 
     if (!apiVersion) {


### PR DESCRIPTION
### Description

Makes `apiVersion` a required parameter in the `ClientOptions` interface and removes the default empty object when calling `getClient`. This ensures that API version is always explicitly specified when creating a new client.

### What to review

- Verify that the `apiVersion` property in `ClientOptions` is now required
- Check that the default parameter for `options` has been removed from `getClient`
- Ensure existing code using `getClient` properly provides an API version

### Testing

The change is type-level only and will be enforced by TypeScript's type checking system. No additional runtime tests are required.

### Fun gif

![Cat typing on computer](https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif)