### PR TITLE
POC - feat: folder based app intents

### DIFF
--- a/apps/kitchensink-react/src/_intents/viewHat.ts
+++ b/apps/kitchensink-react/src/_intents/viewHat.ts
@@ -1,0 +1,71 @@
+// apps/kitchensink-react/src/_intents/viewHat.ts
+import {defineIntent, type IntentParameterConfig} from '@sanity/sdk-react' // Adjust import path as needed
+
+// Define a type for your handler's payload for better type safety
+interface ViewHatPayload {
+  documentHandle: string
+  hatStyle?: string
+  // Allow other properties that might be passed through but are not explicitly typed
+  [key: string]: unknown
+}
+
+export default defineIntent<ViewHatPayload>({
+  action: 'view',
+  name: 'View Current Hat',
+  description:
+    'Navigates the user to view the details of the current hat associated with a person.',
+  filters: [{type: '_person'}, {projectId: 'abc123'}, {dataset: 'production'}],
+  parameters: [
+    {
+      id: 'documentHandle',
+      type: 'documentHandle', // A conceptual type, could be a string ID
+      required: true,
+      description: 'A handle or ID for the person document whose hat is to be viewed.',
+    } as IntentParameterConfig, // Type assertion if needed, or ensure type compatibility
+    {
+      id: 'hatStyle',
+      type: 'string',
+      required: false,
+      description:
+        "Specify a particular style of hat if there are multiple (e.g., 'fedora', 'beanie')",
+    } as IntentParameterConfig,
+  ],
+  async handler(payload: ViewHatPayload) {
+    // eslint-disable-next-line no-console
+    console.log(`[Intent Handler: viewHat] Triggered for document: ${payload.documentHandle}`)
+
+    if (payload.hatStyle) {
+      // eslint-disable-next-line no-console
+      console.log(`[Intent Handler: viewHat] Specific hat style requested: ${payload.hatStyle}`)
+    }
+
+    // --- Example Implementation ---
+    // In a real application, you would use your app's routing and data fetching logic.
+
+    // 1. Fetch person data (if documentHandle is just an ID)
+    // const person = await sanityClient.getDocument(payload.documentHandle);
+    // const hatId = person?.hatReference?._ref;
+
+    // 2. Or, if documentHandle itself implies the hat, use it directly.
+    // const hatId = determineHatIdFromHandle(payload.documentHandle);
+
+    // 3. Navigate to the hat viewing page/component in your application
+    // if (hatId) {
+    //   // Assuming you have a router instance available
+    //   // router.push(`/hats/${hatId}?style=${payload.hatStyle || 'default'}`);
+    //   console.log(`[Intent Handler: viewHat] Navigating to hat view for hat ID (simulated): ${hatId}`);
+    // } else {
+    //   console.warn(
+    //     `[Intent Handler: viewHat] Could not determine hat to view for document: ${payload.documentHandle}`
+    //   );
+    //   // Maybe navigate to a fallback or show an error
+    // }
+
+    // For this example, we'll just log the action.
+    // Replace with your actual navigation/data logic.
+    alert(
+      `Simulating navigation to view hat for document: ${payload.documentHandle}${payload.hatStyle ? ` (Style: ${payload.hatStyle})` : ''}`,
+    )
+    // --- End Example Implementation ---
+  },
+})

--- a/packages/core/src/intents/defineIntent.ts
+++ b/packages/core/src/intents/defineIntent.ts
@@ -1,0 +1,108 @@
+/**
+ * Defines the structure for an intent parameter configuration.
+ */
+export interface IntentParameterConfig {
+  id: string
+  type: string
+  required?: boolean
+  description?: string
+}
+
+/**
+ * Defines the configuration for an intent.
+ * TPayload: The expected type for the payload object that the handler function will receive.
+ * _TContext: The expected type for the context object (if any) that the handler function will receive (currently a placeholder).
+ */
+export interface IntentConfig<
+  TPayload extends Record<string, unknown> = Record<string, unknown>,
+  _TContext extends Record<string, unknown> = Record<string, unknown>, // Context placeholder, note the underscore
+> {
+  /** (Required) The general verb for the intent (e.g., `view`, `edit`, `execute`, `create`). */
+  action: string
+  /** (Required) A short, human-readable name for the intent displayed in UIs. */
+  name: string
+  /** (Optional) A longer description of the intent's purpose. */
+  description?: string
+  /**
+   * (Optional) Conditions that must be met for the intent to be considered applicable.
+   * Used by the Dashboard/Studio to narrow down choices.
+   */
+  filters?: Array<Record<string, unknown>>
+  /** (Optional) Describes the data payload the intent's `handler` expects. */
+  parameters?: IntentParameterConfig[]
+  /**
+   * (Required) The function that executes the intent's logic.
+   * Receives a payload object and an optional context object.
+   */
+  handler: (payload: TPayload /*, context?: _TContext */) => void | Promise<void>
+}
+
+/**
+ * Helper function to define an intent with strong typing.
+ * Provides a structured way to declare an intent's metadata and its handler.
+ *
+ * The `id` of the intent is not defined here; it will be derived from the filename
+ * of the intent definition file (e.g., `viewProduct.ts` becomes intent with id `viewProduct`).
+ *
+ * TPayload: The expected type for the payload object that the handler function will receive.
+ * TContext: The expected type for the context object (if any) that the handler function will receive.
+ * @param config - The intent configuration object.
+ * @returns The configuration object, allowing for type inference and validation.
+ *
+ * @example
+ * ```typescript
+ * // In src/_intents/myCustomIntent.ts
+ * // Assuming this defineIntent is exported from @sanity/core or a similar non-React package
+ * import { defineIntent } from '@sanity/core';
+ *
+ * interface MyPayload {
+ *   documentId: string;
+ *   mode?: 'preview' | 'edit';
+ * }
+ *
+ * export default defineIntent<MyPayload>({
+ *   action: 'customAction',
+ *   name: 'My Custom Intent',
+ *   description: 'Performs a custom operation on a document.',
+ *   parameters: [
+ *     { id: 'documentId', type: 'string', required: true },
+ *     { id: 'mode', type: 'string' }
+ *   ],
+ *   async handler(payload) {
+ *     console.log('Executing myCustomIntent with payload:', payload);
+ *     // payload.documentId is strongly typed
+ *     // ... your logic here
+ *   }
+ * });
+ * ```
+ */
+export function defineIntent<
+  TPayload extends Record<string, unknown> = Record<string, unknown>,
+  // The TContext here is for the function's generic signature, which might be used by advanced users
+  // even if the handler in IntentConfig doesn't immediately use it.
+
+  TContext extends Record<string, unknown> = Record<string, unknown>,
+>(
+  config: IntentConfig<TPayload, TContext>, // IntentConfig now uses _TContext internally for its definition
+): IntentConfig<TPayload, TContext> {
+  // but the function signature can maintain TContext for its own generics
+  // Basic runtime validation (optional, as TypeScript handles this at compile time for users)
+  if (!config || typeof config !== 'object') {
+    throw new Error('Intent configuration must be an object.')
+  }
+  if (typeof config.action !== 'string' || !config.action.trim()) {
+    throw new Error("Intent configuration must include a valid 'action' string.")
+  }
+  if (typeof config.name !== 'string' || !config.name.trim()) {
+    throw new Error("Intent configuration must include a valid 'name' string.")
+  }
+  if (typeof config.handler !== 'function') {
+    throw new Error("Intent configuration must include a 'handler' function.")
+  }
+
+  // Potentially, in the future, this function could do more, like registering
+  // the intent with a global registry if not using file-based discovery for all cases,
+  // or adding default an `id` if not derived from filename in some contexts.
+  // For now, it primarily serves as a type-safe constructor/validator.
+  return config
+}

--- a/packages/core/src/intents/extractIntentManifest.ts
+++ b/packages/core/src/intents/extractIntentManifest.ts
@@ -1,0 +1,144 @@
+import fs from 'fs/promises'
+import path from 'path'
+
+import {type IntentConfig, type IntentParameterConfig} from './defineIntent'
+
+/**
+ * Defines the structure for an intent parameter as part of its manifest.
+ */
+export interface IntentParameterDefinition {
+  id: string
+  type: string
+  required?: boolean
+  description?: string
+}
+
+/**
+ * Defines the structure for an intent's manifest entry.
+ * This is the metadata that will be collected and made available for discovery.
+ */
+export interface IntentManifestEntry {
+  id: string
+  action: string
+  name: string
+  description?: string
+  filters?: Array<Record<string, unknown>>
+  parameters?: IntentParameterDefinition[]
+}
+
+/**
+ * Scans a specified directory for intent definition files (ending in .ts, .js, .mjs, .mts),
+ * extracts their metadata from the default export (expected to be an IntentConfig object),
+ * and returns an array of intent manifest entries.
+ *
+ * This function is designed to be used in build processes (e.g., Vite/Webpack plugins, custom scripts)
+ * to generate a manifest of intents an application can handle.
+ *
+ * @param intentsDirPath - The absolute path to the directory containing intent definition files.
+ * @returns A promise that resolves to an array of {@link IntentManifestEntry} objects.
+ * @throws If the `intentsDirPath` does not exist or if critical errors occur during processing.
+ */
+export async function extractIntentManifest(
+  intentsDirPath: string,
+): Promise<IntentManifestEntry[]> {
+  const manifestEntries: IntentManifestEntry[] = []
+
+  try {
+    await fs.access(intentsDirPath) // Check if directory exists
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        `Intents directory not found at specified path: ${intentsDirPath}. Please ensure the directory exists and the path is correct.`,
+      )
+    }
+    throw new Error(
+      `Error accessing intents directory at ${intentsDirPath}: ${err.message || 'Unknown error'}`,
+    )
+  }
+
+  const files = await fs.readdir(intentsDirPath)
+
+  for (const file of files) {
+    if (file.startsWith('.')) {
+      // Skip hidden files like .DS_Store
+      continue
+    }
+    if (
+      file.endsWith('.ts') ||
+      file.endsWith('.js') ||
+      file.endsWith('.mjs') ||
+      file.endsWith('.mts')
+    ) {
+      const intentId = path.parse(file).name
+      const absoluteFilePath = path.join(intentsDirPath, file)
+      const modulePath = 'file:///' + absoluteFilePath.replace(/\\/g, '/')
+
+      try {
+        const importedModule = (await import(modulePath)) as {default?: unknown}
+
+        if (
+          !importedModule ||
+          typeof importedModule.default !== 'object' ||
+          importedModule.default === null
+        ) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[WARN] Skipping intent file '${file}' in ${intentsDirPath}: Does not have a valid default export or default export is not an object.`,
+          )
+          continue
+        }
+
+        const intentConfig = importedModule.default as IntentConfig<
+          Record<string, unknown>,
+          Record<string, unknown>
+        >
+
+        if (typeof intentConfig.action !== 'string' || !intentConfig.action.trim()) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[WARN] Skipping intent '${intentId}' from file '${file}': 'action' metadata is missing, empty, or not a string in the default export.`,
+          )
+          continue
+        }
+        if (typeof intentConfig.name !== 'string' || !intentConfig.name.trim()) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[WARN] Skipping intent '${intentId}' from file '${file}': 'name' metadata is missing, empty, or not a string in the default export.`,
+          )
+          continue
+        }
+
+        const entry: IntentManifestEntry = {
+          id: intentId,
+          action: intentConfig.action,
+          name: intentConfig.name,
+        }
+
+        if (intentConfig.description && typeof intentConfig.description === 'string') {
+          entry.description = intentConfig.description
+        }
+        if (Array.isArray(intentConfig.filters)) {
+          entry.filters = intentConfig.filters
+        }
+        if (Array.isArray(intentConfig.parameters)) {
+          entry.parameters = intentConfig.parameters.map((p: IntentParameterConfig) => ({
+            id: p.id,
+            type: p.type,
+            required: p.required,
+            description: p.description,
+          }))
+        }
+
+        manifestEntries.push(entry)
+      } catch (e: unknown) {
+        const error = e as Error
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[WARN] Could not fully process intent file '${file}' in ${intentsDirPath}. Error: ${error.message}`,
+        )
+      }
+    }
+  }
+  return manifestEntries
+}

--- a/packages/react/internal-guides/intents.md
+++ b/packages/react/internal-guides/intents.md
@@ -1,0 +1,317 @@
+## Registered App intent
+
+```ts
+import {ALLOWED_INTENTS} from '@sanity/sdk'
+
+config: SanityConfig = {
+  ...
+  intents: [
+    {
+      action: 'view',
+      name: 'View hat',
+      id: 'viewHat',
+      filters?: [
+        type: '_person',
+        projectId: 'abc123'
+        dataset: 'production'
+      ]
+      description: 'Navigates the user to the current hat',
+      parameters: [{
+        id: 'documentHandle'
+        type: 'documentHandle'
+        required: true,
+      }]
+    },
+    {
+      action: 'edit',
+      name: 'Edit favorite foods',
+      id: 'editFavFoods',
+      filters: [
+        type: '_person',
+      ]
+      description: 'Navigates the user to the favorite foods editor only',
+      parameters: [{
+        id: 'documentHandle'
+        type: 'documentHandle'
+        required: true,
+      }]
+    },
+    {
+      action: 'execute',
+      name: 'Go go Gadget arms!',
+      id: 'goGadget',
+      filters: [
+        type: '_person',
+      ]
+      description: 'Allows the user to extend their arms',
+      parameters: [
+        {
+          id: 'documentHandle'
+          type: 'documentHandle'
+          required: true,
+        },
+        {
+          id: 'armLength'
+          type: 'number'
+          required: true,
+          description: 'Length in inches to extend arms'
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Code in App for intent handling
+
+```js
+import {useIntentReceived, useRegisterIntentHandler} from '@sanity/sdk-react'
+
+const sanityConfigs: SanityConfig[] = [
+  {
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+  },
+  {
+    projectId: 'd45jg133',
+    dataset: 'production',
+  },
+]
+
+const MyIntentsHandler() {
+  const intent = useIntentReceived()
+  // maybe the intent handler code should go here?
+  useRegisterIntentHandler('goGadget', (intentPayload) => {
+    personId = intentPayload.id
+    personId.extendArms(intentPayload.length)
+  }, []);
+
+  return null // this is a renderless component
+}
+
+const MyApp(){
+  <SanityApp>
+    <MyIntentHandler />
+    <TheRestOfTheOwl />
+  </SanityApp>
+}
+```
+
+----- generated from llm -----
+
+## Defining App Intents via Files
+
+The primary way to make your application capable of handling intents is by defining them as individual files within a special `_intents/` directory in your project source (e.g., `src/_intents/`). The Sanity SDK build process will automatically detect these files, register their handlers, and generate a manifest for discovery by the Sanity Dashboard.
+
+Each file in the `_intents/` directory represents a single intent. The filename (without the extension) serves as the unique `id` for the intent.
+
+**Structure of an Intent File:**
+
+Each intent file should export several pieces of metadata and a `handler` function.
+
+**Example: `src/_intents/viewProduct.ts`**
+
+```typescript
+// src/_intents/viewProduct.ts
+
+// ---- Metadata ----
+
+/** (Required) Action category of the intent (e.g., 'view', 'edit', 'execute') */
+export const action: string = 'view'
+
+/** (Required) Human-readable name for the intent. */
+export const name: string = 'View Product Details'
+
+/**
+ * (Optional) Array of filter objects to determine when this intent is applicable.
+ * These filters are matched against the context provided by the Dashboard.
+ * For example, an intent might only be relevant for a specific document type
+ * or within a particular project/dataset.
+ */
+export const filters: Array<Record<string, any>> = [
+  {type: 'product'}, // Only applicable if the context involves a 'product' document type
+  {dataset: 'production'}, // And only for the 'production' dataset
+]
+
+/** (Optional) A more detailed description of what the intent does. */
+export const description: string = 'Opens the main product detail view for the specified product.'
+
+/**
+ * (Optional) Array defining the parameters this intent expects.
+ * This helps with validation and can be used by the Dashboard to prepare the intent payload.
+ */
+export const parameters: Array<{
+  id: string // Parameter name
+  type: string // Data type (e.g., 'string', 'number', 'documentHandle')
+  required?: boolean
+  description?: string
+}> = [
+  {
+    id: 'productId',
+    type: 'string',
+    required: true,
+    description: 'The unique ID of the product to view.',
+  },
+]
+
+// ---- Handler ----
+
+/**
+ * (Required) The function that executes the intent's logic.
+ * It receives a payload containing the intent parameters.
+ * The `id` in the payload corresponds to the filename.
+ */
+export async function handler(payload: {productId: string; [key: string]: any}) {
+  console.log(`Handling 'viewProduct' intent for product ID: ${payload.productId}`)
+  // Example:
+  // await router.push(`/products/${payload.productId}`);
+  // Or interact with other services, etc.
+}
+```
+
+**Supported Metadata Fields:**
+
+- `id`: (string, derived from filename) Unique identifier for the intent.
+- `action`: (string, required) The general verb for the intent (e.g., `view`, `edit`, `execute`, `create`).
+- `name`: (string, required) A short, human-readable name for the intent displayed in UIs.
+- `description`: (string, optional) A longer description of the intent's purpose.
+- `filters`: (Array<Record<string, any>>, optional) Conditions that must be met for the intent to be considered applicable. Used by the Dashboard to narrow down choices.
+  - Each object in the array is a key-value pair. For the intent to match, all filter conditions from at least one filter object in the array must be satisfied by the context in which the intent is being considered. (This part might need more refinement based on exact filter logic).
+  - Common filter keys might include `type` (e.g., document type), `projectId`, `dataset`.
+- `parameters`: (Array<IntentParameter>, optional) Describes the data payload the intent's `handler` expects.
+  - `IntentParameter`: `{ id: string, type: string, required?: boolean, description?: string }`
+
+When you build your application, these intent definitions are collected.
+
+## Intent Manifest for Dashboard Discovery
+
+During the build process, the Sanity SDK tools will scan your `_intents/` directory and generate a JSON file (e.g., `public/intent-manifest.json` or a path accessible to the Dashboard). This manifest contains the metadata for all intents your application can handle.
+
+**This manifest does NOT include the `handler` functions themselves**, only their definitions.
+
+The Sanity Dashboard will use this manifest to:
+
+- Discover which applications can handle specific intents based on `action`, `filters`, and `parameters`.
+- Present users with a choice of suitable applications if multiple can handle a given intent.
+
+**Example `intent-manifest.json` Entry:**
+
+```json
+{
+  "id": "viewProduct",
+  "action": "view",
+  "name": "View Product Details",
+  "filters": [{"type": "product"}, {"dataset": "production"}],
+  "description": "Opens the main product detail view for the specified product.",
+  "parameters": [
+    {
+      "id": "productId",
+      "type": "string",
+      "required": true,
+      "description": "The unique ID of the product to view."
+    }
+  ]
+}
+```
+
+## Reacting to Intents in Components
+
+While the primary logic for an intent is defined in its `handler` function within the `_intents/` file, your React components might still need to observe or react when an intent has been dispatched and handled. For this, the SDK provides the `useIntentReceived` hook.
+
+### `useIntentReceived()`
+
+This hook allows a component to be notified after an intent has been processed by the SDK (meaning its corresponding handler from the `_intents/` directory, if matched, has been executed).
+
+```javascript
+import {useIntentReceived} from '@sanity/sdk-react' // Ensure correct import path
+
+const MyActivityLogger = () => {
+  const lastIntent = useIntentReceived() // Gets the most recently processed intent object
+
+  useEffect(() => {
+    if (lastIntent) {
+      console.log(`Intent processed: ${lastIntent.id}`, lastIntent.payload)
+      // Example: send to analytics, update some local state, show a notification
+    }
+  }, [lastIntent])
+
+  return null // This can be a renderless component
+}
+
+// Usage in your app:
+// <SanityApp config={sanityConfigs} fallback={<Loading/>}>
+//   <MyActivityLogger />
+//   <TheRestOfTheApp />
+// </SanityApp>
+```
+
+The `lastIntent` object will typically contain:
+
+- `id`: The ID of the intent (e.g., "viewProduct").
+- `payload`: The parameters that were passed to the intent's handler.
+- Other relevant metadata if included by the SDK.
+
+You can also use `useIntentReceived` to listen for a _specific_ intent:
+
+```javascript
+import { useIntentReceived } from '@sanity/sdk-react';
+
+const ProductPageEnhancer = ({ productId }) => {
+  const intent = useIntentReceived('editProduct', (payload) => payload.productId === productId);
+
+  useEffect(() => {
+    if (intent) {
+      // e.g., refresh product data because it might have been edited via an intent
+      console.log(`Product ${productId} might have been edited via an intent.`);
+    }
+  }, [intent, productId]);
+
+  return (/* ... your component UI ... */);
+};
+```
+
+_(The exact API for specific intent listening might need refinement: e.g., `useIntentReceived('editProduct')` and then check payload, or a predicate function as shown)._
+
+## Dynamic Intent Registration (Advanced)
+
+In less common scenarios, you might need to register or unregister intent handlers dynamically from within a React component's lifecycle, rather than relying solely on the file-based system. For this, the `useRegisterIntentHandler` hook can be used.
+
+This is generally for intents that are highly context-specific to a component's state or temporary conditions.
+
+```javascript
+import {useRegisterIntentHandler} from '@sanity/sdk-react' // Ensure correct import path
+import {useEffect} from 'react'
+
+const TemporaryTaskHandler = ({taskId, onComplete}) => {
+  const handler = (payload) => {
+    if (payload.taskId === taskId) {
+      console.log(`Handling temporary task: ${taskId}`)
+      onComplete()
+      // Perform actions for this specific task
+    }
+  }
+
+  // Register the handler when the component mounts (or taskId changes)
+  // The hook should handle unregistration on cleanup.
+  const unregister = useRegisterIntentHandler(`completeTask_${taskId}`, handler, [
+    taskId,
+    onComplete,
+  ])
+
+  // Optional: Explicitly unregister if needed before component unmounts,
+  // though useRegisterIntentHandler should ideally return a cleanup function.
+  useEffect(() => {
+    return () => {
+      // unregister(); // If useRegisterIntentHandler doesn't auto-cleanup
+    }
+  }, [unregister])
+
+  return <div>Managing task: {taskId}</div>
+}
+```
+
+**Note:** Intents registered via `useRegisterIntentHandler` will likely **not** be part of the statically generated `intent-manifest.json` unless your build process has a way to discover these dynamic registrations (which is typically complex and not standard). Their primary use is for runtime, client-side intent handling logic.
+
+---
+
+_Previous content of intents.md needs to be reviewed and removed or merged if it discussed the old SanityConfig-based registration as the primary method._


### PR DESCRIPTION
### Description

This is one option for registering intents. The user would place intent handlers in a `_intents` folder and the name of the file would be the intent ID.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Fun gif
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExNTFxMnhnY3FkNWd5ejA2cmlwcDk1eDl5enIyZTVpZTdyOXh1Njk4cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BB8Iz3m4X0841qwCp5/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
