### PR TITLE
fix: fix useProjection example (results -> data)

### DIFF
--- a/packages/react/src/hooks/projection/useProjection.ts
+++ b/packages/react/src/hooks/projection/useProjection.ts
@@ -45,7 +45,7 @@ export interface UseProjectionResults<TData extends object> {
  * export default function ProjectionComponent({ document }) {
  *   const ref = useRef(null)
  *   const { data: { title, coverImage, authors }, isPending } = useProjection({
- *     document,
+ *     ...document,
  *     ref,
  *     projection: `{
  *       title,


### PR DESCRIPTION
### Description

Fixes the name of a destructured value from `useProjection` results and a missing spread of the document handle

### What to review

The new name is correct and the spread is correct

### Testing

N/A

### Fun gif

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmExYzhmY3g5ZmNjOXcwYWtsYzhsZHI2emRyY3lsNGtmcnhmbWY1OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o7TKSx0g7RqRniGFG/giphy.gif)
