### PR TITLE
fix: clear error overlay on successful comlink token creation

### DIFF
--- a/packages/react/src/context/ComlinkTokenRefresh.tsx
+++ b/packages/react/src/context/ComlinkTokenRefresh.tsx
@@ -66,6 +66,21 @@ function DashboardTokenRefresh({children}: PropsWithChildren) {
 
       if (res.token) {
         setAuthToken(instance, res.token)
+
+        // Remove the unauthorized error from the error container
+        const errorContainer = document.getElementById('__sanityError')
+        if (errorContainer) {
+          const hasUnauthorizedError = Array.from(errorContainer.getElementsByTagName('div')).some(
+            (div) =>
+              div.textContent?.includes(
+                'Uncaught error: Unauthorized - A valid session is required for this endpoint',
+              ),
+          )
+
+          if (hasUnauthorizedError) {
+            errorContainer.remove()
+          }
+        }
       }
       isTokenRefreshInProgress.current = false
     } catch {


### PR DESCRIPTION
### Description

Added functionality to remove the unauthorized error message from the DOM when a token is successfully refreshed. When a user's session token is refreshed, the code now checks for and removes any unauthorized error messages displayed in the `__sanityError` container, providing a cleaner user experience by eliminating stale error messages that are no longer relevant.

### What to review

- The error removal logic in the token refresh flow
- The DOM manipulation approach using `document.getElementById` and element traversal
- The specific error message text being targeted for removal

### Testing

Tested by:
1. Forcing a token expiration scenario
2. Verifying the unauthorized error appears in the UI
3. Confirming the error is properly removed after successful token refresh

### Fun gif

![Error disappearing](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNnNmemp2aDI0bHhjeHQyMHN5Z2xkNmlra2lrOHFpa2hpdGpvamllZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/XqpnXaeZPnupy/giphy.gif)