### PR TITLE
fix(auth): only attempt to refresh stamped tokens

### DIFF
--- a/packages/core/src/auth/refreshStampedToken.ts
+++ b/packages/core/src/auth/refreshStampedToken.ts
@@ -19,6 +19,7 @@ export const refreshStampedToken = createInternalAction(
           authState.type === AuthStateType.LOGGED_IN,
       ),
       distinctUntilChanged(),
+      filter((authState) => authState.token.includes('-st')), // Ensure we only try to refresh stamped tokens
       switchMap((authState) =>
         interval(10 * 60 * 1000).pipe(
           takeWhile(() => state.get().authState.type === AuthStateType.LOGGED_IN),


### PR DESCRIPTION
### Description

Added a check to only refresh stamped tokens (tokens containing `-st`) in the `refreshStampedToken` function. This prevents unnecessary and erroring refresh attempts for non-stamped tokens.

### What to review

- The new filter condition in `refreshStampedToken.ts` that checks for `-st` in the token
- The new test case that verifies non-stamped tokens aren't refreshed
- Updated test tokens to use the proper format with `sk-` prefix and `-st` suffix

### Testing

Added a specific test case that verifies the function does nothing when a non-stamped token is present. All existing tests were updated to use properly formatted tokens that match the expected pattern.

### Fun gif

![stamp](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExNDFwMXg1MGRiMml4anFhZ2tjZ3d6cXBieGR3aGs1bWx2czN4ZXZzdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKHWdo6pgHHsU9NGo/giphy.gif)