### PR TITLE
docs: improve naming of consts in usePermissions example

### DIFF
--- a/packages/react/src/hooks/document/usePermissions.ts
+++ b/packages/react/src/hooks/document/usePermissions.ts
@@ -25,21 +25,21 @@ import {useSanityInstance} from '../context/useSanityInstance'
  * import {publishDocument} from '@sanity/sdk'
  *
  * export function PublishButton({doc}: {doc: DocumentHandle}) {
- *   const canPublish = usePermissions(publishDocument(doc))
+ *   const publishPermissions = usePermissions(publishDocument(doc))
  *   const applyAction = useApplyActions()
  *
  *   return (
  *     <>
  *       <button
- *         disabled={!canPublish.allowed}
+ *         disabled={!publishPermissions.allowed}
  *         onClick={() => applyAction(publishDocument(doc))}
- *         popoverTarget={`${canPublish.allowed ? undefined : 'publishButtonPopover'}`}
+ *         popoverTarget={`${publishPermissions.allowed ? undefined : 'publishButtonPopover'}`}
  *       >
  *         Publish
  *       </button>
- *       {!canPublish.allowed && (
+ *       {!publishPermissions.allowed && (
  *         <div popover id="publishButtonPopover">
- *           {canPublish.message}
+ *           {publishPermissions.message}
  *         </div>
  *       )}
  *     </>


### PR DESCRIPTION
### Description

Updates the name of the `usePermissions` return value in the example to clarify usage.

### What to review

- Is the new name the best name ever?

### Testing

N/A

### Fun gif

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbnlzaDRldnA4d2pyZWFvcTJ3MWI2bnZlczBnMnl5ZGtubGdudDh2YiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/kHKmt5VrECNNsH1vUI/giphy.gif)
