### PR TITLE
chore: enable automatic renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>sanity-io/renovate-config", ":dependencyDashboardApproval"],
+  "extends": ["local>sanity-io/renovate-config"],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
+  "schedule": ["before 5am"],
+  "prConcurrentLimit": 3,
+  "automerge": true,
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
### Description

Updated Renovate configuration to:
- Remove `:dependencyDashboardApproval` from extends
- Add schedule to run before 5am
- Limit concurrent PRs to 3
- Enable automerge for dependencies

These changes will streamline our dependency management process by allowing Renovate to automatically merge updates and run on a predictable schedule.

### What to review

- Verify the removal of dependency dashboard approval is intentional
- Check if the "before 5am" schedule is appropriate for the team
- Confirm that the PR concurrent limit of 3 is sufficient
- Ensure automerge is desired for all dependencies

### Testing

This configuration change will be tested automatically when Renovate runs next. The bot will follow these new rules, and we can monitor its behavior to ensure it's working as expected.

### Fun gif

![Robot working](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZWJtZnRqZGJtZnRqZGJtZnRqZGJtZnRqZGJtZnRqZGJtZnRqZGJtZg/zXmbOaTpbY6mA/giphy.gif)