### PR TITLE
fix!: change `status` to `_status` in projection and preview

### DIFF
--- a/apps/kitchensink-react/src/DocumentCollection/DocumentPreview.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentPreview.tsx
@@ -21,20 +21,20 @@ export function DocumentPreview(docHandle: DocumentHandle): React.ReactNode {
 function DocumentPreviewResolved(docHandle: DocumentHandle): React.ReactNode {
   const ref = useRef(null)
   const {
-    data: {title, subtitle, media, status},
+    data: {title, subtitle, media, _status},
   } = useDocumentPreview({...docHandle, ref})
 
   let statusLabel
-  if (status?.lastEditedPublishedAt && status?.lastEditedDraftAt) {
-    const published = new Date(status.lastEditedPublishedAt)
-    const draft = new Date(status.lastEditedDraftAt)
+  if (_status?.lastEditedPublishedAt && _status?.lastEditedDraftAt) {
+    const published = new Date(_status.lastEditedPublishedAt)
+    const draft = new Date(_status.lastEditedDraftAt)
 
     if (published.getTime() > draft.getTime()) {
       statusLabel = 'published'
     } else {
       statusLabel = 'draft'
     }
-  } else if (status?.lastEditedPublishedAt) {
+  } else if (_status?.lastEditedPublishedAt) {
     statusLabel = 'published'
   } else {
     statusLabel = 'draft'

--- a/packages/core/src/preview/previewQuery.test.ts
+++ b/packages/core/src/preview/previewQuery.test.ts
@@ -80,7 +80,7 @@ describe('processPreviewQuery', () => {
     expect(val?.data).toEqual({
       title: 'John',
       media: null,
-      status: {lastEditedPublishedAt: '2021-01-01'},
+      _status: {lastEditedPublishedAt: '2021-01-01'},
     })
     expect(val?.isPending).toBe(false)
   })
@@ -126,7 +126,7 @@ describe('processPreviewQuery', () => {
     expect(val?.data).toEqual({
       title: 'Draft Title',
       media: null,
-      status: {
+      _status: {
         lastEditedDraftAt: '2023-12-16T12:00:00Z',
         lastEditedPublishedAt: '2023-12-15T12:00:00Z',
       },
@@ -176,7 +176,7 @@ describe('processPreviewQuery', () => {
       title: titleCandidates[TITLE_CANDIDATES[0] as keyof typeof titleCandidates],
       subtitle: subtitleCandidates[SUBTITLE_CANDIDATES[0] as keyof typeof subtitleCandidates],
       media: null,
-      status: {lastEditedPublishedAt: '2023-12-15T12:00:00Z'},
+      _status: {lastEditedPublishedAt: '2023-12-15T12:00:00Z'},
     })
     expect(val?.isPending).toBe(false)
   })

--- a/packages/core/src/preview/previewQuery.ts
+++ b/packages/core/src/preview/previewQuery.ts
@@ -118,12 +118,12 @@ export function processPreviewQuery({
           media: normalizeMedia(result.media, projectId, dataset),
         }
 
-        const status: PreviewValue['status'] = {
+        const _status: PreviewValue['_status'] = {
           ...(draftResult?._updatedAt && {lastEditedDraftAt: draftResult._updatedAt}),
           ...(publishedResult?._updatedAt && {lastEditedPublishedAt: publishedResult._updatedAt}),
         }
 
-        return [id, {data: {...preview, status}, isPending: false}]
+        return [id, {data: {...preview, _status}, isPending: false}]
       } catch (e) {
         // TODO: replace this with bubbling the error
         // eslint-disable-next-line no-console

--- a/packages/core/src/preview/previewStore.ts
+++ b/packages/core/src/preview/previewStore.ts
@@ -48,7 +48,7 @@ export interface PreviewValue {
   /**
    * The status of the document.
    */
-  status?: {
+  _status?: {
     /** The date of the last published edit */
     lastEditedPublishedAt?: string
     /** The date of the last draft edit */

--- a/packages/core/src/projection/projectionQuery.test.ts
+++ b/packages/core/src/projection/projectionQuery.test.ts
@@ -96,7 +96,7 @@ describe('processProjectionQuery', () => {
       data: {
         title: 'Hello',
         description: 'World',
-        status: {
+        _status: {
           lastEditedPublishedAt: '2021-01-01',
         },
       },
@@ -127,7 +127,7 @@ describe('processProjectionQuery', () => {
       data: {
         title: 'Hello',
         description: 'World',
-        status: {
+        _status: {
           lastEditedPublishedAt: '2021-01-01',
         },
       },
@@ -163,7 +163,7 @@ describe('processProjectionQuery', () => {
     expect(processed['doc1']?.[testProjectionHash]).toEqual({
       data: {
         title: 'Draft',
-        status: {
+        _status: {
           lastEditedDraftAt: '2021-01-02',
           lastEditedPublishedAt: '2021-01-01',
         },
@@ -193,7 +193,7 @@ describe('processProjectionQuery', () => {
     expect(processed['doc1']?.[testProjectionHash]).toEqual({
       data: {
         title: 'Published',
-        status: {
+        _status: {
           lastEditedPublishedAt: '2021-01-01',
         },
       },
@@ -231,7 +231,7 @@ describe('processProjectionQuery', () => {
     expect(processed['doc1']?.[hash1]).toEqual({
       data: {
         title: 'Published Title',
-        status: {
+        _status: {
           lastEditedPublishedAt: '2021-01-01',
         },
       },
@@ -240,7 +240,7 @@ describe('processProjectionQuery', () => {
     expect(processed['doc1']?.[hash2]).toEqual({
       data: {
         description: 'Published Desc',
-        status: {
+        _status: {
           lastEditedPublishedAt: '2021-01-01',
         },
       },

--- a/packages/core/src/projection/projectionQuery.ts
+++ b/packages/core/src/projection/projectionQuery.ts
@@ -123,13 +123,13 @@ export function processProjectionQuery({ids, results}: ProcessProjectionQueryOpt
         continue
       }
 
-      const status = {
+      const _status = {
         ...(draft?._updatedAt && {lastEditedDraftAt: draft._updatedAt}),
         ...(published?._updatedAt && {lastEditedPublishedAt: published._updatedAt}),
       }
 
       finalValues[originalId][hash] = {
-        data: {...projectionResultData, status},
+        data: {...projectionResultData, _status},
         isPending: false,
       }
     }

--- a/packages/core/src/projection/subscribeToStateAndFetchBatches.test.ts
+++ b/packages/core/src/projection/subscribeToStateAndFetchBatches.test.ts
@@ -141,7 +141,7 @@ describe('subscribeToStateAndFetchBatches', () => {
       isPending: false,
       data: {
         title: 'resolved',
-        status: {
+        _status: {
           lastEditedDraftAt: timestamp,
           lastEditedPublishedAt: timestamp,
         },
@@ -299,7 +299,7 @@ describe('subscribeToStateAndFetchBatches', () => {
       data: expect.objectContaining({
         title: 'Test Document',
         description: 'Test Description',
-        status: {
+        _status: {
           lastEditedPublishedAt: timestamp,
         },
       }),

--- a/packages/react/guides/0-Migration-Guide.md
+++ b/packages/react/guides/0-Migration-Guide.md
@@ -2,6 +2,34 @@
 title: Migration guide
 ---
 
+## Migrating to @sanity/sdk-react@2.0.0
+
+### Breaking Changes
+
+1. Changed `status` to `_status` in preview and projection results
+
+The `status` field in preview and projection results has been renamed to `_status` to prevent collisions with user-defined `status` fields and to follow the convention of using underscore prefix for system attributes.
+
+**Before:**
+
+```typescript
+const {data} = useDocumentPreview({documentId: '123', documentType: 'product'})
+console.log(data?.status?.lastEditedPublishedAt)
+```
+
+**After:**
+
+```typescript
+const {data} = useDocumentPreview({documentId: '123', documentType: 'product'})
+console.log(data?._status?.lastEditedPublishedAt)
+```
+
+This change affects:
+
+- `PreviewValue` interface
+- Projection results
+- Preview results
+
 ## Migrating to @sanity/sdk-react@1.0.0
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

Renamed `status` to `_status` in preview and projection results to prevent collisions with user-defined fields and follow the convention of using underscore prefix for system attributes. This change affects the `PreviewValue` interface and both projection and preview results.

Added migration documentation for this breaking change in the migration guide.

### What to review

- Verify that all references to the `status` field in preview and projection results have been updated to `_status`
- Check the migration guide to ensure it clearly explains the change and provides appropriate examples
- Confirm that all tests have been updated to reflect this change

### Testing

Updated all relevant tests to use `_status` instead of `status`. Tests now verify that preview and projection results correctly include the renamed field.

### Fun gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExdXc5NHl5cmk2cWk2cWJmMmc1NXh3bjV2cTExcDB4N2hwejM0NDJidSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/55o60jwgV338VEX6ll/giphy.gif)