### PR TITLE
chore(prettier): ignore CHANGELOG files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ pnpm-lock.yaml
 .gitignore
 .prettierignore
 .cursor/**/*
+CHANGELOG.md
+**/CHANGELOG.md


### PR DESCRIPTION
### Description

Added `CHANGELOG.md` and any nested CHANGELOG files to `.prettierignore` to prevent Prettier from automatically formatting these files.

### What to review

Check that the `.prettierignore` file now includes both `CHANGELOG.md` and `**/CHANGELOG.md` entries.

### Testing

Manual testing was performed by running Prettier to verify that changelog files are now ignored during formatting.

### Fun gif
![ignore](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExMjBwYmgwdWk4enl0aXJoaGJtczlwaHEzd3l4cXhlZ3V5dzlpcnE3YyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/W920wi2GVMv96/giphy.gif)