### PR TITLE
chore(ci): fix workflow conditional

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,7 +67,7 @@ jobs:
   post-release-steps:
     runs-on: ubuntu-latest
     needs: release-please
-    if: ${{ needs.release-please.outputs.command == true }}
+    if: ${{ needs.release-please.outputs.command }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description

Fixed a conditional check in the GitHub workflow by removing the explicit `== true` comparison in the `if` statement. This change simplifies the condition from `${{ needs.release-please.outputs.command == true }}` to `${{ needs.release-please.outputs.command }}`, which is more idiomatic in GitHub Actions workflows since the condition will evaluate the truthiness of the output value directly.

### What to review

- Verify that the simplified condition in the `post-release-steps` job still correctly triggers based on the `release-please` job's output
- Ensure the workflow executes as expected when the `command` output is set

### Testing

Tested by verifying that the workflow executes correctly with the simplified condition. GitHub Actions automatically coerces the output value to a boolean when used in an `if` condition.

### Fun gif

![Simplifying code](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZWJtZnRqZnRqZGJtZnRqZGJtZnRqZGJtZnRqZGJtZnRqZGJtZnRqZA/3o7TKSjRrfIPjeiVyM/giphy.gif)