### PR TITLE
chore(build): add circleci build process for bundles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2.1
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              # Jobs will run each commit unless explicitly told to ignore branches
+              ignore: /.*/
+jobs:
+  build:
+    docker:
+      - image: cimg/node:20.19
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore pnpm Package Cache
+          keys:
+            - pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+      - run:
+          name: Install pnpm package manager
+          command: |
+            corepack enable --install-directory ~/bin
+            corepack prepare pnpm@latest-10 --activate
+            pnpm config set store-dir .pnpm-store
+      - run:
+          name: Install Dependencies
+          command: |
+            pnpm install
+      - save_cache:
+          name: Save pnpm Package Cache
+          key: pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
+          paths:
+            - .pnpm-store
+      - run:
+          name: Build bundle
+          command: pnpm run build:bundle
+      # - run:
+      #     name: Copy to bucket
+      #     command: npm run bundle:upload


### PR DESCRIPTION
### Description

Added CircleCI configuration for automated builds. This setup enables CI/CD pipeline that will trigger builds only for tagged releases (v*) and not for regular branch commits. The pipeline uses Node.js 20.19 with pnpm for dependency management and includes caching for faster builds.

### What to review

- CircleCI workflow configuration that only runs on version tags
- Node.js and pnpm setup
- Cache configuration for pnpm packages
- Build process using `pnpm run build:bundle`
- Note that the bucket upload step is currently commented out

### Testing

The configuration can be tested by creating a version tag (v*) and verifying that the CircleCI pipeline runs correctly. The build process should successfully restore the cache, install dependencies, and build the bundle.

### Fun gif

![CI/CD Pipeline](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZWJtZnRqZnRqZGJtZnRqZGJtZnRqZGJtZnRqZGJtZnRqZGJtZnRqZA/3oKIPnAiaMCws8nOsE/giphy.gif)