### PR TITLE
test(e2e): create initial e2e github action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,125 @@
+name: End-to-End Tests
+permissions:
+  contents: read # allow checkout
+  pull-requests: write # allow commenting later if desired
+
+  # note: should we have env datasets declared like in monorepoe2e.yml?
+
+on:
+  # run on PRs, even drafts
+  pull_request:
+  # run on main branch when it changes
+  push:
+    branches: [main]
+
+# Cancel in-progress runs from the same PR/branch
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # run / share the same install step for all browsers
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: 🛠️ Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: "pnpm"
+          node-version: "lts/*"
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # see if the Playwright version we're using is already cached -- skip download if so
+      - name: 🔍 Determine Playwright version
+        id: pw-version
+        run: echo "version=$(npx playwright --version | sed 's/Version //')" >> "$GITHUB_OUTPUT"
+
+      - name: 💾 Cache Playwright browsers
+        id: cache-playwright-browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-${{ steps.pw-version.outputs.version }}-playwright-browsers
+
+      - name: Install Playwright browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+  playwright-tests:
+    needs: install
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    # Browser matrix to parallelise executions.
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+
+    # Shared env required by the SDK E2E helpers. Configure these in the repo → Settings → Secrets / Variables
+    env:
+      SDK_E2E_PROJECT_ID: ${{ secrets.SDK_E2E_PROJECT_ID }}
+      SDK_E2E_DATASET_0: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}-{2}', github.event.number, matrix.browser, github.run_id) || format('main-{0}-{1}', matrix.browser, github.run_id) }}
+      SDK_E2E_DATASET_1: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}-secondary-{2}', github.event.number, matrix.browser, github.run_id) || format('main-{0}-secondary-{1}', matrix.browser, github.run_id) }}
+      SDK_E2E_SESSION_TOKEN: ${{ secrets.SDK_E2E_SESSION_TOKEN }}
+      SDK_E2E_USER_ID: ${{ secrets.SDK_E2E_USER_ID }}
+      SDK_E2E_USER_PASSWORD: ${{ secrets.SDK_E2E_USER_PASSWORD }}
+      RECAPTCHA_E2E_STAGING_KEY: ${{ secrets.RECAPTCHA_E2E_STAGING_KEY }}
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: 🛠️ Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: "pnpm"
+          node-version: "lts/*"
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 🔍 Determine Playwright version
+        id: pw-version
+        run: echo "version=$(npx playwright --version | sed 's/Version //')" >> "$GITHUB_OUTPUT"
+
+      - name: 💾 Restore cached Playwright browsers
+        id: cache-playwright-browsers
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-${{ steps.pw-version.outputs.version }}-playwright-browsers
+
+      - name: Install Playwright browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Install WebKit Dependencies
+        if: matrix.browser == 'webkit'
+        run: pnpm exec playwright install-deps webkit
+
+      - name: 🧪 Run E2E tests
+        run: pnpm test:e2e -- --project ${{ matrix.browser }}
+
+      - name: 📤 Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.browser }}
+          path: apps/kitchensink-react/e2e/test-report
+          retention-days: 30
+
+      - name: 🧹 Cleanup E2E datasets
+        if: always()
+        run: pnpm cleanup:e2e

--- a/apps/kitchensink-react/package.json
+++ b/apps/kitchensink-react/package.json
@@ -11,6 +11,7 @@
     "install": "npm run schema:extract && npm run types:generate",
     "lint": "eslint .",
     "paramour": "npx paramour --config=./src/css/css.config.js --output=./src/css/paramour.css",
+    "preview": "vite preview",
     "schema:extract": "sanity schema extract --workspace ppsg7ml5-test --path schema.ppsg7ml5.test.json && sanity schema extract --workspace d45jg133-production --path schema.d45jg133.production.json",
     "test:e2e": "playwright test",
     "tsc": "tsc --noEmit",

--- a/apps/kitchensink-react/playwright.config.ts
+++ b/apps/kitchensink-react/playwright.config.ts
@@ -4,7 +4,9 @@ export default createPlaywrightConfig({
   testDir: './e2e',
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'pnpm dev --mode e2e',
+    command: process.env['CI']
+      ? 'pnpm build --mode e2e && pnpm preview --mode e2e --port 3333'
+      : 'pnpm dev --mode e2e',
     url: 'http://localhost:3333',
     reuseExistingServer: !process.env['CI'],
     stdout: 'pipe',

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "all": "turbo run build && turbo run lint && turbo run test:coverage && pnpm build:docs && pnpm depcheck",
     "build": "turbo run build --filter='./packages/*' --filter='./apps/*'",
-    "build:docs": "turbo run docs && typedoc",
     "build:bundle": "turbo run build:bundle --filter='./packages/*' --filter='!./packages/@repo/*'",
+    "build:docs": "turbo run docs && typedoc",
     "build:packages": "turbo run build --filter='./packages/*' --filter='!./packages/@repo/*'",
     "build:visualizer": "VISUALIZER=true turbo run build --filter='./packages/*'",
     "clean": "run-s clean:build clean:deps",
@@ -49,6 +49,7 @@
     "@commitlint/config-conventional": "^19.8.0",
     "@commitlint/types": "^19.8.0",
     "@google-cloud/storage": "^7.16.0",
+    "@playwright/test": "^1.52.0",
     "@repo/config-eslint": "workspace:*",
     "@repo/config-test": "workspace:*",
     "@repo/tsconfig": "workspace:*",

--- a/packages/@repo/e2e/src/helpers/getE2EEnv.ts
+++ b/packages/@repo/e2e/src/helpers/getE2EEnv.ts
@@ -33,6 +33,11 @@ function readEnv(name: KnownEnvVar): string {
   }
   const val = findEnv(name)
   if (val === undefined) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Environment variable "${name}" not found. Available env vars:`,
+      Object.keys(process.env),
+    )
     throw new Error(
       `Missing required environment variable "${name}". Make sure to copy \`.env.example\` to \`.env.local\``,
     )

--- a/packages/@repo/e2e/src/index.ts
+++ b/packages/@repo/e2e/src/index.ts
@@ -53,10 +53,19 @@ export const basePlaywrightConfig: PlaywrightTestConfig = {
       testDir: TEARDOWN_DIR,
       testMatch: /.*\.teardown\.ts/,
     },
-    // we can add as many different projects as we like here
     {
       name: 'chromium',
       use: {...devices['Desktop Chrome'], storageState: AUTH_FILE},
+      dependencies: ['setup'],
+    },
+    {
+      name: 'firefox',
+      use: {...devices['Desktop Firefox'], storageState: AUTH_FILE},
+      dependencies: ['setup'],
+    },
+    {
+      name: 'webkit',
+      use: {...devices['Desktop Safari'], storageState: AUTH_FILE},
       dependencies: ['setup'],
     },
   ],

--- a/packages/@repo/e2e/src/scripts/cleanup-datasets.ts
+++ b/packages/@repo/e2e/src/scripts/cleanup-datasets.ts
@@ -12,8 +12,13 @@ const env = getE2EEnv()
 async function cleanupDatasets() {
   const primaryDataset = sanitizeDatasetName(env.SDK_E2E_DATASET_0)
   const secondaryDataset = sanitizeDatasetName(env.SDK_E2E_DATASET_1)
+  if (!env.CI) {
+    console.log('Skipping cleanup in non-CI environment')
+    return
+  }
 
   const client = getClient()
+
   const timer = startTimer('Cleaning up test datasets')
 
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@google-cloud/storage':
         specifier: ^7.16.0
         version: 7.16.0
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.52.0
       '@repo/config-eslint':
         specifier: workspace:*
         version: link:packages/@repo/config-eslint
@@ -9365,11 +9368,11 @@ snapshots:
       - debug
       - supports-color
 
-  '@sanity/presentation-comlink@1.0.16(@sanity/client@6.29.1)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))':
+  '@sanity/presentation-comlink@1.0.16(@sanity/client@6.29.1(debug@4.4.0))(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))':
     dependencies:
       '@sanity/client': 6.29.1(debug@4.4.0)
       '@sanity/comlink': 3.0.4
-      '@sanity/visual-editing-types': 1.0.15(@sanity/client@6.29.1)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))
+      '@sanity/visual-editing-types': 1.0.15(@sanity/client@6.29.1(debug@4.4.0))(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))
     transitivePeerDependencies:
       - '@sanity/types'
 
@@ -9378,7 +9381,7 @@ snapshots:
       prettier: 3.5.3
       prettier-plugin-packagejson: 2.5.3(prettier@3.5.3)
 
-  '@sanity/preview-url-secret@2.1.8(@sanity/client@6.29.1)':
+  '@sanity/preview-url-secret@2.1.8(@sanity/client@6.29.1(debug@4.4.0))':
     dependencies:
       '@sanity/client': 6.29.1(debug@4.4.0)
       '@sanity/uuid': 3.0.2
@@ -9554,7 +9557,7 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/visual-editing-types@1.0.15(@sanity/client@6.29.1)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))':
+  '@sanity/visual-editing-types@1.0.15(@sanity/client@6.29.1(debug@4.4.0))(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))':
     dependencies:
       '@sanity/client': 6.29.1(debug@4.4.0)
     optionalDependencies:
@@ -13666,8 +13669,8 @@ snapshots:
       '@sanity/message-protocol': 0.9.0
       '@sanity/migrate': 3.87.0(@types/react@19.1.2)
       '@sanity/mutator': 3.87.0(@types/react@19.1.2)
-      '@sanity/presentation-comlink': 1.0.16(@sanity/client@6.29.1)(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))
-      '@sanity/preview-url-secret': 2.1.8(@sanity/client@6.29.1)
+      '@sanity/presentation-comlink': 1.0.16(@sanity/client@6.29.1(debug@4.4.0))(@sanity/types@3.87.0(@types/react@19.1.2)(debug@4.4.0))
+      '@sanity/preview-url-secret': 2.1.8(@sanity/client@6.29.1(debug@4.4.0))
       '@sanity/schema': 3.87.0(@types/react@19.1.2)(debug@4.4.0)
       '@sanity/sdk': 0.0.0-alpha.25(@types/react@19.1.2)(debug@4.4.0)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
       '@sanity/telemetry': 0.8.1(react@18.3.1)

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,19 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["DEV", "VISUALIZER", "PKG_VERSION", "NPM_CONFIG_PROVENANCE", "CI"],
+  "globalEnv": [
+    "DEV",
+    "VISUALIZER",
+    "PKG_VERSION",
+    "NPM_CONFIG_PROVENANCE",
+    "CI",
+    "SDK_E2E_PROJECT_ID",
+    "SDK_E2E_DATASET_0",
+    "SDK_E2E_DATASET_1",
+    "SDK_E2E_SESSION_TOKEN",
+    "SDK_E2E_USER_ID",
+    "SDK_E2E_USER_PASSWORD",
+    "RECAPTCHA_E2E_STAGING_KEY"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -18,6 +31,18 @@
       "dependsOn": ["^check-types"]
     },
     "clean": {},
+    "cleanup": {
+      "cache": false,
+      "env": [
+        "SDK_E2E_PROJECT_ID",
+        "SDK_E2E_DATASET_0",
+        "SDK_E2E_DATASET_1",
+        "SDK_E2E_SESSION_TOKEN"
+      ]
+    },
+    "depcheck": {
+      "env": ["DEPCHECK"]
+    },
     "dev": {
       "persistent": true,
       "cache": false
@@ -59,10 +84,8 @@
       "dependsOn": ["@repo/e2e#build"],
       "outputs": ["e2e/test-results/**", "e2e/test-report/**"]
     },
-    "depcheck": {
-      "env": ["DEPCHECK"]
-    },
     "@repo/e2e#build": {
+      "dependsOn": ["^build"],
       "outputs": ["dist/**"],
       "cache": true
     }


### PR DESCRIPTION
### Description

This PR adds a GitHub Actions workflow for running end-to-end tests across multiple browsers. The workflow runs Playwright tests on Chromium, Firefox, and WebKit browsers for both PRs and the main branch, with attempts at caching of browser binaries to improve performance.

The implementation includes:
- New GitHub workflow file for E2E tests with proper concurrency settings
- Configuration for running tests in CI environment using build+preview instead of dev server
- Added browser matrix to run tests in parallel across different browsers
- Improved error reporting for missing environment variables

### What to review

- The new `.github/workflows/e2e.yml` workflow configuration
- Changes to the Playwright configuration to support CI environments
- Updates to E2E helpers for better error handling and environment detection
- The dataset cleanup process to ensure test data is properly removed after tests

### Testing
If this branch has green tests for the different browsers for the Playwright tests, then it works 😭 

### Fun gif
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExeDdxd2pmOWJ1cHpoZmN6aDNqNzluNGR6Zngzcnd4d3lhMTkzaHo2ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26u4lOMA8JKSnL9Uk/giphy.gif)