### PR TITLE
feat: add suspense boundary to prevent recreating instances

### DIFF
--- a/apps/kitchensink-react/src/AppRoutes.tsx
+++ b/apps/kitchensink-react/src/AppRoutes.tsx
@@ -1,4 +1,5 @@
 import {SanityApp} from '@sanity/sdk-react/components'
+import {Spinner} from '@sanity/ui'
 import {type JSX} from 'react'
 import {Route, Routes} from 'react-router'
 
@@ -86,7 +87,10 @@ export function AppRoutes(): JSX.Element {
         path="/sanity-app"
         index
         element={
-          <SanityApp sanityConfigs={[{projectId: 'ppsg7ml5', dataset: 'test'}]}>
+          <SanityApp
+            sanityConfigs={[{projectId: 'ppsg7ml5', dataset: 'test'}]}
+            fallback={<Spinner />}
+          >
             <div>Welcome to the Sanity App</div>
           </SanityApp>
         }

--- a/apps/kitchensink-react/src/ProjectAuthentication/ProjectInstanceWrapper.tsx
+++ b/apps/kitchensink-react/src/ProjectAuthentication/ProjectInstanceWrapper.tsx
@@ -1,4 +1,5 @@
 import {SDKProvider} from '@sanity/sdk-react/components'
+import {Spinner} from '@sanity/ui'
 import {type JSX} from 'react'
 import {Outlet} from 'react-router'
 
@@ -19,7 +20,7 @@ const sanityConfigs = [
 
 export function ProjectInstanceWrapper(): JSX.Element {
   return (
-    <SDKProvider sanityConfigs={sanityConfigs}>
+    <SDKProvider sanityConfigs={sanityConfigs} fallback={<Spinner />}>
       <Outlet />
     </SDKProvider>
   )

--- a/packages/react/src/components/SDKProvider.test.tsx
+++ b/packages/react/src/components/SDKProvider.test.tsx
@@ -39,7 +39,7 @@ describe('SDKProvider', () => {
 
   it('creates a Sanity instance with the provided config', () => {
     render(
-      <SDKProvider sanityConfigs={[mockConfig]}>
+      <SDKProvider sanityConfigs={[mockConfig]} fallback={<div>Fallback</div>}>
         <div>Test Child</div>
       </SDKProvider>,
     )
@@ -49,7 +49,7 @@ describe('SDKProvider', () => {
 
   it('renders children within SanityProvider and AuthBoundary', () => {
     const {getByText, getByTestId} = render(
-      <SDKProvider sanityConfigs={[mockConfig]}>
+      <SDKProvider sanityConfigs={[mockConfig]} fallback={<div>Fallback</div>}>
         <div>Test Child</div>
       </SDKProvider>,
     )
@@ -66,7 +66,7 @@ describe('SDKProvider', () => {
 
   it('passes the created Sanity instance to SanityProvider', () => {
     const {getByTestId} = render(
-      <SDKProvider sanityConfigs={[mockConfig]}>
+      <SDKProvider sanityConfigs={[mockConfig]} fallback={<div>Fallback</div>}>
         <div>Test Child</div>
       </SDKProvider>,
     )

--- a/packages/react/src/components/SanityApp.test.tsx
+++ b/packages/react/src/components/SanityApp.test.tsx
@@ -1,6 +1,6 @@
 import {AuthStateType, type SanityConfig} from '@sanity/sdk'
 import {render, screen} from '@testing-library/react'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 
 import {SanityApp} from './SanityApp'
 
@@ -44,7 +44,7 @@ describe('SanityApp', () => {
   it('renders children correctly', async () => {
     const testMessage = 'Test Child Component'
     render(
-      <SanityApp sanityConfigs={[mockSanityConfig]}>
+      <SanityApp sanityConfigs={[mockSanityConfig]} fallback={<div>Fallback</div>}>
         <div>{testMessage}</div>
       </SanityApp>,
     )
@@ -68,7 +68,7 @@ describe('SanityApp', () => {
     })
 
     render(
-      <SanityApp sanityConfigs={[mockSanityConfig]}>
+      <SanityApp sanityConfigs={[mockSanityConfig]} fallback={<div>Fallback</div>}>
         <div>Test Child</div>
       </SanityApp>,
     )
@@ -104,7 +104,7 @@ describe('SanityApp', () => {
     })
 
     render(
-      <SanityApp sanityConfigs={[mockSanityConfig]}>
+      <SanityApp sanityConfigs={[mockSanityConfig]} fallback={<div>Fallback</div>}>
         <div>Test Child</div>
       </SanityApp>,
     )
@@ -136,7 +136,7 @@ describe('SanityApp', () => {
     })
 
     render(
-      <SanityApp sanityConfigs={[mockSanityConfig]}>
+      <SanityApp sanityConfigs={[mockSanityConfig]} fallback={<div>Fallback</div>}>
         <div>Test Child</div>
       </SanityApp>,
     )

--- a/packages/react/src/components/SanityApp.tsx
+++ b/packages/react/src/components/SanityApp.tsx
@@ -10,6 +10,7 @@ import {isInIframe, isLocalUrl} from './utils'
 export interface SanityAppProps {
   sanityConfigs: SanityConfig[]
   children: React.ReactNode
+  fallback: React.ReactNode
 }
 
 const CORE_URL = 'https://core.sanity.io'
@@ -66,7 +67,7 @@ const CORE_URL = 'https://core.sanity.io'
  * }
  * ```
  */
-export function SanityApp({sanityConfigs, children}: SanityAppProps): ReactElement {
+export function SanityApp({sanityConfigs, children, fallback}: SanityAppProps): ReactElement {
   const [_sanityConfigs, setSanityConfigs] = useState<SanityConfig[]>(sanityConfigs)
 
   useEffect(() => {
@@ -94,5 +95,9 @@ export function SanityApp({sanityConfigs, children}: SanityAppProps): ReactEleme
     return () => clearTimeout(timeout)
   }, [sanityConfigs])
 
-  return <SDKProvider sanityConfigs={_sanityConfigs}>{children}</SDKProvider>
+  return (
+    <SDKProvider sanityConfigs={_sanityConfigs} fallback={fallback}>
+      {children}
+    </SDKProvider>
+  )
 }


### PR DESCRIPTION
### Description

This change adds a Suspense boundary in the SDKProvider (and consequently in SanityApp) to preserve the Sanity instance state across component suspensions. By providing a fallback UI (such as a Spinner), we avoid recreating instances when a component suspends, leading to a smoother experience and more stable state management.

### What to review

- Examine the modifications in SDKProvider and SanityApp where the Suspense boundary and fallback are implemented.
- Verify that the fallback (e.g. a Spinner) is rendered when the component tree suspends.
- Confirm that the instance state remains stable during transitions and that no unnecessary reinitializations occur.

### Testing

Existing tests for SDKProvider and SanityApp were updated to account for the fallback prop. Manual testing confirms that when parts of the component tree suspend, the fallback is rendered and the instance state is maintained.

### Fun gif

![Energetic otter](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmNrZ3BnaXVhcmdzbjltc2FvcWtpY2R4NXBrZ2RscGFra205eWZ0MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3RBctIB0FOiHe/giphy.gif)