### PR TITLE
fix(kitchensink): allow kitchensink to be deployed and used in dashboard

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,5 +1,5 @@
 // @ts-check
 export default {
-  '!(*.{js,jsx,ts,tsx,npmrc})': 'prettier --write',
+  '!(*.{js,jsx,ts,tsx,npmrc,gitignore})': 'prettier --write',
   '*.{js,jsx,ts,tsx}': ['eslint --fix', 'prettier --write'],
 }

--- a/apps/kitchensink-react/.gitignore
+++ b/apps/kitchensink-react/.gitignore
@@ -1,2 +1,3 @@
 /schema.*.json
 /sanity.types.ts
+.sanity

--- a/apps/kitchensink-react/package.json
+++ b/apps/kitchensink-react/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "build": "pnpm tsc && vite build",
     "clean": "rimraf dist",
+    "deploy": "sanity deploy",
     "dev": "vite",
     "install": "npm run schema:extract && npm run types:generate",
     "lint": "eslint .",
     "paramour": "npx paramour --config=./src/css/css.config.js --output=./src/css/paramour.css",
-    "schema:extract": "sanity schema extract --workspace ppsg7ml5-test --path schema.ppsg7ml5.test.json && sanity schema extract --workspace ezwd8xes-production --path schema.ezwd8xes.production.json",
+    "schema:extract": "sanity schema extract --workspace ppsg7ml5-test --path schema.ppsg7ml5.test.json && sanity schema extract --workspace d45jg133-production --path schema.d45jg133.production.json",
     "tsc": "tsc --noEmit",
     "types:generate": "./node_modules/@sanity/cli/bin/sanity typegen generate"
   },
@@ -29,6 +30,7 @@
     "react-error-boundary": "^5.0.0",
     "react-router": "^7.5.2",
     "sanity": "^3.86.1",
+    "styled-components": "^6.1.18",
     "typescript": "^5.8.3"
   },
   "devDependencies": {

--- a/apps/kitchensink-react/sanity-typegen.json
+++ b/apps/kitchensink-react/sanity-typegen.json
@@ -5,8 +5,8 @@
       "schemaId": "ppsg7ml5.test"
     },
     {
-      "schemaPath": "./schema.ezwd8xes.production.json",
-      "schemaId": "ezwd8xes.production"
+      "schemaPath": "./schema.d45jg133.production.json",
+      "schemaId": "d45jg133.production"
     }
   ],
   "overloadClientMethods": false

--- a/apps/kitchensink-react/sanity.cli.ts
+++ b/apps/kitchensink-react/sanity.cli.ts
@@ -1,0 +1,9 @@
+import {defineCliConfig} from 'sanity/cli'
+
+export default defineCliConfig({
+  app: {
+    organizationId: 'oSyH1iET5',
+    entry: './src/App.tsx',
+    id: 'cbhuuqhkp6sevhpreoh0so8s',
+  },
+})

--- a/apps/kitchensink-react/sanity.config.ts
+++ b/apps/kitchensink-react/sanity.config.ts
@@ -69,20 +69,13 @@ const bookType = defineType({
   ],
 })
 
-// Define a 'dog' schema type based on the Dog interface
-const dogType = defineType({
-  name: 'dog',
-  title: 'Dog',
+const playerType = defineType({
+  name: 'player',
+  title: 'Player',
   type: 'document',
   fields: [
     defineField({name: 'name', title: 'Name', type: 'string'}),
-    defineField({name: 'age', title: 'Age', type: 'string'}), // Assuming age is stored as string per interface
-    defineField({name: 'color', title: 'Color', type: 'string'}),
-    defineField({name: 'ears', title: 'Ears', type: 'string'}),
-    defineField({name: 'status', title: 'Status', type: 'string'}),
-    defineField({name: 'weight', title: 'Weight', type: 'string'}), // Assuming weight is stored as string per interface
-    defineField({name: 'description', title: 'Description', type: 'text'}),
-    defineField({name: 'images', title: 'Images', type: 'array', of: [{type: 'image'}]}),
+    defineField({name: 'slackUserId', title: 'Slack User ID', type: 'string'}),
   ],
 })
 
@@ -97,12 +90,12 @@ export default defineConfig([
     },
   },
   {
-    name: 'ezwd8xes-production',
-    basePath: '/ezwd8xes-production',
-    projectId: 'ezwd8xes',
+    name: 'd45jg133-production',
+    basePath: '/d45jg133-production',
+    projectId: 'd45jg133',
     dataset: 'production',
     schema: {
-      types: [dogType],
+      types: [playerType],
     },
   },
 ])

--- a/apps/kitchensink-react/src/App.tsx
+++ b/apps/kitchensink-react/src/App.tsx
@@ -14,12 +14,12 @@ const sanityConfigs: SanityConfig[] = [
     dataset: 'test',
   },
   {
-    projectId: 'ezwd8xes',
+    projectId: 'd45jg133',
     dataset: 'production',
   },
 ]
 
-export function App(): JSX.Element {
+export default function App(): JSX.Element {
   return (
     <ThemeProvider theme={theme}>
       <SanityApp fallback={<Spinner />} config={sanityConfigs}>

--- a/apps/kitchensink-react/src/DocumentCollection/MultiResourceRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/MultiResourceRoute.tsx
@@ -10,24 +10,24 @@ const doc = createDocumentHandle({
 })
 
 const doc2 = createDocumentHandle({
-  documentType: 'dog',
-  documentId: 'acc11e96-1a01-4907-bd0e-e8347217cf2f',
-  projectId: 'ezwd8xes',
+  documentType: 'player',
+  documentId: 'a1b3019b-a0e0-49d5-8212-9d85b9661202',
+  projectId: 'd45jg133',
   dataset: 'production',
 })
 
 export function MultiResourceRoute(): JSX.Element {
   const {data: author} = useDocument(doc)
-  const {data: dog} = useDocument(doc2)
+  const {data: player} = useDocument(doc2)
   const setAuthorName = useEditDocument({...doc, path: 'name'})
-  const setDogName = useEditDocument({...doc2, path: 'name'})
+  const setPlayerName = useEditDocument({...doc2, path: 'name'})
 
   return (
     <div>
       <p style={{marginBottom: '2rem'}}>
         This route demonstrates how to use multiple resources in a single page.
         <br />
-        Note you must have access to both resources (ppsg7ml5.test and ezwd8xes.production) to see
+        Note you must have access to both resources (ppsg7ml5.test and d45jg133.production) to see
         the documents.
       </p>
       <div style={{display: 'flex', gap: '2rem', flexWrap: 'wrap'}}>
@@ -83,37 +83,27 @@ export function MultiResourceRoute(): JSX.Element {
           }}
         >
           <h2 style={{marginBottom: '1rem', color: '#2a2a2a'}}>
-            Dog Document (ezwd8xes.production)
+            Player Document (d45jg133.production)
           </h2>
           <a
             style={{display: 'block', marginBottom: '1rem', color: '#3e41e7'}}
-            href={`https://bella.sanity.studio/structure/dog;${dog?._id}`}
+            href={`https://autofoos.com/structure/player;${player?._id}`}
             target="_blank"
             rel="noopener noreferrer"
           >
             View in Studio →
           </a>
 
-          <h3 style={{fontSize: '1.5rem', marginBottom: '0.5rem'}}>{dog?.name}</h3>
+          <h3 style={{fontSize: '1.5rem', marginBottom: '0.5rem'}}>{player?.name}</h3>
           <TextInput
             label="Name"
             type="text"
-            value={dog?.name}
-            onChange={(e) => setDogName(e.currentTarget.value)}
+            value={player?.name}
+            onChange={(e) => setPlayerName(e.currentTarget.value)}
           />
           <div style={{color: '#444', marginBottom: '1rem'}}>
-            {dog?.age && <p>Age: {dog.age}</p>}
-            {dog?.color && <p>Color: {dog.color}</p>}
-            {dog?.weight && <p>Weight: {dog.weight}</p>}
-            {dog?.ears && <p>Ears: {dog.ears}</p>}
-            {dog?.status && <p>Status: {dog.status}</p>}
+            {player?.slackUserId && `Slack User ID: ${player.slackUserId}`}
           </div>
-          {dog?.description && (
-            <div>
-              <h4 style={{marginBottom: '0.5rem'}}>About</h4>
-              <p style={{color: '#444'}}>{dog.description}</p>
-            </div>
-          )}
         </div>
       </div>
     </div>

--- a/apps/kitchensink-react/src/main.tsx
+++ b/apps/kitchensink-react/src/main.tsx
@@ -1,7 +1,7 @@
 import {StrictMode} from 'react'
 import {createRoot} from 'react-dom/client'
 
-import {App} from './App'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ importers:
         version: link:../../packages/react
       '@sanity/ui':
         specifier: ^2.15.13
-        version: 2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       groq:
         specifier: 3.88.1-typegen-experimental.0
         version: 3.88.1-typegen-experimental.0
@@ -130,7 +130,10 @@ importers:
         version: 7.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sanity:
         specifier: ^3.86.1
-        version: 3.87.0(@emotion/is-prop-valid@1.2.2)(@types/node@22.13.9)(@types/react@19.1.2)(immer@10.1.1)(jiti@2.4.2)(lightningcss@1.29.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.36.0)(tsx@4.19.4)(yaml@2.7.1)
+        version: 3.87.0(@emotion/is-prop-valid@1.2.2)(@types/node@22.13.9)(@types/react@19.1.2)(immer@10.1.1)(jiti@2.4.2)(lightningcss@1.29.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.36.0)(tsx@4.19.4)(yaml@2.7.1)
+      styled-components:
+        specifier: ^6.1.18
+        version: 6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -5578,8 +5581,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.38:
-    resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
+  postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.3:
@@ -6351,8 +6354,8 @@ packages:
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
-  styled-components@6.1.13:
-    resolution: {integrity: sha512-M0+N2xSnAtwcVAQeFEsGWFFxXDftHUD7XrKla06QbpUMmbmtFBMMTcKWvFXtWxuD5qQkB8iU5gk6QASlx2ZRMw==}
+  styled-components@6.1.18:
+    resolution: {integrity: sha512-Mvf3gJFzZCkhjY2Y/Fx9z1m3dxbza0uI9H1CbNZm/jSHCojzJhQ0R7bByrlFJINnMzz/gPulpoFFGymNwrsMcw==}
     engines: {node: '>= 16'}
     peerDependencies:
       react: '>= 16.8.0'
@@ -9138,11 +9141,11 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@sanity/insert-menu@1.1.10(@emotion/is-prop-valid@1.2.2)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@sanity/insert-menu@1.1.10(@emotion/is-prop-valid@1.2.2)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@sanity/icons': 3.7.0(react@18.3.1)
       '@sanity/types': 3.87.0(@types/react@19.1.2)(debug@4.4.0)
-      '@sanity/ui': 2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/ui': 2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       lodash: 4.17.21
       react: 18.3.1
       react-compiler-runtime: 19.0.0-beta-e993439-20250405(react@18.3.1)
@@ -9388,7 +9391,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/ui@2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@sanity/ui@2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@juggle/resize-observer': 3.4.0
@@ -9401,7 +9404,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.3.1
       react-refractor: 2.2.0(react@18.3.1)
-      styled-components: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      styled-components: 6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       use-effect-event: 1.0.2(react@18.3.1)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -12955,7 +12958,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.4.38:
+  postcss@8.4.49:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -13475,7 +13478,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity@3.87.0(@emotion/is-prop-valid@1.2.2)(@types/node@22.13.9)(@types/react@19.1.2)(immer@10.1.1)(jiti@2.4.2)(lightningcss@1.29.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.36.0)(tsx@4.19.4)(yaml@2.7.1):
+  sanity@3.87.0(@emotion/is-prop-valid@1.2.2)(@types/node@22.13.9)(@types/react@19.1.2)(immer@10.1.1)(jiti@2.4.2)(lightningcss@1.29.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.36.0)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -13502,7 +13505,7 @@ snapshots:
       '@sanity/id-utils': 1.0.0
       '@sanity/image-url': 1.1.0
       '@sanity/import': 3.38.2(@types/react@19.1.2)
-      '@sanity/insert-menu': 1.1.10(@emotion/is-prop-valid@1.2.2)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/insert-menu': 1.1.10(@emotion/is-prop-valid@1.2.2)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/logos': 2.1.13(@sanity/color@3.0.6)(react@18.3.1)
       '@sanity/message-protocol': 0.9.0
       '@sanity/migrate': 3.87.0(@types/react@19.1.2)
@@ -13513,7 +13516,7 @@ snapshots:
       '@sanity/sdk': 0.0.0-alpha.25(@types/react@19.1.2)(debug@4.4.0)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
       '@sanity/telemetry': 0.8.1(react@18.3.1)
       '@sanity/types': 3.87.0(@types/react@19.1.2)(debug@4.4.0)
-      '@sanity/ui': 2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/ui': 2.15.13(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/util': 3.87.0(@types/react@19.1.2)(debug@4.4.0)
       '@sanity/uuid': 3.0.2
       '@sentry/react': 8.55.0(react@18.3.1)
@@ -13598,7 +13601,7 @@ snapshots:
       semver: 7.7.1
       shallow-equals: 1.0.0
       speakingurl: 14.0.1
-      styled-components: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      styled-components: 6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tar-fs: 2.1.2
       tar-stream: 3.1.7
       urlpattern-polyfill: 10.0.0
@@ -13964,14 +13967,14 @@ snapshots:
 
   stubs@3.0.0: {}
 
-  styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  styled-components@6.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@emotion/is-prop-valid': 1.2.2
       '@emotion/unitless': 0.8.1
       '@types/stylis': 4.2.5
       css-to-react-native: 3.2.0
       csstype: 3.1.3
-      postcss: 8.4.38
+      postcss: 8.4.49
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       shallowequal: 1.1.0


### PR DESCRIPTION
### Description

This PR makes various changes to allow the Kitchensink to easily run as Dashboard application. That includes things required by the Sanity runtime (a `sanity.cli.ts` file, App.tsx as a default export) as well as removing things that would cause errors in the dashboard -- like referencing projects and documents from different organizations.

### What to review
Most of this should be pretty minimal. I think the styled-components dep is necessary since we're using @sanity/ui but feel free to call me out on that.

### Testing
The Kitchensink is now deployed [here](https://www.sanity.io/@oSyH1iET5/application/cbhuuqhkp6sevhpreoh0so8s). Please don't re-deploy, I have a downstream PR that I deployed.

### Fun gif

![Foosball players](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWJtZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZnRqZg/3o7TKVUn7iM8FMEU24/giphy.gif)

^ Graphite chose this GIF for me, thank you Graphite