### PR TITLE
chore(docs): show the react-sdk documentation above the core sdk docu…

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -12,7 +12,11 @@
    * Source files to include in documentation generation
    * Includes core SDK exports and React hooks/context
    */
-  "entryPoints": ["packages/*"],
+  "entryPoints": [
+    "packages/react",
+    "packages/core",
+    "packages/!(react|core|react-internal|@repo)/*"
+  ],
   "entryPointStrategy": "packages",
   "alwaysCreateEntryPointModule": false,
   "exclude": ["packages/react-internal"],
@@ -21,5 +25,6 @@
     "includeCategories": true,
     "includeFolders": false
   },
-  "categorizeByGroup": false
+  "categorizeByGroup": false,
+  "sortEntryPoints": false
 }


### PR DESCRIPTION
### Description

This PR updates the TypeDoc configuration to add the `sortEntryPoints: false` option to maintain the original order of entry points so that `sdk-react` is shown first

Before:
![CleanShot 2025-03-21 at 12 00 07@2x](https://github.com/user-attachments/assets/22cccbdd-a553-44e0-af75-75ce69eb5000)


After:
![CleanShot 2025-03-21 at 11 58 52@2x](https://github.com/user-attachments/assets/fd556373-b8f1-4f72-8ebd-d999033ba26d)


### What to review

- Check if the new entry points configuration correctly includes all necessary packages
- Verify that the `react-internal` package is properly excluded
- Ensure that the `sortEntryPoints: false` option works as expected

### Testing

Tested by generating documentation locally and verifying that all expected packages are included while excluded packages are properly omitted.

### Fun gif

![first](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExMHgzczF0amloY3N4b21pdnllajkxbzlrbnhvcnAwM3JiMm90MDlpbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BuklSlyF6MWLNIpaTo/giphy.gif)