### PR TITLE
chore(ci): allow ability to publish rc versions

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,49 @@
+name: Release - Release Candidate
+
+on: workflow_dispatch
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # for checkout
+
+jobs:
+  release-rc:
+    permissions:
+      contents: read # for checkout
+      id-token: write # to enable use of OIDC for npm provenance
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v4
+        with:
+          ref: rc
+          token: ${{ steps.generate-token.outputs.token }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
+      - run: pnpm install --ignore-scripts
+      - run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
+      - name: release rc & commit + push the changed versions
+        env:
+          NPM_CONFIG_PROVENANCE: true
+        run: |
+          pnpm release:rc
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore(release): publish rc [skip ci]"
+          git push

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "packages/core": "0.0.0-alpha.16",
-  "packages/react": "0.0.0-alpha.17"
+  "packages/react": "0.0.0-alpha.17",
+  "packages/react-internal": "0.0.0-alpha.1"
 }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -11,7 +11,15 @@ const baseConfig = {
       typescript: {
         config: 'tsconfig.tsdoc.json',
       },
+      // Knip doesn't support pnpm version
+      ignoreBinaries: ['version'],
       entry: ['package.config.ts', 'vitest.config.mts'],
+    },
+    'scripts/*': {
+      typescript: {
+        config: 'tsconfig.json',
+      },
+      project,
     },
     'apps/kitchensink-react': {
       entry: ['src/main.tsx', 'src/css/css.config.js'],

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:watch": "vitest watch",
     "ts:check": "tsc --noEmit",
     "depcheck": "knip",
-    "test:kitchensink": "turbo run test --filter=@sanity/kitchensink-react"
+    "test:kitchensink": "turbo run test --filter=@sanity/kitchensink-react",
+    "release:rc": "tsx scripts/release-rc.mts"
   },
   "prettier": "@sanity/prettier-config",
   "devDependencies": {
@@ -58,12 +59,14 @@
     "prettier": "^3.5.2",
     "rimraf": "^6.0.1",
     "rollup-plugin-visualizer": "^5.13.1",
+    "tsx": "^4.19.3",
     "turbo": "^2.4.4",
     "typedoc": "^0.27.9",
     "typedoc-github-theme": "^0.2.1",
     "typescript": "^5.7.3",
     "vite": "^6.2.0",
-    "vitest": "^3.0.7"
+    "vitest": "^3.0.7",
+    "zx": "^8.4.1"
   },
   "packageManager": "pnpm@9.15.5",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 22.13.9
       '@vitest/coverage-v8':
         specifier: 3.0.7
-        version: 3.0.7(vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+        version: 3.0.7(vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       eslint:
         specifier: ^9.21.0
         version: 9.21.0(jiti@2.4.2)
@@ -65,6 +65,9 @@ importers:
       rollup-plugin-visualizer:
         specifier: ^5.13.1
         version: 5.14.0(rollup@4.34.4)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.19.3
       turbo:
         specifier: ^2.4.4
         version: 2.4.4
@@ -79,10 +82,13 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.2.0
-        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
+      zx:
+        specifier: ^8.4.1
+        version: 8.4.1
 
   apps/kitchensink-react:
     dependencies:
@@ -149,7 +155,7 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       eslint:
         specifier: ^9.21.0
         version: 9.21.0(jiti@2.4.2)
@@ -161,10 +167,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.2.0
-        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
       vitest:
         specifier: ^3.0.0
-        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
 
   apps/storybook:
     dependencies:
@@ -198,7 +204,7 @@ importers:
         version: 8.6.2(@storybook/test@8.6.2(storybook@8.6.2(prettier@3.5.2)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.2(prettier@3.5.2))(typescript@5.7.3)
       '@storybook/react-vite':
         specifier: ^8.6.2
-        version: 8.6.2(@storybook/test@8.6.2(storybook@8.6.2(prettier@3.5.2)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.4)(storybook@8.6.2(prettier@3.5.2))(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+        version: 8.6.2(@storybook/test@8.6.2(storybook@8.6.2(prettier@3.5.2)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.4)(storybook@8.6.2(prettier@3.5.2))(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       '@storybook/test':
         specifier: ^8.6.2
         version: 8.6.2(storybook@8.6.2(prettier@3.5.2))
@@ -210,7 +216,7 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       eslint:
         specifier: ^9.21.0
         version: 9.21.0(jiti@2.4.2)
@@ -225,7 +231,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.2.0
-        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
 
   packages/@repo/config-eslint:
     devDependencies:
@@ -288,7 +294,7 @@ importers:
         version: link:../dev-aliases
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
 
   packages/@repo/dev-aliases:
     devDependencies:
@@ -359,7 +365,7 @@ importers:
         version: 1.0.3(prettier@3.5.2)
       '@vitest/coverage-v8':
         specifier: 3.0.7
-        version: 3.0.7(vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+        version: 3.0.7(vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       eslint:
         specifier: ^9.21.0
         version: 9.21.0(jiti@2.4.2)
@@ -374,10 +380,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.2.0
-        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
 
   packages/react:
     dependencies:
@@ -438,10 +444,10 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       '@vitest/coverage-v8':
         specifier: 3.0.7
-        version: 3.0.7(vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+        version: 3.0.7(vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       babel-plugin-react-compiler:
         specifier: 19.0.0-beta-bafa41b-20250307
         version: 19.0.0-beta-bafa41b-20250307
@@ -465,10 +471,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.2.0
-        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
 
   packages/react-internal:
     dependencies:
@@ -523,10 +529,10 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+        version: 4.3.4(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       '@vitest/coverage-v8':
         specifier: 3.0.7
-        version: 3.0.7(vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+        version: 3.0.7(vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       babel-plugin-react-compiler:
         specifier: 19.0.0-beta-bafa41b-20250307
         version: 19.0.0-beta-bafa41b-20250307
@@ -550,10 +556,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.2.0
-        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+        version: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
 
 packages:
 
@@ -4638,6 +4644,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.19.3:
+    resolution: {integrity: sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -5050,6 +5061,11 @@ packages:
         optional: true
       use-sync-external-store:
         optional: true
+
+  zx@8.4.1:
+    resolution: {integrity: sha512-1Cb+Tfwt/daKV6wckBeDbB6h3IMauqj9KWp+EcbYzi9doeJeIHCktxp/yWspXOXRdoUzBCQSKoUgm3g8r9fz5A==}
+    engines: {node: '>= 12.17.0'}
+    hasBin: true
 
 snapshots:
 
@@ -5646,12 +5662,12 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.7.3)
-      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
     optionalDependencies:
       typescript: 5.7.3
 
@@ -6221,13 +6237,13 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@storybook/builder-vite@8.6.2(storybook@8.6.2(prettier@3.5.2))(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))':
+  '@storybook/builder-vite@8.6.2(storybook@8.6.2(prettier@3.5.2))(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
       '@storybook/csf-plugin': 8.6.2(storybook@8.6.2(prettier@3.5.2))
       browser-assert: 1.2.1
       storybook: 8.6.2(prettier@3.5.2)
       ts-dedent: 2.2.0
-      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - webpack-sources
 
@@ -6294,11 +6310,11 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       storybook: 8.6.2(prettier@3.5.2)
 
-  '@storybook/react-vite@8.6.2(@storybook/test@8.6.2(storybook@8.6.2(prettier@3.5.2)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.4)(storybook@8.6.2(prettier@3.5.2))(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))':
+  '@storybook/react-vite@8.6.2(@storybook/test@8.6.2(storybook@8.6.2(prettier@3.5.2)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.4)(storybook@8.6.2(prettier@3.5.2))(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.7.3)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       '@rollup/pluginutils': 5.1.4(rollup@4.34.4)
-      '@storybook/builder-vite': 8.6.2(storybook@8.6.2(prettier@3.5.2))(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+      '@storybook/builder-vite': 8.6.2(storybook@8.6.2(prettier@3.5.2))(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       '@storybook/react': 8.6.2(@storybook/test@8.6.2(storybook@8.6.2(prettier@3.5.2)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.2(prettier@3.5.2))(typescript@5.7.3)
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -6308,7 +6324,7 @@ snapshots:
       resolve: 1.22.8
       storybook: 8.6.2(prettier@3.5.2)
       tsconfig-paths: 4.2.0
-      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
     optionalDependencies:
       '@storybook/test': 8.6.2(storybook@8.6.2(prettier@3.5.2))
     transitivePeerDependencies:
@@ -6562,18 +6578,18 @@ snapshots:
       '@typescript-eslint/types': 8.25.0
       eslint-visitor-keys: 4.2.0
 
-  '@vitejs/plugin-react@4.3.4(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))':
+  '@vitejs/plugin-react@4.3.4(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.0.7(vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))':
+  '@vitest/coverage-v8@3.0.7(vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6587,7 +6603,7 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+      vitest: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6605,13 +6621,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))':
+  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -9452,6 +9468,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.19.3:
+    dependencies:
+      esbuild: 0.25.0
+      get-tsconfig: 4.10.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -9625,13 +9648,13 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  vite-node@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1):
+  vite-node@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9646,7 +9669,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1):
+  vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -9657,12 +9680,13 @@ snapshots:
       jiti: 2.4.2
       lightningcss: 1.29.1
       terser: 5.36.0
+      tsx: 4.19.3
       yaml: 2.6.1
 
-  vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1):
+  vitest@3.0.7(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1):
     dependencies:
       '@vitest/expect': 3.0.7
-      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1))
+      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1))
       '@vitest/pretty-format': 3.0.7
       '@vitest/runner': 3.0.7
       '@vitest/snapshot': 3.0.7
@@ -9678,8 +9702,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
-      vite-node: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(yaml@2.6.1)
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
+      vite-node: 3.0.7(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.9
@@ -9843,3 +9867,5 @@ snapshots:
       immer: 10.1.1
       react: 19.0.0
       use-sync-external-store: 1.2.2(react@19.0.0)
+
+  zx@8.4.1: {}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,13 @@
       "prerelease-type": "alpha",
       "versioning": "prerelease"
     },
+    "packages/react-internal": {
+      "release-type": "node",
+      "bump-patch-for-minor-pre-major": true,
+      "bump-minor-pre-major": true,
+      "prerelease-type": "alpha",
+      "versioning": "prerelease"
+    },
     "packages/core": {
       "release-type": "node",
       "bump-patch-for-minor-pre-major": true,

--- a/scripts/release-rc.mts
+++ b/scripts/release-rc.mts
@@ -1,0 +1,49 @@
+#!/usr/bin/env zx
+import 'zx/globals'
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+const {packages} = await fs.readJson('./release-please-config.json')
+const workspaces = Object.keys(packages)
+
+echo`found ${chalk.blue(workspaces.length)} workspaces to publish canaries for`
+
+const prev = new Map()
+const next = new Map()
+
+for (const workspace of workspaces) {
+  const {name, version, private: isPrivate} = await fs.readJson(`./${workspace}/package.json`)
+  if (!isPrivate) {
+    await spinner(`bumping ${chalk.blue(name)} from ${chalk.yellow(version)}`, async () => {
+      prev.set(name, version)
+      // `pnpm version` is really just an alias for `npm version` atm, so we have to jump through some hoops
+      await $`pnpm --filter="${name}" exec pnpm version --no-commit-hooks --no-git-tag-version --preid rc prerelease`
+      next.set(name, (await fs.readJson(`./${workspace}/package.json`)).version)
+    })
+    echo`bumped ${chalk.blue(name)} from ${chalk.yellow(prev.get(name))} to ${chalk.green(next.get(name))}`
+  }
+}
+
+await $`pnpm build --output-logs=errors-only`.pipe(process.stdout)
+
+// If provenance isn't enabled, assume we're running locally and need to confirm before publishing
+if (process.env['NPM_CONFIG_PROVENANCE'] !== 'true') {
+  const shouldProceed = await question('Are you sure you want to proceed? (y/n) ')
+  if (shouldProceed.toLowerCase() !== 'y' && shouldProceed.toLowerCase() !== 'yes') {
+    // eslint-disable-next-line no-console
+    console.log('Operation cancelled.')
+    for (const workspace of workspaces) {
+      const {name, ...rest} = await fs.readJson(`./${workspace}/package.json`)
+      if (prev.has(name)) {
+        await fs.writeJson(`./${workspace}/package.json`, {name, ...rest, version: prev.get(name)})
+        await $`prettier --write ./${workspace}/package.json`
+      }
+    }
+    process.exit(0)
+  }
+}
+
+for (const name of next.keys()) {
+  await $`pnpm --filter="${name}" publish --tag rc --no-git-checks`.pipe(process.stdout)
+}
+
+echo`published release candidates for ${chalk.blue(workspaces.length)} workspaces`

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@repo/tsconfig/base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
+    "allowJs": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "release-rc.mts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["DEV", "VISUALIZER", "PKG_VERSION"],
+  "globalEnv": ["DEV", "VISUALIZER", "PKG_VERSION", "NPM_CONFIG_PROVENANCE"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
### Description
Proudly stole from https://github.com/sanity-io/visual-editing

Added a GitHub workflow for creating release candidates (RC) from the `rc` branch. This workflow:
- Runs on manual trigger
- Bumps package versions with an RC prerelease tag
- Builds the packages
- Publishes them to npm with the `rc` tag

Also added support for the `react-internal` package in the release configuration files and updated Knip configuration to handle version scripts and new script files.

### What to review

- The new GitHub workflow file `.github/workflows/release-rc.yml`
- The release script `scripts/release-rc.mts` that handles version bumping and publishing
- Updates to release configuration files to include the `react-internal` package
- Knip configuration changes to support the new scripts

### Testing

Tested the release script locally to ensure it correctly bumps versions and can publish packages. The workflow will use GitHub's OIDC for npm provenance when running in CI.

### Fun gif

![Release time](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZg/3o7btQ8jDTPGDpgc6I/giphy.gif)