### PR TITLE
test(e2e): create fixtures for creating documents and deleting them at the end of a run

### DIFF
--- a/packages/@repo/e2e/package.json
+++ b/packages/@repo/e2e/package.json
@@ -33,6 +33,8 @@
     "prepare": "pnpm build"
   },
   "dependencies": {
+    "@sanity/client": "^6.12.5",
+    "@sanity/uuid": "^3.0.0",
     "dotenv": "^16.5.0"
   },
   "devDependencies": {

--- a/packages/@repo/e2e/src/fixtures.ts
+++ b/packages/@repo/e2e/src/fixtures.ts
@@ -1,12 +1,35 @@
 import {test as base} from '@playwright/test'
+import {type MultipleMutationResult, SanityClient} from '@sanity/client'
+
+import {getClient} from './helpers/clients'
+import {cleanupDocuments, createDocuments, type DocumentStub} from './helpers/documents'
+
+interface SanityFixtures {
+  createDocuments: (
+    data: DocumentStub[],
+    options?: {asDraft?: boolean},
+    dataset?: string,
+  ) => Promise<MultipleMutationResult>
+  getClient: (dataset?: string) => SanityClient
+}
 
 /**
  * @internal
  * Playwright test configuration for SDK E2E tests
- * (If different apps diverge dramatically, we can move this logic)
  */
-export const test = base.extend({
-  // We'll add custom fixtures shortly
+export const test = base.extend<SanityFixtures>({
+  // Playwright will error if we don't pass an object to destructure
+  // eslint-disable-next-line no-empty-pattern
+  createDocuments: async ({}, use) => {
+    await use(createDocuments)
+
+    // cleanup documents after each test
+    await cleanupDocuments()
+  },
+  // eslint-disable-next-line no-empty-pattern
+  getClient: async ({}, use) => {
+    await use(getClient)
+  },
 })
 
 export {expect} from '@playwright/test'

--- a/packages/@repo/e2e/src/helpers/clients.ts
+++ b/packages/@repo/e2e/src/helpers/clients.ts
@@ -1,0 +1,26 @@
+import {createClient, type SanityClient} from '@sanity/client'
+
+import {getE2EEnv} from './getE2EEnv'
+
+const env = getE2EEnv()
+
+const baseConfig = {
+  projectId: env.SDK_E2E_PROJECT_ID,
+  token: env.SDK_E2E_SESSION_TOKEN,
+  useCdn: false,
+  apiVersion: '2021-08-31',
+  apiHost: 'https://api.sanity.work',
+}
+
+const clients: Record<string, SanityClient> = {}
+
+export function getClient(dataset: string = env.SDK_E2E_DATASET_0): SanityClient {
+  if (!clients[dataset]) {
+    clients[dataset] = createClient({
+      ...baseConfig,
+      dataset,
+    })
+  }
+
+  return clients[dataset]
+}

--- a/packages/@repo/e2e/src/helpers/documents.ts
+++ b/packages/@repo/e2e/src/helpers/documents.ts
@@ -1,0 +1,63 @@
+import {type MultipleMutationResult, type SanityDocumentStub} from '@sanity/client'
+import {uuid} from '@sanity/uuid'
+
+import {getClient} from './clients'
+import {getE2EEnv} from './getE2EEnv'
+
+const env = getE2EEnv()
+
+export type DocumentStub = Omit<SanityDocumentStub, '_id'>
+
+// Keep track of document IDs created during tests
+const documentIds = new Set<string>()
+
+function getUniqueDocumentId(): string {
+  const documentId = uuid()
+  documentIds.add(documentId)
+  return documentId
+}
+
+export async function createDocuments<T extends DocumentStub>(
+  data: T[],
+  options?: {asDraft?: boolean},
+  dataset?: string,
+): Promise<MultipleMutationResult> {
+  const client = getClient(dataset)
+  const asDraft = options?.asDraft ?? true // Default to draft if not specified
+
+  const docs = data.map((doc) => {
+    const documentId = getUniqueDocumentId()
+    return {
+      ...doc,
+      _type: doc['_type'],
+      _id: asDraft ? `drafts.${documentId}` : documentId,
+    }
+  })
+
+  const transaction = client.transaction()
+  docs.forEach((doc) => transaction.create(doc))
+  return transaction.commit()
+}
+
+export async function cleanupDocuments(): Promise<void> {
+  if (documentIds.size === 0) return
+
+  // Clean up documents in both datasets
+  await Promise.all(
+    [env.SDK_E2E_DATASET_0, env.SDK_E2E_DATASET_1].map(async (dataset) => {
+      try {
+        const client = getClient(dataset)
+        await client.delete({
+          query: '*[_id in $ids]',
+          params: {ids: [...[...documentIds].map((id) => `drafts.${id}`), ...documentIds]},
+        })
+      } catch (error) {
+        // Log error but don't fail teardown
+        // eslint-disable-next-line no-console
+        console.error(`Failed to clean up documents in ${dataset}:`, error)
+      }
+    }),
+  )
+
+  documentIds.clear()
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,12 @@ importers:
 
   packages/@repo/e2e:
     dependencies:
+      '@sanity/client':
+        specifier: ^6.12.5
+        version: 6.29.1(debug@4.4.0)
+      '@sanity/uuid':
+        specifier: ^3.0.0
+        version: 3.0.2
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -9312,11 +9318,11 @@ snapshots:
       - debug
       - supports-color
 
-  '@sanity/presentation-comlink@1.0.16(@sanity/client@6.29.1(debug@4.4.0))(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))':
+  '@sanity/presentation-comlink@1.0.16(@sanity/client@6.29.1)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))':
     dependencies:
       '@sanity/client': 6.29.1(debug@4.4.0)
       '@sanity/comlink': 3.0.4
-      '@sanity/visual-editing-types': 1.0.15(@sanity/client@6.29.1(debug@4.4.0))(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))
+      '@sanity/visual-editing-types': 1.0.15(@sanity/client@6.29.1)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))
     transitivePeerDependencies:
       - '@sanity/types'
 
@@ -9325,7 +9331,7 @@ snapshots:
       prettier: 3.5.3
       prettier-plugin-packagejson: 2.5.3(prettier@3.5.3)
 
-  '@sanity/preview-url-secret@2.1.8(@sanity/client@6.29.1(debug@4.4.0))':
+  '@sanity/preview-url-secret@2.1.8(@sanity/client@6.29.1)':
     dependencies:
       '@sanity/client': 6.29.1(debug@4.4.0)
       '@sanity/uuid': 3.0.2
@@ -9501,7 +9507,7 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/visual-editing-types@1.0.15(@sanity/client@6.29.1(debug@4.4.0))(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))':
+  '@sanity/visual-editing-types@1.0.15(@sanity/client@6.29.1)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))':
     dependencies:
       '@sanity/client': 6.29.1(debug@4.4.0)
     optionalDependencies:
@@ -11046,7 +11052,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11068,7 +11074,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -13577,8 +13583,8 @@ snapshots:
       '@sanity/message-protocol': 0.9.0
       '@sanity/migrate': 3.87.0(@types/react@19.1.2)
       '@sanity/mutator': 3.87.0(@types/react@19.1.2)
-      '@sanity/presentation-comlink': 1.0.16(@sanity/client@6.29.1(debug@4.4.0))(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))
-      '@sanity/preview-url-secret': 2.1.8(@sanity/client@6.29.1(debug@4.4.0))
+      '@sanity/presentation-comlink': 1.0.16(@sanity/client@6.29.1)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))
+      '@sanity/preview-url-secret': 2.1.8(@sanity/client@6.29.1)
       '@sanity/schema': 3.87.0(@types/react@19.1.2)(debug@4.4.0)
       '@sanity/sdk': 0.0.0-alpha.25(@types/react@19.1.2)(debug@4.4.0)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
       '@sanity/telemetry': 0.8.1(react@18.3.1)


### PR DESCRIPTION
### Description

This PR adds Sanity client and document management utilities to the E2E testing framework. These fixtures can create (or bulk creates) test documents and lets devs access Sanity clients, along with cleanup functionality to ensure test documents are removed after tests complete.

### What to review

- The new fixtures in `fixtures.ts` that expose `createDocuments` and `clients` to tests, and cleans up after each test.
- The document management helpers in `helpers/documents.ts` for creating and cleaning up test documents
- The client configuration in `helpers/clients.ts` that sets up connections to primary and secondary datasets

### Testing
Unfortunately, none of this is used in this particular PR. If you want to test this out manually, I'd go to #560 and do the following:
1. pull down the branch
2. run `pnpm dev:e2e`
3. Go to the "document list"
4. Run `pnpm test:e2e` (make sure you're not in "CI" mode
5. You should see the documents appear and disappear

### Fun gif
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXFtdnAzbHAyNHJodGxrZXg5Mjl1bDh3YTNsN3Y1aGd1ZGt3a3R6MyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xu5b6xRwkOQ36/giphy.gif)