### PR TITLE
feat!: rename `results` to `data` for useProjection hook

### DIFF
--- a/apps/kitchensink-react/src/DocumentCollection/DocumentProjectionRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentProjectionRoute.tsx
@@ -14,13 +14,13 @@ interface AuthorProjection {
 }
 
 // Component for displaying projection data with proper error handling
-function ProjectionData({results}: {results: AuthorProjection}) {
+function ProjectionData({data}: {data: AuthorProjection}) {
   return (
     <>
-      <TD padding={2}>{results.name || 'Untitled'}</TD>
-      <TD padding={2}>{results.address || 'No address'}</TD>
+      <TD padding={2}>{data.name || 'Untitled'}</TD>
+      <TD padding={2}>{data.address || 'No address'}</TD>
       <TD padding={2}>
-        {results.favoriteBookTitles.filter(Boolean).join(', ') || 'No favorite books'}
+        {data.favoriteBookTitles.filter(Boolean).join(', ') || 'No favorite books'}
       </TD>
     </>
   )
@@ -56,7 +56,7 @@ function ProjectionError({error}: {error: Error}): ReactNode {
 function AuthorRow({document}: {document: DocumentHandle}) {
   const ref = useRef<HTMLTableRowElement>(null)
 
-  const {results} = useProjection<AuthorProjection>({
+  const {data} = useProjection<AuthorProjection>({
     document,
     projection: `{
       name,
@@ -70,7 +70,7 @@ function AuthorRow({document}: {document: DocumentHandle}) {
     <TR ref={ref}>
       <ErrorBoundary fallbackRender={({error}) => <ProjectionError error={error} />}>
         <Suspense fallback={<ProjectionFallback />}>
-          <ProjectionData results={results} />
+          <ProjectionData data={data} />
         </Suspense>
       </ErrorBoundary>
     </TR>

--- a/packages/core/src/projection/getProjectionState.test.ts
+++ b/packages/core/src/projection/getProjectionState.test.ts
@@ -50,20 +50,20 @@ describe('getProjectionState', () => {
     expect(subscriber).toHaveBeenCalledTimes(0)
 
     state.set('relatedChange', (prev) => ({
-      values: {...prev.values, exampleId: {results: {field: 'Changed!'}, isPending: false}},
+      values: {...prev.values, exampleId: {data: {field: 'Changed!'}, isPending: false}},
     }))
     expect(subscriber).toHaveBeenCalledTimes(1)
 
     state.set('unrelatedChange', (prev) => ({
       values: {
         ...prev.values,
-        unrelatedId: {results: {field: 'Unrelated Document'}, isPending: false},
+        unrelatedId: {data: {field: 'Unrelated Document'}, isPending: false},
       },
     }))
     expect(subscriber).toHaveBeenCalledTimes(1)
 
     state.set('relatedChange', (prev) => ({
-      values: {...prev.values, exampleId: {results: {field: 'Changed again!'}, isPending: false}},
+      values: {...prev.values, exampleId: {data: {field: 'Changed again!'}, isPending: false}},
     }))
     expect(subscriber).toHaveBeenCalledTimes(2)
   })
@@ -97,7 +97,7 @@ describe('getProjectionState', () => {
 
   it('resets to pending false on unsubscribe if the subscription is the last one', () => {
     state.set('presetValueToPending', (prev) => ({
-      values: {...prev.values, [document._id]: {results: {field: 'Foo'}, isPending: true}},
+      values: {...prev.values, [document._id]: {data: {field: 'Foo'}, isPending: true}},
     }))
 
     const projectionState = getProjectionState({state, instance}, {document, projection})
@@ -105,14 +105,14 @@ describe('getProjectionState', () => {
     const unsubscribe1 = projectionState.subscribe(vi.fn())
     const unsubscribe2 = projectionState.subscribe(vi.fn())
 
-    expect(state.get().values[document._id]).toEqual({results: {field: 'Foo'}, isPending: true})
+    expect(state.get().values[document._id]).toEqual({data: {field: 'Foo'}, isPending: true})
 
     unsubscribe1()
-    expect(state.get().values[document._id]).toEqual({results: {field: 'Foo'}, isPending: true})
+    expect(state.get().values[document._id]).toEqual({data: {field: 'Foo'}, isPending: true})
 
     unsubscribe2()
     expect(state.get().subscriptions).toEqual({})
-    expect(state.get().values[document._id]).toEqual({results: {field: 'Foo'}, isPending: false})
+    expect(state.get().values[document._id]).toEqual({data: {field: 'Foo'}, isPending: false})
   })
 
   it('calls getOrCreateResource if no state is provided', () => {

--- a/packages/core/src/projection/getProjectionState.ts
+++ b/packages/core/src/projection/getProjectionState.ts
@@ -87,7 +87,7 @@ export const _getProjectionState = createAction(projectionStore, ({state}) => {
             const documentSubscriptions = omit(prev.subscriptions[documentId], subscriptionId)
             const hasSubscribers = !!Object.keys(documentSubscriptions).length
             const prevValue = prev.values[documentId]
-            const projectionValue = prevValue?.results ? prevValue.results : null
+            const projectionValue = prevValue?.data ? prevValue.data : null
 
             return {
               subscriptions: hasSubscribers
@@ -95,7 +95,7 @@ export const _getProjectionState = createAction(projectionStore, ({state}) => {
                 : omit(prev.subscriptions, documentId),
               values: hasSubscribers
                 ? prev.values
-                : {...prev.values, [documentId]: {results: projectionValue, isPending: false}},
+                : {...prev.values, [documentId]: {data: projectionValue, isPending: false}},
             }
           })
         }

--- a/packages/core/src/projection/projectionQuery.test.ts
+++ b/packages/core/src/projection/projectionQuery.test.ts
@@ -51,7 +51,7 @@ describe('processProjectionQuery', () => {
       results: [], // no results
     })
 
-    expect(result['doc1']).toEqual({results: null, isPending: false})
+    expect(result['doc1']).toEqual({data: null, isPending: false})
   })
 
   it('processes query results into projection values', () => {
@@ -72,7 +72,7 @@ describe('processProjectionQuery', () => {
     })
 
     expect(processed['doc1']).toEqual({
-      results: {
+      data: {
         title: 'Hello',
         description: 'World',
         status: {
@@ -107,7 +107,7 @@ describe('processProjectionQuery', () => {
     })
 
     expect(processed['doc1']).toEqual({
-      results: {
+      data: {
         title: 'Draft',
         status: {
           lastEditedDraftAt: '2021-01-02',
@@ -136,7 +136,7 @@ describe('processProjectionQuery', () => {
     })
 
     expect(processed['doc1']).toEqual({
-      results: {
+      data: {
         title: 'Published',
         status: {
           lastEditedPublishedAt: '2021-01-01',

--- a/packages/core/src/projection/projectionQuery.ts
+++ b/packages/core/src/projection/projectionQuery.ts
@@ -83,14 +83,14 @@ export function processProjectionQuery({ids, results}: ProcessProjectionQueryOpt
       const publishedResult = resultMap[publishedId]
 
       const projectionResult = draftResult?.result ?? publishedResult?.result
-      if (!projectionResult) return [id, {results: null, isPending: false}]
+      if (!projectionResult) return [id, {data: null, isPending: false}]
 
       const status = {
         ...(draftResult?._updatedAt && {lastEditedDraftAt: draftResult._updatedAt}),
         ...(publishedResult?._updatedAt && {lastEditedPublishedAt: publishedResult._updatedAt}),
       }
 
-      return [id, {results: {...projectionResult, status}, isPending: false}]
+      return [id, {data: {...projectionResult, status}, isPending: false}]
     }),
   )
 }

--- a/packages/core/src/projection/projectionStore.ts
+++ b/packages/core/src/projection/projectionStore.ts
@@ -20,7 +20,7 @@ export interface ProjectionQueryResult<TValue = Record<string, unknown>> {
  * @beta
  */
 export interface ProjectionValuePending<TValue extends object> {
-  results: TValue | null
+  data: TValue | null
   isPending: boolean
 }
 

--- a/packages/core/src/projection/resolveProjection.test.ts
+++ b/packages/core/src/projection/resolveProjection.test.ts
@@ -56,14 +56,14 @@ describe('resolveProjection', () => {
     state.set('updateDifferentDocument', (prev) => ({
       values: {
         ...prev.values,
-        differentId: {results: {title: 'Different Document'}, isPending: false},
+        differentId: {data: {title: 'Different Document'}, isPending: false},
       },
     }))
 
     expect(state.get().subscriptions).toEqual({exampleId: {pseudoRandomId: true}})
 
     state.set('updateCorrectDocumentButNull', (prev) => ({
-      values: {...prev.values, exampleId: {results: null, isPending: true}},
+      values: {...prev.values, exampleId: {data: null, isPending: true}},
     }))
 
     expect(state.get().subscriptions).toEqual({exampleId: {pseudoRandomId: true}})
@@ -72,7 +72,7 @@ describe('resolveProjection', () => {
       values: {
         ...prev.values,
         exampleId: {
-          results: {title: 'Correct Document', description: 'Test'},
+          data: {title: 'Correct Document', description: 'Test'},
           isPending: false,
         },
       },
@@ -80,7 +80,7 @@ describe('resolveProjection', () => {
 
     const projectionResult = await projectionPromise
     expect(projectionResult).toEqual({
-      results: {title: 'Correct Document', description: 'Test'},
+      data: {title: 'Correct Document', description: 'Test'},
       isPending: false,
     })
 
@@ -90,7 +90,7 @@ describe('resolveProjection', () => {
 
   it('resolves with the next emitted state (not current state)', async () => {
     const currentValue: ProjectionValuePending<Record<string, unknown>> = {
-      results: {title: 'Current Document', description: 'Test'},
+      data: {title: 'Current Document', description: 'Test'},
       isPending: false,
     }
     state.set('setInitialDocument', (prev) => ({
@@ -108,7 +108,7 @@ describe('resolveProjection', () => {
     state.set('updateDifferentDocument', (prev) => ({
       values: {
         ...prev.values,
-        differentId: {results: {title: 'Different Document'}, isPending: false},
+        differentId: {data: {title: 'Different Document'}, isPending: false},
       },
     }))
     expect(state.get().subscriptions).toEqual({exampleId: {pseudoRandomId: true}})
@@ -122,7 +122,7 @@ describe('resolveProjection', () => {
       values: {
         ...prev.values,
         exampleId: {
-          results: {title: 'New Value', description: 'Updated'},
+          data: {title: 'New Value', description: 'Updated'},
           isPending: false,
         },
       },
@@ -131,7 +131,7 @@ describe('resolveProjection', () => {
 
     const projectionResult = await projectionPromise
     expect(projectionResult).toEqual({
-      results: {title: 'New Value', description: 'Updated'},
+      data: {title: 'New Value', description: 'Updated'},
       isPending: false,
     })
   })

--- a/packages/core/src/projection/resolveProjection.ts
+++ b/packages/core/src/projection/resolveProjection.ts
@@ -26,7 +26,7 @@ export const resolveProjection = createAction(projectionStore, () => {
     return new Promise<ProjectionValuePending<TResult>>((resolve) => {
       const unsubscribe = subscribe(() => {
         const current = getCurrent()
-        if (current?.results) {
+        if (current?.data) {
           resolve(current)
           unsubscribe()
         }

--- a/packages/core/src/projection/subscribeToStateAndFetchBatches.test.ts
+++ b/packages/core/src/projection/subscribeToStateAndFetchBatches.test.ts
@@ -104,7 +104,7 @@ describe('subscribeToStateAndFetchBatches', () => {
   it('handles new subscriptions optimistically with pending states', async () => {
     state.set('initializeValues', {
       documentProjections: {doc1: '{title, description}', doc2: '{title, description}'},
-      values: {doc1: {results: {title: 'Doc 1'}, isPending: false}},
+      values: {doc1: {data: {title: 'Doc 1'}, isPending: false}},
       subscriptions: {doc1: {sub1: true}},
     })
 
@@ -117,7 +117,7 @@ describe('subscribeToStateAndFetchBatches', () => {
 
     // this isn't a new subscription so it isn't pending by design.
     // the pending state is intended to only appear for new documents
-    expect(state.get().values['doc1']).toEqual({results: {title: 'Doc 1'}, isPending: false})
+    expect(state.get().values['doc1']).toEqual({data: {title: 'Doc 1'}, isPending: false})
 
     expect(state.get().values['doc2']).toBeUndefined()
 
@@ -127,7 +127,7 @@ describe('subscribeToStateAndFetchBatches', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 100))
 
-    expect(state.get().values['doc2']).toEqual({results: null, isPending: true})
+    expect(state.get().values['doc2']).toEqual({data: null, isPending: true})
 
     subscription.unsubscribe()
   })
@@ -205,7 +205,7 @@ describe('subscribeToStateAndFetchBatches', () => {
 
     // Check that the state was updated
     expect(state.get().values['doc1']).toEqual({
-      results: expect.objectContaining({
+      data: expect.objectContaining({
         title: 'Test Document',
         description: 'Test Description',
         status: {

--- a/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
+++ b/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
@@ -51,8 +51,8 @@ export const subscribeToStateAndFetchBatches = createInternalAction(
           state.set('updatingPending', (prev) => {
             const pendingValues = newIds.reduce<ProjectionStoreState['values']>((acc, id) => {
               const prevValue = prev.values[id]
-              const value = prevValue?.results ? prevValue.results : null
-              acc[id] = {results: value, isPending: true}
+              const value = prevValue?.data ? prevValue.data : null
+              acc[id] = {data: value, isPending: true}
               return acc
             }, {})
             return {values: {...prev.values, ...pendingValues}}

--- a/packages/core/src/projection/util.ts
+++ b/packages/core/src/projection/util.ts
@@ -3,7 +3,7 @@ import {type ValidProjection} from './projectionStore'
 export const PROJECTION_TAG = 'sdk.projection'
 
 export const STABLE_EMPTY_PROJECTION = {
-  results: null,
+  data: null,
   isPending: false,
 }
 

--- a/packages/react/src/hooks/projection/useProjection.test.tsx
+++ b/packages/react/src/hooks/projection/useProjection.test.tsx
@@ -61,12 +61,12 @@ function TestComponent({
   projection: ValidProjection
 }) {
   const ref = useRef(null)
-  const {results, isPending} = useProjection<ProjectionResult>({document, projection, ref})
+  const {data, isPending} = useProjection<ProjectionResult>({document, projection, ref})
 
   return (
     <div ref={ref}>
-      <h1>{results.title}</h1>
-      <p>{results.description}</p>
+      <h1>{data.title}</h1>
+      <p>{data.description}</p>
       {isPending && <div>Pending...</div>}
     </div>
   )
@@ -91,7 +91,7 @@ describe('useProjection', () => {
   test('it only subscribes when element is visible', async () => {
     // Setup initial state
     getCurrent.mockReturnValue({
-      results: {title: 'Initial Title', description: 'Initial Description'},
+      data: {title: 'Initial Title', description: 'Initial Description'},
       isPending: false,
     })
     const eventsUnsubscribe = vi.fn()
@@ -129,12 +129,12 @@ describe('useProjection', () => {
   test('it suspends and resolves data when element becomes visible', async () => {
     // Mock the initial state to trigger suspense
     getCurrent.mockReturnValueOnce({
-      results: null,
+      data: null,
       isPending: true,
     })
 
     const resolvedData = {
-      results: {title: 'Resolved Title', description: 'Resolved Description'},
+      data: {title: 'Resolved Title', description: 'Resolved Description'},
       isPending: false,
     }
 
@@ -169,7 +169,7 @@ describe('useProjection', () => {
     delete window.IntersectionObserver
 
     getCurrent.mockReturnValue({
-      results: {title: 'Fallback Title', description: 'Fallback Description'},
+      data: {title: 'Fallback Title', description: 'Fallback Description'},
       isPending: false,
     })
     subscribe.mockImplementation(() => vi.fn())
@@ -188,7 +188,7 @@ describe('useProjection', () => {
 
   test('it updates when projection changes', async () => {
     getCurrent.mockReturnValue({
-      results: {title: 'Initial Title'},
+      data: {title: 'Initial Title'},
       isPending: false,
     })
     const eventsUnsubscribe = vi.fn()
@@ -202,7 +202,7 @@ describe('useProjection', () => {
 
     // Change projection
     getCurrent.mockReturnValue({
-      results: {title: 'Updated Title', description: 'Added Description'},
+      data: {title: 'Updated Title', description: 'Added Description'},
       isPending: false,
     })
 

--- a/packages/react/src/hooks/projection/useProjection.ts
+++ b/packages/react/src/hooks/projection/useProjection.ts
@@ -24,7 +24,7 @@ export interface UseProjectionOptions {
  * @category Types
  */
 export interface UseProjectionResults<TResult extends object> {
-  results: TResult
+  data: TResult
   isPending: boolean
 }
 
@@ -138,7 +138,7 @@ export function useProjection<TResult extends object>({
   // Create getSnapshot function to return current state
   const getSnapshot = useCallback(() => {
     const currentState = stateSource.getCurrent()
-    if (currentState.results === null)
+    if (currentState.data === null)
       throw resolveProjection(instance, {document: {_id, _type}, projection})
     return currentState as UseProjectionResults<TResult>
   }, [_id, _type, projection, instance, stateSource])


### PR DESCRIPTION
### Description

FIXES SDK-266

Renamed the `results` property to `data` in the projection API to better align with our naming conventions across the codebase. This change affects both the core projection store and React hooks, making the API more intuitive and consistent.

### What to review

- The renaming of `results` to `data` in the projection store types and implementation
- Updates to the React hook interface and implementation
- Changes to test files to reflect the new property name
- The sample app (kitchensink-react) implementation using the updated API

### Testing

All existing tests have been updated to use the new property name. The tests continue to verify the same functionality, ensuring that the projection system works correctly with the renamed property.