### PR TITLE
chore(docs): fix docs warnings

### DIFF
--- a/packages/@repo/package.config/src/package.config.ts
+++ b/packages/@repo/package.config/src/package.config.ts
@@ -4,7 +4,6 @@ export const basePackageConfig = defineConfig({
   legacyExports: false,
   extract: {
     rules: {
-      'ae-forgotten-export': 'off',
       'ae-internal-missing-underscore': 'off',
     },
     customTags: [

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -1,10 +1,17 @@
 // Use import type to access the internal type and re-export it
-import {type SanityProject as _SanityProject} from '@sanity/client'
+import {
+  type ClientConfig as _ClientConfig,
+  type SanityProject as _SanityProject,
+} from '@sanity/client'
 
 /**
  * @public
  */
 export type SanityProject = _SanityProject
+/**
+ * @public
+ */
+export type ClientConfig = _ClientConfig
 
 export {AuthStateType} from '../auth/authStateType'
 export {
@@ -12,6 +19,7 @@ export {
   type AuthProvider,
   type AuthState,
   type AuthStoreState,
+  type DashboardContext,
   type ErrorAuthState,
   getAuthState,
   getCurrentUserState,
@@ -24,16 +32,19 @@ export {
 export {fetchLoginUrls} from '../auth/fetchLoginUrls'
 export {handleCallback} from '../auth/handleCallback'
 export {logout} from '../auth/logout'
-export type {ClientState} from '../client/clientStore'
+export {type ClientState} from '../client/clientStore'
 export {type ClientOptions, getClient, getClientState} from '../client/clientStore'
 export {destroyController} from '../comlink/controller/actions/destroyController'
 export {getOrCreateChannel} from '../comlink/controller/actions/getOrCreateChannel'
 export {getOrCreateController} from '../comlink/controller/actions/getOrCreateController'
 export {releaseChannel} from '../comlink/controller/actions/releaseChannel'
-export type {ComlinkControllerState} from '../comlink/controller/comlinkControllerStore'
+export {
+  type ChannelEntry,
+  type ComlinkControllerState,
+} from '../comlink/controller/comlinkControllerStore'
 export {getOrCreateNode} from '../comlink/node/actions/getOrCreateNode'
 export {releaseNode} from '../comlink/node/actions/releaseNode'
-export type {ComlinkNodeState} from '../comlink/node/comlinkNodeStore'
+export {type ComlinkNodeState, type NodeEntry} from '../comlink/node/comlinkNodeStore'
 export {type FrameMessage, type WindowMessage} from '../comlink/types'
 export {getDatasetsState, resolveDatasets} from '../datasets/datasets'
 export {
@@ -53,6 +64,8 @@ export {
 } from '../document/actions'
 export {type ActionsResult, applyActions, type ApplyActionsOptions} from '../document/applyActions'
 export {
+  type DocumentState,
+  type DocumentStoreState,
   getDocumentState,
   getDocumentSyncStatus,
   getPermissionsState,
@@ -68,28 +81,56 @@ export {
   type DocumentEditedEvent,
   type DocumentEvent,
   type DocumentPublishedEvent,
+  type DocumentRebaseErrorEvent,
   type DocumentUnpublishedEvent,
   type TransactionAcceptedEvent,
   type TransactionRevertedEvent,
 } from '../document/events'
 export {
+  type DeepGet,
   type DocumentHandle,
   type DocumentTypeHandle,
   type JsonMatch,
   jsonMatch,
   type JsonMatchPath,
+  type MatchEntry,
+  type ParseBracket,
+  type ParseSegment,
+  type PathParts,
+  type SingleValuePath,
+  type ToNumber,
 } from '../document/patchOperations'
 export {type DocumentResourceId, getResourceId, type ResourceId} from '../document/patchOperations'
+export {type Grant} from '../document/permissions'
 export {type PermissionDeniedReason, type PermissionsResult} from '../document/permissions'
+export {type DocumentSet} from '../document/processMutations'
+export {
+  type ActionMap,
+  type AppliedTransaction,
+  type HttpAction,
+  type OptimisticLock,
+  type OutgoingTransaction,
+  type QueuedTransaction,
+  type UnverifiedDocumentRevision,
+} from '../document/reducers'
 export {createSanityInstance} from '../instance/sanityInstance'
 export type {SanityConfig, SanityInstance, SdkIdentity} from '../instance/types'
 export {getPreviewState, type GetPreviewStateOptions} from '../preview/getPreviewState'
-export type {PreviewStoreState, PreviewValue, ValuePending} from '../preview/previewStore'
+export {
+  type PreviewMedia,
+  type PreviewStoreState,
+  type PreviewValue,
+  type ValuePending,
+} from '../preview/previewStore'
 export {resolvePreview, type ResolvePreviewOptions} from '../preview/resolvePreview'
 export {getProjectState, resolveProject} from '../project/project'
-export {getProjectionState} from '../projection/getProjectionState'
-export type {ProjectionValuePending, ValidProjection} from '../projection/projectionStore'
-export {resolveProjection} from '../projection/resolveProjection'
+export {getProjectionState, type GetProjectionStateOptions} from '../projection/getProjectionState'
+export {
+  type ProjectionStoreState,
+  type ProjectionValuePending,
+  type ValidProjection,
+} from '../projection/projectionStore'
+export {resolveProjection, type ResolveProjectionOptions} from '../projection/resolveProjection'
 export {getProjectsState, resolveProjects} from '../projects/projects'
 export {
   getQueryKey,
@@ -97,13 +138,23 @@ export {
   parseQueryKey,
   type QueryOptions,
   resolveQuery,
+  type ResolveQueryOptions,
 } from '../query/queryStore'
+export {type QueryState, type QueryStoreState} from '../query/reducers'
 export {type ActionContext, type ResourceAction} from '../resources/createAction'
 export {type ResourceState} from '../resources/createResource'
 export type {StateSource} from '../resources/createStateSourceAction'
-export {type BoundResourceAction} from '../resources/createStore'
+export {
+  type BoundActions,
+  type BoundResourceAction,
+  type StoreFactory,
+} from '../resources/createStore'
 export {type Membership, type ResourceType, type SanityUser, type UserProfile} from '../users/types'
-export {createUsersStore, type UsersStoreState} from '../users/usersStore'
-export {type FetcherStore, type FetcherStoreState} from '../utils/createFetcherStore'
+export {createUsersStore, type SanityUserResponse, type UsersStoreState} from '../users/usersStore'
+export {
+  type FetcherStore,
+  type FetcherStoreState,
+  type StoreEntry,
+} from '../utils/createFetcherStore'
 export {CORE_SDK_VERSION} from '../version'
 export type {CurrentUser, Role, SanityDocument, SanityDocumentLike} from '@sanity/types'

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -54,6 +54,9 @@ import {
 } from './reducers'
 import {createFetchDocument, createSharedListener} from './sharedListener'
 
+/**
+ * @beta
+ */
 export interface DocumentStoreState {
   documentStates: {[TDocumentId in string]?: DocumentState}
   queued: QueuedTransaction[]
@@ -66,6 +69,9 @@ export interface DocumentStoreState {
   events: Subject<DocumentEvent>
 }
 
+/**
+ * @beta
+ */
 export interface DocumentState {
   id: string
   /**

--- a/packages/core/src/document/patchOperations.ts
+++ b/packages/core/src/document/patchOperations.ts
@@ -10,7 +10,10 @@ import {
   type SanityDocumentLike,
 } from '@sanity/types'
 
-type SingleValuePath = Exclude<PathSegment, IndexTuple>[]
+/**
+ * @beta
+ */
+export type SingleValuePath = Exclude<PathSegment, IndexTuple>[]
 
 /**
  * @beta
@@ -55,11 +58,16 @@ export interface DocumentTypeHandle<TDocument extends SanityDocumentLike = Sanit
   resourceId?: DocumentResourceId
 }
 
-type ToNumber<TInput extends string> = TInput extends `${infer TNumber extends number}`
+/**
+ * @beta
+ */
+export type ToNumber<TInput extends string> = TInput extends `${infer TNumber extends number}`
   ? TNumber
   : TInput
 
 /**
+ * @beta
+ *
  * Parse a single “segment” that may include bracket parts.
  *
  * For example, the literal
@@ -74,7 +82,7 @@ type ToNumber<TInput extends string> = TInput extends `${infer TNumber extends n
  * ["friends", 0, 1]
  * ```
  */
-type ParseSegment<TInput extends string> = TInput extends `${infer TProp}[${infer TRest}`
+export type ParseSegment<TInput extends string> = TInput extends `${infer TProp}[${infer TRest}`
   ? TProp extends ''
     ? [...ParseBracket<`[${TRest}`>] // no property name before '['
     : [TProp, ...ParseBracket<`[${TRest}`>]
@@ -83,6 +91,8 @@ type ParseSegment<TInput extends string> = TInput extends `${infer TProp}[${infe
     : [TInput]
 
 /**
+ * @beta
+ *
  * Parse one or more bracketed parts from a segment.
  *
  * It recursively “peels off” a bracketed part and then continues.
@@ -99,11 +109,13 @@ type ParseSegment<TInput extends string> = TInput extends `${infer TProp}[${infe
  * [ToNumber<"0">, "foo"]
  * ```
  */
-type ParseBracket<TInput extends string> = TInput extends `[${infer TPart}]${infer TRest}`
+export type ParseBracket<TInput extends string> = TInput extends `[${infer TPart}]${infer TRest}`
   ? [ToNumber<TPart>, ...ParseSegment<TRest>]
   : [] // no leading bracket → end of this segment
 
 /**
+ * @beta
+ *
  * Split the entire path string on dots “outside” of any brackets.
  *
  * For example:
@@ -119,17 +131,22 @@ type ParseBracket<TInput extends string> = TInput extends `[${infer TPart}]${inf
  *
  * (We use a simple recursion that splits on the first dot.)
  */
-type PathParts<TPath extends string> = TPath extends `${infer TLeft}.${infer TRight}`
+export type PathParts<TPath extends string> = TPath extends `${infer TLeft}.${infer TRight}`
   ? [...ParseSegment<TLeft>, ...PathParts<TRight>]
   : ParseSegment<TPath>
 
 /**
+ * @beta
+ *
  * Given a type T and an array of “access keys” Parts, recursively index into T.
  *
  * If a part is a key, it looks up that property.
  * If T is an array and the part is a number, it “indexes” into the element type.
  */
-type DeepGet<T, TParts extends readonly unknown[]> = TParts extends [infer Head, ...infer Tail]
+export type DeepGet<T, TParts extends readonly unknown[]> = TParts extends [
+  infer Head,
+  ...infer Tail,
+]
   ? Head extends keyof T
     ? DeepGet<T[Head], Tail>
     : T extends Array<infer U>
@@ -296,7 +313,10 @@ export function stringifyPath(path: Path): string {
   return result
 }
 
-type MatchEntry<T = unknown> = {
+/**
+ * @beta
+ */
+export interface MatchEntry<T = unknown> {
   value: T
   path: SingleValuePath
 }

--- a/packages/core/src/document/permissions.ts
+++ b/packages/core/src/document/permissions.ts
@@ -10,6 +10,9 @@ import {ActionError, PermissionActionError, processActions} from './processActio
 import {type DocumentSet} from './processMutations'
 import {type SyncTransactionState} from './reducers'
 
+/**
+ * @beta
+ */
 export type Grant = 'read' | 'update' | 'create' | 'history'
 
 export type DatasetAcl = {

--- a/packages/core/src/document/processMutations.ts
+++ b/packages/core/src/document/processMutations.ts
@@ -21,6 +21,8 @@ import {
  * applying a mutation, it's expected that all relevant documents that the
  * mutations affect are included, including those that do not exist yet.
  * Documents that don't exist have a `null` value.
+ *
+ * @beta
  */
 export type DocumentSet<TDocument extends SanityDocument = SanityDocument> = {
   [TDocumentId in string]?: TDocument | null

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -18,7 +18,10 @@ export type SyncTransactionState = Pick<
   'queued' | 'applied' | 'documentStates' | 'outgoing' | 'grants'
 >
 
-type ActionMap = {
+/**
+ * @beta
+ */
+export interface ActionMap {
   create: 'sanity.action.document.version.create'
   discard: 'sanity.action.document.version.discard'
   unpublish: 'sanity.action.document.unpublish'
@@ -27,11 +30,17 @@ type ActionMap = {
   publish: 'sanity.action.document.publish'
 }
 
-type OptimisticLock = {
+/**
+ * @beta
+ */
+export interface OptimisticLock {
   ifDraftRevisionId?: string
   ifPublishedRevisionId?: string
 }
 
+/**
+ * @beta
+ */
 export type HttpAction =
   | {actionType: ActionMap['create']; publishedId: string; attributes: SanityDocumentLike}
   | {actionType: ActionMap['discard']; versionId: string; purge?: boolean}
@@ -41,6 +50,8 @@ export type HttpAction =
   | ({actionType: ActionMap['publish']; draftId: string; publishedId: string} & OptimisticLock)
 
 /**
+ * @beta
+ *
  * Represents a transaction that is queued to be applied but has not yet been
  * applied. A transaction will remain in a queued state until all required
  * documents for the transactions are available locally.
@@ -64,6 +75,8 @@ export interface QueuedTransaction {
 }
 
 /**
+ * @beta
+ *
  * Represents a transaction that has been applied locally but has not been
  * committed/transitioned-to-outgoing. These transactions are visible to the
  * user but may be rebased upon a new working document set. Applied transactions
@@ -121,6 +134,8 @@ export interface AppliedTransaction extends QueuedTransaction {
 }
 
 /**
+ * @beta
+ *
  * Represents a set of applied transactions batched into a single outgoing
  * transaction. An outgoing transaction is the result of batching many applied
  * actions. An outgoing transaction may be reverted locally if the server
@@ -131,6 +146,9 @@ export interface OutgoingTransaction extends AppliedTransaction {
   batchedTransactionIds: string[]
 }
 
+/**
+ * @beta
+ */
 export interface UnverifiedDocumentRevision {
   transactionId: string
   documentId: string

--- a/packages/core/src/projection/getProjectionState.ts
+++ b/packages/core/src/projection/getProjectionState.ts
@@ -13,7 +13,10 @@ import {
 } from './projectionStore'
 import {STABLE_EMPTY_PROJECTION, validateProjection} from './util'
 
-interface GetProjectionStateOptions {
+/**
+ * @beta
+ */
+export interface GetProjectionStateOptions {
   document: DocumentHandle
   projection: ValidProjection
 }

--- a/packages/core/src/projection/projectionStore.ts
+++ b/packages/core/src/projection/projectionStore.ts
@@ -24,6 +24,9 @@ export interface ProjectionValuePending<TValue extends object> {
   isPending: boolean
 }
 
+/**
+ * @beta
+ */
 export interface ProjectionStoreState<TValue extends object = object> extends LiveEventAwareState {
   values: {[TDocumentId in string]?: ProjectionValuePending<TValue>}
   documentProjections: {[TDocumentId in string]?: ValidProjection}

--- a/packages/core/src/projection/resolveProjection.ts
+++ b/packages/core/src/projection/resolveProjection.ts
@@ -8,7 +8,10 @@ import {
   type ValidProjection,
 } from './projectionStore'
 
-interface ResolveProjectionOptions {
+/**
+ * @beta
+ */
+export interface ResolveProjectionOptions {
   document: DocumentHandle
   projection: ValidProjection
 }

--- a/packages/core/src/query/reducers.ts
+++ b/packages/core/src/query/reducers.ts
@@ -1,6 +1,9 @@
 import {omit} from 'lodash-es'
 
-interface QueryState {
+/**
+ * @beta
+ */
+export interface QueryState {
   syncTags?: string[]
   result?: unknown
   error?: unknown
@@ -8,6 +11,9 @@ interface QueryState {
   subscribers: string[]
 }
 
+/**
+ * @beta
+ */
 export interface QueryStoreState {
   queries: {[key: string]: QueryState | undefined}
   error?: unknown

--- a/packages/core/src/resources/createStore.ts
+++ b/packages/core/src/resources/createStore.ts
@@ -12,13 +12,19 @@ export type BoundResourceAction<TParams extends unknown[], TReturn> = (
   ...params: TParams
 ) => TReturn
 
-type BoundActions<TActions extends {[key: string]: ResourceAction<any, any, any>}> = {
+/**
+ * @public
+ */
+export type BoundActions<TActions extends {[key: string]: ResourceAction<any, any, any>}> = {
   [K in keyof TActions]: TActions[K] extends ResourceAction<any, infer TParams, infer TReturn>
     ? BoundResourceAction<TParams, TReturn>
     : never
 }
 
-type StoreFactory<TActions extends {[key: string]: ResourceAction<any, any, any>}> = (
+/**
+ * @public
+ */
+export type StoreFactory<TActions extends {[key: string]: ResourceAction<any, any, any>}> = (
   instance: SanityInstance | ActionContext<any>,
 ) => {
   dispose: () => void

--- a/packages/core/src/utils/createFetcherStore.ts
+++ b/packages/core/src/utils/createFetcherStore.ts
@@ -51,7 +51,10 @@ interface CreateFetcherStoreOptions<TParams extends unknown[], TData> {
   fetchThrottleInternal?: number
 }
 
-interface StoreEntry<TParams extends unknown[], TData> {
+/**
+ * @public
+ */
+export interface StoreEntry<TParams extends unknown[], TData> {
   params: TParams
   key: string
   data?: TData

--- a/packages/react/src/_exports/index.ts
+++ b/packages/react/src/_exports/index.ts
@@ -5,7 +5,7 @@ export type {SanityProviderProps} from '../context/SanityProvider'
 export {SanityProvider} from '../context/SanityProvider'
 export {useAuthState} from '../hooks/auth/useAuthState'
 export {useAuthToken} from '../hooks/auth/useAuthToken'
-export {useCurrentUser} from '../hooks/auth/useCurrentUser'
+export {type UseCurrentUser, useCurrentUser} from '../hooks/auth/useCurrentUser'
 export {useHandleCallback} from '../hooks/auth/useHandleCallback'
 export {useLoginUrls} from '../hooks/auth/useLoginUrls'
 export {useLogOut} from '../hooks/auth/useLogOut'
@@ -16,8 +16,11 @@ export {
   useFrameConnection,
   type UseFrameConnectionOptions,
 } from '../hooks/comlink/useFrameConnection'
-export {useManageFavorite} from '../hooks/comlink/useManageFavorite'
-export {useRecordDocumentHistoryEvent} from '../hooks/comlink/useRecordDocumentHistoryEvent'
+export {type ManageFavorite, useManageFavorite} from '../hooks/comlink/useManageFavorite'
+export {
+  type DocumentInteractionHistory,
+  useRecordDocumentHistoryEvent,
+} from '../hooks/comlink/useRecordDocumentHistoryEvent'
 export {
   useWindowConnection,
   type UseWindowConnectionOptions,
@@ -25,12 +28,15 @@ export {
   type WindowMessageHandler,
 } from '../hooks/comlink/useWindowConnection'
 export {useSanityInstance} from '../hooks/context/useSanityInstance'
-export {useDatasets} from '../hooks/datasets/useDatasets'
+export {type UseDatasets, useDatasets} from '../hooks/datasets/useDatasets'
 export {useApplyActions} from '../hooks/document/useApplyActions'
 export {useDocument} from '../hooks/document/useDocument'
 export {useDocumentEvent} from '../hooks/document/useDocumentEvent'
-export {useDocumentSyncStatus} from '../hooks/document/useDocumentSyncStatus'
-export {useEditDocument} from '../hooks/document/useEditDocument'
+export {
+  type UseDocumentSyncStatus,
+  useDocumentSyncStatus,
+} from '../hooks/document/useDocumentSyncStatus'
+export {type Updater, useEditDocument} from '../hooks/document/useEditDocument'
 export {usePermissions} from '../hooks/document/usePermissions'
 export {
   type InfiniteList,
@@ -53,7 +59,11 @@ export {
   type UseProjectionResults,
 } from '../hooks/projection/useProjection'
 export {useProject} from '../hooks/projects/useProject'
-export {type ProjectWithoutMembers, useProjects} from '../hooks/projects/useProjects'
+export {
+  type ProjectWithoutMembers,
+  type UseProjects,
+  useProjects,
+} from '../hooks/projects/useProjects'
 export {useQuery} from '../hooks/query/useQuery'
 export {useUsers, type UseUsersParams, type UseUsersResult} from '../hooks/users/useUsers'
 export {REACT_SDK_VERSION} from '../version'

--- a/packages/react/src/hooks/auth/useCurrentUser.tsx
+++ b/packages/react/src/hooks/auth/useCurrentUser.tsx
@@ -2,7 +2,10 @@ import {type CurrentUser, getCurrentUserState} from '@sanity/sdk'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
 
-type UseCurrentUser = {
+/**
+ * @public
+ */
+export interface UseCurrentUser {
   /**
    * @public
    *
@@ -28,6 +31,6 @@ type UseCurrentUser = {
 
 /**
  * @public
- * @TODO This should not return null — users of a custom app will always be authenticated via Core
+ * @todo This should not return null — users of a custom app will always be authenticated via Core
  */
 export const useCurrentUser: UseCurrentUser = createStateSourceHook(getCurrentUserState)

--- a/packages/react/src/hooks/comlink/useManageFavorite.ts
+++ b/packages/react/src/hooks/comlink/useManageFavorite.ts
@@ -6,7 +6,10 @@ import {useWindowConnection} from './useWindowConnection'
 
 // should we import this whole type from the message protocol?
 
-interface ManageFavorite {
+/**
+ * @beta
+ */
+export interface ManageFavorite {
   favorite: () => void
   unfavorite: () => void
   isFavorited: boolean

--- a/packages/react/src/hooks/comlink/useRecordDocumentHistoryEvent.ts
+++ b/packages/react/src/hooks/comlink/useRecordDocumentHistoryEvent.ts
@@ -4,7 +4,10 @@ import {useCallback} from 'react'
 
 import {useWindowConnection} from './useWindowConnection'
 
-interface DocumentInteractionHistory {
+/**
+ * @public
+ */
+export interface DocumentInteractionHistory {
   recordEvent: (eventType: 'viewed' | 'edited' | 'created' | 'deleted') => void
   isConnected: boolean
 }

--- a/packages/react/src/hooks/datasets/useDatasets.ts
+++ b/packages/react/src/hooks/datasets/useDatasets.ts
@@ -3,7 +3,10 @@ import {getDatasetsState, resolveDatasets, type SanityInstance, type StateSource
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
 
-type UseDatasets = {
+/**
+ * @public
+ */
+export interface UseDatasets {
   /**
    *
    * Returns metadata for each dataset in your organization.

--- a/packages/react/src/hooks/document/useDocumentSyncStatus.ts
+++ b/packages/react/src/hooks/document/useDocumentSyncStatus.ts
@@ -2,7 +2,10 @@ import {type DocumentHandle, getDocumentSyncStatus} from '@sanity/sdk'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
 
-type UseDocumentSyncStatus = {
+/**
+ * @beta
+ */
+export interface UseDocumentSyncStatus {
   /**
    * Exposes the document’s sync status between local and remote document states.
    *

--- a/packages/react/src/hooks/document/useEditDocument.ts
+++ b/packages/react/src/hooks/document/useEditDocument.ts
@@ -16,7 +16,10 @@ import {useApplyActions} from './useApplyActions'
 
 const ignoredKeys = ['_id', '_type', '_createdAt', '_updatedAt', '_rev']
 
-type Updater<TValue> = TValue | ((nextValue: TValue) => TValue)
+/**
+ * @beta
+ */
+export type Updater<TValue> = TValue | ((nextValue: TValue) => TValue)
 
 /**
  *

--- a/packages/react/src/hooks/projection/useProjection.ts
+++ b/packages/react/src/hooks/projection/useProjection.ts
@@ -29,7 +29,7 @@ export interface UseProjectionResults<TResult extends object> {
 }
 
 /**
- * @beta
+ * @public
  *
  * Returns the projection values of a document (specified via a `DocumentHandle`),
  * based on the provided projection string. These values are live and will update in realtime.

--- a/packages/react/src/hooks/projects/useProjects.ts
+++ b/packages/react/src/hooks/projects/useProjects.ts
@@ -9,7 +9,10 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
  */
 export type ProjectWithoutMembers = Omit<SanityProject, 'members'>
 
-type UseProjects = {
+/**
+ * @public
+ */
+export interface UseProjects {
   /**
    *
    * Returns metadata for each project in your organization.


### PR DESCRIPTION
### Description

This PR exports additional types from the SDK to make them available for public consumption. It also removes the `ae-forgotten-export` rule from the package config, as we're now properly exporting these types.

The changes include:
- Exporting various types from the core package
- Adding proper JSDoc annotations to types (`@public`, `@beta`)
- Exporting interface types from React hooks
- Ensuring consistent type naming conventions

### What to review

- Check that all exported types have appropriate JSDoc annotations
- Verify that the types being exported are intended for public consumption
- Ensure that the removal of the `ae-forgotten-export` rule is appropriate now that we're properly exporting these types

### Testing

The changes are type-only and don't affect runtime behavior. The existing type system and build process will validate that the exports are correct.

### Fun gif

![Type checking](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZnRqZnRqZGJtZGJtZGJtZGJtZGJtZGJtZGJtZGJtZGJtZGJtZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/13HgwGsXF0aiGY/giphy.gif)