### PR TITLE
fix(core): use drafts instead of previewDrafts

### DIFF
--- a/packages/core/src/documentList/documentListStore.test.ts
+++ b/packages/core/src/documentList/documentListStore.test.ts
@@ -29,7 +29,7 @@ describe('documentListStore', () => {
     state = createResourceState<DocumentListState>(
       {
         limit: PAGE_SIZE,
-        options: {perspective: 'previewDrafts'},
+        options: {perspective: 'drafts'},
         results: [],
         syncTags: [],
         isPending: false,
@@ -83,7 +83,7 @@ describe('documentListStore', () => {
 
       await expect(statePromise).resolves.toMatchObject({
         options: {
-          perspective: 'previewDrafts',
+          perspective: 'drafts',
           filter: '_type == "testType"',
         },
       })
@@ -99,7 +99,7 @@ describe('documentListStore', () => {
 
       await expect(statePromise).resolves.toMatchObject({
         options: {
-          perspective: 'previewDrafts',
+          perspective: 'drafts',
           sort: [{field: '_createdAt', direction: 'asc'}],
         },
       })

--- a/packages/core/src/documentList/documentListStore.ts
+++ b/packages/core/src/documentList/documentListStore.ts
@@ -21,7 +21,7 @@ export interface DocumentListOptions {
   filter?: string
   /** Array of sort ordering specifications to determine the order of results */
   sort?: SortOrderingItem[]
-  /** The Content Lake perspective to use for this list. Defaults to `previewDrafts`. */
+  /** The Content Lake perspective to use for this list. Defaults to `drafts`. */
   perspective?: string
 }
 
@@ -52,7 +52,7 @@ const documentList = createResource<DocumentListState>({
   name: 'documentList',
   getInitialState: () => ({
     limit: PAGE_SIZE,
-    options: {perspective: 'previewDrafts'},
+    options: {perspective: 'drafts'},
     results: [],
     syncTags: [],
     isPending: false,

--- a/packages/core/src/documentList/subscribeToLiveClientAndSetLastLiveEventId.test.ts
+++ b/packages/core/src/documentList/subscribeToLiveClientAndSetLastLiveEventId.test.ts
@@ -31,7 +31,7 @@ describe('subscribeToLiveClientAndSetLastLiveEventId', () => {
 
     state = createResourceState<DocumentListState>({
       limit: 25,
-      options: {perspective: 'previewDrafts'},
+      options: {perspective: 'drafts'},
       results: [],
       syncTags: [],
       isPending: false,

--- a/packages/core/src/documentList/subscribeToStateAndFetchResults.test.ts
+++ b/packages/core/src/documentList/subscribeToStateAndFetchResults.test.ts
@@ -38,7 +38,7 @@ describe('subscribeToStateAndFetchResults', () => {
     state = createResourceState<DocumentListState>(
       {
         limit: 25,
-        options: {perspective: 'previewDrafts'},
+        options: {perspective: 'drafts'},
         results: [],
         syncTags: [],
         isPending: false,
@@ -63,7 +63,7 @@ describe('subscribeToStateAndFetchResults', () => {
 
     await expect(statePromise).resolves.toEqual({
       limit: 25,
-      options: {perspective: 'previewDrafts'},
+      options: {perspective: 'drafts'},
       results: mockResults,
       count: 1,
       syncTags: ['s1:initial'],
@@ -77,7 +77,7 @@ describe('subscribeToStateAndFetchResults', () => {
       {
         filterResponse: false,
         lastLiveEventId: undefined,
-        perspective: 'previewDrafts',
+        perspective: 'drafts',
         returnQuery: false,
         tag: 'sdk.document-list',
       },
@@ -107,7 +107,7 @@ describe('subscribeToStateAndFetchResults', () => {
       {
         filterResponse: false,
         lastLiveEventId: undefined,
-        perspective: 'previewDrafts',
+        perspective: 'drafts',
         returnQuery: false,
         tag: 'sdk.document-list',
       },
@@ -142,7 +142,7 @@ describe('subscribeToStateAndFetchResults', () => {
       {
         filterResponse: false,
         lastLiveEventId: undefined,
-        perspective: 'previewDrafts',
+        perspective: 'drafts',
         returnQuery: false,
         tag: 'sdk.document-list',
       },
@@ -199,7 +199,7 @@ describe('subscribeToStateAndFetchResults', () => {
       {
         filterResponse: false,
         lastLiveEventId: 'live-event-id',
-        perspective: 'previewDrafts',
+        perspective: 'drafts',
         returnQuery: false,
         tag: 'sdk.document-list',
       },

--- a/packages/core/src/documentList/subscribeToStateAndFetchResults.ts
+++ b/packages/core/src/documentList/subscribeToStateAndFetchResults.ts
@@ -50,7 +50,7 @@ export const subscribeToStateAndFetchResults = createInternalAction(
                 returnQuery: false,
                 lastLiveEventId,
                 tag: 'sdk.document-list',
-                perspective: 'previewDrafts',
+                perspective: 'drafts',
               },
             )
           }),

--- a/packages/core/src/preview/subscribeToStateAndFetchBatches.ts
+++ b/packages/core/src/preview/subscribeToStateAndFetchBatches.ts
@@ -70,7 +70,7 @@ export const subscribeToStateAndFetchBatches = createInternalAction(
               .fetch<PreviewQueryResult[]>(query, params, {
                 filterResponse: false,
                 returnQuery: false,
-                perspective: 'raw',
+                perspective: 'drafts',
                 tag: PREVIEW_TAG,
                 lastLiveEventId,
               })


### PR DESCRIPTION
### Description
Updates instances of perspectives from `previewDrafts` to `drafts`. This is deprecated and was causing console errors.

### What to review
I've opted for `drafts` over `raw`, which includes content releases -- I assumed we will likely have to have a more thoughtful conversation about what it means to includes versions. I'm happy to change it to either.

### Testing
Tests were updated.

### Fun gif
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXJwZHBiN2FobGc3ODh5eDFjaHRkdnNnb28zYm1vcnZtNHBjenB2ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/dQpUkK59l5Imxsh8jN/giphy.gif)
