### PR TITLE
feat!: rename `result` to `data` for usePreview hook

### DIFF
--- a/apps/kitchensink-react/src/DocumentCollection/DocumentPreview.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentPreview.tsx
@@ -26,7 +26,7 @@ export function DocumentPreview(props: DocumentPreviewProps): React.ReactNode {
 function DocumentPreviewResolved({document}: DocumentPreviewProps): React.ReactNode {
   const ref = useRef(null)
   const {
-    results: {title, subtitle, media, status},
+    data: {title, subtitle, media, status},
   } = usePreview({document, ref})
 
   let statusLabel

--- a/packages/core/src/preview/getPreviewState.test.ts
+++ b/packages/core/src/preview/getPreviewState.test.ts
@@ -49,20 +49,20 @@ describe('getPreviewState', () => {
     expect(subscriber).toHaveBeenCalledTimes(0)
 
     state.set('relatedChange', (prev) => ({
-      values: {...prev.values, exampleId: {results: {title: 'Changed!'}, isPending: false}},
+      values: {...prev.values, exampleId: {data: {title: 'Changed!'}, isPending: false}},
     }))
     expect(subscriber).toHaveBeenCalledTimes(1)
 
     state.set('unrelatedChange', (prev) => ({
       values: {
         ...prev.values,
-        unrelatedId: {results: {title: 'Unrelated Document'}, isPending: false},
+        unrelatedId: {data: {title: 'Unrelated Document'}, isPending: false},
       },
     }))
     expect(subscriber).toHaveBeenCalledTimes(1)
 
     state.set('relatedChange', (prev) => ({
-      values: {...prev.values, exampleId: {results: {title: 'Changed again!'}, isPending: false}},
+      values: {...prev.values, exampleId: {data: {title: 'Changed again!'}, isPending: false}},
     }))
     expect(subscriber).toHaveBeenCalledTimes(2)
   })
@@ -93,7 +93,7 @@ describe('getPreviewState', () => {
 
   it('resets to pending false on unsubscribe if the subscription is the last one', () => {
     state.set('presetValueToPending', (prev) => ({
-      values: {...prev.values, [document._id]: {results: {title: 'Foo'}, isPending: true}},
+      values: {...prev.values, [document._id]: {data: {title: 'Foo'}, isPending: true}},
     }))
 
     const previewState = getPreviewState({state, instance}, {document})
@@ -101,14 +101,14 @@ describe('getPreviewState', () => {
     const unsubscribe1 = previewState.subscribe(vi.fn())
     const unsubscribe2 = previewState.subscribe(vi.fn())
 
-    expect(state.get().values[document._id]).toEqual({results: {title: 'Foo'}, isPending: true})
+    expect(state.get().values[document._id]).toEqual({data: {title: 'Foo'}, isPending: true})
 
     unsubscribe1()
-    expect(state.get().values[document._id]).toEqual({results: {title: 'Foo'}, isPending: true})
+    expect(state.get().values[document._id]).toEqual({data: {title: 'Foo'}, isPending: true})
 
     unsubscribe2()
     expect(state.get().subscriptions).toEqual({})
-    expect(state.get().values[document._id]).toEqual({results: {title: 'Foo'}, isPending: false})
+    expect(state.get().values[document._id]).toEqual({data: {title: 'Foo'}, isPending: false})
   })
 
   it('calls getOrCreateResource if no state is provided', () => {

--- a/packages/core/src/preview/getPreviewState.ts
+++ b/packages/core/src/preview/getPreviewState.ts
@@ -61,7 +61,7 @@ export const getPreviewState = createAction(previewStore, ({state}) => {
             const documentSubscriptions = omit(prev.subscriptions[documentId], subscriptionId)
             const hasSubscribers = !!Object.keys(documentSubscriptions).length
             const prevValue = prev.values[documentId]
-            const previewValue = prevValue?.results ? prevValue.results : null
+            const previewValue = prevValue?.data ? prevValue.data : null
 
             return {
               subscriptions: hasSubscribers
@@ -69,7 +69,7 @@ export const getPreviewState = createAction(previewStore, ({state}) => {
                 : omit(prev.subscriptions, documentId),
               values: hasSubscribers
                 ? prev.values
-                : {...prev.values, [documentId]: {results: previewValue, isPending: false}},
+                : {...prev.values, [documentId]: {data: previewValue, isPending: false}},
             }
           })
         }

--- a/packages/core/src/preview/previewQuery.test.ts
+++ b/packages/core/src/preview/previewQuery.test.ts
@@ -77,7 +77,7 @@ describe('processPreviewQuery', () => {
     })
 
     const val = processed['person1']
-    expect(val?.results).toEqual({
+    expect(val?.data).toEqual({
       title: 'John',
       media: null,
       status: {lastEditedPublishedAt: '2021-01-01'},
@@ -123,7 +123,7 @@ describe('processPreviewQuery', () => {
     })
 
     const val = processed['article1']
-    expect(val?.results).toEqual({
+    expect(val?.data).toEqual({
       title: 'Draft Title',
       media: null,
       status: {
@@ -172,7 +172,7 @@ describe('processPreviewQuery', () => {
     })
 
     const val = processed['article1']
-    expect(val?.results).toEqual({
+    expect(val?.data).toEqual({
       title: titleCandidates[TITLE_CANDIDATES[0] as keyof typeof titleCandidates],
       subtitle: subtitleCandidates[SUBTITLE_CANDIDATES[0] as keyof typeof subtitleCandidates],
       media: null,

--- a/packages/core/src/preview/previewQuery.ts
+++ b/packages/core/src/preview/previewQuery.ts
@@ -123,7 +123,7 @@ export function processPreviewQuery({
           ...(publishedResult?._updatedAt && {lastEditedPublishedAt: publishedResult._updatedAt}),
         }
 
-        return [id, {results: {...preview, status}, isPending: false}]
+        return [id, {data: {...preview, status}, isPending: false}]
       } catch (e) {
         // TODO: replace this with bubbling the error
         // eslint-disable-next-line no-console

--- a/packages/core/src/preview/previewStore.ts
+++ b/packages/core/src/preview/previewStore.ts
@@ -70,7 +70,7 @@ export interface PreviewValue {
  * @public
  */
 export type ValuePending<T> = {
-  results: T | null
+  data: T | null
   isPending: boolean
 }
 

--- a/packages/core/src/preview/resolvePreview.test.ts
+++ b/packages/core/src/preview/resolvePreview.test.ts
@@ -52,24 +52,24 @@ describe('resolvePreview', () => {
     state.set('updateDifferentDocument', (prev) => ({
       values: {
         ...prev.values,
-        differentId: {results: {title: 'Different Document'}, isPending: false},
+        differentId: {data: {title: 'Different Document'}, isPending: false},
       },
     }))
 
     expect(state.get().subscriptions).toEqual({exampleId: {pseudoRandomId: true}})
 
     state.set('updateCorrectDocumentButNull', (prev) => ({
-      values: {...prev.values, exampleId: {results: null, isPending: true}},
+      values: {...prev.values, exampleId: {data: null, isPending: true}},
     }))
 
     expect(state.get().subscriptions).toEqual({exampleId: {pseudoRandomId: true}})
 
     state.set('updateCorrectDocument', (prev) => ({
-      values: {...prev.values, exampleId: {results: {title: 'Correct Document'}, isPending: false}},
+      values: {...prev.values, exampleId: {data: {title: 'Correct Document'}, isPending: false}},
     }))
 
     const preview = await previewPromise
-    expect(preview).toEqual({results: {title: 'Correct Document'}, isPending: false})
+    expect(preview).toEqual({data: {title: 'Correct Document'}, isPending: false})
 
     // subscription is removed after
     expect(state.get().subscriptions).toEqual({})
@@ -77,7 +77,7 @@ describe('resolvePreview', () => {
 
   it('resolves with the next emitted state (not current state)', async () => {
     const currentValue: ValuePending<PreviewValue> = {
-      results: {title: 'Correct Document'},
+      data: {title: 'Correct Document'},
       isPending: false,
     }
     state.set('setInitialDocument', (prev) => ({
@@ -92,7 +92,7 @@ describe('resolvePreview', () => {
     state.set('updateDifferentDocument', (prev) => ({
       values: {
         ...prev.values,
-        differentId: {results: {title: 'Different Document'}, isPending: false},
+        differentId: {data: {title: 'Different Document'}, isPending: false},
       },
     }))
     expect(state.get().subscriptions).toEqual({exampleId: {pseudoRandomId: true}})
@@ -103,12 +103,12 @@ describe('resolvePreview', () => {
     expect(state.get().subscriptions).toEqual({exampleId: {pseudoRandomId: true}})
 
     state.set('updateWithNewValue', (prev) => ({
-      values: {...prev.values, exampleId: {results: {title: 'New Value'}, isPending: false}},
+      values: {...prev.values, exampleId: {data: {title: 'New Value'}, isPending: false}},
     }))
     expect(state.get().subscriptions).toEqual({})
 
     const preview = await previewPromise
-    expect(preview).toEqual({results: {title: 'New Value'}, isPending: false})
+    expect(preview).toEqual({data: {title: 'New Value'}, isPending: false})
   })
 
   it('calls getOrCreateResource if no state is provided', () => {

--- a/packages/core/src/preview/resolvePreview.ts
+++ b/packages/core/src/preview/resolvePreview.ts
@@ -20,7 +20,7 @@ export const resolvePreview = createAction(previewStore, () => {
     return new Promise<ValuePending<PreviewValue>>((resolve) => {
       const unsubscribe = subscribe(() => {
         const current = getCurrent()
-        if (current?.results) {
+        if (current?.data) {
           resolve(current)
           unsubscribe()
         }

--- a/packages/core/src/preview/subscribeToStateAndFetchBatches.test.ts
+++ b/packages/core/src/preview/subscribeToStateAndFetchBatches.test.ts
@@ -102,7 +102,7 @@ describe('subscribeToStateAndFetchBatches', () => {
   it('handles new subscriptions optimistically with pending states', async () => {
     state.set('initializeValues', {
       documentTypes: {doc1: 'test', doc2: 'test'},
-      values: {doc1: {results: {title: 'Doc 1'}, isPending: false}},
+      values: {doc1: {data: {title: 'Doc 1'}, isPending: false}},
       subscriptions: {doc1: {sub1: true}},
     })
 
@@ -115,7 +115,7 @@ describe('subscribeToStateAndFetchBatches', () => {
 
     // this isn't a new subscription so it isn't pending by design.
     // the pending state is intended to only appear for new documents
-    expect(state.get().values['doc1']).toEqual({results: {title: 'Doc 1'}, isPending: false})
+    expect(state.get().values['doc1']).toEqual({data: {title: 'Doc 1'}, isPending: false})
 
     expect(state.get().values['doc2']).toBeUndefined()
 
@@ -125,7 +125,7 @@ describe('subscribeToStateAndFetchBatches', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 100))
 
-    expect(state.get().values['doc2']).toEqual({results: null, isPending: true})
+    expect(state.get().values['doc2']).toEqual({data: null, isPending: true})
 
     subscription.unsubscribe()
   })
@@ -204,7 +204,7 @@ describe('subscribeToStateAndFetchBatches', () => {
 
     // Check that the state was updated
     expect(state.get().values['doc1']).toEqual({
-      results: expect.objectContaining({
+      data: expect.objectContaining({
         title: 'Test Document',
       }),
       isPending: false,

--- a/packages/core/src/preview/subscribeToStateAndFetchBatches.ts
+++ b/packages/core/src/preview/subscribeToStateAndFetchBatches.ts
@@ -47,8 +47,8 @@ export const subscribeToStateAndFetchBatches = createInternalAction(
           state.set('updatingPending', (prev) => {
             const pendingValues = newIds.reduce<PreviewStoreState['values']>((acc, id) => {
               const prevValue = prev.values[id]
-              const value = prevValue?.results ? prevValue.results : null
-              acc[id] = {results: value, isPending: true}
+              const value = prevValue?.data ? prevValue.data : null
+              acc[id] = {data: value, isPending: true}
               return acc
             }, {})
             return {values: {...prev.values, ...pendingValues}}

--- a/packages/core/src/preview/util.ts
+++ b/packages/core/src/preview/util.ts
@@ -2,9 +2,9 @@ import {getEnv} from '../utils/getEnv'
 import {type PreviewValue, type ValuePending} from './previewStore'
 
 export const PREVIEW_TAG = 'preview'
-export const STABLE_EMPTY_PREVIEW: ValuePending<PreviewValue> = {results: null, isPending: false}
+export const STABLE_EMPTY_PREVIEW: ValuePending<PreviewValue> = {data: null, isPending: false}
 export const STABLE_ERROR_PREVIEW: ValuePending<PreviewValue> = {
-  results: {
+  data: {
     title: 'Preview Error',
     ...(!!getEnv('DEV') && {subtitle: 'Check the console for more details'}),
   },

--- a/packages/react/src/hooks/preview/usePreview.test.tsx
+++ b/packages/react/src/hooks/preview/usePreview.test.tsx
@@ -45,12 +45,12 @@ const mockDocument: DocumentHandle = {
 
 function TestComponent({document}: {document: DocumentHandle}) {
   const ref = useRef(null)
-  const {results, isPending} = usePreview({document, ref})
+  const {data, isPending} = usePreview({document, ref})
 
   return (
     <div ref={ref}>
-      <h1>{results?.title}</h1>
-      <p>{results?.subtitle}</p>
+      <h1>{data?.title}</h1>
+      <p>{data?.subtitle}</p>
       {isPending && <div>Pending...</div>}
     </div>
   )
@@ -75,7 +75,7 @@ describe('usePreview', () => {
   test('it only subscribes when element is visible', async () => {
     // Setup initial state
     getCurrent.mockReturnValue({
-      results: {title: 'Initial Title', subtitle: 'Initial Subtitle'},
+      data: {title: 'Initial Title', subtitle: 'Initial Subtitle'},
       isPending: false,
     })
     const eventsUnsubscribe = vi.fn()
@@ -139,7 +139,7 @@ describe('usePreview', () => {
       intersectionObserverCallback([{isIntersecting: true} as IntersectionObserverEntry])
       await resolvePromise
       getCurrent.mockReturnValue({
-        results: {title: 'Resolved Title', subtitle: 'Resolved Subtitle'},
+        data: {title: 'Resolved Title', subtitle: 'Resolved Subtitle'},
         isPending: false,
       })
       subscriber?.()
@@ -156,7 +156,7 @@ describe('usePreview', () => {
     delete window.IntersectionObserver
 
     getCurrent.mockReturnValue({
-      results: {title: 'Fallback Title', subtitle: 'Fallback Subtitle'},
+      data: {title: 'Fallback Title', subtitle: 'Fallback Subtitle'},
       isPending: false,
     })
     subscribe.mockImplementation(() => vi.fn())

--- a/packages/react/src/hooks/preview/usePreview.tsx
+++ b/packages/react/src/hooks/preview/usePreview.tsx
@@ -19,7 +19,7 @@ export interface UsePreviewOptions {
  */
 export interface UsePreviewResults {
   /** The results of resolving the document’s preview values */
-  results: PreviewValue
+  data: PreviewValue
   /** True when preview values are being refreshed */
   isPending: boolean
 }
@@ -40,7 +40,7 @@ export interface UsePreviewResults {
  * ```
  * // PreviewComponent.jsx
  * export default function PreviewComponent({ document }) {
- *   const { results: { title, subtitle, media }, isPending } = usePreview({ document })
+ *   const { data: { title, subtitle, media }, isPending } = usePreview({ document })
  *   return (
  *     <article style={{ opacity: isPending ? 0.5 : 1}}>
  *       {media?.type === 'image-asset' ? <img src={media.url} alt='' /> : ''}
@@ -51,12 +51,12 @@ export interface UsePreviewResults {
  * }
  *
  * // DocumentList.jsx
- * const { results, isPending } = useDocuments({ filter: '_type == "movie"' })
+ * const { data, isPending } = useDocuments({ filter: '_type == "movie"' })
  * return (
  *   <div>
  *     <h1>Movies</h1>
  *     <ul>
- *       {isPending ? 'Loading…' : results.map(movie => (
+ *       {isPending ? 'Loading…' : data.map(movie => (
  *         <li key={movie._id}>
  *           <Suspense fallback='Loading…'>
  *             <PreviewComponent document={movie} />
@@ -115,7 +115,7 @@ export function usePreview({document: {_id, _type}, ref}: UsePreviewOptions): Us
   // Create getSnapshot function to return current state
   const getSnapshot = useCallback(() => {
     const currentState = stateSource.getCurrent()
-    if (currentState.results === null) throw resolvePreview(instance, {document: {_id, _type}})
+    if (currentState.data === null) throw resolvePreview(instance, {document: {_id, _type}})
     return currentState as UsePreviewResults
   }, [_id, _type, instance, stateSource])
 


### PR DESCRIPTION
### Description

Renamed the `results` property to `data` in the preview state interface to maintain consistency with other API patterns. This change affects the preview store, query processing, and all components that consume preview data.

### What to review

- Check the renamed property in `usePreview` hook and its consumers
- Verify that all references to the previous `results` property have been updated to `data`
- Ensure the preview functionality works correctly with the renamed property

### Testing

All existing tests have been updated to use the new property name. The changes are thoroughly tested through the existing test suite which verifies that preview functionality continues to work as expected.

### Fun gif

![data GIF by Ryan Seslow](https://media1.giphy.com/media/3osxYc2axjCJNsCXyE/giphy.gif)