### PR TITLE
chore: eslint ignore auto-generated typegen file

### DIFF
--- a/apps/kitchensink-react/eslint.config.mjs
+++ b/apps/kitchensink-react/eslint.config.mjs
@@ -17,6 +17,9 @@ export default [
       'pnpm-lock.yaml',
       'package-lock.json',
       'yarn.lock',
+
+      // Ignore files for Sanity TypeGen
+      'sanity.types.ts',
     ],
   },
   ...baseESLintConfig,


### PR DESCRIPTION
### Description

Added `sanity.types.ts` to the ESLint ignore list in the kitchensink-react app. This file is generated by Sanity TypeGen and should not be linted.

### What to review

Check that the ESLint configuration properly ignores the `sanity.types.ts` file, which is now listed under the "Ignore files for Sanity TypeGen" comment.

### Testing

Verified that ESLint no longer attempts to lint the `sanity.types.ts` file when running linting commands.

### Fun gif
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWh2ZTN2eTczcmt5YzNzNW56ODJmenFhOGNpNnZkbWVjaDYzY2RmciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MUHNdrm3vk7MoyUsCO/giphy.gif)