### PR TITLE
feat(docs): add a migration guide

### DIFF
--- a/packages/react/guides/MIGRATION.md
+++ b/packages/react/guides/MIGRATION.md
@@ -1,0 +1,8 @@
+# Migration guide
+
+## Migrating to @sanity/sdk-react@0.0.0-rc.1
+
+### `results` -> `data`
+
+- rename `results` to `data` for `useProjection` hook
+- rename `result` to `data` for `usePreview` hook


### PR DESCRIPTION
### Description

Added a migration guide for `@sanity/sdk-react@0.0.0-rc.1` that documents breaking changes in the React SDK. Placing it in the `guides` folder will make it show up in the docs.

https://sdk-docs-git-rb-add-migration-guide.sanity.dev/documents/sdk-react.MIGRATION.html

![CleanShot 2025-03-21 at 14 40 04@2x](https://github.com/user-attachments/assets/a3800adb-c42b-4bd4-bf7f-ad20d661342d)


### What to review

- Verify that the migration instructions are clear and accurate
- Check that all breaking changes between versions are properly documented
- Ensure the file is placed in the correct location within the package structure

### Testing

Manual verification of the migration steps was performed to ensure accuracy.

### Fun gif

![Migration journey](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExamM4Z2N1ODF4ZW0yNXdvbGp4bGpuazBxOWdnbjg4OW41dXV4cjJhOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/775UhhzsSkZd8d81jp/giphy.gif)