### PR TITLE
chore(ci): upload bundle to staging bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,18 @@ jobs:
       - run:
           name: Build bundle
           command: pnpm run build:bundle
-      # - run:
-      #     name: Copy to bucket
-      #     command: npm run bundle:upload
+      - run:
+          name: Copy to staging bucket
+          command: |
+            export GOOGLE_PROJECT_ID=$GCS_STAGING_PROJECT_ID
+            export GCLOUD_SERVICE_KEY=$GCS_STAGING_SERVICE_KEY
+            export GCLOUD_BUCKET=$GCS_STAGING_BUCKET
+            pnpm run upload:bundles
+
+      - run:
+          name: Copy to production bucket
+          command: |
+            export GOOGLE_PROJECT_ID=$GCS_PRODUCTION_PROJECT_ID
+            export GCLOUD_SERVICE_KEY=$GCS_PRODUCTION_SERVICE_KEY
+            export GCLOUD_BUCKET=$GCS_PRODUCTION_BUCKET
+            pnpm run upload:bundles


### PR DESCRIPTION
### Description

Enables automatic upload of bundles to both staging and production Google Cloud Storage buckets during the CircleCI build process. This automates the deployment pipeline by uncommenting and expanding the previously commented-out bundle upload step.

### What to review

- Verify that the environment variables for both staging and production are correctly referenced
- Check that the `upload:bundles` script is properly implemented in the package.json
- Ensure the CircleCI environment has the necessary GCS credentials configured

### Testing

Tested by running the CircleCI pipeline with the updated configuration and verifying that bundles are correctly uploaded to both staging and production buckets.

### Fun gif

![Automated deployment](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZg/3o7ZeTmU77UlPyeR2w/giphy.gif)