### PR TITLE
feat(react): create workspaces hook

### DIFF
--- a/apps/kitchensink-react/src/AppRoutes.tsx
+++ b/apps/kitchensink-react/src/AppRoutes.tsx
@@ -17,6 +17,7 @@ import {ProjectAuthHome} from './ProjectAuthentication/ProjectAuthHome'
 import {ProjectInstanceWrapper} from './ProjectAuthentication/ProjectInstanceWrapper'
 import {ProtectedRoute} from './ProtectedRoute'
 import {DashboardContextRoute} from './routes/DashboardContextRoute'
+import {DashboardWorkspacesRoute} from './routes/DashboardWorkspacesRoute'
 import {UsersRoute} from './routes/UsersRoute'
 import {UnauthenticatedHome} from './Unauthenticated/UnauthenticatedHome'
 import {UnauthenticatedInstanceWrapper} from './Unauthenticated/UnauthenticatedInstanceWrapper'
@@ -60,6 +61,13 @@ const documentCollectionRoutes = [
   },
 ]
 
+const dashboardInteractionRoutes = [
+  {
+    path: 'workspaces',
+    element: <DashboardWorkspacesRoute />,
+  },
+]
+
 const frameRoutes = [1, 2, 3].map((frameNum) => ({
   path: `frame${frameNum}`,
   element: <Framed />,
@@ -71,7 +79,14 @@ export function AppRoutes(): JSX.Element {
       <Route path="/" element={<Home />} />
 
       <Route path="/authenticated" element={<ProjectInstanceWrapper />}>
-        <Route index element={<ProjectAuthHome routes={documentCollectionRoutes} />} />
+        <Route
+          index
+          element={
+            <ProjectAuthHome
+              routes={[...documentCollectionRoutes, ...dashboardInteractionRoutes]}
+            />
+          }
+        />
         <Route element={<ProtectedRoute subPath="/authenticated" />}>
           {documentCollectionRoutes.map((route) => (
             <Route key={route.path} path={route.path} element={route.element} />
@@ -87,8 +102,18 @@ export function AppRoutes(): JSX.Element {
       </Route>
 
       <Route path="/unauthenticated" element={<UnauthenticatedInstanceWrapper />}>
-        <Route index element={<UnauthenticatedHome routes={documentCollectionRoutes} />} />
+        <Route
+          index
+          element={
+            <UnauthenticatedHome
+              routes={[...documentCollectionRoutes, ...dashboardInteractionRoutes]}
+            />
+          }
+        />
         {documentCollectionRoutes.map((route) => (
+          <Route key={route.path} path={route.path} element={route.element} />
+        ))}
+        {dashboardInteractionRoutes.map((route) => (
           <Route key={route.path} path={route.path} element={route.element} />
         ))}
       </Route>

--- a/apps/kitchensink-react/src/routes/DashboardWorkspacesRoute.tsx
+++ b/apps/kitchensink-react/src/routes/DashboardWorkspacesRoute.tsx
@@ -1,0 +1,36 @@
+import {useStudioWorkspacesByResourceId} from '@sanity/sdk-react'
+import {Card, Code, Container, Flex, Heading, Stack, Text} from '@sanity/ui'
+import {type ReactElement} from 'react'
+
+export function DashboardWorkspacesRoute(): ReactElement {
+  const {workspacesByResourceId, error, isConnected} = useStudioWorkspacesByResourceId()
+
+  return (
+    <Container width={2}>
+      <Stack space={4} paddingY={4}>
+        <Heading>Studio Workspaces By Resource ID</Heading>
+
+        <Card padding={4} radius={2} shadow={1}>
+          <Stack space={4}>
+            <Flex direction="column" gap={2}>
+              <Text weight="semibold">Connection Status:</Text>
+              <Text>{isConnected ? 'Connected' : 'Not Connected'}</Text>
+            </Flex>
+
+            {error && (
+              <Flex direction="column" gap={2}>
+                <Text weight="semibold">Error:</Text>
+                <Text>{error}</Text>
+              </Flex>
+            )}
+
+            <Flex direction="column" gap={2}>
+              <Text weight="semibold">Workspaces by Resource ID:</Text>
+              <Code language="json">{JSON.stringify(workspacesByResourceId, null, 2)}</Code>
+            </Flex>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}

--- a/packages/react/src/_exports/index.ts
+++ b/packages/react/src/_exports/index.ts
@@ -26,6 +26,7 @@ export {
   type WindowMessageHandler,
 } from '../hooks/comlink/useWindowConnection'
 export {useSanityInstance} from '../hooks/context/useSanityInstance'
+export {useStudioWorkspacesByResourceId} from '../hooks/dashboard/useStudioWorkspacesByResourceId'
 export {useDatasets} from '../hooks/datasets/useDatasets'
 export {useApplyActions} from '../hooks/document/useApplyActions'
 export {useDocument} from '../hooks/document/useDocument'

--- a/packages/react/src/hooks/dashboard/useStudioWorkspacesByResourceId.test.tsx
+++ b/packages/react/src/hooks/dashboard/useStudioWorkspacesByResourceId.test.tsx
@@ -1,0 +1,274 @@
+import {type Message, type Status} from '@sanity/comlink'
+import {renderHook, waitFor} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {useWindowConnection, type WindowConnection} from '../comlink/useWindowConnection'
+import {useStudioWorkspacesByResourceId} from './useStudioWorkspacesByResourceId'
+
+vi.mock('../comlink/useWindowConnection', () => ({
+  useWindowConnection: vi.fn(),
+}))
+
+const mockWorkspaceData = {
+  context: {
+    availableResources: [
+      {
+        projectId: 'project1',
+        workspaces: [
+          {
+            name: 'workspace1',
+            title: 'Workspace 1',
+            basePath: '/workspace1',
+            dataset: 'dataset1',
+            userApplicationId: 'user1',
+            url: 'https://test.sanity.studio',
+            _ref: 'user1-workspace1',
+          },
+          {
+            name: 'workspace2',
+            title: 'Workspace 2',
+            basePath: '/workspace2',
+            dataset: 'dataset1',
+            userApplicationId: 'user1',
+            url: 'https://test.sanity.studio',
+            _ref: 'user1-workspace2',
+          },
+        ],
+      },
+      {
+        projectId: 'project2',
+        workspaces: [
+          {
+            name: 'workspace3',
+            title: 'Workspace 3',
+            basePath: '/workspace3',
+            dataset: 'dataset2',
+            userApplicationId: 'user2',
+            url: 'https://test.sanity.studio',
+            _ref: 'user2-workspace3',
+          },
+        ],
+      },
+      {
+        // Project without workspaces
+        projectId: 'project3',
+        workspaces: [],
+      },
+    ],
+  },
+}
+
+describe('useStudioWorkspacesByResourceId', () => {
+  it('should return empty workspaces and connected=false when not connected', async () => {
+    // Create a mock that captures the onStatus callback
+    let capturedOnStatus: ((status: Status) => void) | undefined
+
+    vi.mocked(useWindowConnection).mockImplementation(({onStatus}) => {
+      capturedOnStatus = onStatus
+
+      return {
+        fetch: undefined,
+        sendMessage: vi.fn(),
+      } as unknown as WindowConnection<Message>
+    })
+
+    const {result} = renderHook(() => useStudioWorkspacesByResourceId())
+
+    // Call onStatus with 'idle' to simulate not connected
+    if (capturedOnStatus) capturedOnStatus('idle')
+
+    expect(result.current).toEqual({
+      workspacesByResourceId: {},
+      error: null,
+      isConnected: false,
+    })
+  })
+
+  it('should process workspaces into lookup by projectId:dataset', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(mockWorkspaceData)
+    let capturedOnStatus: ((status: Status) => void) | undefined
+
+    vi.mocked(useWindowConnection).mockImplementation(({onStatus}) => {
+      capturedOnStatus = onStatus
+
+      return {
+        fetch: mockFetch,
+        sendMessage: vi.fn(),
+      } as unknown as WindowConnection<Message>
+    })
+
+    const {result} = renderHook(() => useStudioWorkspacesByResourceId())
+
+    // Call onStatus with 'connected' to simulate connected state
+    if (capturedOnStatus) capturedOnStatus('connected')
+
+    await waitFor(() => {
+      expect(result.current.workspacesByResourceId).toEqual({
+        'project1:dataset1': [
+          {
+            name: 'workspace1',
+            title: 'Workspace 1',
+            basePath: '/workspace1',
+            dataset: 'dataset1',
+            userApplicationId: 'user1',
+            url: 'https://test.sanity.studio',
+            _ref: 'user1-workspace1',
+          },
+          {
+            name: 'workspace2',
+            title: 'Workspace 2',
+            basePath: '/workspace2',
+            dataset: 'dataset1',
+            userApplicationId: 'user1',
+            url: 'https://test.sanity.studio',
+            _ref: 'user1-workspace2',
+          },
+        ],
+        'project2:dataset2': [
+          {
+            name: 'workspace3',
+            title: 'Workspace 3',
+            basePath: '/workspace3',
+            dataset: 'dataset2',
+            userApplicationId: 'user2',
+            url: 'https://test.sanity.studio',
+            _ref: 'user2-workspace3',
+          },
+        ],
+      })
+      expect(result.current.error).toBeNull()
+      expect(result.current.isConnected).toBe(true)
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith('core/v1/bridge/context', undefined, expect.any(Object))
+  })
+
+  it('should handle fetch errors', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Failed to fetch'))
+    let capturedOnStatus: ((status: Status) => void) | undefined
+
+    vi.mocked(useWindowConnection).mockImplementation(({onStatus}) => {
+      capturedOnStatus = onStatus
+
+      return {
+        fetch: mockFetch,
+        sendMessage: vi.fn(),
+      } as unknown as WindowConnection<Message>
+    })
+
+    const {result} = renderHook(() => useStudioWorkspacesByResourceId())
+
+    // Call onStatus with 'connected' to simulate connected state
+    if (capturedOnStatus) capturedOnStatus('connected')
+
+    await waitFor(() => {
+      expect(result.current.workspacesByResourceId).toEqual({})
+      expect(result.current.error).toBe('Failed to fetch workspaces')
+      expect(result.current.isConnected).toBe(true)
+    })
+  })
+
+  it('should handle AbortError silently', async () => {
+    const abortError = new Error('Aborted')
+    abortError.name = 'AbortError'
+    const mockFetch = vi.fn().mockRejectedValue(abortError)
+    let capturedOnStatus: ((status: Status) => void) | undefined
+
+    vi.mocked(useWindowConnection).mockImplementation(({onStatus}) => {
+      capturedOnStatus = onStatus
+
+      return {
+        fetch: mockFetch,
+        sendMessage: vi.fn(),
+      } as unknown as WindowConnection<Message>
+    })
+
+    const {result} = renderHook(() => useStudioWorkspacesByResourceId())
+
+    // Call onStatus with 'connected' to simulate connected state
+    if (capturedOnStatus) capturedOnStatus('connected')
+
+    await waitFor(() => {
+      expect(result.current.workspacesByResourceId).toEqual({})
+      expect(result.current.error).toBeNull()
+      expect(result.current.isConnected).toBe(true)
+    })
+  })
+
+  it('should handle projects without workspaces', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      context: {
+        availableResources: [
+          {
+            projectId: 'project1',
+            workspaces: [],
+          },
+        ],
+      },
+    })
+    let capturedOnStatus: ((status: Status) => void) | undefined
+
+    vi.mocked(useWindowConnection).mockImplementation(({onStatus}) => {
+      capturedOnStatus = onStatus
+
+      return {
+        fetch: mockFetch,
+        sendMessage: vi.fn(),
+      } as unknown as WindowConnection<Message>
+    })
+
+    const {result} = renderHook(() => useStudioWorkspacesByResourceId())
+
+    // Call onStatus with 'connected' to simulate connected state
+    if (capturedOnStatus) capturedOnStatus('connected')
+
+    await waitFor(() => {
+      expect(result.current.workspacesByResourceId).toEqual({})
+      expect(result.current.error).toBeNull()
+      expect(result.current.isConnected).toBe(true)
+    })
+  })
+
+  it('should handle projects without projectId', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      context: {
+        availableResources: [
+          {
+            workspaces: [
+              {
+                name: 'workspace1',
+                title: 'Workspace 1',
+                basePath: '/workspace1',
+                dataset: 'dataset1',
+                userApplicationId: 'user1',
+                url: 'https://test.sanity.studio',
+                _ref: 'user1-workspace1',
+              },
+            ],
+          },
+        ],
+      },
+    })
+    let capturedOnStatus: ((status: Status) => void) | undefined
+
+    vi.mocked(useWindowConnection).mockImplementation(({onStatus}) => {
+      capturedOnStatus = onStatus
+
+      return {
+        fetch: mockFetch,
+        sendMessage: vi.fn(),
+      } as unknown as WindowConnection<Message>
+    })
+
+    const {result} = renderHook(() => useStudioWorkspacesByResourceId())
+
+    // Call onStatus with 'connected' to simulate connected state
+    if (capturedOnStatus) capturedOnStatus('connected')
+
+    await waitFor(() => {
+      expect(result.current.workspacesByResourceId).toEqual({})
+      expect(result.current.error).toBeNull()
+      expect(result.current.isConnected).toBe(true)
+    })
+  })
+})

--- a/packages/react/src/hooks/dashboard/useStudioWorkspacesByResourceId.ts
+++ b/packages/react/src/hooks/dashboard/useStudioWorkspacesByResourceId.ts
@@ -1,0 +1,91 @@
+import {type Status} from '@sanity/comlink'
+import {useEffect, useState} from 'react'
+
+import {useWindowConnection} from '../comlink/useWindowConnection'
+
+interface Workspace {
+  name: string
+  title: string
+  basePath: string
+  dataset: string
+  userApplicationId: string
+  url: string
+  _ref: string
+}
+
+interface WorkspacesByResourceId {
+  [key: string]: Workspace[] // key format: `${projectId}:${dataset}`
+}
+
+interface StudioWorkspacesResult {
+  workspacesByResourceId: WorkspacesByResourceId
+  error: string | null
+  isConnected: boolean
+}
+
+/**
+ * Hook that fetches studio workspaces and organizes them by projectId:dataset
+ * @internal
+ */
+export function useStudioWorkspacesByResourceId(): StudioWorkspacesResult {
+  const [workspacesByResourceId, setWorkspacesByResourceId] = useState<WorkspacesByResourceId>({})
+  const [status, setStatus] = useState<Status>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const {fetch} = useWindowConnection({
+    name: 'core/nodes/sdk',
+    connectTo: 'core/channels/sdk',
+    onStatus: setStatus,
+  })
+
+  // Once computed, this should probably be in a store and poll for changes
+  // However, our stores are currently being refactored
+  useEffect(() => {
+    if (!fetch || status !== 'connected') return
+
+    async function fetchWorkspaces(signal: AbortSignal) {
+      try {
+        const data = await fetch<{
+          context: {availableResources: Array<{projectId: string; workspaces: Workspace[]}>}
+        }>('core/v1/bridge/context', undefined, {signal})
+
+        const workspaceMap: WorkspacesByResourceId = {}
+
+        data.context.availableResources.forEach((resource) => {
+          if (!resource.projectId || !resource.workspaces?.length) return
+
+          resource.workspaces.forEach((workspace) => {
+            const key = `${resource.projectId}:${workspace.dataset}`
+            if (!workspaceMap[key]) {
+              workspaceMap[key] = []
+            }
+            workspaceMap[key].push(workspace)
+          })
+        })
+
+        setWorkspacesByResourceId(workspaceMap)
+        setError(null)
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          if (err.name === 'AbortError') {
+            return
+          }
+          setError('Failed to fetch workspaces')
+        }
+      }
+    }
+
+    const controller = new AbortController()
+    fetchWorkspaces(controller.signal)
+
+    return () => {
+      controller.abort()
+    }
+  }, [fetch, status])
+
+  return {
+    workspacesByResourceId,
+    error,
+    isConnected: status === 'connected',
+  }
+}


### PR DESCRIPTION
### Description
This PR creates a hook that retrieves context from Comlink and creates a lookup of workspaces by projectId and dataset that is fetched from Dashboard. This is still a draft, but this will probably turn into a store we can keep updated (using the same functionality as `useProjects` or `useDatasets`) but I'll check the feasability on that. 

### What to review
It's a pretty simple piece of logic on top of Comlink fetch but see if there are any gotchas. There's a route inside the Kitchensink to display the workspaces but you have to run it inside Dashboard. Here's a screenshot:

![Screenshot 2025-03-20 at 11 44 02 AM](https://github.com/user-attachments/assets/ca4cff21-35b7-4b58-b4d4-fcc9393b9644)


### Testing
Tests were indeed added.

### Fun gif
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHljN2xnejQ0enc0b295OWo4czhiOHg4bngxejZ6Z2k2ZHg0eHpzdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/6UVQNGEMsetC8/giphy.gif)