### PR TITLE
fix(docs): remove custom docs entrypoint names

### DIFF
--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -1,5 +1,4 @@
 {
-  "name": "Core App SDK",
   "extends": ["../../typedoc.base.json"],
   "entryPoints": ["./src/_exports/*"],
   "projectDocuments": ["./guides/*.md"],

--- a/packages/react/typedoc.json
+++ b/packages/react/typedoc.json
@@ -1,5 +1,4 @@
 {
-  "name": "React App SDK",
   "extends": ["../../typedoc.base.json"],
   "entryPoints": ["./src/_exports/sdk-react.ts"],
   "projectDocuments": ["guides/*.md"],


### PR DESCRIPTION
### Description

Removes custom entrypoint names for typedoc

### What to review

Pretty wild!

### Testing

N/A

### Fun gif

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExejhnY3M2ZjF3OWZuem94MjY0dXA3MGFuZjFqejRreHMybmp3MDE5cyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jUwpNzg9IcyrK/giphy.gif)
