### PR TITLE
chore(ci): fixes release notes spacing

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -32,4 +32,4 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "${{steps.releasemarkdown.outputs.text}}"
+                  text: ${{toJson(steps.releasemarkdown.outputs.text)}}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Using `toJSON` it should properly escape newline characters. Tested it by creating a DM hook and the spacing looks correct now 


![Screenshot 2025-03-11 at 11 22 52 AM](https://github.com/user-attachments/assets/5e9100b2-3060-4627-9a58-c6740bf9632f)

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->

![Happy Lets Go GIF by Holler Studios](https://media0.giphy.com/media/5K7ngCtszoxxbaBieC/giphy.gif)