### PR TITLE
feat(react): expose comlink fetch and use example

### DIFF
--- a/apps/kitchensink-react/src/Comlink/Framed.tsx
+++ b/apps/kitchensink-react/src/Comlink/Framed.tsx
@@ -1,15 +1,18 @@
 import {type ComlinkStatus, useWindowConnection} from '@sanity/sdk-react'
 import {Box, Button, Card, Container, Label, Stack, Text, TextInput} from '@sanity/ui'
-import {type ReactElement, useState} from 'react'
+import {type ReactElement, useEffect, useRef, useState} from 'react'
 
-import {FromIFrameMessage, ToIFrameMessage} from './types'
+import {FromIFrameMessage, ToIFrameMessage, UserData} from './types'
 
 const Framed = (): ReactElement => {
-  const [message, setMessage] = useState('')
   const [status, setStatus] = useState<ComlinkStatus>('idle')
   const [receivedMessages, setReceivedMessages] = useState<string[]>([])
+  const [users, setUsers] = useState<UserData[]>([])
+  const [error, setError] = useState<string | null>(null)
 
-  const {sendMessage} = useWindowConnection<FromIFrameMessage, ToIFrameMessage>({
+  const messageInputRef = useRef<HTMLInputElement>(null)
+
+  const {sendMessage, fetch} = useWindowConnection<FromIFrameMessage, ToIFrameMessage>({
     name: 'frame',
     connectTo: 'main-app',
     onStatus: setStatus,
@@ -20,15 +23,44 @@ const Framed = (): ReactElement => {
     },
   })
 
+  // Fetch all users when connected
+  useEffect(() => {
+    if (!fetch || status !== 'connected') return
+
+    async function fetchUsers(signal: AbortSignal) {
+      try {
+        const data = await fetch<UserData[]>('FETCH_USERS', undefined, {signal})
+        setUsers(data)
+        setError(null)
+      } catch (err) {
+        if (err?.name !== 'AbortError') {
+          setError('Failed to fetch users')
+        }
+      }
+    }
+
+    const controller = new AbortController()
+    fetchUsers(controller.signal)
+
+    return () => {
+      controller.abort()
+    }
+  }, [fetch, status])
+
   const sendMessageToParent = () => {
+    const message = messageInputRef.current?.value || ''
     if (message.trim()) {
       sendMessage('FROM_IFRAME', {message})
-      setMessage('')
+      if (messageInputRef.current) {
+        messageInputRef.current.value = ''
+      }
     }
   }
 
+  const isConnected = status === 'connected'
+
   return (
-    <Container height={'fill'}>
+    <Container height="fill">
       <Card tone="transparent">
         <Stack padding={4} space={4}>
           <Text weight="semibold" size={2}>
@@ -41,20 +73,48 @@ const Framed = (): ReactElement => {
             <Box display="flex">
               <Box flex={1}>
                 <TextInput
-                  value={message}
-                  onChange={(event) => setMessage(event.currentTarget.value)}
+                  ref={messageInputRef}
                   onKeyDown={(e) => e.key === 'Enter' && sendMessageToParent()}
-                  disabled={status !== 'connected'}
+                  disabled={!isConnected}
                 />
               </Box>
               <Button
                 text="Send"
                 tone="primary"
                 onClick={sendMessageToParent}
-                disabled={status !== 'connected'}
+                disabled={!isConnected}
               />
             </Box>
           </Stack>
+
+          {/* Users section */}
+          <Card padding={3} border radius={2}>
+            <Stack space={3}>
+              <Label>Users</Label>
+              {users.length > 0 ? (
+                <Stack space={2}>
+                  {users.map((user) => (
+                    <Card key={user.id} padding={3} tone="positive" radius={2}>
+                      <Stack space={2}>
+                        <Text size={1} weight="semibold">
+                          {user.name}
+                        </Text>
+                        <Text size={1}>{user.email}</Text>
+                      </Stack>
+                    </Card>
+                  ))}
+                </Stack>
+              ) : error ? (
+                <Card padding={3} tone="critical" radius={2}>
+                  <Text size={1}>{error}</Text>
+                </Card>
+              ) : (
+                <Card padding={3} tone="default" radius={2}>
+                  <Text size={1}>Loading users...</Text>
+                </Card>
+              )}
+            </Stack>
+          </Card>
 
           {/* Received messages */}
           <Box flex={1} style={{height: '500px'}}>

--- a/apps/kitchensink-react/src/Comlink/types.ts
+++ b/apps/kitchensink-react/src/Comlink/types.ts
@@ -1,9 +1,19 @@
-export type ToIFrameMessage = {
+export interface UserData {
+  id: string
+  name: string
+  email: string
+}
+
+export interface ToIFrameMessage {
   type: 'TO_IFRAME'
   data: {message: string}
 }
 
-export type FromIFrameMessage = {
+export interface FromIFrameMessage {
   type: 'FROM_IFRAME'
   data: {message: string}
+}
+
+export interface FetchUsersRequest {
+  type: 'FETCH_USERS'
 }


### PR DESCRIPTION
### Description
This PR exposes the `fetch` function of a Comlink node. I had originally somewhat misunderstood what fetch was for -- rather than being an on-demand fetch (as you would HTTP calls) it seems to be more closely tied to the Node and React mount lifecycles to fill stores. If you are reviewing, examples like these: 

https://github.com/sanity-io/visual-editing/blob/b9591ffcc64d2243aa9bb2644835adef009a19e6/packages/visual-editing/src/ui/usePerspectiveSync.tsx
https://github.com/sanity-io/visual-editing/blob/b9591ffcc64d2243aa9bb2644835adef009a19e6/packages/visual-editing/src/ui/useDatasetMutator.ts

may be helpful.

(There are more complicated implementations, like this: 
https://github.com/sanity-io/visual-editing/blob/b9591ffcc64d2243aa9bb2644835adef009a19e6/packages/core-loader/src/live-mode/enableLiveMode.ts#L101
but I don't think this is required at this moment)

I've added such an example to the kitchen sink, which looks like the attached:
![Screenshot 2025-03-20 at 9 48 25 AM](https://github.com/user-attachments/assets/a528818b-95b4-47e6-b600-b69f7273fadc)


### What to review
The new exposed fetch function. 

### Testing
No tests were added since this is really a Comlink responsibilty.