### PR TITLE
chore(deps): update pnpm to 10.8.0

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,5 +1,5 @@
 // @ts-check
 export default {
-  '!(*.{js,jsx,ts,tsx})': 'prettier --write',
+  '!(*.{js,jsx,ts,tsx,npmrc})': 'prettier --write',
   '*.{js,jsx,ts,tsx}': ['eslint --fix', 'prettier --write'],
 }

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=*prettier*

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "vitest": "^3.1.1",
     "zx": "^8.5.0"
   },
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@10.8.0",
   "engines": {
     "node": ">=20.0.0"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,7 +82,7 @@
     "vite": "^6.2.4",
     "vitest": "^3.1.1"
   },
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@10.8.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/react-internal/package.json
+++ b/packages/react-internal/package.json
@@ -93,7 +93,7 @@
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
-  "packageManager": "pnpm@9.15.2",
+  "packageManager": "pnpm@10.8.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -94,7 +94,7 @@
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@10.8.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
-  - 'examples'
-  - 'packages/@repo/*'
-  - 'packages/*'
-  - 'apps/*'
+  - examples
+  - packages/@repo/*
+  - packages/*
+  - apps/*
   - '@repo/package.config'
+
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
### Description

Upgraded pnpm from 9.15.5 to 10.8.0 across all package.json files. Added a new .npmrc file to hoist eslint and prettier dependencies. Updated the lint-staged configuration to exclude .npmrc files from prettier formatting. Also updated the pnpm-workspace.yaml to include esbuild as an onlyBuiltDependency.

### What to review

- Verify the pnpm version upgrade in all package.json files
- Check the new .npmrc configuration for hoisting eslint and prettier
- Review the lint-staged configuration change to exclude .npmrc files
- Confirm the addition of esbuild to onlyBuiltDependencies in pnpm-workspace.yaml

### Testing

Tested by running the build process with the new pnpm version and verifying that all dependencies are correctly resolved. The hoisting configuration was tested by ensuring eslint and prettier are properly available across the workspace.

### Fun gif

![A Series Of Unfortunate Events Nero GIF by NETFLIX](https://media1.giphy.com/media/5tvJS6ZZslR9nBYxUA/giphy.gif)