### PR TITLE
chore(ci): fix slack message markdown format

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -8,6 +8,11 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      - name: Convert markdown to slack markdown
+        uses: LoveToKnow/slackify-markdown-action@v1.1.1
+        id: releasemarkdown
+        with:
+          text: "*Notes:*\n${{ github.event.release.body }}"
       - name: Send release notes to Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:
@@ -24,9 +29,7 @@ jobs:
                 fields:
                   - type: mrkdwn
                     text: "*Name:*\n${{ github.event.release.name }}"
-                  - type: mrkdwn
-                    text: "*Tag:*\n${{ github.event.release.tag_name }}"
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Notes:*\n${{ github.event.release.body }}"
+                  text: ${{steps.releasemarkdown.outputs.text}}


### PR DESCRIPTION
### Description

Enhances Slack release note formatting by converting GitHub markdown to Slack-compatible markdown. This improves the readability of release notes in Slack notifications and removes redundant tag information from the message.

### What to review

- Verify the new markdown conversion step using `slackify-markdown-action`
- Check the updated Slack message structure without the tag field
- Confirm the converted markdown text is properly passed to the Slack notification

### Testing

Tested the output using a script inside slack block message preview. 🤞 that in the action works

![Screenshot 2025-03-05 at 1.53.20 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/PDkcC35kPWS8bTs7BD65/98ddb0a2-2594-4451-83ac-182ff1520985.png)

### Fun gif

![Release notes transformation](https://media.giphy.com/media/3o7btNa0RUYa5E7iiQ/giphy.gif)