### PR TITLE
chore: remove private npm token

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,12 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>sanity-io/renovate-config", ":dependencyDashboardApproval"],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
-  "hostRules": [
-    {
-      "matchHost": "registry.npmjs.org",
-      "token": "{{ secrets.SANITY_NPM_TOKEN }}"
-    }
-  ],
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Configure npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMRC }}" > ~/.npmrc
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -43,9 +43,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Configure npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMRC }}" > ~/.npmrc
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,9 +43,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Configure npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMRC }}" > ~/.npmrc
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,8 +46,6 @@ jobs:
         with:
           cache: pnpm
           node-version: lts/*
-      - name: Configure npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMRC }}" > ~/.npmrc
       - name: install deps & build
         run: pnpm install --ignore-scripts && pnpm build --filter=!./apps/*
         if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Configure npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMRC }}" > ~/.npmrc
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
### Description

SDK is public and we should not be installing any private packages as it could break for users. Removing the token ensures that we do not do that catching it earlier 

### What to review

- Verify that all GitHub workflow files no longer reference npm authentication
- Check that the Renovate configuration no longer includes host rules for npm registry
- Ensure that the removal of authentication doesn't break any build, test, or deployment processes

### Testing

All CI passes

### Fun gif

![Dim Sum Dreaming GIF](https://media3.giphy.com/media/wAS9Nr0CyP5nNn4QAi/giphy.gif)