### PR TITLE
chore: add action for posting release notes

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,32 @@
+name: Post Release Notes to Slack
+
+on:
+  release:
+    types: [published] # triggers only when a new release is published
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send release notes to Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            icon_emoji: "ship-it-pirate"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: "New SDK Release Published!"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Name:*\n${{ github.event.release.name }}"
+                  - type: mrkdwn
+                    text: "*Tag:*\n${{ github.event.release.tag_name }}"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*Notes:*\n${{ github.event.release.body }}"


### PR DESCRIPTION
### Description

Adds a new GitHub Action workflow that automatically posts release notes to Slack when a new SDK release is published. The notification includes the release name, tag, and release notes in a formatted Slack message with a custom ship-it-pirate emoji.

### What to review

- Verify the Slack webhook configuration
- Check the message formatting structure in the payload
- Ensure the GitHub release event trigger is correct
- Confirm the required secrets are properly referenced

### Fun gif

![Ship it](https://media.giphy.com/media/3o85xGocUH8RYoDKKs/giphy.gif)