### PR TITLE
fix(core): determine env for version

### DIFF
--- a/packages/core/src/utils/getEnv.ts
+++ b/packages/core/src/utils/getEnv.ts
@@ -4,7 +4,7 @@ type WindowWithEnv = Window &
     ENV?: Record<string, unknown>
   }
 
-type KnownEnvVar = 'DEV'
+type KnownEnvVar = 'DEV' | 'PKG_VERSION'
 
 export function getEnv(key: KnownEnvVar): unknown {
   if (typeof import.meta !== 'undefined' && import.meta.env) {

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,7 +1,8 @@
 import {version} from '../package.json'
+import {getEnv} from './utils/getEnv'
 
 /**
  * This version is provided by pkg-utils at build time
  * @internal
  */
-export const CORE_SDK_VERSION = process.env['PKG_VERSION'] || `${version}-development`
+export const CORE_SDK_VERSION = getEnv('PKG_VERSION') || `${version}-development`


### PR DESCRIPTION
### Description
I was getting the error `ReferenceError: process is not defined` when running Kitchensink locally, since it's Vite and doesn't use process.env. We have a util to solve this, so I added it.

### What to review
Does this make sense? Is it necessary, or did I mess something else up?

### Testing
Pretty sure no tests needed.