### PR TITLE
feat(auth): check for stamped token expiration after browser idle

### DIFF
--- a/packages/core/src/auth/authStore.ts
+++ b/packages/core/src/auth/authStore.ts
@@ -35,6 +35,7 @@ export type LoggedInAuthState = {
   type: AuthStateType.LOGGED_IN
   token: string
   currentUser: CurrentUser | null
+  lastTokenRefresh?: number
 }
 
 /**

--- a/packages/core/src/auth/refreshStampedToken.test.ts
+++ b/packages/core/src/auth/refreshStampedToken.test.ts
@@ -16,6 +16,7 @@ import {refreshStampedToken} from './refreshStampedToken'
 describe('refreshStampedToken', () => {
   let mockStorage: Storage
   let originalNavigator: typeof navigator // Restored
+  let originalDocument: Document
   let subscriptions: Subscription[]
   // mockLocksRequest removed
 
@@ -25,6 +26,19 @@ describe('refreshStampedToken', () => {
     vi.useFakeTimers()
 
     originalNavigator = global.navigator // Restore original navigator setup
+
+    // Mock document for visibility API
+    originalDocument = global.document
+    Object.defineProperty(global, 'document', {
+      value: {
+        visibilityState: 'visible',
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+      writable: true,
+      configurable: true,
+    })
+
     mockStorage = {
       getItem: vi.fn(),
       setItem: vi.fn(),
@@ -74,6 +88,11 @@ describe('refreshStampedToken', () => {
     // Restore original navigator
     Object.defineProperty(global, 'navigator', {
       value: originalNavigator,
+      writable: true,
+    })
+    // Restore original document
+    Object.defineProperty(global, 'document', {
+      value: originalDocument,
       writable: true,
     })
     // Restore real timers

--- a/packages/core/src/auth/refreshStampedToken.ts
+++ b/packages/core/src/auth/refreshStampedToken.ts
@@ -20,16 +20,19 @@ import {type AuthState, type AuthStoreState} from './authStore'
 const REFRESH_INTERVAL = 12 * 60 * 60 * 1000 // 12 hours in milliseconds
 const LOCK_NAME = 'sanity-token-refresh-lock'
 
-function getLastRefreshTime(storageArea: Storage | undefined, storageKey: string): number {
+/** @internal */
+export function getLastRefreshTime(storageArea: Storage | undefined, storageKey: string): number {
   try {
     const data = storageArea?.getItem(`${storageKey}_last_refresh`)
-    return data ? parseInt(data, 10) : 0
+    const parsed = data ? parseInt(data, 10) : 0
+    return isNaN(parsed) ? 0 : parsed
   } catch {
     return 0
   }
 }
 
-function setLastRefreshTime(storageArea: Storage | undefined, storageKey: string): void {
+/** @internal */
+export function setLastRefreshTime(storageArea: Storage | undefined, storageKey: string): void {
   try {
     storageArea?.setItem(`${storageKey}_last_refresh`, Date.now().toString())
   } catch {
@@ -37,7 +40,8 @@ function setLastRefreshTime(storageArea: Storage | undefined, storageKey: string
   }
 }
 
-function getNextRefreshDelay(storageArea: Storage | undefined, storageKey: string): number {
+/** @internal */
+export function getNextRefreshDelay(storageArea: Storage | undefined, storageKey: string): number {
   const lastRefresh = getLastRefreshTime(storageArea, storageKey)
   if (!lastRefresh) return 0
 


### PR DESCRIPTION
### Description
If a browser is idle then the rxJS `timer` function is not reliable.

This PR improves token refresh handling by:
1. Adding a `lastTokenRefresh` timestamp to the `LoggedInAuthState` type
2. Implementing a visibility-aware token refresh mechanism that refreshes tokens when the tab becomes visible
3. Adding a `shouldRefreshToken` function to determine if a token needs refreshing based on time elapsed
4. Optimizing token refresh logic to prevent unnecessary refreshes

These changes ensure tokens are refreshed appropriately when users return to the application after it's been in the background, improving authentication reliability.

### What to review

- The new `lastTokenRefresh` property in the `LoggedInAuthState` type
- The visibility change event handler implementation
- The token refresh logic that now considers document visibility state
- The `shouldRefreshToken` function that determines if a refresh is needed

### Testing

Tested the following scenarios:
- Token refresh on regular intervals when tab is visible
- Token refresh when returning to a tab that's been in background
- No unnecessary refreshes when the time threshold hasn't been met
- Proper cleanup of event listeners when component unmounts

### Fun gif
![idle/idol](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2x6MnlleTE0aHJvNWptd20xc2ZhbThkdWxnNHF5c3p5ZWU2cWNoOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WpD1gFWnFrlG9QhHy9/giphy.gif)