### PR TITLE
fix(core): align release order with studio release order

### DIFF
--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -47,6 +47,7 @@ export {
   type DocumentTypeHandle,
   type PerspectiveHandle,
   type ProjectHandle,
+  type ReleasePerspective,
   type SanityConfig,
 } from '../config/sanityConfig'
 export {getDatasetsState, resolveDatasets} from '../datasets/datasets'

--- a/packages/core/src/releases/getPerspectiveState.test.ts
+++ b/packages/core/src/releases/getPerspectiveState.test.ts
@@ -38,7 +38,8 @@ describe('getPerspectiveState', () => {
     metadata: {title: 'Release 2', releaseType: 'asap'},
   }
 
-  const activeReleases = [release1, release2]
+  // the release store is reversed in getActiveReleases to match UI elsewhere
+  const activeReleases = [release2, release1]
 
   beforeEach(() => {
     instance = createSanityInstance({projectId: 'test', dataset: 'test'})

--- a/packages/core/src/releases/getPerspectiveState.ts
+++ b/packages/core/src/releases/getPerspectiveState.ts
@@ -4,6 +4,7 @@ import {type PerspectiveHandle, type ReleasePerspective} from '../config/sanityC
 import {bindActionByDataset} from '../store/createActionBinder'
 import {createStateSourceAction, type SelectorContext} from '../store/createStateSourceAction'
 import {releasesStore, type ReleasesStoreState} from './releasesStore'
+import {sortReleases} from './utils/sortReleases'
 
 function isReleasePerspective(
   perspective: PerspectiveHandle['perspective'],
@@ -75,7 +76,7 @@ export const getPerspectiveState = bindActionByDataset(
         // if there are no active releases we can't compute the release perspective
         if (!activeReleases || activeReleases.length === 0) return undefined
 
-        const releaseNames = activeReleases.map((release) => release.name)
+        const releaseNames = sortReleases(activeReleases).map((release) => release.name)
         const index = releaseNames.findIndex((name) => name === perspective.releaseName)
 
         if (index < 0) {

--- a/packages/core/src/releases/releasesStore.test.ts
+++ b/packages/core/src/releases/releasesStore.test.ts
@@ -61,7 +61,7 @@ describe('releasesStore', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(state.getCurrent()).toEqual(mockReleases)
+    expect(state.getCurrent()).toEqual(mockReleases.reverse())
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
@@ -105,7 +105,7 @@ describe('releasesStore', () => {
     releasesSubject.next(updatedReleases)
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(state.getCurrent()).toEqual(updatedReleases)
+    expect(state.getCurrent()).toEqual(updatedReleases.reverse())
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
### Description

This PR updates the release perspective handling in @sdk/core to match the behavior in the Studio -- it seems like better DX that these behaviors are the same across applications. Additionally, it exports the `ReleasePerspective` type and filters out archived and published releases from the active releases list.

### What to review

- The changes to `getPerspectiveState.ts` and `releasesStore.ts` to ensure the sorting and filtering logic is correct
- The updated tests in `getPerspectiveState.test.ts` and `releasesStore.test.ts` to verify the new behavior
- The export of the `ReleasePerspective` type in the core exports

### Testing

Updated existing tests to account for the reversed order of releases. The tests now correctly expect the releases to be in reverse order to match the UI behavior elsewhere.

### Fun gif
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExejMwbW1sankzc3Zuc3BiMzV6aWZ0cTgwdWNwejg3bDZtaXc2ZGo3bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/13hzdQ3QCID172/giphy.gif)