### PR TITLE
feat: make packages public

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,6 +88,6 @@
     "node": ">=20.0.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -97,6 +97,6 @@
     "node": ">=20.0.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }


### PR DESCRIPTION
### Description

Should react-internal also be public? 🤔 

Changed the `publishConfig.access` setting from "restricted" to "public" in both the core and react packages. This change allows the packages to be published publicly on npm, making them accessible to all users without authentication.

### What to review

- Verify that changing the access setting to "public" aligns with the project's publishing strategy
- Confirm that both packages (core and react) should have the same access level
- Check if any additional configuration changes are needed for public publishing

### Testing

This change only affects package publishing configuration and doesn't require functional testing. The change will take effect the next time the packages are published to npm.

### Fun gif

![Open door](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZWJtZnRqZnRqZGJtZnRqZGJtZnRqZGJtZnRqZGJtZnRqZGJtZnRqZA/l0MYt5jPR6QX5pnqM/giphy.gif)