### PR TITLE
fix(core): use raw perspective for functions that coalesce draft/published

### DIFF
--- a/packages/core/src/preview/util.ts
+++ b/packages/core/src/preview/util.ts
@@ -2,7 +2,7 @@ import {getEnv} from '../utils/getEnv'
 import {type PreviewValue, type ValuePending} from './previewStore'
 
 export const PREVIEW_TAG = 'preview'
-export const PREVIEW_PERSPECTIVE = 'drafts'
+export const PREVIEW_PERSPECTIVE = 'raw'
 export const STABLE_EMPTY_PREVIEW: ValuePending<PreviewValue> = {data: null, isPending: false}
 export const STABLE_ERROR_PREVIEW: ValuePending<PreviewValue> = {
   data: {

--- a/packages/core/src/projection/util.ts
+++ b/packages/core/src/projection/util.ts
@@ -1,7 +1,7 @@
 import {type ValidProjection} from './types'
 
 export const PROJECTION_TAG = 'sdk.projection'
-export const PROJECTION_PERSPECTIVE = 'drafts'
+export const PROJECTION_PERSPECTIVE = 'raw'
 export const PROJECTION_STATE_CLEAR_DELAY = 1000
 
 export const STABLE_EMPTY_PROJECTION = {


### PR DESCRIPTION
### Description
In their respective stores, reviews and projections coalesce draft and query results and return a "status" object that includes params for when the draft was last edited and when the published version was last edited, so people could indicate the status of the document. However, they were also using the `drafts` perspective, which does the coalescing in the query result so everything was mistakenly "published" from the status perspective.

This restores the raw perspective. 

### What to review
It's a larger question about what we want to do about "status". This may only get more complex once we introduce perspectives. Are we going to return the version document and the published document?

Should we just use the `drafts` perspective and get the data some other way?

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGhjdXFsdHJsMm1oM2p6NDZrdXg5dTdnb2NmbGw1ZWE5aGZ0N2oxMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jPAdK8Nfzzwt2/giphy.gif)
