### PR TITLE
fix(deps): update dependency @sanity/comlink to ^3.0.4

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -74,7 +74,7 @@
     "@repo/package.config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
     "@sanity/browserslist-config": "^1.0.5",
-    "@sanity/comlink": "^3.0.2",
+    "@sanity/comlink": "^3.0.4",
     "@sanity/pkg-utils": "^7.2.2",
     "@sanity/prettier-config": "^1.0.3",
     "@testing-library/jest-dom": "^6.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,7 +430,7 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5
       '@sanity/comlink':
-        specifier: ^3.0.2
+        specifier: ^3.0.4
         version: 3.0.4
       '@sanity/pkg-utils':
         specifier: ^7.2.2
@@ -11015,7 +11015,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11037,7 +11037,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
### Description

Upgraded `@sanity/comlink` from version 3.0.2 to 3.0.4 to ensure we're using the latest version with bug fixes and improvements.

### What to review

- Verify that the package.json dependency update is correct
- Check that the pnpm-lock.yaml changes reflect the proper version update

### Testing

The change is a minor version update to a dependency, which should not introduce breaking changes. The package's existing tests should cover functionality that depends on this library.

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdXlmNmduNzQ2eTUyc2k0MDdld2cyeG9zZm5hZWRkcnR0bzR5cmJ5ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/kkFOYzdDi8Jaw/giphy.gif)