### PR TITLE
chore(release): unify versions and tags for packages

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,20 @@
 {
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
+  "plugins": [
+    {
+      "type": "node-workspace",
+      "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "sdk",
+      "components": ["core", "react", "react-internal"]
+    }
+  ],
   "packages": {
     "packages/react": {
+      "component": "react",
       "release-type": "node",
       "bump-patch-for-minor-pre-major": true,
       "bump-minor-pre-major": true,
@@ -8,6 +22,7 @@
       "versioning": "prerelease"
     },
     "packages/react-internal": {
+      "component": "react-internal",
       "release-type": "node",
       "bump-patch-for-minor-pre-major": true,
       "bump-minor-pre-major": true,
@@ -15,6 +30,7 @@
       "versioning": "prerelease"
     },
     "packages/core": {
+      "component": "core",
       "release-type": "node",
       "bump-patch-for-minor-pre-major": true,
       "bump-minor-pre-major": true,


### PR DESCRIPTION
### Description

Enhanced the release-please configuration to better manage versioning across our SDK packages. Added a JSON schema reference for validation, configured component tagging, and set up plugins for node-workspace and linked-versions to ensure consistent versioning between core, react, and react-internal packages.

### What to review

- The addition of the `$schema` reference for validation
- The `include-component-in-tag` setting (now set to false)
- The new plugins configuration:
  - `node-workspace` plugin with merge set to false
  - `linked-versions` plugin that groups core, react, and react-internal components
- The component identifiers added to each package configuration

### Testing

This configuration change doesn't require automated tests. The changes will be validated when the next release is created using release-please.

### Fun gif

![deploy-now-it-PApUm1HPVYlDNLoMmr](https://media0.giphy.com/media/PApUm1HPVYlDNLoMmr/giphy.gif)