### PR TITLE
feat(react): add SDKProvider app to use SDK without core

### DIFF
--- a/apps/kitchensink-react/src/ProjectAuthentication/ProjectInstanceWrapper.tsx
+++ b/apps/kitchensink-react/src/ProjectAuthentication/ProjectInstanceWrapper.tsx
@@ -1,20 +1,19 @@
-import {createSanityInstance} from '@sanity/sdk'
-import {SanityProvider} from '@sanity/sdk-react/context'
+import {SDKProvider} from '@sanity/sdk-react/components'
 import {type JSX} from 'react'
 import {Outlet} from 'react-router'
 
 import {schema} from '../schema'
 
-const sanityInstance = createSanityInstance({
+const sanityConfig = {
   projectId: 'ppsg7ml5',
   dataset: 'test',
   schema,
-})
+}
 
 export function ProjectInstanceWrapper(): JSX.Element {
   return (
-    <SanityProvider sanityInstance={sanityInstance}>
+    <SDKProvider sanityConfig={sanityConfig}>
       <Outlet />
-    </SanityProvider>
+    </SDKProvider>
   )
 }

--- a/apps/kitchensink-react/vite.config.ts
+++ b/apps/kitchensink-react/vite.config.ts
@@ -5,6 +5,7 @@ import {defineConfig} from 'vite'
 
 export default defineConfig({
   plugins: [react()],
+  clearScreen: false,
   resolve: {
     alias: {
       '@sanity/sdk': resolve(import.meta.dirname, '../../packages/core/src/_exports'),

--- a/packages/react/src/_exports/components.ts
+++ b/packages/react/src/_exports/components.ts
@@ -1,2 +1,3 @@
 export {AuthBoundary} from '../components/auth/AuthBoundary'
 export {SanityApp, type SanityAppProps} from '../components/SanityApp'
+export {SDKProvider, type SDKProviderProps} from '../components/SDKProvider'

--- a/packages/react/src/components/SDKProvider.test.tsx
+++ b/packages/react/src/components/SDKProvider.test.tsx
@@ -1,0 +1,79 @@
+import * as SanitySDK from '@sanity/sdk'
+import {render} from '@testing-library/react'
+import {type ReactNode} from 'react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {type SanityProviderProps} from '../context/SanityProvider'
+import {SDKProvider} from './SDKProvider'
+
+// Mock the SDK module
+vi.mock('@sanity/sdk', () => ({
+  createSanityInstance: vi.fn(() => ({
+    // Mock return value of createSanityInstance
+    id: 'mock-instance',
+  })),
+}))
+
+// Mock the SanityProvider context to verify the instance is passed correctly
+vi.mock('../context/SanityProvider', () => ({
+  SanityProvider: ({children, sanityInstance}: SanityProviderProps) => (
+    <div data-testid="sanity-provider" data-instance={JSON.stringify(sanityInstance)}>
+      {children}
+    </div>
+  ),
+  useSanity: vi.fn(),
+}))
+
+// Mock the AuthBoundary component
+vi.mock('./auth/AuthBoundary', () => ({
+  AuthBoundary: ({children}: {children: ReactNode}) => (
+    <div data-testid="auth-boundary">{children}</div>
+  ),
+}))
+
+describe('SDKProvider', () => {
+  const mockConfig = {
+    projectId: 'test-project',
+    dataset: 'test-dataset',
+  }
+
+  it('creates a Sanity instance with the provided config', () => {
+    render(
+      <SDKProvider sanityConfig={mockConfig}>
+        <div>Test Child</div>
+      </SDKProvider>,
+    )
+
+    expect(SanitySDK.createSanityInstance).toHaveBeenCalledWith(mockConfig)
+  })
+
+  it('renders children within SanityProvider and AuthBoundary', () => {
+    const {getByText, getByTestId} = render(
+      <SDKProvider sanityConfig={mockConfig}>
+        <div>Test Child</div>
+      </SDKProvider>,
+    )
+
+    // Verify the component hierarchy
+    const sanityProvider = getByTestId('sanity-provider')
+    const authBoundary = getByTestId('auth-boundary')
+    const childElement = getByText('Test Child')
+
+    expect(sanityProvider).toBeInTheDocument()
+    expect(authBoundary).toBeInTheDocument()
+    expect(childElement).toBeInTheDocument()
+  })
+
+  it('passes the created Sanity instance to SanityProvider', () => {
+    const {getByTestId} = render(
+      <SDKProvider sanityConfig={mockConfig}>
+        <div>Test Child</div>
+      </SDKProvider>,
+    )
+
+    const sanityProvider = getByTestId('sanity-provider')
+    const passedInstance = JSON.parse(sanityProvider.dataset['instance'] || '{}')
+
+    expect(passedInstance).toEqual({id: 'mock-instance'})
+  })
+})

--- a/packages/react/src/components/SDKProvider.tsx
+++ b/packages/react/src/components/SDKProvider.tsx
@@ -1,0 +1,29 @@
+import {createSanityInstance, type SanityConfig} from '@sanity/sdk'
+import {type ReactElement, type ReactNode} from 'react'
+
+import {SanityProvider} from '../context/SanityProvider'
+import {AuthBoundary} from './auth/AuthBoundary'
+
+/**
+ * @internal
+ */
+export interface SDKProviderProps {
+  children: ReactNode
+  sanityConfig: SanityConfig
+}
+
+// Marking this as internal since this should not be used directly by consumers
+/**
+ * @internal
+ *
+ * Top-level context provider that provides access to the Sanity SDK.
+ */
+export function SDKProvider({children, sanityConfig}: SDKProviderProps): ReactElement {
+  const sanityInstance = createSanityInstance(sanityConfig)
+
+  return (
+    <SanityProvider sanityInstance={sanityInstance}>
+      <AuthBoundary>{children}</AuthBoundary>
+    </SanityProvider>
+  )
+}

--- a/packages/react/src/components/SanityApp.tsx
+++ b/packages/react/src/components/SanityApp.tsx
@@ -1,8 +1,7 @@
-import {createSanityInstance, type SanityConfig} from '@sanity/sdk'
+import {type SanityConfig} from '@sanity/sdk'
 import {type ReactElement} from 'react'
 
-import {SanityProvider} from '../context/SanityProvider'
-import {AuthBoundary} from './auth/AuthBoundary'
+import {SDKProvider} from './SDKProvider'
 import {isInIframe} from './utils'
 
 /**
@@ -51,11 +50,6 @@ export function SanityApp({sanityConfig, children}: SanityAppProps): ReactElemen
       storageArea: undefined,
     }
   }
-  const sanityInstance = createSanityInstance(sanityConfig)
 
-  return (
-    <SanityProvider sanityInstance={sanityInstance}>
-      <AuthBoundary>{children}</AuthBoundary>
-    </SanityProvider>
-  )
+  return <SDKProvider sanityConfig={sanityConfig}>{children}</SDKProvider>
 }


### PR DESCRIPTION
### Description

Introduces a new `SDKProvider` (better name suggestions welcomed) component to centralize the creation and provision of Sanity SDK instances throughout the application. This component combines the `SanityProvider` and `AuthBoundary` components into a single, reusable wrapper. The `SanityApp` component has been refactored to use this new provider, simplifying its implementation.

This is exported but internal because we only want internal apps for now to use this

### What to review

- Implementation of the new `SDKProvider` component
- Test coverage for the `SDKProvider`
- Usage of `SDKProvider` in both the kitchensink app and `SanityApp`
- Proper type exports and internal component marking
- Configuration handling in the provider

### Testing

Added comprehensive test suite for the `SDKProvider` component that verifies:
- Correct instance creation with provided config
- Proper component hierarchy
- Instance passing to child components
- Integration with `AuthBoundary`

### Fun gif

![Cat typing on computer](https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif)