### PR TITLE
fix(core): add raw perspective to client

### DIFF
--- a/packages/core/src/preview/subscribeToStateAndFetchBatches.ts
+++ b/packages/core/src/preview/subscribeToStateAndFetchBatches.ts
@@ -73,6 +73,7 @@ export const subscribeToStateAndFetchBatches = createInternalAction(
               .fetch<PreviewQueryResult[]>(query, params, {
                 filterResponse: false,
                 returnQuery: false,
+                perspective: 'raw',
                 tag: PREVIEW_TAG,
                 lastLiveEventId,
               })


### PR DESCRIPTION
### Description
With the release of Content Releases, the default perspective on the Sanity client switched to `published`. As our preview mechanisms are on vX, that change also trickled down to us. This meant that our previews did not reflect drafts, and documents that only had a draft state constantly read "Loading" (see screenshot).

![Screenshot 2025-02-27 at 12 03 15 PM](https://github.com/user-attachments/assets/cda5565f-24f6-44db-8d0e-2bda307df15d)

This PR updates the perspective to restore the old behavior. Ideally, we should not be on vX much longer, but I'm not sure what the status of that is with the Live Content API.

### What to review
Not too much code! But please compare the [results of the deployed PR branch](https://sdk-kitchensink-react-git-fix-add-raw-perspective-to-client.sanity.dev/project-auth/document-list) to [our current state, which has the broken behavior](https://sdk-kitchensink-react.sanity.dev/project-auth/document-list)

### Testing
Sadly, I don't think we have e2e tests for this kind of thing.

### Fun gif
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGZhdmU4eHNkczR3amIyNnNxeGNpNHlwOHZ1aHIzeHprd2pnNWJwdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oriffwzyfDUmz0pfa/giphy.gif)
