### PR TITLE
fix(auth): do not perform multiple sid token exchanges

### DIFF
--- a/packages/react/src/components/SanityApp.tsx
+++ b/packages/react/src/components/SanityApp.tsx
@@ -1,5 +1,5 @@
 import {type SanityConfig} from '@sanity/sdk'
-import {type ReactElement, useEffect, useState} from 'react'
+import {type ReactElement, useEffect} from 'react'
 
 import {SDKProvider} from './SDKProvider'
 import {isInIframe, isLocalUrl} from './utils'
@@ -68,23 +68,10 @@ const CORE_URL = 'https://core.sanity.io'
  * ```
  */
 export function SanityApp({sanityConfigs, children, fallback}: SanityAppProps): ReactElement {
-  const [_sanityConfigs, setSanityConfigs] = useState<SanityConfig[]>(sanityConfigs)
-
   useEffect(() => {
     let timeout: NodeJS.Timeout | undefined
 
-    if (isInIframe()) {
-      // When running in an iframe Content OS, we don't want to store tokens
-      setSanityConfigs(
-        sanityConfigs.map((sanityConfig) => ({
-          ...sanityConfig,
-          auth: {
-            ...sanityConfig.auth,
-            storageArea: undefined,
-          },
-        })),
-      )
-    } else if (!isLocalUrl(window)) {
+    if (!isInIframe() && !isLocalUrl(window)) {
       // If the app is not running in an iframe and is not a local url, redirect to core.
       timeout = setTimeout(() => {
         // eslint-disable-next-line no-console
@@ -96,7 +83,7 @@ export function SanityApp({sanityConfigs, children, fallback}: SanityAppProps): 
   }, [sanityConfigs])
 
   return (
-    <SDKProvider sanityConfigs={_sanityConfigs} fallback={fallback}>
+    <SDKProvider sanityConfigs={sanityConfigs} fallback={fallback}>
       {children}
     </SDKProvider>
   )


### PR DESCRIPTION
### Description

Fix the bug where the `sid` token exchange was performed multiple times when, causing an auth error but removing the override of the stoargeArea to undefined. This override was not actual doing anything since it was then overridden by the default so it was safe to remove. If we want to stop using localStorage in the future then we can remove the default.

The logic for handling iframe detection has been optimized with a simplified conditional that combines the checks more efficiently.

### What to review

- Verify that the `SanityApp` component still functions correctly without the state management
- Check that the iframe detection logic works as expected with the new conditional structure
- Ensure that the redirect to core.sanity.io still works properly when not in an iframe and not on a local URL

### Testing

Tested the component in both iframe and non-iframe environments to ensure the behavior remains consistent with the previous implementation.

### Fun gif

![framily](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdjg1NHpvZXUxbHowMXBjZXhlOGF1cGJxdWN3eDAxaWUwNGVmdXF3eiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/4acXzicT7jldqYrRC8/giphy.gif)