### PR TITLE
chore(e2e): clean up unnecessary config and reduce flakiness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,6 @@ permissions:
   contents: read # allow checkout
   pull-requests: write # allow commenting later if desired
 
-  # note: should we have env datasets declared like in monorepoe2e.yml?
-
 on:
   # run on PRs, even drafts
   pull_request:

--- a/apps/kitchensink-react/e2e/document-list.spec.ts
+++ b/apps/kitchensink-react/e2e/document-list.spec.ts
@@ -6,7 +6,7 @@ test.describe('Document List', () => {
 
     // Create 10 author documents in a single transaction
     const {documentIds} = await createDocuments(
-      Array.from({length: 10}, (_, i) => ({
+      Array.from({length: 5}, (_, i) => ({
         _type: 'author',
         name: `Test Author ${i}`,
         biography: `This is a test biography for author ${i}`,

--- a/turbo.json
+++ b/turbo.json
@@ -1,19 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": [
-    "DEV",
-    "VISUALIZER",
-    "PKG_VERSION",
-    "NPM_CONFIG_PROVENANCE",
-    "CI",
-    "SDK_E2E_PROJECT_ID",
-    "SDK_E2E_DATASET_0",
-    "SDK_E2E_DATASET_1",
-    "SDK_E2E_SESSION_TOKEN",
-    "SDK_E2E_USER_ID",
-    "SDK_E2E_USER_PASSWORD",
-    "RECAPTCHA_E2E_STAGING_KEY"
-  ],
+  "globalEnv": ["DEV", "VISUALIZER", "PKG_VERSION", "NPM_CONFIG_PROVENANCE"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -32,13 +19,7 @@
     },
     "clean": {},
     "cleanup": {
-      "cache": false,
-      "env": [
-        "SDK_E2E_PROJECT_ID",
-        "SDK_E2E_DATASET_0",
-        "SDK_E2E_DATASET_1",
-        "SDK_E2E_SESSION_TOKEN"
-      ]
+      "cache": false
     },
     "depcheck": {
       "env": ["DEPCHECK"]
@@ -53,8 +34,7 @@
     },
     "dev:e2e": {
       "persistent": true,
-      "cache": false,
-      "env": ["SDK_E2E_PROJECT_ID", "SDK_E2E_DATASET_0", "SDK_E2E_DATASET_1"]
+      "cache": false
     },
     "lint": {
       "cache": false
@@ -71,16 +51,6 @@
     },
     "test:e2e": {
       "cache": false,
-      "env": [
-        "SDK_E2E_PROJECT_ID",
-        "SDK_E2E_DATASET_0",
-        "SDK_E2E_DATASET_1",
-        "SDK_E2E_SESSION_TOKEN",
-        "NODE_ENV",
-        "SDK_E2E_USER_ID",
-        "SDK_E2E_USER_PASSWORD",
-        "RECAPTCHA_E2E_STAGING_KEY"
-      ],
       "dependsOn": ["@repo/e2e#build"],
       "outputs": ["e2e/test-results/**", "e2e/test-report/**"]
     },


### PR DESCRIPTION
### Description
Removed a comment in the e2e.yml file, removed unnecessary turbo.json env vars (they're only used for hashing and none of these jobs are cached, nor should they be), and I noticed a bit of flake in the document list test -- reduced so that there's no possibility (hopefully) that an element gets shoved out the viewport.

### What to review
Are we doing anything here to cause less coverage or slower runs? 

### Testing
If the CI jobs run we should be all right

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGtuY2d3cDFnc3MyOXNmZXB2MnRrNnk3NjZlcjlsb3l1d2JqNTN6dSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/w0uVgtVp4AxVQgpgUk/giphy.gif)