### PR TITLE
chore: prevent the release of e2e package

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,7 +52,7 @@ jobs:
           cache: pnpm
           node-version: lts/*
       - name: install deps & build
-        run: pnpm install --ignore-scripts && pnpm build --filter=!./apps/*
+        run: pnpm install --ignore-scripts && pnpm build --filter=!./apps/* --filter=!./e2e
         if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
       - name: Set publishing config
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
@@ -61,7 +61,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
       # Release Please has already incremented versions and published tags, so we just
       # need to publish all unpublished versions to NPM here
-      - run: pnpm -r publish
+      - run: pnpm publish -r --filter=!./apps/* --filter=!./e2e
         if: ${{ steps.release.outputs.releases_created == 'true' || github.event.inputs.publish == 'true' }}
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
### Description

This PR updates the release-please workflow to exclude the e2e directory from both the build and publish steps. This ensures that e2e tests are not included in the build process or published to NPM.

### What to review

- Verify that the `--filter=!./e2e` flag is correctly added to both the build command and the publish command
- Check that the publish command now includes the same filters as the build command for consistency

### Testing

The changes were tested by verifying that the workflow correctly excludes e2e tests during the build and publish process.

### Fun gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ2dlc2dlNzJobWV6enMwY290aHV5ZGc4NW50ZmM1dGgzdml2cGE5ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/wYyTHMm50f4Dm/giphy.gif)