### PR TITLE
chore(ci): actually fix the conditional for workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,16 +67,16 @@ jobs:
   post-release-steps:
     runs-on: ubuntu-latest
     needs: release-please
-    if: ${{ needs.release-please.outputs.command }}
+    if: ${{ needs.release-please.outputs.command == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Vercel CLI
-        run: pnpm install --global vercel@latest
+        run: npm install --global vercel@latest
 
       - name: Prepare vercel.json
-        run: pnpm docs:prepare
+        run: npm run docs:prepare
 
       - name: Deploy Docs to Vercel
         run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
### Description

This PR fixes the condition for triggering post-release steps and switches from pnpm to npm for the Vercel CLI installation and docs preparation. The condition now explicitly checks if the release-please output command equals 'true' rather than just checking if it exists.

### What to review

- The condition change in the `if` statement for the post-release-steps job
- The package manager change from pnpm to npm for Vercel CLI installation
- The package manager change from pnpm to npm for the docs:prepare script

### Testing

The changes were tested by verifying that the post-release workflow triggers correctly when the release-please output command equals 'true', and that the Vercel CLI installation and docs preparation work properly with npm.

### Fun gif

![True GIF by South Park](https://media3.giphy.com/media/ZcKRYQo7R2HPp1aN9w/giphy.gif)