### PR TITLE
chore(deps): use bump stratergy for package deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,7 +44,23 @@
       "semanticCommitType": "chore"
     },
     {
+      "group": {"semanticCommitType": "chore"},
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies",
+        "engines",
+        "optionalDependencies",
+        "peerDependencies"
+      ],
+      "matchManagers": ["npm"],
+      "semanticCommitType": "chore",
+      "description": "Group all dependencies from the app directory",
+      "matchFileNames": ["apps/**/package.json"],
+      "groupName": "App dependencies"
+    },
+    {
       "matchDepTypes": ["dependencies", "peerDependencies"],
+      "rangeStrategy": "bump",
       "semanticCommitType": "fix"
     }
   ]

--- a/apps/kitchensink-react/package.json
+++ b/apps/kitchensink-react/package.json
@@ -25,8 +25,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-error-boundary": "^4.1.2",
-    "react-router": "^7.0.2",
-    "vitest": "^3.0.0"
+    "react-router": "^7.0.2"
   },
   "devDependencies": {
     "@repo/config-eslint": "workspace:*",
@@ -40,6 +39,7 @@
     "eslint": "^9.21.0",
     "prettier": "^3.5.2",
     "typescript": "^5.7.3",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,9 +125,6 @@ importers:
       react-router:
         specifier: ^7.0.2
         version: 7.1.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      vitest:
-        specifier: ^3.0.0
-        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
     devDependencies:
       '@repo/config-eslint':
         specifier: workspace:*
@@ -165,6 +162,9 @@ importers:
       vite:
         specifier: ^6.2.0
         version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
 
   apps/storybook:
     dependencies:


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

From my understanding why the renovate were not working was because even though the commits were `fix(deps):` but they were not actually changing inside the `packages/*/` so when renovate ran it had no actual changes scoped to that folder. This changes the `rangeStrategy` to bump for deps so it updates the package.json always which should (🤞) cause a new release note to be created

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->

![About Time Phone GIF by John Crist Comedy](https://media3.giphy.com/media/NEOHyi0WgES1h98eAR/giphy.gif)