### PR TITLE
fix: add correct perspective to useProjection

### DIFF
--- a/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
+++ b/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
@@ -72,7 +72,7 @@ export const subscribeToStateAndFetchBatches = createInternalAction(
               .fetch<ProjectionQueryResult[]>(query, params, {
                 filterResponse: false,
                 returnQuery: false,
-                perspective: 'raw',
+                perspective: 'drafts',
                 tag: PROJECTION_TAG,
                 lastLiveEventId,
               })


### PR DESCRIPTION
### Description
The underlying mechanism for `useProjection` was incorrectly using the wrong perspective, which doesn't resolve drafts or send live event updates when a referenced document changes. Changing this to drafts means the entire dataset is live and functions as expected.

### What to review
You can try this out by going to a "favorite book" on the Document Projection route in the deployed Kitchensink, editing it, and seeing the changes.

### Testing
No e2e tests.