### PR TITLE
chore: allow `pnpm dev` to be used to dev kichensink

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clean": "run-s clean:build clean:deps",
     "clean:build": "turbo run clean",
     "clean:deps": "rimraf packages/*/node_modules apps/*/node_modules node_modules",
+    "dev": "pnpm dev:kitchensink",
     "dev:kitchensink": "turbo run dev --filter=@sanity/kitchensink-react",
     "dev:storybook": "turbo run dev --filter={@sanity/storybook,@sanity/sdk,@sanity/sdk-react} --parallel",
     "format": "prettier --write --cache --ignore-unknown .",


### PR DESCRIPTION
### Description

Added a new `dev` script to `package.json` that aliases `dev:kitchensink`, providing a shorter command for developers to start the kitchen sink development environment.

### What to review

Verify that running `pnpm dev` correctly executes the same behavior as `pnpm dev:kitchensink`.

### Testing

This change only affects developer tooling and doesn't require automated testing. Manual verification of the script alias functionality is sufficient.

### Fun gif

![I cant speell](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGRxYnk4eGM4N3ltbHQ3Y3FncDRhajl0aWw3Y3YwajE1dnQwdWJmbiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o6nV0vQCWaUVCOecM/giphy.gif)