### PR TITLE
chore(ci): only trigger circleci job from github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,27 @@
 version: 2.1
 
+parameters:
+  GHA_Actor:
+    type: string
+    default: ""
+  GHA_Action:
+    type: string
+    default: ""
+  GHA_Event:
+    type: string
+    default: ""
+  GHA_Meta:
+    type: string
+    default: ""
+
 workflows:
   version: 2
   build-and-deploy:
     jobs:
       - build:
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              # Jobs will run each commit unless explicitly told to ignore branches
+              # Jobs will only run when manually triggered
               ignore: /.*/
 jobs:
   build:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -87,3 +87,8 @@ jobs:
           initial_state_id: "c56956cd-c281-4ca5-889f-6189ce231a6d"
           # Label: Shipped
           done_state_id: "5a35b7bf-6d37-4cc2-854a-2f18d160e2e5"
+
+      - name: Trigger CircleCI Pipeline
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}


### PR DESCRIPTION
### Description

This PR modifies the CI/CD pipeline to improve the release process. It updates the CircleCI configuration to only run when manually triggered (rather than on every commit) by adding GHA parameters and changing branch filters. Additionally, it adds a step to the release-please GitHub Action workflow to trigger CircleCI after a release is created, using the CircleCI-Public/trigger-circleci-pipeline-action.

### What to review

- CircleCI configuration changes, particularly the new parameters and updated branch filters
- The new step in the release-please workflow that triggers CircleCI
- Verify that the CCI_TOKEN secret is properly configured

### Testing

These changes have been tested by verifying that:
1. CircleCI no longer runs on every commit
2. The release-please workflow successfully triggers CircleCI after creating a release

### Fun gif

![Automated release](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZWJtZnRqZnRqZGJtZnRqZmRqZmRqZmRqZmRqZmRqZmRqZmRqZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o7ZetIsjtbkgNE1I4/giphy.gif)