### PR TITLE
fix(core): bump default api versions

### DIFF
--- a/packages/core/src/document/documentConstants.ts
+++ b/packages/core/src/document/documentConstants.ts
@@ -7,4 +7,4 @@
  */
 export const DOCUMENT_STATE_CLEAR_DELAY = 1000
 export const INITIAL_OUTGOING_THROTTLE_TIME = 1000
-export const API_VERSION = 'vX'
+export const API_VERSION = 'v2025-05-06'

--- a/packages/core/src/document/sharedListener.ts
+++ b/packages/core/src/document/sharedListener.ts
@@ -16,7 +16,7 @@ import {
 import {getClientState} from '../client/clientStore'
 import {type SanityInstance} from '../store/createSanityInstance'
 
-const API_VERSION = 'vX'
+const API_VERSION = 'v2025-05-06'
 
 export interface SharedListener {
   events: Observable<ListenEvent<SanityDocument>>

--- a/packages/core/src/query/queryStoreConstants.ts
+++ b/packages/core/src/query/queryStoreConstants.ts
@@ -6,5 +6,4 @@
  * different views quickly.
  */
 export const QUERY_STATE_CLEAR_DELAY = 1000
-// NOTE: Have to use vX for the text::query groq function
-export const QUERY_STORE_API_VERSION = 'vX'
+export const QUERY_STORE_API_VERSION = 'v2025-05-06'


### PR DESCRIPTION
### Description
Ups API versions now that text query search is GA.

### What to review
The very extensive changes

### Testing
Search worked when I tried manually

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExcGR4N2RjbTlucjI1czFodzQ2eTZ4OTIwYnJkd2lrNm5meGtkMjhsbiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/XimMPYY3ojXRc2C8T9/giphy.gif)