### PR TITLE
chore: remove useCallback from kitchensink

### DIFF
--- a/apps/kitchensink-react/src/Comlink/Framed.tsx
+++ b/apps/kitchensink-react/src/Comlink/Framed.tsx
@@ -1,6 +1,6 @@
 import {useWindowConnection} from '@sanity/sdk-react/hooks'
 import {Box, Button, Card, Container, Label, Stack, Text, TextInput} from '@sanity/ui'
-import {ReactElement, useCallback, useState} from 'react'
+import {type ReactElement, useState} from 'react'
 
 import {FromIFrameMessage, ToIFrameMessage} from './types'
 
@@ -18,12 +18,12 @@ const Framed = (): ReactElement => {
     },
   })
 
-  const sendMessageToParent = useCallback(() => {
+  const sendMessageToParent = () => {
     if (message.trim()) {
       sendMessage('FROM_IFRAME', {message})
       setMessage('')
     }
-  }, [message, sendMessage])
+  }
 
   return (
     <Container height={'fill'}>

--- a/apps/kitchensink-react/src/Comlink/ParentApp.tsx
+++ b/apps/kitchensink-react/src/Comlink/ParentApp.tsx
@@ -1,6 +1,6 @@
 import {useFrameConnection} from '@sanity/sdk-react/hooks'
 import {Box, Button, Card, Label, Stack, Text, TextInput} from '@sanity/ui'
-import {ReactElement, useCallback, useEffect, useRef, useState} from 'react'
+import {ReactElement, useEffect, useRef, useState} from 'react'
 
 import {PageLayout} from '../components/PageLayout'
 import {FromIFrameMessage, ToIFrameMessage} from './types'
@@ -55,12 +55,12 @@ const ParentApp = (): ReactElement => {
     }
   }, [connect, selectedFrame])
 
-  const sendMessageToFramedApp = useCallback(() => {
+  const sendMessageToFramedApp = () => {
     if (message.trim()) {
       sendMessage('TO_IFRAME', {message})
       setMessage('')
     }
-  }, [message, sendMessage])
+  }
 
   const frames = [1, 2, 3]
 

--- a/apps/kitchensink-react/vite.config.ts
+++ b/apps/kitchensink-react/vite.config.ts
@@ -6,6 +6,9 @@ import {defineConfig} from 'vite'
 const ReactCompilerConfig = {}
 
 export default defineConfig({
+  server: {
+    port: 3333,
+  },
   plugins: [
     react({
       babel: {


### PR DESCRIPTION
### Description

This PR refactors the Comlink components in the kitchensink-react app by:
1. Removing unnecessary `useCallback` hooks in both `Framed.tsx` and `ParentApp.tsx`
2. Updating the React import in `Framed.tsx` to use `type ReactElement` instead of directly importing `ReactElement`
3. Configuring a specific port (3333) for the development server in `vite.config.ts`

### What to review

- Check the removal of `useCallback` hooks in both Comlink components
- Verify the type import change for ReactElement
- Confirm the Vite server configuration works correctly with port 3333

### Testing

The changes are primarily refactoring and configuration updates. I've manually tested that:
- The Comlink functionality continues to work as expected
- The app correctly starts on port 3333 when running the dev server

### Fun gif

![Refactoring](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZWJtZnRqZnRqZGJtZnRqZmRqZmRqZmRqZmRqZmRqZmRqZmRqZmQvZ2lmXzQ4MHg0ODAuZ2lm/3oKIPnAiaMCws8nOsE/giphy.gif)