### PR TITLE
fix(build): use mjs extensions for bundle output

### DIFF
--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -45,6 +45,8 @@ export const defaultConfig: UserConfig = {
         exports: 'named',
         dir: 'lib',
         format: 'es',
+        entryFileNames: `[name].mjs`,
+        chunkFileNames: `[name].[hash].mjs`,
       },
       treeshake: {
         preset: 'recommended',


### PR DESCRIPTION
### Description

Added explicit file naming configuration for ES module output in the package bundle. This change sets `.mjs` extension for both entry files and chunk files, ensuring proper identification of ES modules in the bundled output. This is necessary for Auto updates 

### What to review

- Verify that the `entryFileNames` and `chunkFileNames` properties are correctly configured with `.mjs` extensions
- Check that the naming pattern follows the expected format (`[name].mjs` for entry files and `[name].[hash].mjs` for chunks)
- Ensure this change doesn't break existing imports or module resolution

### Testing

Tested by building the package bundle and verifying that output files are correctly named with `.mjs` extensions. The module format is properly recognized by Node.js and modern bundlers.

### Fun gif

![ES Modules Excitement](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZWJtZnRqZnRqZGJtZnRqZmRqZmRqZmRqZmRqZmRqZmRqZmRqZmQvZ2lmY3Jl/3o7btNa0RUYa5E7iiQ/giphy.gif)