### PR TITLE
fix: prevent max update depth error for projections

### DIFF
--- a/packages/core/src/projection/util.ts
+++ b/packages/core/src/projection/util.ts
@@ -2,6 +2,7 @@ import {type ValidProjection} from './projectionStore'
 
 export const PROJECTION_TAG = 'sdk.projection'
 export const PROJECTION_PERSPECTIVE = 'drafts'
+export const PROJECTION_STATE_CLEAR_DELAY = 1000
 
 export const STABLE_EMPTY_PROJECTION = {
   data: null,


### PR DESCRIPTION
### Description

This PR adds a clear state delay to the projection subscription unsubscribe handler. When the last subscriber is removed, the cleanup of projections is now delayed by PROJECTION_STATE_CLEAR_DELAY (1000ms) rather than happening immediately.

This fixes an issue where components using `useProjection` without a ref in combination with `useNavigateToStudioDocument` were causing a max update depth error from React. The error occurred when components would suspend and their suspending promises would remove subscriptions immediately, which removes the state, leading to it needed to suspend again.

Fixes SDK-314

### What to review

- Look at the implementation of the delay in `getProjectionState.ts` where we wrap the subscription removal in a `setTimeout`
- Review the test changes to confirm proper handling of the delayed cleanup
- Verify the delay time (1000ms) is appropriate - same as DOCUMENT_STATE_CLEAR_DELAY

### Testing

- Unit tests have been updated to use `vi.useFakeTimers()` and verify the behavior before and after the delay
- Tested against the reproduction case in https://github.com/sanity-io/test-sdk-hello-world-useprojection-ref-hook-bug
- To reproduce: take out the ref in useProjection in DocumentContent.tsx of the repro repo to see the error

### Fun gif

![Patience is a virtue](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHY3ejgwbGJncGt4ODlzaWhuNDBub2Y5bDZkNnB4aDhpYXVjaDJkayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0HlBO7eyXzSZkJri/giphy.gif)
