### PR TITLE
chore(ci): fixes conditional for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ parameters:
 workflows:
   version: 2
   build-and-deploy:
-    when: << pipeline.parameters.GHA_Action >>
+    when:
+      equal: ["push", << pipeline.parameters.GHA_Event >>]
     jobs:
       - build:
           filters:


### PR DESCRIPTION
### Description

Updated CircleCI configuration to automatically trigger builds on push events to the main branch, rather than requiring manual triggering. This change modifies the workflow configuration to run when the pipeline parameter `GHA_Event` equals "push" and changes the branch filter from ignoring all branches to only running on the main branch.

### What to review

- Verify that the CircleCI workflow now triggers automatically on pushes to the main branch
- Check that the `when` condition correctly uses the `GHA_Event` parameter
- Confirm that the branch filter is properly set to only run on the main branch

### Testing

Tested by pushing changes to the main branch and verifying that CircleCI workflows triggered automatically. The configuration was also validated using CircleCI's config validation tool.

### Fun gif

![Automation at work](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZWJtZnRqZnRqZGJxZnRqZGJxZnRqZGJxZnRqZGJxZnRqZGJxZnRqZA/13GIgrGdslD9oQ/giphy.gif)