### PR TITLE
fix(react): allow sdk-react to work in react 18

### DIFF
--- a/apps/kitchensink-react/package.json
+++ b/apps/kitchensink-react/package.json
@@ -20,8 +20,9 @@
     "@sanity/ui": "^2.15.12",
     "inter-ui": "^4.1.0",
     "json-edit-react": "^1.25.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "^18.3.1",
+    "react-compiler-runtime": "19.0.0-beta-ebf51a3-20250411",
+    "react-dom": "^18.3.1",
     "react-error-boundary": "^5.0.0",
     "react-router": "^7.4.1"
   },

--- a/apps/kitchensink-react/vite.config.ts
+++ b/apps/kitchensink-react/vite.config.ts
@@ -3,7 +3,9 @@ import {resolve} from 'node:path'
 import react from '@vitejs/plugin-react'
 import {defineConfig} from 'vite'
 
-const ReactCompilerConfig = {}
+const ReactCompilerConfig = {
+  target: '18',
+}
 
 export default defineConfig({
   server: {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -26,7 +26,12 @@ const baseConfig = {
       typescript: {
         config: 'tsconfig.json',
       },
-      ignoreDependencies: ['@repo/tsconfig', '@testing-library/jest-dom', '@testing-library/react'],
+      ignoreDependencies: [
+        '@repo/tsconfig',
+        '@testing-library/jest-dom',
+        '@testing-library/react',
+        'react-compiler-runtime',
+      ],
       project,
     },
     'apps/*': {
@@ -42,6 +47,14 @@ const baseConfig = {
       project,
       entry: ['package.bundle.ts'],
       ignoreDependencies: ['@sanity/browserslist-config'],
+    },
+    'packages/react': {
+      typescript: {
+        config: 'tsconfig.settings.json',
+      },
+      project,
+      entry: ['package.bundle.ts'],
+      ignoreDependencies: ['@sanity/browserslist-config', 'react-compiler-runtime'],
     },
   },
 } satisfies KnipConfig

--- a/packages/react/package.config.ts
+++ b/packages/react/package.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     reactCompiler: true,
   },
   reactCompilerOptions: {
-    target: '19',
+    target: '18',
   },
   rollup: {
     plugins: [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,6 +62,7 @@
     "@sanity/types": "^3.83.0",
     "@types/lodash-es": "^4.17.12",
     "lodash-es": "^4.17.21",
+    "react-compiler-runtime": "19.0.0-beta-ebf51a3-20250411",
     "react-error-boundary": "^5.0.0",
     "rxjs": "^7.8.2"
   },
@@ -82,7 +83,7 @@
     "@types/react-dom": "^19.1.1",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "3.1.1",
-    "babel-plugin-react-compiler": "19.0.0-beta-e993439-20250328",
+    "babel-plugin-react-compiler": "19.0.0-beta-ebf51a3-20250411",
     "eslint": "^9.22.0",
     "jsdom": "^25.0.1",
     "prettier": "^3.5.3",

--- a/packages/react/src/context/ResourceProvider.tsx
+++ b/packages/react/src/context/ResourceProvider.tsx
@@ -1,5 +1,5 @@
 import {createSanityInstance, type SanityConfig, type SanityInstance} from '@sanity/sdk'
-import {Suspense, use, useEffect, useMemo, useRef} from 'react'
+import {Suspense, useContext, useEffect, useMemo, useRef} from 'react'
 
 import {SanityInstanceContext} from './SanityInstanceContext'
 
@@ -72,7 +72,7 @@ export function ResourceProvider({
   fallback,
   ...config
 }: ResourceProviderProps): React.ReactNode {
-  const parent = use(SanityInstanceContext)
+  const parent = useContext(SanityInstanceContext)
   const instance = useMemo(
     () => (parent ? parent.createChild(config) : createSanityInstance(config)),
     [config, parent],

--- a/packages/react/src/hooks/context/useSanityInstance.ts
+++ b/packages/react/src/hooks/context/useSanityInstance.ts
@@ -1,5 +1,5 @@
 import {type SanityConfig, type SanityInstance} from '@sanity/sdk'
-import {use} from 'react'
+import {useContext} from 'react'
 
 import {SanityInstanceContext} from '../../context/SanityInstanceContext'
 
@@ -58,7 +58,7 @@ import {SanityInstanceContext} from '../../context/SanityInstanceContext'
  * @throws Error if no matching instance is found for the provided config
  */
 export const useSanityInstance = (config?: SanityConfig): SanityInstance => {
-  const instance = use(SanityInstanceContext)
+  const instance = useContext(SanityInstanceContext)
 
   if (!instance) {
     throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 1.0.0-rc.2
       '@sanity/icons':
         specifier: ^3.7.0
-        version: 3.7.0(react@19.1.0)
+        version: 3.7.0(react@18.3.1)
       '@sanity/sdk-react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -103,25 +103,28 @@ importers:
         version: 3.83.0(@types/react@19.1.0)
       '@sanity/ui':
         specifier: ^2.15.12
-        version: 2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       inter-ui:
         specifier: ^4.1.0
         version: 4.1.0
       json-edit-react:
         specifier: ^1.25.0
-        version: 1.25.0(react@19.1.0)
+        version: 1.25.0(react@18.3.1)
       react:
-        specifier: ^19.1.0
-        version: 19.1.0
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-compiler-runtime:
+        specifier: 19.0.0-beta-ebf51a3-20250411
+        version: 19.0.0-beta-ebf51a3-20250411(react@18.3.1)
       react-dom:
-        specifier: ^19.1.0
-        version: 19.1.0(react@19.1.0)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       react-error-boundary:
         specifier: ^5.0.0
-        version: 5.0.0(react@19.1.0)
+        version: 5.0.0(react@18.3.1)
       react-router:
         specifier: ^7.4.1
-        version: 7.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 7.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@repo/config-eslint':
         specifier: workspace:*
@@ -137,7 +140,7 @@ importers:
         version: 6.6.3
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: ^19.1.0
         version: 19.1.0
@@ -362,6 +365,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
+      react-compiler-runtime:
+        specifier: 19.0.0-beta-ebf51a3-20250411
+        version: 19.0.0-beta-ebf51a3-20250411(react@19.1.0)
       react-error-boundary:
         specifier: ^5.0.0
         version: 5.0.0(react@19.1.0)
@@ -395,7 +401,7 @@ importers:
         version: 3.0.1
       '@sanity/pkg-utils':
         specifier: ^7.2.2
-        version: 7.2.2(@types/babel__core@7.20.5)(@types/node@22.13.9)(babel-plugin-react-compiler@19.0.0-beta-e993439-20250328)(typescript@5.8.2)
+        version: 7.2.2(@types/babel__core@7.20.5)(@types/node@22.13.9)(babel-plugin-react-compiler@19.0.0-beta-ebf51a3-20250411)(typescript@5.8.2)
       '@sanity/prettier-config':
         specifier: ^1.0.3
         version: 1.0.3(prettier@3.5.3)
@@ -418,8 +424,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(vitest@3.1.1(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.3)(yaml@2.7.0))
       babel-plugin-react-compiler:
-        specifier: 19.0.0-beta-e993439-20250328
-        version: 19.0.0-beta-e993439-20250328
+        specifier: 19.0.0-beta-ebf51a3-20250411
+        version: 19.0.0-beta-ebf51a3-20250411
       eslint:
         specifier: ^9.22.0
         version: 9.23.0(jiti@2.4.2)
@@ -1827,6 +1833,9 @@ packages:
 
   babel-plugin-react-compiler@19.0.0-beta-e993439-20250328:
     resolution: {integrity: sha512-eq0lxXDicCNfhtIhm2L2nW2FyDcPMfuJTQG641ZWMWxEVqwmtUlAkWXC4o5C3vykhWMTsXmiJe7/hxXVUbV8ZA==}
+
+  babel-plugin-react-compiler@19.0.0-beta-ebf51a3-20250411:
+    resolution: {integrity: sha512-q84bNR9JG1crykAlJUt5Ud0/5BUyMFuQww/mrwIQDFBaxsikqBDj3f/FNDsVd2iR26A1HvXKWPEIfgJDv8/V2g==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -3677,6 +3686,16 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental
 
+  react-compiler-runtime@19.0.0-beta-ebf51a3-20250411:
+    resolution: {integrity: sha512-CetwBv7Wny+4Re6TZRPtVbNMx65CvLNDMkMp2KJ/pRmEc6WLPUoSSBuyY0bML9GPWiO/3LcWQ4iDGKitFU0qng==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
@@ -3714,6 +3733,10 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -3865,6 +3888,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -5079,6 +5105,12 @@ snapshots:
       '@floating-ui/core': 1.6.9
       '@floating-ui/utils': 0.2.9
 
+  '@floating-ui/react-dom@2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.6.13
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@floating-ui/react-dom@2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@floating-ui/dom': 1.6.13
@@ -5436,6 +5468,10 @@ snapshots:
       event-source-polyfill: 1.0.31
       eventsource: 2.0.2
 
+  '@sanity/icons@3.7.0(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+
   '@sanity/icons@3.7.0(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -5513,6 +5549,57 @@ snapshots:
       - debug
       - supports-color
 
+  '@sanity/pkg-utils@7.2.2(@types/babel__core@7.20.5)(@types/node@22.13.9)(babel-plugin-react-compiler@19.0.0-beta-ebf51a3-20250411)(typescript@5.8.2)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
+      '@babel/types': 7.27.0
+      '@microsoft/api-extractor': 7.52.2(@types/node@22.13.9)
+      '@microsoft/tsdoc-config': 0.17.1
+      '@optimize-lodash/rollup-plugin': 5.0.2(rollup@4.39.0)
+      '@rollup/plugin-alias': 5.1.1(rollup@4.39.0)
+      '@rollup/plugin-babel': 6.0.4(@babel/core@7.26.10)(@types/babel__core@7.20.5)(rollup@4.39.0)
+      '@rollup/plugin-commonjs': 28.0.3(rollup@4.39.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.39.0)
+      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.39.0)
+      '@rollup/plugin-replace': 6.0.2(rollup@4.39.0)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.39.0)
+      '@sanity/browserslist-config': 1.0.5
+      browserslist: 4.24.4
+      cac: 6.7.14
+      chalk: 4.1.2
+      chokidar: 4.0.3
+      esbuild: 0.25.2
+      esbuild-register: 3.6.0(esbuild@0.25.2)
+      find-config: 1.0.0
+      get-latest-version: 5.1.0
+      git-url-parse: 16.0.1
+      globby: 11.1.0
+      jsonc-parser: 3.3.1
+      mkdirp: 3.0.1
+      outdent: 0.8.0
+      pkg-up: 3.1.0
+      prettier: 3.5.3
+      pretty-bytes: 5.6.0
+      prompts: 2.4.2
+      recast: 0.23.11
+      rimraf: 4.4.1
+      rollup: 4.39.0
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.25.2)(rollup@4.39.0)
+      rxjs: 7.8.2
+      treeify: 1.1.0
+      typescript: 5.8.2
+      uuid: 11.1.0
+      zod: 3.24.2
+      zod-validation-error: 3.4.0(zod@3.24.2)
+    optionalDependencies:
+      babel-plugin-react-compiler: 19.0.0-beta-ebf51a3-20250411
+    transitivePeerDependencies:
+      - '@types/babel__core'
+      - '@types/node'
+      - debug
+      - supports-color
+
   '@sanity/prettier-config@1.0.3(prettier@3.5.3)':
     dependencies:
       prettier: 3.5.3
@@ -5524,6 +5611,24 @@ snapshots:
       '@types/react': 19.1.0
     transitivePeerDependencies:
       - debug
+
+  '@sanity/ui@2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@juggle/resize-observer': 3.4.0
+      '@sanity/color': 3.0.6
+      '@sanity/icons': 3.7.0(react@18.3.1)
+      csstype: 3.1.3
+      framer-motion: 12.6.3(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-compiler-runtime: 19.0.0-beta-e993439-20250405(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-refractor: 2.2.0(react@18.3.1)
+      styled-components: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      use-effect-event: 1.0.2(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
 
   '@sanity/ui@2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
@@ -5586,6 +5691,16 @@ snapshots:
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@testing-library/dom': 10.4.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.1.0
+      '@types/react-dom': 19.1.1(@types/react@19.1.0)
 
   '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -6049,6 +6164,10 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   babel-plugin-react-compiler@19.0.0-beta-e993439-20250328:
+    dependencies:
+      '@babel/types': 7.27.0
+
+  babel-plugin-react-compiler@19.0.0-beta-ebf51a3-20250411:
     dependencies:
       '@babel/types': 7.27.0
 
@@ -6837,6 +6956,16 @@ snapshots:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
+  framer-motion@12.6.3(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      motion-dom: 12.6.3
+      motion-utils: 12.6.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@emotion/is-prop-valid': 1.2.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   framer-motion@12.6.3(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       motion-dom: 12.6.3
@@ -7366,11 +7495,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
-  json-edit-react@1.25.0(react@19.1.0):
+  json-edit-react@1.25.0(react@18.3.1):
     dependencies:
       object-property-assigner: 1.3.5
       object-property-extractor: 1.0.13
-      react: 19.1.0
+      react: 18.3.1
 
   json-parse-even-better-errors@2.3.1: {}
 
@@ -7966,14 +8095,37 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-compiler-runtime@19.0.0-beta-e993439-20250405(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-compiler-runtime@19.0.0-beta-e993439-20250405(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  react-compiler-runtime@19.0.0-beta-ebf51a3-20250411(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  react-compiler-runtime@19.0.0-beta-ebf51a3-20250411(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
 
   react-dom@19.1.0(react@19.1.0):
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-error-boundary@5.0.0(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      react: 18.3.1
 
   react-error-boundary@5.0.0(react@19.1.0):
     dependencies:
@@ -7986,6 +8138,13 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-refractor@2.2.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      refractor: 3.6.0
+      unist-util-filter: 2.0.3
+      unist-util-visit-parents: 3.1.1
+
   react-refractor@2.2.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -7995,15 +8154,19 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-router@7.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-router@7.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@types/cookie': 0.6.0
       cookie: 1.0.2
-      react: 19.1.0
+      react: 18.3.1
       set-cookie-parser: 2.7.1
       turbo-stream: 2.4.0
     optionalDependencies:
-      react-dom: 19.1.0(react@19.1.0)
+      react-dom: 18.3.1(react@18.3.1)
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@19.1.0: {}
 
@@ -8192,6 +8355,10 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.26.0: {}
 
@@ -8414,6 +8581,20 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.1: {}
+
+  styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@emotion/is-prop-valid': 1.2.2
+      '@emotion/unitless': 0.8.1
+      '@types/stylis': 4.2.5
+      css-to-react-native: 3.2.0
+      csstype: 3.1.3
+      postcss: 8.4.38
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      shallowequal: 1.1.0
+      stylis: 4.3.2
+      tslib: 2.6.2
 
   styled-components@6.1.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -8686,6 +8867,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-effect-event@1.0.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   use-effect-event@1.0.2(react@19.1.0):
     dependencies:


### PR DESCRIPTION
### Description

Downgraded React from v19.1.0 to v18.3.1 in the kitchensink-react app and updated the React Compiler target to '18' in both the kitchensink-react app and the React package. Added the react-compiler-runtime dependency to support the React Compiler with React 18.

Also updated the babel-plugin-react-compiler to the latest version (19.0.0-beta-ebf51a3-20250411) and replaced `use` hook calls with `useContext` in the React package to maintain compatibility with React 18.

FIXES SDK-339 
### What to review

- React version downgrade in kitchensink-react app
- React Compiler target configuration changes in vite.config.ts and package.config.ts
- Replacement of `use` hook with `useContext` in React package components
- Addition of react-compiler-runtime dependency
- Updated babel-plugin-react-compiler version

### Testing

Verified that the kitchensink-react app and React package work correctly with React 18 and the React Compiler. All existing tests continue to pass.

### Fun gif

![nightcap GIF by Pop TV](https://media1.giphy.com/media/3o7btXlAWhDqk9W8ne/giphy.gif)