### PR TITLE
fix: update the react README to use the updated app template

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -26,7 +26,7 @@ Here's how to implement your Sanity application:
 1. Create a new React TypeScript project using the Sanity template
 
 ```bash
-pnpx sanity@latest init --template core-app
+pnpx sanity@latest init --template app-quickstart
 cd my-content-os-app
 ```
 


### PR DESCRIPTION
### Description

Updated the Sanity initialization command in the React README to use the `app-quickstart` template instead of `core-app`. This change ensures users follow the current recommended setup process for Sanity applications.

### What to review

Check that the template name change from `core-app` to `app-quickstart` is correct and aligns with the current Sanity CLI capabilities.

### Testing

Verified that the `app-quickstart` template is available and works correctly with the `sanity@latest init` command.

### Fun gif

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2xqamtjaXJ5MmlkOXh2dGt2enFyMW11MDk1MWt3YXJnOW9hYXI1ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tCWO3BsgjED9F2vJiq/200.gif)