### PR TITLE
fix(core): prevent race condition in document store

### DIFF
--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -189,8 +189,9 @@ const _getDocumentState = bindActionByDataset(
       const draft = documentStates[draftId]?.local
       const published = documentStates[publishedId]?.local
 
+      // wait for draft and published to be loaded before returning a value
+      if (draft === undefined || published === undefined) return undefined
       const document = draft ?? published
-      if (document === undefined) return undefined
       if (path) return jsonMatch(document, path).at(0)?.value
       return document
     },


### PR DESCRIPTION
### Description

Fix a race condition in the document store where the function could return a document before both draft and published versions were properly loaded. This change ensures we wait for both `draft` and `published` to be loaded (not `undefined`) before returning a value.

This prevents inconsistent state and potential UI flashing when documents are being loaded.

### What to review

- The logic change in `_getDocumentState` selector function
- Verify that the new condition `if (draft === undefined || published === undefined) return undefined` properly handles the loading state
- Consider edge cases where documents might be `null` vs `undefined`

### Testing

This fix addresses a race condition that would be difficult to reproduce consistently in automated tests. The change was tested manually by observing document loading behavior and ensuring no UI flashing occurs during the loading process. Caught during testing something else.

### Fun gif

![Race condition fixed](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXc4dGZkMjBkMWR0Y3N0ZDZhN3U4dGZkMWR0Y3N0ZDZhN3U4dGZkMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o7btPCcdNniyf0ArS/giphy.gif)