### PR TITLE
fix(build): fixes build warning

### DIFF
--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -1,4 +1,4 @@
-import {type Action, type ListenEvent, SanityClient} from '@sanity/client'
+import {type Action, type ListenEvent, type SanityClient} from '@sanity/client'
 import {getPublishedId} from '@sanity/client/csm'
 import {type SanityDocument} from '@sanity/types'
 import {type ExprNode} from 'groq-js'


### PR DESCRIPTION
Fixes this build warning 

```
Warning:  "SanityClient" is imported from external module "@sanity/client" but never used in "src/client/actions/getSubscribableClient.ts", "src/documentList/subscribeToStateAndFetchResults.ts", "src/documentList/subscribeToLiveClientAndSetLastLiveEventId.ts", "src/documentList/documentListStore.ts", "src/auth/fetchLoginUrls.ts", "src/auth/authStore.ts", "src/document/listen.ts", "src/document/applyActions.ts", "src/document/sharedListener.ts", "src/client/clientStore.ts", "src/client/actions/getClient.ts", "src/preview/subscribeToLiveAndSetLastLiveEventId.ts", "src/document/events.ts", "src/preview/subscribeToStateAndFetchBatches.ts", "src/preview/previewStore.ts" and "src/document/documentStore.ts".
```