### PR TITLE
chore: fix double deps

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,7 +74,6 @@
     "@sanity/browserslist-config": "^1.0.5",
     "@sanity/pkg-utils": "^6.13.4",
     "@sanity/prettier-config": "^1.0.3",
-    "@sanity/types": "^3.79.0",
     "@vitest/coverage-v8": "3.0.9",
     "eslint": "^9.22.0",
     "groq-js": "^1.16.1",


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

`@sanity/types` was used both in dependencies and dev, there is on place where it not only used for types so removing it from dev