### PR TITLE
feat: add versions information to all packages

### DIFF
--- a/packages/@repo/package.config/src/package.config.ts
+++ b/packages/@repo/package.config/src/package.config.ts
@@ -5,6 +5,7 @@ export const basePackageConfig = defineConfig({
   extract: {
     rules: {
       'ae-forgotten-export': 'off',
+      'ae-internal-missing-underscore': 'off',
     },
     customTags: [
       {

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -123,3 +123,4 @@ export type SanityProject = _SanityProject
 
 /** DATASETS */
 export {getDatasetsState, resolveDatasets} from '../datasets/datasets'
+export {CORE_SDK_VERSION} from '../version'

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,0 +1,7 @@
+import {version} from '../package.json'
+
+/**
+ * This version is provided by pkg-utils at build time
+ * @internal
+ */
+export const CORE_SDK_VERSION = process.env['PKG_VERSION'] || `${version}-development`

--- a/packages/react-internal/src/_exports/index.ts
+++ b/packages/react-internal/src/_exports/index.ts
@@ -1,10 +1,1 @@
-/**
- * An example function that will be removed.
- * @public
- */
-export function main(): void {
-  //
-}
-
-// export * from './components'
-// export * from './hooks'
+export {REACT_INTERNAL_SDK_VERSION} from '../version'

--- a/packages/react-internal/src/version.ts
+++ b/packages/react-internal/src/version.ts
@@ -1,0 +1,7 @@
+import {version} from '../package.json'
+
+/**
+ * This version is provided by pkg-utils at build time
+ * @internal
+ */
+export const REACT_INTERNAL_SDK_VERSION = process.env['PKG_VERSION'] || `${version}-development`

--- a/packages/react/src/_exports/index.ts
+++ b/packages/react/src/_exports/index.ts
@@ -1,10 +1,1 @@
-/**
- * An example function that will be removed.
- * @internal
- */
-export function main(): void {
-  //
-}
-
-// export * from './components'
-// export * from './hooks'
+export {REACT_SDK_VERSION} from '../version'

--- a/packages/react/src/version.ts
+++ b/packages/react/src/version.ts
@@ -1,0 +1,7 @@
+import {version} from '../package.json'
+
+/**
+ * This version is provided by pkg-utils at build time
+ * @internal
+ */
+export const REACT_SDK_VERSION = process.env['PKG_VERSION'] || `${version}-development`

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["DEV", "VISUALIZER"],
+  "globalEnv": ["DEV", "VISUALIZER", "PKG_VERSION"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
### Description

Adds SDK version exports to core, react, and react-internal packages. Each package now exposes its version through a dedicated version constant that can be imported by consumers. The version is provided by pkg-utils at build time, falling back to a development version if not available. This is similar to studio and can be useful for things like telemetry in the future 

### What to review

- Version constant implementation in each package's `version.ts`
- Export declarations in respective `_exports/index.ts` files
- Addition of `PKG_VERSION` to turbo.json's globalEnv
- Package config update to disable 'ae-internal-missing-underscore' rule

### Testing

The changes are straightforward constant exports that rely on build-time environment variables. Testing is handled through TypeScript compilation and package export verification.

### Fun gif

![Version control](https://media.giphy.com/media/3o7TKSjRrfIPjeiVyM/giphy.gif)