### PR TITLE
fix(react): update useNavigateToStudioDocument for new dashboard context

### DIFF
--- a/apps/kitchensink-react/src/DocumentCollection/DocumentDashboardInteractionsRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentDashboardInteractionsRoute.tsx
@@ -23,8 +23,10 @@ function ActionButtons(docHandle: DocumentHandle) {
     ...docHandle,
     resourceType: 'studio',
   })
-  const {navigateToStudioDocument, isConnected: isNavigateConnected} =
-    useNavigateToStudioDocument(docHandle)
+  const {navigateToStudioDocument, isConnected: isNavigateConnected} = useNavigateToStudioDocument(
+    docHandle,
+    'https://test-studio.sanity.build',
+  )
 
   return (
     <Flex gap={2} padding={2}>

--- a/packages/react/src/hooks/dashboard/useNavigateToStudioDocument.test.ts
+++ b/packages/react/src/hooks/dashboard/useNavigateToStudioDocument.test.ts
@@ -43,13 +43,13 @@ describe('useNavigateToStudioDocument', () => {
   }
 
   const mockWorkspace = {
+    id: 'workspace123',
     name: 'workspace1',
     title: 'Workspace 1',
     basePath: '/workspace1',
     dataset: 'dataset1',
     userApplicationId: 'user1',
     url: 'https://test.sanity.studio',
-    _ref: 'workspace123',
   }
 
   beforeEach(() => {
@@ -129,7 +129,7 @@ describe('useNavigateToStudioDocument', () => {
 
   it('warns when multiple workspaces are found', () => {
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const mockWorkspace2 = {...mockWorkspace, _ref: 'workspace2'}
+    const mockWorkspace2 = {...mockWorkspace, id: 'workspace2'}
 
     mockWorkspacesByProjectIdAndDataset = {
       'project1:dataset1': [mockWorkspace, mockWorkspace2],
@@ -145,15 +145,131 @@ describe('useNavigateToStudioDocument', () => {
     result.current.navigateToStudioDocument()
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      'Multiple workspaces found for document',
+      'Multiple workspaces found for document and no preferred studio url',
       mockDocumentHandle,
     )
     expect(mockSendMessage).toHaveBeenCalledWith(
       'dashboard/v1/bridge/navigate-to-resource',
       expect.objectContaining({
-        resourceId: mockWorkspace._ref,
+        resourceId: mockWorkspace.id,
       }),
     )
+
+    consoleSpy.mockRestore()
+  })
+
+  it('warns and does not navigate when projectId or dataset is missing', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const incompleteDocumentHandle: DocumentHandle = {
+      documentId: 'doc123',
+      documentType: 'article',
+      // missing projectId and dataset
+    }
+
+    const {result} = renderHook(() => useNavigateToStudioDocument(incompleteDocumentHandle))
+
+    // Simulate connection
+    act(() => {
+      mockStatusCallback?.('connected')
+    })
+
+    result.current.navigateToStudioDocument()
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Project ID and dataset are required to navigate to a studio document',
+    )
+    expect(mockSendMessage).not.toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
+  })
+
+  it('uses preferred studio URL when multiple workspaces are available', () => {
+    const preferredUrl = 'https://preferred.sanity.studio'
+    const mockWorkspace2 = {...mockWorkspace, id: 'workspace2', url: preferredUrl}
+
+    mockWorkspacesByProjectIdAndDataset = {
+      'project1:dataset1': [mockWorkspace, mockWorkspace2],
+    }
+
+    const {result} = renderHook(() => useNavigateToStudioDocument(mockDocumentHandle, preferredUrl))
+
+    // Simulate connection
+    act(() => {
+      mockStatusCallback?.('connected')
+    })
+
+    result.current.navigateToStudioDocument()
+
+    // Should choose workspace2 because it matches the preferred URL
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      'dashboard/v1/bridge/navigate-to-resource',
+      expect.objectContaining({
+        resourceId: 'workspace2',
+      }),
+    )
+  })
+
+  it('considers NO_PROJECT_ID:NO_DATASET workspaces when matching preferred URL', () => {
+    const preferredUrl = 'https://preferred.sanity.studio'
+    // Only have a workspace without projectId/dataset that matches the preferred URL
+    const mockWorkspaceNoProject = {
+      ...mockWorkspace,
+      id: 'workspace3',
+      url: preferredUrl,
+      projectId: undefined,
+      dataset: undefined,
+    }
+
+    mockWorkspacesByProjectIdAndDataset = {
+      'NO_PROJECT_ID:NO_DATASET': [mockWorkspaceNoProject],
+    }
+
+    const {result} = renderHook(() => useNavigateToStudioDocument(mockDocumentHandle, preferredUrl))
+
+    // Simulate connection
+    act(() => {
+      mockStatusCallback?.('connected')
+    })
+
+    result.current.navigateToStudioDocument()
+
+    // Should choose the NO_PROJECT_ID:NO_DATASET workspace because it matches the preferred URL
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      'dashboard/v1/bridge/navigate-to-resource',
+      expect.objectContaining({
+        resourceId: 'workspace3',
+      }),
+    )
+  })
+
+  it('warns with preferred URL info when no matching workspace is found', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const preferredUrl = 'https://nonexistent.sanity.studio'
+
+    // Set up workspaces that don't match the preferred URL
+    mockWorkspacesByProjectIdAndDataset = {
+      'project1:dataset1': [
+        {
+          ...mockWorkspace,
+          url: 'https://different.sanity.studio',
+        },
+      ],
+    }
+
+    const {result} = renderHook(() => useNavigateToStudioDocument(mockDocumentHandle, preferredUrl))
+
+    // Simulate connection
+    act(() => {
+      mockStatusCallback?.('connected')
+    })
+
+    result.current.navigateToStudioDocument()
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      `No workspace found for document with projectId: ${mockDocumentHandle.projectId} and dataset: ${mockDocumentHandle.dataset} or with preferred studio url: ${preferredUrl}`,
+    )
+    expect(mockSendMessage).not.toHaveBeenCalled()
 
     consoleSpy.mockRestore()
   })

--- a/packages/react/src/hooks/dashboard/useStudioWorkspacesByProjectIdDataset.test.tsx
+++ b/packages/react/src/hooks/dashboard/useStudioWorkspacesByProjectIdDataset.test.tsx
@@ -13,52 +13,47 @@ const mockWorkspaceData = {
   context: {
     availableResources: [
       {
+        id: 'user1-workspace1',
         projectId: 'project1',
-        workspaces: [
-          {
-            name: 'workspace1',
-            title: 'Workspace 1',
-            basePath: '/workspace1',
-            dataset: 'dataset1',
-            userApplicationId: 'user1',
-            url: 'https://test.sanity.studio',
-            _ref: 'user1-workspace1',
-          },
-          {
-            name: 'workspace2',
-            title: 'Workspace 2',
-            basePath: '/workspace2',
-            dataset: 'dataset1',
-            userApplicationId: 'user1',
-            url: 'https://test.sanity.studio',
-            _ref: 'user1-workspace2',
-          },
-        ],
+        dataset: 'dataset1',
+        name: 'workspace1',
+        title: 'Workspace 1',
+        basePath: '/workspace1',
+        userApplicationId: 'user1',
+        url: 'https://test1.sanity.studio',
+        type: 'studio',
       },
       {
+        id: 'user1-workspace2',
+        projectId: 'project1',
+        dataset: 'dataset1',
+        name: 'workspace2',
+        title: 'Workspace 2',
+        basePath: '/workspace2',
+        userApplicationId: 'user1',
+        url: 'https://test2.sanity.studio',
+        type: 'studio',
+      },
+      {
+        id: 'user2-workspace3',
         projectId: 'project2',
-        workspaces: [
-          {
-            name: 'workspace3',
-            title: 'Workspace 3',
-            basePath: '/workspace3',
-            dataset: 'dataset2',
-            userApplicationId: 'user2',
-            url: 'https://test.sanity.studio',
-            _ref: 'user2-workspace3',
-          },
-        ],
-      },
-      {
-        // Project without workspaces
-        projectId: 'project3',
-        workspaces: [],
+        dataset: 'dataset2',
+        name: 'workspace3',
+        title: 'Workspace 3',
+        basePath: '/workspace3',
+        userApplicationId: 'user2',
+        url: 'https://test3.sanity.studio',
+        type: 'studio',
       },
     ],
   },
 }
 
 describe('useStudioWorkspacesByResourceId', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should return empty workspaces and connected=false when not connected', async () => {
     // Create a mock that captures the onStatus callback
     let capturedOnStatus: ((status: Status) => void) | undefined
@@ -106,33 +101,39 @@ describe('useStudioWorkspacesByResourceId', () => {
       expect(result.current.workspacesByProjectIdAndDataset).toEqual({
         'project1:dataset1': [
           {
+            id: 'user1-workspace1',
+            projectId: 'project1',
+            dataset: 'dataset1',
             name: 'workspace1',
             title: 'Workspace 1',
             basePath: '/workspace1',
-            dataset: 'dataset1',
             userApplicationId: 'user1',
-            url: 'https://test.sanity.studio',
-            _ref: 'user1-workspace1',
+            url: 'https://test1.sanity.studio',
+            type: 'studio',
           },
           {
+            id: 'user1-workspace2',
+            projectId: 'project1',
+            dataset: 'dataset1',
             name: 'workspace2',
             title: 'Workspace 2',
             basePath: '/workspace2',
-            dataset: 'dataset1',
             userApplicationId: 'user1',
-            url: 'https://test.sanity.studio',
-            _ref: 'user1-workspace2',
+            url: 'https://test2.sanity.studio',
+            type: 'studio',
           },
         ],
         'project2:dataset2': [
           {
+            id: 'user2-workspace3',
+            projectId: 'project2',
+            dataset: 'dataset2',
             name: 'workspace3',
             title: 'Workspace 3',
             basePath: '/workspace3',
-            dataset: 'dataset2',
             userApplicationId: 'user2',
-            url: 'https://test.sanity.studio',
-            _ref: 'user2-workspace3',
+            url: 'https://test3.sanity.studio',
+            type: 'studio',
           },
         ],
       })
@@ -199,60 +200,56 @@ describe('useStudioWorkspacesByResourceId', () => {
     })
   })
 
-  it('should handle projects without workspaces', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
+  it('should filter non-studio resources and handle resources without projectId/dataset', async () => {
+    const mockDataWithMixedResources = {
       context: {
         availableResources: [
           {
+            id: 'studio1',
             projectId: 'project1',
-            workspaces: [],
+            dataset: 'dataset1',
+            name: 'workspace1',
+            title: 'Workspace 1',
+            basePath: '/workspace1',
+            userApplicationId: 'user1',
+            url: 'https://test1.sanity.studio',
+            type: 'studio',
           },
-        ],
-      },
-    })
-    let capturedOnStatus: ((status: Status) => void) | undefined
-
-    vi.mocked(useWindowConnection).mockImplementation(({onStatus}) => {
-      capturedOnStatus = onStatus
-
-      return {
-        fetch: mockFetch,
-        sendMessage: vi.fn(),
-      } as unknown as WindowConnection<Message>
-    })
-
-    const {result} = renderHook(() => useStudioWorkspacesByProjectIdDataset())
-
-    // Call onStatus with 'connected' to simulate connected state
-    if (capturedOnStatus) capturedOnStatus('connected')
-
-    await waitFor(() => {
-      expect(result.current.workspacesByProjectIdAndDataset).toEqual({})
-      expect(result.current.error).toBeNull()
-      expect(result.current.isConnected).toBe(true)
-    })
-  })
-
-  it('should handle projects without projectId', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      context: {
-        availableResources: [
           {
-            workspaces: [
-              {
-                name: 'workspace1',
-                title: 'Workspace 1',
-                basePath: '/workspace1',
-                dataset: 'dataset1',
-                userApplicationId: 'user1',
-                url: 'https://test.sanity.studio',
-                _ref: 'user1-workspace1',
-              },
-            ],
+            id: 'non-studio',
+            projectId: 'project2',
+            dataset: 'dataset2',
+            name: 'non-studio',
+            title: 'Non Studio Resource',
+            basePath: '/non-studio',
+            userApplicationId: 'user2',
+            url: 'https://test2.sanity.studio',
+            type: 'other',
+          },
+          {
+            id: 'studio-no-project',
+            name: 'incomplete-workspace',
+            title: 'Incomplete Workspace',
+            basePath: '/incomplete',
+            userApplicationId: 'user3',
+            url: 'https://test3.sanity.studio',
+            type: 'studio',
+          },
+          {
+            id: 'studio-no-dataset',
+            projectId: 'project3',
+            name: 'no-dataset-workspace',
+            title: 'No Dataset Workspace',
+            basePath: '/no-dataset',
+            userApplicationId: 'user4',
+            url: 'https://test4.sanity.studio',
+            type: 'studio',
           },
         ],
       },
-    })
+    }
+
+    const mockFetch = vi.fn().mockResolvedValue(mockDataWithMixedResources)
     let capturedOnStatus: ((status: Status) => void) | undefined
 
     vi.mocked(useWindowConnection).mockImplementation(({onStatus}) => {
@@ -270,7 +267,23 @@ describe('useStudioWorkspacesByResourceId', () => {
     if (capturedOnStatus) capturedOnStatus('connected')
 
     await waitFor(() => {
-      expect(result.current.workspacesByProjectIdAndDataset).toEqual({})
+      // Should only include the studio resource with valid projectId and dataset
+      expect(result.current.workspacesByProjectIdAndDataset['project1:dataset1']).toHaveLength(1)
+      expect(result.current.workspacesByProjectIdAndDataset['project1:dataset1'][0].id).toBe(
+        'studio1',
+      )
+
+      // Should not include the non-studio resource
+      expect(result.current.workspacesByProjectIdAndDataset['project2:dataset2']).toBeUndefined()
+
+      // Should group resources without projectId or dataset under NO_PROJECT_ID:NO_DATASET
+      expect(
+        result.current.workspacesByProjectIdAndDataset['NO_PROJECT_ID:NO_DATASET'],
+      ).toHaveLength(2)
+      expect(
+        result.current.workspacesByProjectIdAndDataset['NO_PROJECT_ID:NO_DATASET'].map((r) => r.id),
+      ).toEqual(['studio-no-project', 'studio-no-dataset'])
+
       expect(result.current.error).toBeNull()
       expect(result.current.isConnected).toBe(true)
     })


### PR DESCRIPTION
### Description
This PR updates the logic of `useStudioWorkspacesByProjectIdDataset` and `useNavigateToStudioDocument` to match the changes made in Ada in [this PR](https://github.com/sanity-io/ada/pull/278). Because of some behavior I noticed in testing this out, there was some additional functionality added to allow developers to specify a preferred studio URL to help have better control over the behavior of this hook.

### What to review
Although you can try to test this locally, the changes in Ada removed a basePath parameter which means the functionality isn't quite there yet -- see my comment [here](https://sanity-io.slack.com/archives/C07L81HJX4P/p1744899716202329?thread_ts=1744887515.320589&cid=C07L81HJX4P). Regardless, I felt we might as well put in a best-effort change and update this later as we figure out how to best go about this.

With that in mind, please feel free to ensure that all edge cases are handled and that the hook behaves gracefully. 

### Testing
Tests were updated for 100% coverage.

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExc3pjdmUxcHF0eWE0dDhoMmNrbWZyMGh2c2V4bXZ5bndiMHVlbWtsMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/wJIxvAerMxkal1BLm2/giphy.gif)
