### PR TITLE
fix(core): correct element removal order in `unset`s

### DIFF
--- a/packages/core/src/document/patchOperations.test.ts
+++ b/packages/core/src/document/patchOperations.test.ts
@@ -668,7 +668,7 @@ describe('unset', () => {
   it('unsets multiple array elements when using a range', () => {
     const input = {items: [1, 2, 3, 4, 5]}
     const output = unset(input, ['items[1:3]'])
-    expect(output).toEqual({items: [1, 3, 5]})
+    expect(output).toEqual({items: [1, 4, 5]})
   })
 
   it('leaves input unchanged if no path expression matches', () => {

--- a/packages/core/src/document/patchOperations.ts
+++ b/packages/core/src/document/patchOperations.ts
@@ -484,6 +484,9 @@ export function unset<R>(input: unknown, pathExpressions: string[]): R
 export function unset(input: unknown, pathExpressions: string[]): unknown {
   const result = pathExpressions
     .flatMap((pathExpression) => jsonMatch(input, pathExpression))
+    // ensure that we remove in the reverse order the paths were found in
+    // this is necessary for array unsets so the indexes don't change as we unset
+    .reverse()
     .reduce((acc, {path}) => unsetDeep(acc, path), input)
 
   return ensureArrayKeysDeep(result)


### PR DESCRIPTION
### Description

Fix array element removal order in JSONMatch `unset` operations to prevent index shifting issues.

When unsetting multiple array elements using range expressions (e.g., `items[1:3]`), the elements were being removed in forward order, causing subsequent removals to target incorrect indices due to array shifting. This change ensures elements are removed in reverse order (from highest to lowest index) to maintain index stability during the removal process.

**Changes introduced:**
- Added `.reverse()` to the unset operation to process matches in reverse order
- Updated test expectations to reflect correct behavior when unsetting array ranges
- Added explanatory comments about why reverse order is necessary

**Example fix:**
- Input: `{items: [1, 2, 3, 4, 5]}`
- Unset path: `items[1:3]` (should remove indices 1 and 2, values 2 and 3)
- Before fix: `{items: [1, 3, 5]}` ❌ (incorrect - removed wrong elements due to shifting)
- After fix: `{items: [1, 4, 5]}` ✅ (correct - removed indices 1 and 2 as expected)

### What to review

**Focus areas for review:**
1. **Core logic in `unset` function**: Review the addition of `.reverse()` and understand why it's necessary for array operations
2. **Test correction**: Verify that the updated test expectation `{items: [1, 4, 5]}` is mathematically correct for removing indices 1-2 from `[1, 2, 3, 4, 5]`
3. **Edge cases**: Consider scenarios with overlapping ranges, negative indices, and out-of-bounds ranges

**Affected functionality:**
- JSONMatch `unset` operations on arrays with range expressions
- Any code that removes multiple array elements using paths like `array[1:3]`, `array[2:5]`, etc.

### Testing

Updated the existing unit test to reflect the correct behavior, but **we should add comprehensive end-to-end tests** to ensure our `unset` behavior matches content-lake exactly, especially for complex scenarios involving:
- Multiple overlapping ranges
- Mixed range and single index unsets
- Negative index ranges
- Out-of-bounds scenarios

**Current testing:**
- ✅ Updated unit test for range unset operations
- ✅ Test verifies correct element removal without index shifting

**Missing testing:**
- ❌ E2E tests comparing our results with content-lake responses
- ❌ Tests for complex multi-range unset scenarios
- ❌ Performance tests for large arrays with many unset operations

### Fun gif

![Arrays when you remove elements in the wrong order](https://media.giphy.com/media/l0IyjiXOXTX6Yemsg/giphy.gif)