### PR TITLE
fix(comlink): expose statuses and destroy unused resources

### DIFF
--- a/apps/kitchensink-react/src/AppRoutes.tsx
+++ b/apps/kitchensink-react/src/AppRoutes.tsx
@@ -2,7 +2,7 @@ import {SanityApp} from '@sanity/sdk-react/components'
 import {type JSX} from 'react'
 import {Route, Routes} from 'react-router'
 
-import Frame from './Comlink/Frame'
+import Framed from './Comlink/Framed'
 import ParentApp from './Comlink/ParentApp'
 import {DocumentEditorRoute} from './DocumentCollection/DocumentEditorRoute'
 import {DocumentGridRoute} from './DocumentCollection/DocumentGridRoute'
@@ -33,7 +33,7 @@ const documentCollectionRoutes = [
 
 const frameRoutes = [1, 2, 3].map((frameNum) => ({
   path: `frame${frameNum}`,
-  element: <Frame />,
+  element: <Framed />,
 }))
 
 export function AppRoutes(): JSX.Element {

--- a/apps/kitchensink-react/src/Comlink/types.ts
+++ b/apps/kitchensink-react/src/Comlink/types.ts
@@ -1,0 +1,9 @@
+export type ToIFrameMessage = {
+  type: 'TO_IFRAME'
+  data: {message: string}
+}
+
+export type FromIFrameMessage = {
+  type: 'FROM_IFRAME'
+  data: {message: string}
+}

--- a/packages/core/src/comlink/controller/actions/releaseChannel.test.ts
+++ b/packages/core/src/comlink/controller/actions/releaseChannel.test.ts
@@ -23,23 +23,31 @@ describe('releaseChannel', () => {
     vi.clearAllMocks()
   })
 
-  it('should decrement refCount when channel is released', () => {
+  it('should remove channel when released', () => {
     // Create a channel
     getOrCreateChannel(instance, channelConfig)
 
     // Get store state
     const store = getOrCreateResource(instance, comlinkControllerStore)
-    const channelEntry = store.state.get().channels.get('test')
-
-    // Initial refCount should be 1
-    expect(channelEntry?.refCount).toBe(1)
+    expect(store.state.get().channels.has('test')).toBe(true)
 
     // Release the channel
     releaseChannel(instance, 'test')
 
-    // Check refCount is decremented
-    const updatedEntry = store.state.get().channels.get('test')
-    expect(updatedEntry?.refCount).toBe(0)
+    // Check channel is removed
+    expect(store.state.get().channels.has('test')).toBe(false)
+  })
+
+  it('should stop the channel when released', () => {
+    // Create a channel
+    const channel = getOrCreateChannel(instance, channelConfig)
+    const stopSpy = vi.spyOn(channel, 'stop')
+
+    // Release the channel
+    releaseChannel(instance, 'test')
+
+    // Verify channel was stopped
+    expect(stopSpy).toHaveBeenCalled()
   })
 
   it('should stop the channel when refCount reaches 0', () => {
@@ -81,10 +89,8 @@ describe('releaseChannel', () => {
     releaseChannel(instance, 'test')
     releaseChannel(instance, 'test')
 
-    // Verify refCount doesn't go below 0
     const store = getOrCreateResource(instance, comlinkControllerStore)
-    const channelEntry = store.state.get().channels.get('test')
-    expect(channelEntry?.refCount).toBe(0)
+    expect(store.state.get().channels.has('test')).toBe(false)
   })
 
   it('should handle releasing non-existent channels', () => {
@@ -121,7 +127,6 @@ describe('releaseChannel', () => {
     // Verify channel was stopped
     expect(stopSpy).toHaveBeenCalled()
 
-    channelEntry = store.state.get().channels.get('test')
-    expect(channelEntry?.refCount).toBe(0)
+    expect(store.state.get().channels.has('test')).toBe(false)
   })
 })

--- a/packages/core/src/comlink/controller/actions/releaseChannel.ts
+++ b/packages/core/src/comlink/controller/actions/releaseChannel.ts
@@ -12,14 +12,18 @@ export const releaseChannel = createAction(comlinkControllerStore, ({state}) => 
 
     if (channelEntry) {
       const newRefCount = channelEntry.refCount === 0 ? 0 : channelEntry.refCount - 1
-      state.set('releaseChannel', {
-        channels: new Map(channels).set(name, {
-          ...channelEntry,
-          refCount: newRefCount,
-        }),
-      })
+
       if (newRefCount === 0) {
         channelEntry.channel.stop()
+        channels.delete(name)
+        state.set('releaseChannel', {channels: new Map(channels)})
+      } else {
+        state.set('releaseChannel', {
+          channels: new Map(channels).set(name, {
+            ...channelEntry,
+            refCount: newRefCount,
+          }),
+        })
       }
     }
   }

--- a/packages/core/src/comlink/node/actions/releaseNode.test.ts
+++ b/packages/core/src/comlink/node/actions/releaseNode.test.ts
@@ -28,35 +28,20 @@ describe('releaseNode', () => {
     vi.clearAllMocks()
   })
 
-  it('should decrement refCount when node is released', () => {
-    // Create a node
-    getOrCreateNode(instance, nodeConfig)
-
-    // Get store state
+  it('should stop and remove node when released', () => {
     const store = getOrCreateResource(instance, comlinkNodeStore)
-    const nodeEntry = store.state.get().nodes.get('test-node')
-
-    // Initial refCount should be 1
-    expect(nodeEntry?.refCount).toBe(1)
-
-    // Release the node
-    releaseNode(instance, 'test-node')
-
-    // Check refCount is decremented
-    const updatedEntry = store.state.get().nodes.get('test-node')
-    expect(updatedEntry?.refCount).toBe(0)
-  })
-
-  it('should stop the node when refCount reaches 0', () => {
     // Create a node
     const node = getOrCreateNode(instance, nodeConfig)
     const stopSpy = vi.spyOn(node, 'stop')
 
+    expect(store.state.get().nodes.has('test-node')).toBe(true)
+
     // Release the node
     releaseNode(instance, 'test-node')
 
-    // Verify node was stopped
+    // Check node is removed
     expect(stopSpy).toHaveBeenCalled()
+    expect(store.state.get().nodes.has('test-node')).toBe(false)
   })
 
   it('should not stop the node if refCount is still above 0', () => {
@@ -88,8 +73,7 @@ describe('releaseNode', () => {
 
     // Verify refCount doesn't go below 0
     const store = getOrCreateResource(instance, comlinkNodeStore)
-    const nodeEntry = store.state.get().nodes.get('test-node')
-    expect(nodeEntry?.refCount).toBe(0)
+    expect(store.state.get().nodes.has('test-node')).toBe(false)
   })
 
   it('should handle releasing non-existent nodes', () => {
@@ -127,6 +111,6 @@ describe('releaseNode', () => {
     expect(stopSpy).toHaveBeenCalled()
 
     nodeEntry = store.state.get().nodes.get('test-node')
-    expect(nodeEntry?.refCount).toBe(0)
+    expect(store.state.get().nodes.has('test-node')).toBe(false)
   })
 })

--- a/packages/core/src/comlink/node/actions/releaseNode.ts
+++ b/packages/core/src/comlink/node/actions/releaseNode.ts
@@ -12,14 +12,18 @@ export const releaseNode = createAction(comlinkNodeStore, ({state}) => {
 
     if (nodeEntry) {
       const newRefCount = nodeEntry.refCount === 0 ? 0 : nodeEntry.refCount - 1
-      state.set('releaseNode', {
-        nodes: new Map(nodes).set(name, {
-          ...nodeEntry,
-          refCount: newRefCount,
-        }),
-      })
+
       if (newRefCount === 0) {
         nodeEntry.node.stop()
+        nodes.delete(name)
+        state.set('releaseNode', {nodes: new Map(nodes)})
+      } else {
+        state.set('releaseNode', {
+          nodes: new Map(nodes).set(name, {
+            ...nodeEntry,
+            refCount: newRefCount,
+          }),
+        })
       }
     }
   }


### PR DESCRIPTION
### Description
This PR makes some more opinionated decisions about the baseline implementation of Comlink utilities. Because of the nature of nodes and connections, we wanted to avoid stale resources, so this PR is more aggressive about deleting channels and nodes when they're not in use.

Statuses are also exposed, which will provide better DX for loading states and other possible states.

Finally, the Kitchensink example was updated to be less confusing and more in line with what will be in CORE UI.

### What to review
Do the changes make sense?

### Testing
Tests were cleaned up or updated when necessary.

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGhneWc3ZHBmcXB2MzN6b2M0MGhoYXRxcmpib3h0YTFhd3M0dzB1ZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/qt7bBGJ8x7ZRu/giphy.gif)