### PR TITLE
chore: fix release notes after revert

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "ccabf2422346ba442f15327acda7634f28a46811",
   "always-link-local": true,
   "changelog-sections": [
     {"type": "feat", "section": "Features", "hidden": false},


### PR DESCRIPTION
### Description

Added `last-release-sha` configuration to the release-please-config.json file, pointing to commit `ccabf2422346ba442f15327acda7634f28a46811`. This helps Release Please track the last release point for generating accurate changelogs and version bumps.

### What to review

- Verify that the SHA `ccabf2422346ba442f15327acda7634f28a46811` is the correct commit for the last release
- Check that the JSON formatting is maintained properly

### Testing

This configuration change doesn't require automated testing. The change will be validated when Release Please runs for the next release cycle.

### Fun gif

![Release tracking](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZWJtZnRqZnRqZGJtZnRqZmRqZmRqZmRqZmRqZmRqZmRqZmRqZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o7TKNthed4OG7T5Je/giphy.gif)