### PR TITLE
feat(react): add dashboard navigate function

### DIFF
--- a/apps/kitchensink-react/src/App.tsx
+++ b/apps/kitchensink-react/src/App.tsx
@@ -1,8 +1,8 @@
-import {SanityApp, SanityConfig} from '@sanity/sdk-react'
+import {SanityApp, SanityConfig, useDashboardNavigate} from '@sanity/sdk-react'
 import {Spinner, ThemeProvider} from '@sanity/ui'
 import {buildTheme} from '@sanity/ui/theme'
-import {type JSX} from 'react'
-import {BrowserRouter} from 'react-router'
+import {type JSX, Suspense} from 'react'
+import {BrowserRouter, useNavigate} from 'react-router'
 
 import {AppRoutes} from './AppRoutes'
 
@@ -19,11 +19,22 @@ const sanityConfigs: SanityConfig[] = [
   },
 ]
 
+function NavigationHandler() {
+  const navigate = useNavigate()
+  useDashboardNavigate(({path, type}) => {
+    navigate(path, {replace: type === 'replace'})
+  })
+  return null
+}
+
 export default function App(): JSX.Element {
   return (
     <ThemeProvider theme={theme}>
       <SanityApp fallback={<Spinner />} config={sanityConfigs}>
         <BrowserRouter>
+          <Suspense>
+            <NavigationHandler />
+          </Suspense>
           <AppRoutes />
         </BrowserRouter>
       </SanityApp>

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -27,6 +27,7 @@ export {
   type WindowMessageHandler,
 } from '../hooks/comlink/useWindowConnection'
 export {useSanityInstance} from '../hooks/context/useSanityInstance'
+export {useDashboardNavigate} from '../hooks/dashboard/useDashboardNavigate'
 export {useManageFavorite} from '../hooks/dashboard/useManageFavorite'
 export {
   type NavigateToStudioResult,

--- a/packages/react/src/hooks/dashboard/useDashboardNavigate.test.ts
+++ b/packages/react/src/hooks/dashboard/useDashboardNavigate.test.ts
@@ -1,0 +1,44 @@
+import {type PathChangeMessage} from '@sanity/message-protocol'
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useDashboardNavigate} from './useDashboardNavigate'
+
+const mockOnMessage = vi.fn()
+let mockMessageHandler: ((data: PathChangeMessage['data']) => void) | undefined
+
+vi.mock('../comlink/useWindowConnection', () => {
+  return {
+    useWindowConnection: ({
+      onMessage,
+    }: {
+      onMessage: Record<string, (data: PathChangeMessage['data']) => void>
+    }) => {
+      mockMessageHandler = onMessage['dashboard/v1/history/change-path']
+      return {
+        onMessage: mockOnMessage,
+      }
+    },
+  }
+})
+
+describe('useDashboardNavigate', () => {
+  const mockNavigateFn = vi.fn()
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockMessageHandler = undefined
+  })
+
+  it('calls navigate function with correct data when message is received', () => {
+    renderHook(() => useDashboardNavigate(mockNavigateFn))
+
+    const mockNavigationData = {
+      path: '/test-path',
+      type: 'push' as const,
+    }
+    mockMessageHandler?.(mockNavigationData)
+
+    expect(mockNavigateFn).toHaveBeenCalledWith(mockNavigationData)
+  })
+})

--- a/packages/react/src/hooks/dashboard/useDashboardNavigate.ts
+++ b/packages/react/src/hooks/dashboard/useDashboardNavigate.ts
@@ -1,0 +1,60 @@
+import {type PathChangeMessage, SDK_CHANNEL_NAME, SDK_NODE_NAME} from '@sanity/message-protocol'
+
+import {useWindowConnection} from '../comlink/useWindowConnection'
+
+/**
+ * @public
+ *
+ * A helper hook designed to be injected into routing components for apps within the Dashboard.
+ * While the Dashboard can usually handle navigation, there are special cases when you
+ * are already within a target app, and need to navigate to another route inside of that app.
+ *
+ * For example, your user might "favorite" a document inside of your application.
+ * If they click on the Dashboard favorites item in the sidebar, and are already within your application,
+ * there needs to be some way for the dashboard to signal to your application to reroute to where that document was favorited.
+ *
+ * This hook is intended to receive those messages, and takes a function to route to the correct path.
+ *
+ * @param navigateFn - Function to handle navigation; should accept:
+ * - `path`: a string, which will be a relative path (for example, 'my-route')
+ * - `type`: 'push', 'replace', or 'pop', which will be the type of navigation to perform
+ *
+ * @example
+ * ```tsx
+ * import {useDashboardNavigate} from '@sanity/sdk-react'
+ * import {BrowserRouter, useNavigate} from 'react-router'
+ * import {Suspense} from 'react'
+ *
+ * function DashboardNavigationHandler() {
+ *   const navigate = useNavigate()
+ *   useDashboardNavigate(({path, type}) => {
+ *     navigate(path, {replace: type === 'replace'})
+ *   })
+ *   return null
+ * }
+ *
+ * // Wrap the component with Suspense since the hook may suspend
+ * function MyApp() {
+ *   return (
+ *     <BrowserRouter>
+ *       <Suspense>
+ *         <DashboardNavigationHandler />
+ *       </Suspense>
+ *     </BrowserRouter>
+ *   )
+ * }
+ * ```
+ */
+export function useDashboardNavigate(
+  navigateFn: (options: PathChangeMessage['data']) => void,
+): void {
+  useWindowConnection<PathChangeMessage, never>({
+    name: SDK_NODE_NAME,
+    connectTo: SDK_CHANNEL_NAME,
+    onMessage: {
+      'dashboard/v1/history/change-path': (data: PathChangeMessage['data']) => {
+        navigateFn(data)
+      },
+    },
+  })
+}


### PR DESCRIPTION
### Description

Add a new `useDashboardNavigate` hook that enables navigation functionality based on dashboard messages -- this is required for cases when you are in an application that you have favorited and click on the favorites item in the Dashboard sidebar. There may be additional occasions where this will be necessary.

The hook is now exported from the SDK React package and implemented in the kitchen sink app to demonstrate its usage with React Router.

### What to review
Does this implementation feel like good DX?

### Testing
The single test provides 100% test coverage. You can try the hook out manually by doing the following:
1. Go to the [dashboard interactions in deployed Kitchensink in Dashboard](https://www.sanity.io/@oSyH1iET5/application/cbhuuqhkp6sevhpreoh0so8s/document-dashboard-interactions).
2. Favorite a document.
3. Navigate somewhere else in the application.
4. Click on the favorite in the sidebar and you should be redirected back to the URL where you favorited the document.

[Screen Recording 2025-05-12 at 1.31.56 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/U4ak1bRiL7QX0YFs4Qiz/e591d783-f18c-4cdf-854c-61241b2ddb9c.mov" />](https://app.graphite.dev/media/video/U4ak1bRiL7QX0YFs4Qiz/e591d783-f18c-4cdf-854c-61241b2ddb9c.mov)

See attached video.


### Fun gif
![Favorite](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExOXliaG1xZG05ZXFjOTgxZWhwcGdxemcyeHJ0MGQ2bHF5MmtkMm44ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fjpYUp612jgXe/giphy.gif)