### PR TITLE
docs: add guide for integrating UI components

### DIFF
--- a/packages/react/guides/UI-Components.md
+++ b/packages/react/guides/UI-Components.md
@@ -4,7 +4,7 @@ title: Integrating UI Components
 
 # Integrating UI Components
 
-The Sanity App SDK gives you complete freedom to craft your application’s design. The SDK empowers you to create exactly the user experience you envision — using your preferred styling solutions or component libraries — all while benefiting from the powerful hooks and functionality of the Sanity platform.
+The Sanity App SDK gives you complete freedom to craft your application’s design. Whether your preferred styling solution is Sanity UI, Tailwind, vanilla CSS, or something else entirely, the SDK‘s headless approach allows you to style your app with the tools your team knows best, while benefiting from powerful React hooks that unlock Sanity platform capabilities.
 
 ## Example: Sanity UI
 


### PR DESCRIPTION
### Description

Added a guide for integrating UI components, with an example for setting up Sanity UI. The `studioTheme` part is technically deprecated, but it matches the current Sanity UI docs for consistency. We can update this later if needed.

### What to review

- Does the guide make sense?
- Any technical errors?
- Any suggestions?

### Testing

N/A

### Fun gif

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHhpbnR0MDdmNzBiM21rcTJ1OHhlZGRsaTR4NDA2MTAxcGY1ZG1uOCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WNzUV6hvktgoU/giphy.gif)

