### PR TITLE
docs!: remove reference to SDKProvider and ResourceProvider in migration guide

### DIFF
--- a/packages/react/guides/0-Migration-Guide.md
+++ b/packages/react/guides/0-Migration-Guide.md
@@ -341,30 +341,6 @@ For most applications, particularly dashboard applications, we recommend using t
 
 The `config` prop replaces the previous `sanityConfigs` prop and supports both single and multiple configurations. When providing multiple configurations, the first one in the array will be the default instance.
 
-#### For Advanced Use Cases
-
-For more complex applications that need finer control, you can use `<SDKProvider />` or `<ResourceProvider />` directly:
-
-```tsx
-// Using SDKProvider directly
-<SDKProvider
-  config={[
-    {projectId: 'abc12345', dataset: 'production'},
-    {projectId: 'xyz12345', dataset: 'production'},
-  ]}
-  fallback={<>Loading…</>}
->
-  <App />
-</SDKProvider>
-
-// Using ResourceProvider for full control
-<ResourceProvider projectId="xyz12345" dataset="production">
-  <ResourceProvider projectId="abc12345" dataset="production">
-    <App />
-  </ResourceProvider>
-</ResourceProvider>
-```
-
 ### Document Handle Pattern
 
 We've introduced a consistent "handle" pattern across the SDK for working with documents and configuration. This replaces the previous `resourceId` concept with more explicit fields.


### PR DESCRIPTION
### Description

Removes a reference to using SDKProvider and ResourceProvider in the migration guide. We don't expose these components currently and it's likely less confusing to not expose them in this guide.

### What to review

Did the text go away?

### Testing

N/A

### Fun gif

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExeW44aHBvaTF3dWhydTF1ZXdnOXY0c3gydzFuY3kwMTNpemdxYW83NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SpoV1pB4g7gXvWo3Up/giphy.gif)