### PR TITLE
test(e2e): run e2e test suite in Dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,25 @@
 # Copy this file to `.env.local` (`cp .env.example .env.local`) and fill in the values there
 # (`.env.local` is ignored by git)
 
-# This is a write token that allows Playwright to interact with the kitchensink app / project as an authenticated user
-# You can generate your own token by heading over to the tokens-section of
-# https://www.sanity.work/manage/, or 
-# by using your CLI user token (`SANITY_INTERNAL_ENV=staging sanity debug --secrets`)
-SDK_E2E_SESSION_TOKEN=
+# Because tests run both in Dashboard and in a standalone app, we need full user information
+# to login and interact with our APIs. You can find the details for SDK_E2E_USER_PASSWORD and
+# RECAPTCHA_E2E_STAGING_KEY in 1Password.
 SDK_E2E_PROJECT_ID=3j6vt2rg
+SDK_E2E_ORGANIZATION_ID=oFvj4MZWQ
+SDK_E2E_USER_ID=sdk+e2e@sanity.io
+SDK_E2E_USER_PASSWORD=
+RECAPTCHA_E2E_STAGING_KEY=
+
 
 # we test with multiple Resource configurations at once. For now, these are in the same project
 SDK_E2E_DATASET_0=production
 SDK_E2E_DATASET_1=testing
+
+
+# This is a write token that allows us to use the client to create / destroy / edit resources
+# (which Playwright will then load in the kitchensink app to test against)
+# You can generate your own token by heading over to the tokens section of
+# https://www.sanity.work/manage/, or
+# by using your CLI user token (`SANITY_INTERNAL_ENV=staging sanity debug --secrets`)
+SDK_E2E_SESSION_TOKEN=
+

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,11 +62,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium, firefox, webkit]
+        browser: [chromium, firefox, webkit, dashboard-chromium]
 
     # Shared env required by the SDK E2E helpers. Configure these in the repo → Settings → Secrets / Variables
     env:
       SDK_E2E_PROJECT_ID: ${{ secrets.SDK_E2E_PROJECT_ID }}
+      SDK_E2E_ORGANIZATION_ID: ${{ secrets.SDK_E2E_ORGANIZATION_ID }}
       SDK_E2E_DATASET_0: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}-{2}', github.event.number, matrix.browser, github.run_id) || format('main-{0}-{1}', matrix.browser, github.run_id) }}
       SDK_E2E_DATASET_1: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}-secondary-{2}', github.event.number, matrix.browser, github.run_id) || format('main-{0}-secondary-{1}', matrix.browser, github.run_id) }}
       SDK_E2E_SESSION_TOKEN: ${{ secrets.SDK_E2E_SESSION_TOKEN }}
@@ -108,6 +109,13 @@ jobs:
       - name: Install WebKit Dependencies
         if: matrix.browser == 'webkit'
         run: pnpm exec playwright install-deps webkit
+
+      - name: 🚀 Start preview server
+        run: |
+          cd apps/kitchensink-react
+          pnpm build --mode e2e && pnpm run preview --mode e2e --port 3333 &
+          timeout 60 bash -c 'until curl -f -s http://localhost:3333 > /dev/null; do echo "Waiting for server..."; sleep 2; done'
+          echo "Server is ready!"
 
       - name: 🧪 Run E2E tests
         run: pnpm test:e2e -- --project ${{ matrix.browser }}

--- a/apps/kitchensink-react/e2e/authenticated.spec.ts
+++ b/apps/kitchensink-react/e2e/authenticated.spec.ts
@@ -1,15 +1,17 @@
-// we may want to have our own unauthenticated fixture in the future.
 import {expect, test} from '@repo/e2e'
 
 test.describe('Authenticated', () => {
-  test('Kitchen sink loads when authenticated', async ({page}) => {
-    await page.goto('/')
+  test('Kitchen sink loads when authenticated', async ({page, getPageContext}) => {
+    await page.goto('./')
 
     // wait a bit -- the redirect can happen too quickly and then be misleading
     await page.waitForTimeout(1000)
 
+    // we may be in an iframe or just a page -- get the right locators
+    const pageContext = await getPageContext(page)
+
     // should be able to see the component beneath the AuthBoundary
-    await expect(page.getByTestId('project-auth-home')).toBeVisible()
+    await expect(pageContext.getByTestId('project-auth-home')).toBeVisible()
     // Verify we're authenticated by checking for the absence of the sign-in link
     await expect(page.getByRole('link', {name: 'Sign in with email'})).not.toBeVisible()
   })
@@ -18,8 +20,13 @@ test.describe('Authenticated', () => {
 // We might go for a dedicated unauthenticated fixture in the future
 // rather than just clearing the localStorage
 test.describe('Unauthenticated', () => {
-  test('Can test unauthenticated state', async ({page}) => {
-    await page.goto('/')
+  test('Can test unauthenticated state', async ({page, getPageContext}) => {
+    await page.goto('./')
+
+    const pageContext = await getPageContext(page)
+
+    // Skip this test if we're in dashboard context - auth is handled by the dashboard
+    test.skip(pageContext.isDashboard, 'Skipping unauthenticated test in dashboard context')
 
     await page.evaluate(() => {
       window.localStorage.clear()
@@ -28,8 +35,8 @@ test.describe('Unauthenticated', () => {
     await page.reload()
 
     // should not be able to see the component beneath the AuthBoundary
-    await expect(page.getByTestId('project-auth-home')).not.toBeVisible()
+    await expect(pageContext.getByTestId('project-auth-home')).not.toBeVisible()
     // The sign in link should be visible when not authenticated
-    await expect(page.getByRole('link', {name: 'Sign in with email'})).toBeVisible()
+    await expect(pageContext.getByRole('link', {name: 'Sign in with email'})).toBeVisible()
   })
 })

--- a/apps/kitchensink-react/e2e/document-editor.spec.ts
+++ b/apps/kitchensink-react/e2e/document-editor.spec.ts
@@ -1,7 +1,7 @@
 import {expect, test} from '@repo/e2e'
 
 test.describe('Document Editor', () => {
-  test('can edit an author document', async ({page, createDocuments}) => {
+  test('can edit an author document', async ({page, createDocuments, getPageContext}) => {
     // Create an author document
     const {
       documentIds: [id],
@@ -14,26 +14,29 @@ test.describe('Document Editor', () => {
     ])
 
     // Navigate to the document editor
-    await page.goto('/document-editor')
+    await page.goto('./document-editor')
+
+    // we may be in an iframe or just a page -- get the right locators
+    const pageContext = await getPageContext(page)
 
     // Wait for the document to load
-    await page.getByTestId('document-id-input').fill(id.replace('drafts.', ''))
-    await page.getByTestId('load-document-button').click()
+    await pageContext.getByTestId('document-id-input').fill(id.replace('drafts.', ''))
+    await pageContext.getByTestId('load-document-button').click()
 
     // Wait for the document to be loaded and match expected initial values
     await expect(async () => {
-      const content = await page.getByTestId('document-content').textContent()
+      const content = await pageContext.getByTestId('document-content').textContent()
       const document = JSON.parse(content || '{}')
       expect(document.name).toBe('Test Author for document editor')
       expect(document.biography).toBe('This is a test biography')
     }).toPass({timeout: 5000})
 
     // Update content
-    await page.getByTestId('name-input').fill('Updated Author Name')
-    await page.getByTestId('name-input').press('Enter')
+    await pageContext.getByTestId('name-input').fill('Updated Author Name')
+    await pageContext.getByTestId('name-input').press('Enter')
 
     // Verify the changes are reflected
-    const updatedContent = await page.getByTestId('document-content').textContent()
+    const updatedContent = await pageContext.getByTestId('document-content').textContent()
     const updatedDocument = JSON.parse(updatedContent || '{}')
     expect(updatedDocument.name).toBe('Updated Author Name')
     expect(updatedDocument.biography).toBe('This is a test biography')

--- a/apps/kitchensink-react/e2e/document-list.spec.ts
+++ b/apps/kitchensink-react/e2e/document-list.spec.ts
@@ -1,7 +1,12 @@
 import {expect, test} from '@repo/e2e'
 
 test.describe('Document List', () => {
-  test('can list and update author documents', async ({page, getClient, createDocuments}) => {
+  test('can list and update author documents', async ({
+    page,
+    getClient,
+    createDocuments,
+    getPageContext,
+  }) => {
     const client = getClient()
 
     // Create 10 author documents in a single transaction
@@ -11,30 +16,35 @@ test.describe('Document List', () => {
         name: `Test Author ${i}`,
         biography: `This is a test biography for author ${i}`,
       })),
+      {asDraft: false},
     )
 
     // Query for the most recent document by _updatedAt
     // (it should be at the top of the list and thus visible in the viewport for the test)
     const mostRecentDoc = await client.fetch(
-      `*[_type == "author"] | order(_updatedAt desc)[0]{_id}`,
+      `*[_id in $documentIds] | order(_updatedAt desc)[0]{_id}`,
       {documentIds},
     )
-    const id = mostRecentDoc._id.replace('drafts.', '')
+
+    const id = mostRecentDoc._id
 
     // Navigate to the document list
-    await page.goto('/document-list')
+    await page.goto('./document-list')
+
+    // we may be in an iframe or just a page -- get the right locators
+    const pageContext = await getPageContext(page)
 
     // Wait for the target document to be visible
-    const targetDocumentPreview = page.getByTestId(`document-preview-${id}`)
+    const targetDocumentPreview = pageContext.getByTestId(`document-preview-${id}`)
     await targetDocumentPreview.waitFor()
     await expect(targetDocumentPreview).toBeVisible()
 
     // Update the document using the client
-    await client.patch(`drafts.${id}`).set({name: 'Updated Author Name'}).commit()
+    await client.patch(id).set({name: 'Updated Author Name'}).commit()
 
     // Wait for the document preview to update with the new name
     await expect(async () => {
-      const updatedDocumentPreview = page.getByTestId(`document-preview-${id}`)
+      const updatedDocumentPreview = pageContext.getByTestId(`document-preview-${id}`)
       await expect(updatedDocumentPreview).toBeVisible()
 
       const updatedDocumentTitle = await updatedDocumentPreview

--- a/apps/kitchensink-react/playwright.config.ts
+++ b/apps/kitchensink-react/playwright.config.ts
@@ -7,8 +7,7 @@ export default createPlaywrightConfig({
     command: process.env['CI']
       ? 'pnpm build --mode e2e && pnpm preview --mode e2e --port 3333'
       : 'pnpm dev --mode e2e',
-    url: 'http://localhost:3333',
-    reuseExistingServer: !process.env['CI'],
+    reuseExistingServer: true,
     stdout: 'pipe',
   },
 })

--- a/packages/@repo/e2e/README.md
+++ b/packages/@repo/e2e/README.md
@@ -4,8 +4,13 @@
 
 The tests expect to find the below env variables. Either define them in your shell, or add them to the `.env.local` file in the repository root.
 
-- `SDK_E2E_SESSION_TOKEN`: As a developer running locally, you should use a user token. The client fixture also needs to use this token. Running `SANITY_INTERNAL_ENV=staging sanity debug --secrets` will give you your token provided you are logged in (`sanity login`).
+-- `SDK_E2E_SESSION_TOKEN`: The client fixture needs to use this token. Running `SANITY_INTERNAL_ENV=staging sanity debug --secrets` will give you your token provided you are logged in (`SANITY_INTERNAL_ENV=staging sanity login`).
+
 - `SDK_E2E_PROJECT_ID`: We use 3j6vt2rg internally
+- `SDK_E2E_ORGANIZATION_ID`: We use oFvj4MZWQ internally
+- `SDK_E2E_USER_ID`: sdk+e2e@sanity.io
+- `SDK_E2E_USER_PASSWORD`: found in 1Password
+- `RECAPTCHA_E2E_STAGING_KEY`: found in 1Password
 - `SDK_E2E_DATASET_0`=production
 - `SDK_E2E_DATASET_1`=testing
 
@@ -42,9 +47,6 @@ You can run your tests in your editor with the help of some useful editor plugin
 
 ### Running in CI mode
 
-These tests run in CI with a dedicated e2e test user. If you'd like to replicate that, you should add the following variables to your .env.local file:
+These tests run in CI with a built application (rather than dev server). It also runs its tests in the Dashboard. If you'd like to replicate that, you should add the following variables to your .env.local file:
 
 - `CI`: true
-- `SDK_E2E_USER_ID`: sdk+e2e@sanity.io
-- `SDK_E2E_USER_PASSWORD` (found in 1Password under "SDK e2e user Sanity login")
-- `RECAPTCHA_E2E_STAGING_KEY` (found in 1Password under "Legion E2E staging reCAPTCHA bypass token")

--- a/packages/@repo/e2e/README.md
+++ b/packages/@repo/e2e/README.md
@@ -14,6 +14,28 @@ The tests expect to find the below env variables. Either define them in your she
 - `SDK_E2E_DATASET_0`=production
 - `SDK_E2E_DATASET_1`=testing
 
+## Writing tests
+
+@repo/e2e provides a specialized fixture for your tests, called `getPageContext`. This is because the tests run both standalone and in the Dashboard, meaning locators work a bit differently. Please use this fixture to ensure your tests work well in both environments. To do so, you should write your tests so that they do the following:
+
+1. Navigate to the route you intend to test on, i.e., `await page.goto('./my-route')` (otherwise Playwright will be at about:blank and not know anything about iframes or not)
+2. Use the `getPageContext` function with your page, like `const pageContext = await getPageContext(page)`
+3. Use the locators provided by `pageContext`, like `const button = pageContext.getByTestId('my-button')
+
+Here is a full example:
+
+```ts
+import {expect, test} from '@repo/e2e'
+
+test('can click a button', async ({page, getPageContext}) => {
+  await page.goto('./button-test-page')
+
+  const pageContext = await getPageContext(page)
+
+  await pageContext.getByTestId('my-button').click()
+})
+```
+
 ## Running tests
 
 To run E2E tests run the following commands from the root of the project
@@ -32,7 +54,7 @@ To run E2E tests run the following commands from the root of the project
 
 - For help, run
   ```sh
-  pnpm test:e2e --help
+  pnpm test:e2e -- --help
   ```
 
 Other useful helper commands

--- a/packages/@repo/e2e/src/fixtures.ts
+++ b/packages/@repo/e2e/src/fixtures.ts
@@ -1,8 +1,9 @@
-import {test as base} from '@playwright/test'
+import {type Page, test as base} from '@playwright/test'
 import {type MultipleMutationResult, SanityClient} from '@sanity/client'
 
 import {getClient} from './helpers/clients'
 import {cleanupDocuments, createDocuments, type DocumentStub} from './helpers/documents'
+import {createPageContext, type PageContext} from './helpers/pageContext'
 
 interface SanityFixtures {
   createDocuments: (
@@ -11,6 +12,7 @@ interface SanityFixtures {
     dataset?: string,
   ) => Promise<MultipleMutationResult>
   getClient: (dataset?: string) => SanityClient
+  getPageContext: (page: Page) => Promise<PageContext>
 }
 
 /**
@@ -29,6 +31,13 @@ export const test = base.extend<SanityFixtures>({
   // eslint-disable-next-line no-empty-pattern
   getClient: async ({}, use) => {
     await use(getClient)
+  },
+  // eslint-disable-next-line no-empty-pattern
+  getPageContext: async ({}, use, testInfo) => {
+    const getPageContext = async (page: Page) => {
+      return await createPageContext(page, testInfo.project.name)
+    }
+    await use(getPageContext)
   },
 })
 

--- a/packages/@repo/e2e/src/helpers/clients.ts
+++ b/packages/@repo/e2e/src/helpers/clients.ts
@@ -8,7 +8,7 @@ const baseConfig = {
   projectId: env.SDK_E2E_PROJECT_ID,
   token: env.SDK_E2E_SESSION_TOKEN,
   useCdn: false,
-  apiVersion: '2021-08-31',
+  apiVersion: '2025-06-01',
   apiHost: 'https://api.sanity.work',
 }
 

--- a/packages/@repo/e2e/src/helpers/getE2EEnv.ts
+++ b/packages/@repo/e2e/src/helpers/getE2EEnv.ts
@@ -3,6 +3,8 @@ import {loadEnvFiles} from './loadEnvFiles'
 interface E2EEnv {
   /** The project ID for the primary dataset */
   SDK_E2E_PROJECT_ID: string
+  /** The organization  ID for the project */
+  SDK_E2E_ORGANIZATION_ID: string
   /** The dataset for the primary dataset */
   SDK_E2E_DATASET_0: string
   /** The dataset for the secondary dataset (for multi-resource tests) */
@@ -12,11 +14,11 @@ interface E2EEnv {
   /** Whether we're running in CI */
   CI?: boolean
   /** E2E test user ID */
-  SDK_E2E_USER_ID?: string
+  SDK_E2E_USER_ID: string
   /** E2E test user password */
-  SDK_E2E_USER_PASSWORD?: string
+  SDK_E2E_USER_PASSWORD: string
   /** E2E test recaptcha key for CI */
-  RECAPTCHA_E2E_STAGING_KEY?: string
+  RECAPTCHA_E2E_STAGING_KEY: string
 }
 
 type KnownEnvVar = keyof E2EEnv
@@ -55,23 +57,18 @@ function findEnv(name: KnownEnvVar): string | undefined {
 export function getE2EEnv(): E2EEnv {
   const CI = findEnv('CI') === 'true'
   const SDK_E2E_PROJECT_ID = readEnv('SDK_E2E_PROJECT_ID')
+  const SDK_E2E_ORGANIZATION_ID = readEnv('SDK_E2E_ORGANIZATION_ID')
   const SDK_E2E_DATASET_0 = readEnv('SDK_E2E_DATASET_0')
   const SDK_E2E_DATASET_1 = readEnv('SDK_E2E_DATASET_1')
   const SDK_E2E_SESSION_TOKEN = readEnv('SDK_E2E_SESSION_TOKEN')
-
-  let SDK_E2E_USER_ID: string | undefined
-  let SDK_E2E_USER_PASSWORD: string | undefined
-  let RECAPTCHA_E2E_STAGING_KEY: string | undefined
-
-  if (CI) {
-    SDK_E2E_USER_ID = readEnv('SDK_E2E_USER_ID')
-    SDK_E2E_USER_PASSWORD = readEnv('SDK_E2E_USER_PASSWORD')
-    RECAPTCHA_E2E_STAGING_KEY = readEnv('RECAPTCHA_E2E_STAGING_KEY')
-  }
+  const SDK_E2E_USER_ID = readEnv('SDK_E2E_USER_ID')
+  const SDK_E2E_USER_PASSWORD = readEnv('SDK_E2E_USER_PASSWORD')
+  const RECAPTCHA_E2E_STAGING_KEY = readEnv('RECAPTCHA_E2E_STAGING_KEY')
 
   return {
     CI,
     SDK_E2E_PROJECT_ID,
+    SDK_E2E_ORGANIZATION_ID,
     SDK_E2E_DATASET_0,
     SDK_E2E_DATASET_1,
     SDK_E2E_SESSION_TOKEN,

--- a/packages/@repo/e2e/src/helpers/pageContext.ts
+++ b/packages/@repo/e2e/src/helpers/pageContext.ts
@@ -1,21 +1,11 @@
-import {type FrameLocator, type Locator, type Page} from '@playwright/test'
+import {type FrameLocator, type Page} from '@playwright/test'
 
 /**
  * Unified interface for detecting elements in pages whether in iframe or not
  * (this might get lengthy with time but hopefully what we've provided here is sufficient)
  */
-export interface PageContext {
-  getByTestId: (testId: string) => Locator
-  getByText: (text: string | RegExp) => Locator
-  getByRole: (
-    role: Parameters<Page['getByRole']>[0],
-    options?: Parameters<Page['getByRole']>[1],
-  ) => Locator
-  /** Get a locator by any selector */
-  locator: (selector: string) => Locator
-  /** Whether we're running in dashboard context */
+export type PageContext = Pick<Page, 'getByTestId' | 'getByText' | 'getByRole' | 'locator'> & {
   isDashboard: boolean
-  /** The underlying page or frame */
   context: Page | FrameLocator
 }
 

--- a/packages/@repo/e2e/src/helpers/pageContext.ts
+++ b/packages/@repo/e2e/src/helpers/pageContext.ts
@@ -1,0 +1,67 @@
+import {type FrameLocator, type Locator, type Page} from '@playwright/test'
+
+/**
+ * Unified interface for detecting elements in pages whether in iframe or not
+ * (this might get lengthy with time but hopefully what we've provided here is sufficient)
+ */
+export interface PageContext {
+  getByTestId: (testId: string) => Locator
+  getByText: (text: string | RegExp) => Locator
+  getByRole: (
+    role: Parameters<Page['getByRole']>[0],
+    options?: Parameters<Page['getByRole']>[1],
+  ) => Locator
+  /** Get a locator by any selector */
+  locator: (selector: string) => Locator
+  /** Whether we're running in dashboard context */
+  isDashboard: boolean
+  /** The underlying page or frame */
+  context: Page | FrameLocator
+}
+
+const DASHBOARD_PROJECTS = ['dashboard-chromium']
+
+/**
+ * Determines if we're in a dashboard context by checking the project name
+ */
+function isDashboardContext(projectName: string): boolean {
+  return DASHBOARD_PROJECTS.includes(projectName)
+}
+
+/**
+ * Creates a unified page context that works both in iframe and standalone modes
+ */
+export async function createPageContext(page: Page, projectName: string): Promise<PageContext> {
+  const inDashboard = isDashboardContext(projectName)
+
+  if (inDashboard) {
+    // Dashboard context - needs to be up-to-date with how this is implemented in the dashboard
+    const iframe = page.getByTestId('app-frame')
+    await iframe.waitFor({state: 'visible'})
+
+    // Wait for iframe to be ready
+    const frame = iframe.contentFrame()
+    if (!frame) {
+      throw new Error('Failed to get iframe content frame')
+    }
+
+    return {
+      getByTestId: (testId: string) => frame.getByTestId(testId),
+      getByText: (text: string | RegExp) => frame.getByText(text),
+      getByRole: (role, options) => frame.getByRole(role, options),
+      locator: (selector: string) => frame.locator(selector),
+      isDashboard: true,
+      context: frame,
+    }
+  } else {
+    // Standalone context - work directly with page
+    return {
+      getByTestId: (testId: string) => page.getByTestId(testId),
+      getByText: (text: string | RegExp) => page.getByText(text),
+      getByRole: (role, options) => page.getByRole(role, options),
+      locator: (selector: string) => page.locator(selector),
+      isDashboard: false,
+      context: page,
+    }
+  }
+}

--- a/packages/@repo/e2e/src/index.ts
+++ b/packages/@repo/e2e/src/index.ts
@@ -9,9 +9,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const SETUP_DIR = path.join(path.dirname(__dirname), 'src', 'setup')
 const TEARDOWN_DIR = path.join(path.dirname(__dirname), 'src', 'teardown')
 const AUTH_FILE = path.join(path.dirname(__dirname), '.auth', 'user.json')
-const BASE_URL = 'http://localhost:3333'
+const BASE_URL = 'http://localhost:3333/'
 
-const {CI} = getE2EEnv()
+const {CI, SDK_E2E_ORGANIZATION_ID} = getE2EEnv()
 
 /**
  * @internal
@@ -55,17 +55,26 @@ export const basePlaywrightConfig: PlaywrightTestConfig = {
     },
     {
       name: 'chromium',
-      use: {...devices['Desktop Chrome'], storageState: AUTH_FILE},
+      use: {...devices['Desktop Chrome'], storageState: AUTH_FILE, baseURL: BASE_URL},
       dependencies: ['setup'],
     },
     {
       name: 'firefox',
-      use: {...devices['Desktop Firefox'], storageState: AUTH_FILE},
+      use: {...devices['Desktop Firefox'], storageState: AUTH_FILE, baseURL: BASE_URL},
       dependencies: ['setup'],
     },
     {
       name: 'webkit',
-      use: {...devices['Desktop Safari'], storageState: AUTH_FILE},
+      use: {...devices['Desktop Safari'], storageState: AUTH_FILE, baseURL: BASE_URL},
+      dependencies: ['setup'],
+    },
+    {
+      name: 'dashboard-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: AUTH_FILE,
+        baseURL: `https://www.sanity.work/@${SDK_E2E_ORGANIZATION_ID}/application/__dev/`,
+      },
       dependencies: ['setup'],
     },
   ],

--- a/packages/@repo/e2e/src/setup/auth.setup.ts
+++ b/packages/@repo/e2e/src/setup/auth.setup.ts
@@ -1,22 +1,25 @@
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 
-import {type Browser, test as setup} from '@playwright/test'
+import {type BrowserContext, test as setup} from '@playwright/test'
 
 import {getE2EEnv} from '../helpers/getE2EEnv'
 
 const __filename = fileURLToPath(import.meta.url)
 const AUTH_FILE = path.join(path.dirname(__filename), '..', '..', '.auth', 'user.json')
+const env = getE2EEnv()
+
+interface AuthConfig {
+  origin: string
+  expectedRedirectUrl: string
+}
 
 /**
- * Used in CI to authenticate the user with the Sanity API
+ * Used to authenticate the user with the Sanity API
+ * @param context - The browser context to use for authentication
+ * @param config - Configuration for the authentication flow
  */
-const authenticateUser = async (browser: Browser) => {
-  const env = getE2EEnv()
-
-  // get a clean, isolated browser context to isolate this auth flow from other logic
-  const context = await browser.newContext()
-
+const authenticateUser = async (context: BrowserContext, config: AuthConfig) => {
   const response = await context.request.post('https://accounts.sanity.work/api/v1/login', {
     headers: {
       'Content-Type': 'application/json',
@@ -32,58 +35,62 @@ const authenticateUser = async (browser: Browser) => {
     throw new Error(`Failed to authenticate: ${response.statusText()}`)
   }
 
-  // the previous request has set a connect.sid cookie
-  // we can use that to get a session token
   const page = await context.newPage()
 
   const loginUrl = new URL('https://api.sanity.work/v1/auth/login/sanity')
-  loginUrl.searchParams.set('origin', 'http://localhost:3333')
+  loginUrl.searchParams.set('origin', config.origin)
   loginUrl.searchParams.set('type', 'token')
 
   await page.goto(loginUrl.toString())
 
-  // the /auth/login/sanity endpoint will redirect to the origin we set above
-  // our own site / SDK will receive the token it sent in the request
-  // and set it to be used by every other request
+  // Wait for the redirect to complete AND network to be idle
   await Promise.all([
-    page.waitForURL('http://localhost:3333'),
+    page.waitForURL(config.expectedRedirectUrl),
     page.waitForLoadState('networkidle'),
   ])
 
-  // get the "state" of the current browser we used to do the auth flow
-  // and save it to a file
-  // this will be used by the next tests as though we were logged in
-  // and be destroyed when the tests are done
-  await context.storageState({path: AUTH_FILE})
-  await context.close()
+  await page.close()
 }
 
-/**
- * Used in local development to inject the token into the local storage
- */
-const injectLocalStorageToken = async (browser: Browser, e2eSessionToken: string) => {
-  // get a clean, isolated browser context to isolate this auth flow from other logic
-  const context = await browser.newContext()
+const setDashboardRedirectCookie = async (context: BrowserContext) => {
   const page = await context.newPage()
 
-  await page.addInitScript((token) => {
-    window.addEventListener('load', () => {
-      window.localStorage.setItem('__sanity_auth_token', JSON.stringify({token}))
-    })
-  }, e2eSessionToken)
+  // visit the dashboard url to set the redirect cookie
+  await page.goto(
+    `https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}?dev=http://localhost:3333`,
+  )
 
-  await page.goto('http://localhost:3333')
+  // wait until the url is /application/__dev (indicating the redirect cookie was set)
+  await page.waitForURL(`https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}/application/__dev`)
 
-  // as above, save the state to a file
-  await context.storageState({path: AUTH_FILE})
-  await context.close()
+  await page.close()
 }
 
 setup('setup authentication', async ({browser}) => {
-  const {CI, SDK_E2E_SESSION_TOKEN} = getE2EEnv()
-  if (CI) {
-    await authenticateUser(browser)
-  } else {
-    await injectLocalStorageToken(browser, SDK_E2E_SESSION_TOKEN!)
+  // Create a single browser context that will be used for all authentication operations
+  const context = await browser.newContext()
+
+  try {
+    // Authenticate for standalone apps
+    await authenticateUser(context, {
+      origin: 'http://localhost:3333',
+      expectedRedirectUrl: 'http://localhost:3333',
+    })
+
+    // Authenticate for embedded apps (Dashboard)
+    await authenticateUser(context, {
+      origin: 'https://www.sanity.work/api/dashboard/authenticate',
+      expectedRedirectUrl: `https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}`,
+    })
+
+    // Set the dashboard redirect cookie
+    await setDashboardRedirectCookie(context)
+
+    // Save the combined context state to the auth file
+    // This will contain all cookies, localStorage, and sessionStorage from all operations
+    await context.storageState({path: AUTH_FILE})
+  } finally {
+    // close the context to clean up resources
+    await context.close()
   }
 })

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,7 @@
     "NPM_CONFIG_PROVENANCE",
     "CI",
     "SDK_E2E_PROJECT_ID",
+    "SDK_E2E_ORGANIZATION_ID",
     "SDK_E2E_DATASET_0",
     "SDK_E2E_DATASET_1",
     "SDK_E2E_SESSION_TOKEN",
@@ -73,6 +74,7 @@
       "cache": false,
       "env": [
         "SDK_E2E_PROJECT_ID",
+        "SDK_E2E_ORGANIZATION_ID",
         "SDK_E2E_DATASET_0",
         "SDK_E2E_DATASET_1",
         "SDK_E2E_SESSION_TOKEN",


### PR DESCRIPTION
### Description
This PR adds a number of helpers and additional logic to ensure that e2e tests can work both in a standalone context as well as in the Dashboard. It adds an additional Playwright project that runs its tests in the Dashboard, as well as an additional fixture to ensure we can target elements both inside and outside of an iframe.

### What to review
- I've removed the "local dev" method to authenticate e2e tests using a user token. Since local devs will also run the Dashboard test project, they would not be able to effectively sign into Dashboard with just that token. I apologize for making this more complicated.
- Does the pageContext fixture make sense?
- Any other specific logic that might be obscure to future devs?

### Testing
`dashboard-chromium` runs tests within the dashboard. I'll add a test for something like `useNavigateToStudioDocument` soon.

### Fun gif
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmpiNzF0bGo0dzBlbHdvejI2bWF5cHJhanhxdDVnN2g3ZHQxZjl2aCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/eaz5Br9FmAU27WTImy/giphy.gif)
