### PR TITLE
chore!: rename useProjection to useDocumentProjection & rename usePreview to useDocumentPreview

### DIFF
--- a/apps/kitchensink-react/src/DocumentCollection/DocumentPreview.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentPreview.tsx
@@ -1,4 +1,4 @@
-import {DocumentHandle, usePreview} from '@sanity/sdk-react'
+import {DocumentHandle, useDocumentPreview} from '@sanity/sdk-react'
 import {Suspense, useRef} from 'react'
 import {ErrorBoundary} from 'react-error-boundary'
 
@@ -22,7 +22,7 @@ function DocumentPreviewResolved(docHandle: DocumentHandle): React.ReactNode {
   const ref = useRef(null)
   const {
     data: {title, subtitle, media, status},
-  } = usePreview({...docHandle, ref})
+  } = useDocumentPreview({...docHandle, ref})
 
   let statusLabel
   if (status?.lastEditedPublishedAt && status?.lastEditedDraftAt) {

--- a/apps/kitchensink-react/src/DocumentCollection/DocumentProjectionRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentProjectionRoute.tsx
@@ -1,4 +1,4 @@
-import {DocumentHandle, usePaginatedDocuments, useProjection} from '@sanity/sdk-react'
+import {DocumentHandle, useDocumentProjection, usePaginatedDocuments} from '@sanity/sdk-react'
 import {Box, Button, Card, Flex, Label, Spinner, Stack, Text, TextInput} from '@sanity/ui'
 import {defineProjection} from 'groq'
 import {JSX, ReactNode, Suspense, useRef, useState} from 'react'
@@ -28,7 +28,7 @@ function ProjectionData({
 
   const ref = useRef<HTMLTableCellElement>(null)
   const projection = useFirstProjection ? authorProjection : bestFriendProjection
-  const {data} = useProjection({
+  const {data} = useDocumentProjection({
     ...docHandle,
     ref,
     projection,

--- a/apps/kitchensink-react/src/DocumentCollection/OrgDocumentExplorerRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/OrgDocumentExplorerRoute.tsx
@@ -3,10 +3,10 @@ import {
   ResourceProvider,
   useDatasets,
   useDocument,
+  useDocumentPreview,
   useDocumentSyncStatus,
   useEditDocument,
   usePaginatedDocuments,
-  usePreview,
   useProject,
   useProjects,
   useQuery,
@@ -112,7 +112,7 @@ function DocumentEditorDialog({
 function DocumentTableRow(doc: DocumentHandle) {
   const ref = useRef<HTMLTableRowElement>(null)
   const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const {data} = usePreview(doc)
+  const {data} = useDocumentPreview(doc)
 
   const handleOpenDialog = () => setIsDialogOpen(true)
   const handleCloseDialog = () => setIsDialogOpen(false)

--- a/packages/react/guides/0-Migration-Guide.md
+++ b/packages/react/guides/0-Migration-Guide.md
@@ -154,6 +154,18 @@ function MyDocumentAction(props: DocumentActionProps) {
 }
 ```
 
+2. Renamed hooks for better clarity and consistency:
+
+   - `usePreview` → `useDocumentPreview`
+   - `useProjection` → `useDocumentProjection`
+
+Also renamed associated types to match:
+
+- `UsePreviewOptions` → `useDocumentPreviewOptions`
+- `UsePreviewResults` → `useDocumentPreviewResults`
+- `UseProjectionOptions` → `useDocumentProjectionOptions`
+- `UseProjectionResults` → `useDocumentProjectionResults`
+
 ## Migrating to @sanity/sdk-react@0.0.0-rc.7
 
 This version introduces significant improvements for TypeScript users by integrating [Sanity TypeGen](https://www.sanity.io/docs/sanity-typegen). While Typegen is optional, using it unlocks strong type safety for documents, queries, and projections. These changes also refine hook signatures for better consistency, even for JavaScript users.

--- a/packages/react/guides/Document-Handles.md
+++ b/packages/react/guides/Document-Handles.md
@@ -58,7 +58,7 @@ Hooks like {@link useDocuments} and {@link usePaginatedDocuments} can return pot
 
 This is where the concept of Document Handles comes in. By returning a small amount of metadata for each document instead of unfurling every returned document, hooks like {@link useDocuments} can respond as fast as possible, allowing your application to remain snappy.
 
-Of course, unless you’re just looking to get a count of documents matching the parameters you pass to these hooks, Document Handles aren't incredibly useful on their own. This is by design — they’re only meant to serve as references to documents which can then be consumed by more specialized hooks, such as {@link useProjection}, {@link useDocument}, and many more hooks provided by the SDK. These specialized hooks are designed to consume document handles and emit only the document content you request, which also delivers huge performance benefits. Other hooks, such as {@link useDocumentEvent} and {@link useDocumentPermissions} have no need to know the contents of a document — instead, they use the provided Document Handle to reference a document and retrieve information pertaining to that document.
+Of course, unless you’re just looking to get a count of documents matching the parameters you pass to these hooks, Document Handles aren't incredibly useful on their own. This is by design — they’re only meant to serve as references to documents which can then be consumed by more specialized hooks, such as {@link useDocumentProjection}, {@link useDocument}, and many more hooks provided by the SDK. These specialized hooks are designed to consume document handles and emit only the document content you request, which also delivers huge performance benefits. Other hooks, such as {@link useDocumentEvent} and {@link useDocumentPermissions} have no need to know the contents of a document — instead, they use the provided Document Handle to reference a document and retrieve information pertaining to that document.
 
 In short, Document Handles promote deferring the retrieval of document contents until such time as those contents are actually needed by your application.
 
@@ -111,7 +111,7 @@ const myDocumentHandle = {
 // Now, myDocumentHandle.documentType is typed as 'book', not string
 ```
 
-Using either `createDocumentHandle` or `as const` ensures that subsequent hooks like `useDocument` or `useProjection` can correctly infer types based on the specific `documentType` provided in the handle when Typegen is enabled.
+Using either `createDocumentHandle` or `as const` ensures that subsequent hooks like `useDocument` or `useDocumentProjection` can correctly infer types based on the specific `documentType` provided in the handle when Typegen is enabled.
 
 ## A quick example
 
@@ -143,10 +143,14 @@ export function AuthorList() {
 }
 ```
 
-If we wanted to instead render content from each of these documents — for example, the author’s name — we’d then need to provide each Document Handle to a different hook — for example, {@link useProjection}. Note how the document handle is [spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) in the arguments to the `useProjection` hook below:
+If we wanted to instead render content from each of these documents — for example, the author’s name — we’d then need to provide each Document Handle to a different hook — for example, {@link useDocumentProjection}. Note how the document handle is [spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) in the arguments to the `useDocumentProjection` hook below:
 
 ```tsx
-import {useProjection, type DocumentHandle, type UseProjectionResults} from '@sanity/sdk'
+import {
+  useDocumentProjection,
+  type DocumentHandle,
+  type useDocumentProjectionResults,
+} from '@sanity/sdk'
 
 interface NameProjection {
   name: string
@@ -154,7 +158,7 @@ interface NameProjection {
 
 // The AuthorDetails component will accept a Document Handle for its `document` prop
 export function AuthorDetails({document}: {document: DocumentHandle}) {
-  const {data}: UseProjectionResults<NameProjection> = useProjection({
+  const {data}: useDocumentProjectionResults<NameProjection> = useDocumentProjection({
     ...document,
     projection: '{ name }',
   })

--- a/packages/react/guides/Typescript.md
+++ b/packages/react/guides/Typescript.md
@@ -200,11 +200,11 @@ const handle = {
 
 ### Projections: `defineProjection`
 
-To get types for GROQ projections used with `useProjection`, you **must** define them using the `defineProjection` helper from `groq`. Typegen scans your code for these definitions.
+To get types for GROQ projections used with `useDocumentProjection`, you **must** define them using the `defineProjection` helper from `groq`. Typegen scans your code for these definitions.
 
 ```typescript
 import {defineProjection} from 'groq'
-import {useProjection, type DocumentHandle} from '@sanity/sdk-react'
+import {useDocumentProjection, type DocumentHandle} from '@sanity/sdk-react'
 
 // Typegen derives the type name (AuthorSummaryProjectionResult) from the variable name
 export const authorSummary = defineProjection({
@@ -214,7 +214,7 @@ export const authorSummary = defineProjection({
 
 function AuthorDetails({doc}: {doc: DocumentHandle<'author'>}) {
   // The type of `data` is inferred from `authorProjection`
-  const {data} = useProjection({
+  const {data} = useDocumentProjection({
     ...doc, // Spread the handle containing documentId, type, etc.
     projection: authorProjection,
   })
@@ -227,7 +227,7 @@ function AuthorDetails({doc}: {doc: DocumentHandle<'author'>}) {
 
 - The generated type (e.g., `AuthorSummaryProjectionResult`) includes a `DocumentTypeScoped` brand, allowing unions of projection results if a projection applies to multiple document types.
 - Typegen intelligently removes types from the projection result if all fields in the projection evaluate to `null` for a given document type.
-- When using Typegen, you **cannot** pass raw projection strings to `useProjection` and get type inference; you must use `defineProjection`.
+- When using Typegen, you **cannot** pass raw projection strings to `useDocumentProjection` and get type inference; you must use `defineProjection`.
 
 ### Queries: `defineQuery`
 

--- a/packages/react/internal-guides/Advanced-Resource-Management.md
+++ b/packages/react/internal-guides/Advanced-Resource-Management.md
@@ -297,7 +297,7 @@ For example, here's a component that works with document handles:
 // A component that works with any document with address fields
 function Address(docHandle: DocumentHandle) {
   // Get address fields from the document
-  const {data} = useProjection({
+  const {data} = useDocumentProjection({
     ...docHandle, // Pass along all the handle properties
     projection: '{address1, address2, city, state, "zipCode": zip}',
   })
@@ -324,7 +324,7 @@ interface DocumentPreviewProps extends DocumentHandle {
 
 function DocumentPreview({showDescription, ...docHandle}: DocumentPreviewProps) {
   // Use the handle properties plus your own custom ones
-  const {data} = useProjection({
+  const {data} = useDocumentProjection({
     ...docHandle,
     projection: showDescription ? '{name,description}' : '{name}',
   })
@@ -548,7 +548,7 @@ import {
   ResourceProvider,
   useDatasets,
   usePaginatedList,
-  useProjection,
+  useDocumentProjection,
   useProjects,
   useQuery,
 } from '@sanity/sdk-react'
@@ -678,7 +678,7 @@ function DocumentList({type}) {
 
 function DocumentPreview(docHandle: DocumentHandle) {
   // Get just the title field from the document
-  const {data} = useProjection<{title?: string}>({
+  const {data} = useDocumentProjection<{title?: string}>({
     ...docHandle,
     projection: '{title}',
   })

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -57,10 +57,10 @@ export {
   type UsePreviewResults,
 } from '../hooks/preview/usePreview'
 export {
-  useProjection,
-  type UseProjectionOptions,
-  type UseProjectionResults,
-} from '../hooks/projection/useProjection'
+  useDocumentProjection,
+  type useDocumentProjectionOptions,
+  type useDocumentProjectionResults,
+} from '../hooks/projection/useDocumentProjection'
 export {useProject} from '../hooks/projects/useProject'
 export {type ProjectWithoutMembers, useProjects} from '../hooks/projects/useProjects'
 export {useQuery} from '../hooks/query/useQuery'

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -52,10 +52,10 @@ export {
   usePaginatedDocuments,
 } from '../hooks/paginatedDocuments/usePaginatedDocuments'
 export {
-  usePreview,
-  type UsePreviewOptions,
-  type UsePreviewResults,
-} from '../hooks/preview/usePreview'
+  useDocumentPreview,
+  type useDocumentPreviewOptions,
+  type useDocumentPreviewResults,
+} from '../hooks/preview/useDocumentPreview'
 export {
   useDocumentProjection,
   type useDocumentProjectionOptions,

--- a/packages/react/src/hooks/document/useDocument.ts
+++ b/packages/react/src/hooks/document/useDocument.ts
@@ -3,9 +3,9 @@ import {type SanityDocumentResult} from 'groq'
 import {identity} from 'rxjs'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
-// used in an `{@link useProjection}` and `{@link useQuery}`
+// used in an `{@link useDocumentProjection}` and `{@link useQuery}`
 // eslint-disable-next-line import/consistent-type-specifier-style, unused-imports/no-unused-imports
-import type {useProjection} from '../projection/useProjection'
+import type {useDocumentProjection} from '../projection/useDocumentProjection'
 // eslint-disable-next-line import/consistent-type-specifier-style, unused-imports/no-unused-imports
 import type {useQuery} from '../query/useQuery'
 
@@ -191,7 +191,7 @@ interface UseDocument {
  * - Realtime updates aren't critical
  * - You want better performance
  *
- * …consider using {@link useProjection} or {@link useQuery} instead. These hooks are more efficient
+ * …consider using {@link useDocumentProjection} or {@link useQuery} instead. These hooks are more efficient
  * for read-heavy applications.
  *
  * @function

--- a/packages/react/src/hooks/documents/useDocuments.ts
+++ b/packages/react/src/hooks/documents/useDocuments.ts
@@ -106,9 +106,9 @@ export interface DocumentsResponse<
  * } from '@sanity/sdk-react'
  * import {Suspense} from 'react'
  *
- * // Define a component to display a single document (using useProjection for efficiency)
+ * // Define a component to display a single document (using useDocumentProjection for efficiency)
  * function MyDocumentComponent({doc}: {doc: DocumentHandle}) {
- *   const {data} = useProjection<{title?: string}>({
+ *   const {data} = useDocumentProjection<{title?: string}>({
  *     ...doc, // Pass the full handle
  *     projection: '{title}'
  *   })

--- a/packages/react/src/hooks/paginatedDocuments/usePaginatedDocuments.ts
+++ b/packages/react/src/hooks/paginatedDocuments/usePaginatedDocuments.ts
@@ -148,14 +148,14 @@ export interface PaginatedDocumentsResponse<
  *   type DatasetHandle,
  *   type DocumentHandle,
  *   type SortOrderingItem,
- *   useProjection
+ *   useDocumentProjection
  * } from '@sanity/sdk-react'
  * import {Suspense} from 'react'
  * import {ErrorBoundary} from 'react-error-boundary'
  *
  * // Define a component to display a single document row
  * function MyTableRowComponent({doc}: {doc: DocumentHandle}) {
- *   const {data} = useProjection<{title?: string}>({
+ *   const {data} = useDocumentProjection<{title?: string}>({
  *     ...doc,
  *     projection: '{title}',
  *   })

--- a/packages/react/src/hooks/preview/useDocumentPreview.test.tsx
+++ b/packages/react/src/hooks/preview/useDocumentPreview.test.tsx
@@ -3,7 +3,7 @@ import {act, render, screen} from '@testing-library/react'
 import {Suspense, useRef} from 'react'
 import {type Mock} from 'vitest'
 
-import {usePreview} from './usePreview'
+import {useDocumentPreview} from './useDocumentPreview'
 
 // Mock IntersectionObserver
 const mockIntersectionObserver = vi.fn()
@@ -45,7 +45,7 @@ const mockDocument: DocumentHandle = {
 
 function TestComponent(docHandle: DocumentHandle) {
   const ref = useRef(null)
-  const {data, isPending} = usePreview({...docHandle, ref})
+  const {data, isPending} = useDocumentPreview({...docHandle, ref})
 
   return (
     <div ref={ref}>
@@ -56,7 +56,7 @@ function TestComponent(docHandle: DocumentHandle) {
   )
 }
 
-describe('usePreview', () => {
+describe('useDocumentPreview', () => {
   let getCurrent: Mock
   let subscribe: Mock
 
@@ -182,7 +182,7 @@ describe('usePreview', () => {
     subscribe.mockImplementation(() => eventsUnsubscribe)
 
     function NoRefComponent(docHandle: DocumentHandle) {
-      const {data} = usePreview(docHandle) // No ref provided
+      const {data} = useDocumentPreview(docHandle) // No ref provided
       return (
         <div>
           <h1>{data?.title}</h1>
@@ -212,7 +212,7 @@ describe('usePreview', () => {
 
     function NonHtmlRefComponent(docHandle: DocumentHandle) {
       const ref = useRef({}) // ref.current is not an HTML element
-      const {data} = usePreview({...docHandle, ref})
+      const {data} = useDocumentPreview({...docHandle, ref})
       return (
         <div>
           <h1>{data?.title}</h1>

--- a/packages/react/src/hooks/preview/useDocumentPreview.tsx
+++ b/packages/react/src/hooks/preview/useDocumentPreview.tsx
@@ -8,7 +8,7 @@ import {useSanityInstance} from '../context/useSanityInstance'
  * @beta
  * @category Types
  */
-export interface UsePreviewOptions extends DocumentHandle {
+export interface useDocumentPreviewOptions extends DocumentHandle {
   /**
    * Optional ref object to track visibility. When provided, preview resolution
    * only occurs when the referenced element is visible in the viewport.
@@ -20,7 +20,7 @@ export interface UsePreviewOptions extends DocumentHandle {
  * @beta
  * @category Types
  */
-export interface UsePreviewResults {
+export interface useDocumentPreviewResults {
   /** The results of resolving the document’s preview values */
   data: PreviewValue
   /** True when preview values are being refreshed */
@@ -43,7 +43,7 @@ export interface UsePreviewResults {
  * ```
  * // PreviewComponent.jsx
  * export default function PreviewComponent({ document }) {
- *   const { data: { title, subtitle, media }, isPending } = usePreview({ document })
+ *   const { data: { title, subtitle, media }, isPending } = useDocumentPreview({ document })
  *   return (
  *     <article style={{ opacity: isPending ? 0.5 : 1}}>
  *       {media?.type === 'image-asset' ? <img src={media.url} alt='' /> : ''}
@@ -71,7 +71,10 @@ export interface UsePreviewResults {
  * )
  * ```
  */
-export function usePreview({ref, ...docHandle}: UsePreviewOptions): UsePreviewResults {
+export function useDocumentPreview({
+  ref,
+  ...docHandle
+}: useDocumentPreviewOptions): useDocumentPreviewResults {
   const instance = useSanityInstance()
   const stateSource = getPreviewState(instance, docHandle)
 
@@ -121,7 +124,7 @@ export function usePreview({ref, ...docHandle}: UsePreviewOptions): UsePreviewRe
   const getSnapshot = useCallback(() => {
     const currentState = stateSource.getCurrent()
     if (currentState.data === null) throw resolvePreview(instance, docHandle)
-    return currentState as UsePreviewResults
+    return currentState as useDocumentPreviewResults
   }, [docHandle, instance, stateSource])
 
   return useSyncExternalStore(subscribe, getSnapshot)

--- a/packages/react/src/hooks/projection/useDocumentProjection.test.tsx
+++ b/packages/react/src/hooks/projection/useDocumentProjection.test.tsx
@@ -8,7 +8,7 @@ import {act, render, screen} from '@testing-library/react'
 import {Suspense, useRef} from 'react'
 import {type Mock} from 'vitest'
 
-import {useProjection} from './useProjection'
+import {useDocumentProjection} from './useDocumentProjection'
 
 // Mock IntersectionObserver
 const mockIntersectionObserver = vi.fn()
@@ -61,7 +61,7 @@ function TestComponent({
   projection: ValidProjection
 }) {
   const ref = useRef(null)
-  const {data, isPending} = useProjection<ProjectionResult>({...document, projection, ref})
+  const {data, isPending} = useDocumentProjection<ProjectionResult>({...document, projection, ref})
 
   return (
     <div ref={ref}>
@@ -72,7 +72,7 @@ function TestComponent({
   )
 }
 
-describe('useProjection', () => {
+describe('useDocumentProjection', () => {
   let getCurrent: Mock
   let subscribe: Mock
 
@@ -228,7 +228,7 @@ describe('useProjection', () => {
       projection,
       ...docHandle
     }: DocumentHandle & {projection: ValidProjection}) {
-      const {data} = useProjection<ProjectionResult>({...docHandle, projection}) // No ref provided
+      const {data} = useDocumentProjection<ProjectionResult>({...docHandle, projection}) // No ref provided
       return (
         <div>
           <h1>{data.title}</h1>
@@ -261,7 +261,7 @@ describe('useProjection', () => {
       ...docHandle
     }: DocumentHandle & {projection: ValidProjection}) {
       const ref = useRef({}) // ref.current is not an HTML element
-      const {data} = useProjection<ProjectionResult>({...docHandle, projection, ref})
+      const {data} = useDocumentProjection<ProjectionResult>({...docHandle, projection, ref})
       return (
         <div>
           <h1>{data.title}</h1>

--- a/packages/react/src/hooks/projection/useDocumentProjection.ts
+++ b/packages/react/src/hooks/projection/useDocumentProjection.ts
@@ -14,7 +14,7 @@ import {useSanityInstance} from '../context/useSanityInstance'
  * @public
  * @category Types
  */
-export interface UseProjectionOptions<
+export interface useDocumentProjectionOptions<
   TProjection extends ValidProjection = ValidProjection,
   TDocumentType extends string = string,
   TDataset extends string = string,
@@ -32,7 +32,7 @@ export interface UseProjectionOptions<
  * @public
  * @category Types
  */
-export interface UseProjectionResults<TData> {
+export interface useDocumentProjectionResults<TData> {
   /** The projected data */
   data: TData
   /** True if the projection is currently being resolved */
@@ -69,7 +69,7 @@ export interface UseProjectionResults<TData> {
  * @example Using Typegen for a book preview
  * ```tsx
  * // ProjectionComponent.tsx
- * import {useProjection, type DocumentHandle} from '@sanity/sdk-react'
+ * import {useDocumentProjection, type DocumentHandle} from '@sanity/sdk-react'
  * import {useRef} from 'react'
  * import {defineProjection} from 'groq'
  *
@@ -90,7 +90,7 @@ export interface UseProjectionResults<TData> {
  *
  *   // Spread the doc handle into the options
  *   // Typegen infers the return type based on 'book' and the projection
- *   const { data } = useProjection({
+ *   const { data } = useDocumentProjection({
  *     ...doc, // Pass the handle properties
  *     ref,
  *     projection: myProjection,
@@ -114,14 +114,16 @@ export interface UseProjectionResults<TData> {
  * // </Suspense>
  * ```
  */
-export function useProjection<
+export function useDocumentProjection<
   TProjection extends ValidProjection = ValidProjection,
   TDocumentType extends string = string,
   TDataset extends string = string,
   TProjectId extends string = string,
 >(
-  options: UseProjectionOptions<TProjection, TDocumentType, TDataset, TProjectId>,
-): UseProjectionResults<SanityProjectionResult<TProjection, TDocumentType, TDataset, TProjectId>>
+  options: useDocumentProjectionOptions<TProjection, TDocumentType, TDataset, TProjectId>,
+): useDocumentProjectionResults<
+  SanityProjectionResult<TProjection, TDocumentType, TDataset, TProjectId>
+>
 
 // Overload 2: Explicit type provided
 /**
@@ -133,7 +135,7 @@ export function useProjection<
  *
  * @example Explicitly typing the projection result
  * ```tsx
- * import {useProjection, type DocumentHandle} from '@sanity/sdk-react'
+ * import {useDocumentProjection, type DocumentHandle} from '@sanity/sdk-react'
  * import {useRef} from 'react'
  *
  * interface SimpleBookPreview {
@@ -147,7 +149,7 @@ export function useProjection<
  *
  * function BookPreview({ doc }: BookPreviewProps) {
  *   const ref = useRef(null)
- *   const { data } = useProjection<SimpleBookPreview>({
+ *   const { data } = useDocumentProjection<SimpleBookPreview>({
  *     ...doc,
  *     ref,
  *     projection: `{ title, 'authorName': author->name }`
@@ -169,16 +171,16 @@ export function useProjection<
  * // </Suspense>
  * ```
  */
-export function useProjection<TData extends object>(
-  options: UseProjectionOptions, // Uses base options type
-): UseProjectionResults<TData>
+export function useDocumentProjection<TData extends object>(
+  options: useDocumentProjectionOptions, // Uses base options type
+): useDocumentProjectionResults<TData>
 
 // Implementation (no JSDoc needed here as it's covered by overloads)
-export function useProjection<TData extends object>({
+export function useDocumentProjection<TData extends object>({
   ref,
   projection,
   ...docHandle
-}: UseProjectionOptions): UseProjectionResults<TData> {
+}: useDocumentProjectionOptions): useDocumentProjectionResults<TData> {
   const instance = useSanityInstance()
   const stateSource = getProjectionState<TData>(instance, {...docHandle, projection})
 
@@ -228,5 +230,8 @@ export function useProjection<TData extends object>({
     [stateSource, ref],
   )
 
-  return useSyncExternalStore(subscribe, stateSource.getCurrent) as UseProjectionResults<TData>
+  return useSyncExternalStore(
+    subscribe,
+    stateSource.getCurrent,
+  ) as useDocumentProjectionResults<TData>
 }


### PR DESCRIPTION
### Description

Renamed hooks for better clarity and consistency:
- `usePreview` → `useDocumentPreview`
- `useProjection` → `useDocumentProjection`

Also renamed associated types to match:
- `UsePreviewOptions` → `useDocumentPreviewOptions`
- `UsePreviewResults` → `useDocumentPreviewResults`
- `UseProjectionOptions` → `useDocumentProjectionOptions`
- `UseProjectionResults` → `useDocumentProjectionResults`

These changes make the hook names more explicit about their purpose and align with the existing naming pattern of document-related hooks like `useDocument` and `useDocumentEvent`.

### What to review

- Check that all imports and references to the renamed hooks have been updated
- Verify that the renamed types are properly exported
- Ensure documentation references have been updated to reflect the new names
- Confirm that the test files have been renamed and updated correctly

### Testing

All existing tests have been updated to use the new hook names. The test files themselves have been renamed to match the new hook names while maintaining the same test coverage.

### Fun gif
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExYWk2dzlybHhtMjV1bXh6MjZiN2k4cHBvYWVlNms5NzN3aW4wYTVtaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l41lFeWQ3QOHsgHks/giphy.gif)