### PR TITLE
fix: prevent bridge script addition if already loaded

### DIFF
--- a/packages/react/src/components/auth/AuthBoundary.tsx
+++ b/packages/react/src/components/auth/AuthBoundary.tsx
@@ -10,8 +10,8 @@ import {LoginCallback} from './LoginCallback'
 import {LoginError, type LoginErrorProps} from './LoginError'
 
 // Only import bridge if we're in an iframe. This assumes that the app is
-// running within SanityOS if it is in an iframe.
-if (isInIframe()) {
+// running within SanityOS if it is in an iframe and that the bridge hasn't already been loaded
+if (isInIframe() && !document.querySelector('[data-sanity-core]')) {
   const parsedUrl = new URL(window.location.href)
   const mode = new URLSearchParams(parsedUrl.hash.slice(1)).get('mode')
   const script = document.createElement('script')
@@ -122,7 +122,8 @@ function AuthSwitch({CallbackComponent = LoginCallback, children, ...props}: Aut
   const loginUrl = useLoginUrl()
 
   useEffect(() => {
-    if (isLoggedOut) {
+    if (isLoggedOut && !isInIframe()) {
+      // We don't want to redirect to login if we're in the Dashboard
       window.location.href = loginUrl
     }
   }, [isLoggedOut, loginUrl])


### PR DESCRIPTION
### Description

Prevents loading the bridge script in the Dashboard by checking if the bridge has already been loaded. Also prevents redirecting to login when in an iframe (Dashboard) to avoid the login screen being shown when in dashboard.

### What to review

- Check the condition for loading the bridge script now includes a check for existing bridge
- Verify the login redirect is skipped when in an iframe (Dashboard context)
- Ensure these changes don't break authentication flows in both standalone and embedded contexts

### Testing

Tested authentication flows in both standalone and Dashboard contexts:
- Verified bridge script is not loaded twice in Dashboard
- Confirmed login redirects work correctly in standalone mode
- Ensured no login redirects occur when embedded in Dashboard

### Fun gif
![bridge](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExNTF6dGdwa251cG51ZjFjMXdzNTJxa3Jkcmdsam4wc3RiczY0dXJueCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SoofARhN5oXRe/giphy.gif)