### PR TITLE
fix: ensure usePreview and useProjection hooks subscribe if no ref is…

### DIFF
--- a/packages/react/src/hooks/preview/usePreview.test.tsx
+++ b/packages/react/src/hooks/preview/usePreview.test.tsx
@@ -172,4 +172,63 @@ describe('usePreview', () => {
     // Restore IntersectionObserver
     window.IntersectionObserver = originalIntersectionObserver
   })
+
+  test('it subscribes immediately when no ref is provided', async () => {
+    getCurrent.mockReturnValue({
+      data: {title: 'Title', subtitle: 'Subtitle'},
+      isPending: false,
+    })
+    const eventsUnsubscribe = vi.fn()
+    subscribe.mockImplementation(() => eventsUnsubscribe)
+
+    function NoRefComponent(docHandle: DocumentHandle) {
+      const {data} = usePreview(docHandle) // No ref provided
+      return (
+        <div>
+          <h1>{data?.title}</h1>
+          <p>{data?.subtitle}</p>
+        </div>
+      )
+    }
+
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <NoRefComponent {...mockDocument} />
+      </Suspense>,
+    )
+
+    // Should subscribe immediately without waiting for intersection
+    expect(subscribe).toHaveBeenCalled()
+    expect(screen.getByText('Title')).toBeInTheDocument()
+  })
+
+  test('it subscribes immediately when ref.current is not an HTML element', async () => {
+    getCurrent.mockReturnValue({
+      data: {title: 'Title', subtitle: 'Subtitle'},
+      isPending: false,
+    })
+    const eventsUnsubscribe = vi.fn()
+    subscribe.mockImplementation(() => eventsUnsubscribe)
+
+    function NonHtmlRefComponent(docHandle: DocumentHandle) {
+      const ref = useRef({}) // ref.current is not an HTML element
+      const {data} = usePreview({...docHandle, ref})
+      return (
+        <div>
+          <h1>{data?.title}</h1>
+          <p>{data?.subtitle}</p>
+        </div>
+      )
+    }
+
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <NonHtmlRefComponent {...mockDocument} />
+      </Suspense>,
+    )
+
+    // Should subscribe immediately without waiting for intersection
+    expect(subscribe).toHaveBeenCalled()
+    expect(screen.getByText('Title')).toBeInTheDocument()
+  })
 })

--- a/packages/react/src/hooks/preview/usePreview.tsx
+++ b/packages/react/src/hooks/preview/usePreview.tsx
@@ -79,8 +79,10 @@ export function usePreview({ref, ...docHandle}: UsePreviewOptions): UsePreviewRe
   const subscribe = useCallback(
     (onStoreChanged: () => void) => {
       const subscription = new Observable<boolean>((observer) => {
-        // for environments that don't have an intersection observer
+        // For environments that don't have an intersection observer (e.g. server-side),
+        // we pass true to always subscribe since we can't detect visibility
         if (typeof IntersectionObserver === 'undefined' || typeof HTMLElement === 'undefined') {
+          observer.next(true)
           return
         }
 
@@ -90,6 +92,10 @@ export function usePreview({ref, ...docHandle}: UsePreviewOptions): UsePreviewRe
         )
         if (ref?.current && ref.current instanceof HTMLElement) {
           intersectionObserver.observe(ref.current)
+        } else {
+          // If no ref is provided or ref.current isn't an HTML element,
+          // pass true to always subscribe since we can't track visibility
+          observer.next(true)
         }
         return () => intersectionObserver.disconnect()
       })

--- a/packages/react/src/hooks/projection/useProjection.ts
+++ b/packages/react/src/hooks/projection/useProjection.ts
@@ -102,8 +102,10 @@ export function useProjection<TData extends object>({
   const subscribe = useCallback(
     (onStoreChanged: () => void) => {
       const subscription = new Observable<boolean>((observer) => {
-        // for environments that don't have an intersection observer
+        // For environments that don't have an intersection observer (e.g. server-side),
+        // we pass true to always subscribe since we can't detect visibility
         if (typeof IntersectionObserver === 'undefined' || typeof HTMLElement === 'undefined') {
+          observer.next(true)
           return
         }
 
@@ -113,6 +115,10 @@ export function useProjection<TData extends object>({
         )
         if (ref?.current && ref.current instanceof HTMLElement) {
           intersectionObserver.observe(ref.current)
+        } else {
+          // If no ref is provided or ref.current isn't an HTML element,
+          // pass true to always subscribe since we can't track visibility
+          observer.next(true)
         }
         return () => intersectionObserver.disconnect()
       })


### PR DESCRIPTION
### Description

This PR enhances the subscription behavior in `usePreview` and `useProjection` hooks to handle cases where:

1. No ref is provided
2. The ref.current is not an HTML element
3. The environment lacks IntersectionObserver support

These changes ensure immediate subscription in scenarios where visibility tracking is not possible or not needed, improving the hooks' reliability across different environments and use cases.

### What to review

Please review:

1. The updated subscription logic in both `usePreview.tsx` and `useProjection.ts`
2. The new test cases that verify the immediate subscription behavior
3. The consistent implementation between both hooks
4. The comments explaining the different subscription scenarios

Key files affected:

- `packages/react/src/hooks/preview/usePreview.tsx`
- `packages/react/src/hooks/preview/usePreview.test.tsx`
- `packages/react/src/hooks/projection/useProjection.ts`
- `packages/react/src/hooks/projection/useProjection.test.tsx`

### Testing

✅ Added comprehensive test coverage including:

- Test for immediate subscription when no ref is provided
- Test for immediate subscription when ref.current is not an HTML element
- Existing tests continue to pass, ensuring backward compatibility

### Fun gif

![Smart cat typing](https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif)
