### PR TITLE
chore(tests): reduce stderr output while running tests

### DIFF
--- a/packages/core/src/query/queryStore.test.ts
+++ b/packages/core/src/query/queryStore.test.ts
@@ -20,6 +20,7 @@ describe('queryStore', () => {
   let instance: SanityInstance
   let liveEvents: Subject<LiveEvent>
   let fetch: SanityClient['observable']['fetch']
+  let listen: SanityClient['observable']['listen']
   // Mock data for testing
   const mockData = {
     movies: [
@@ -37,6 +38,8 @@ describe('queryStore', () => {
         of({result: mockData.movies, syncTags: []}).pipe(delay(0)),
       ) as SanityClient['observable']['fetch']
 
+    listen = vi.fn().mockReturnValue(of(mockData.movies))
+
     liveEvents = new Subject<LiveEvent>()
 
     const events = vi.fn().mockReturnValue(liveEvents) as SanityClient['live']['events']
@@ -47,7 +50,7 @@ describe('queryStore', () => {
       observable: of({
         config,
         live: {events},
-        observable: {fetch},
+        observable: {fetch, listen},
       } as SanityClient),
     } as StateSource<SanityClient>)
   })

--- a/packages/core/src/releases/releasesStore.test.ts
+++ b/packages/core/src/releases/releasesStore.test.ts
@@ -17,7 +17,7 @@ vi.mock('../utils/listenQuery', () => ({
 }))
 
 // Mock console.error to prevent test runner noise and allow verification
-const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>
 
 describe('releasesStore', () => {
   let instance: SanityInstance
@@ -25,7 +25,7 @@ describe('releasesStore', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
-    consoleErrorSpy.mockClear()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     instance = createSanityInstance({projectId: 'test', dataset: 'test'})
 
@@ -36,6 +36,7 @@ describe('releasesStore', () => {
 
   afterEach(() => {
     instance.dispose()
+    consoleErrorSpy.mockRestore()
   })
 
   it('should set active releases state when listenQuery succeeds', async () => {
@@ -63,6 +64,8 @@ describe('releasesStore', () => {
 
     expect(state.getCurrent()).toEqual(mockReleases.reverse())
     expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
   })
 
   it('should update active releases state when listenQuery emits new data', async () => {

--- a/packages/react/src/components/SanityApp.test.tsx
+++ b/packages/react/src/components/SanityApp.test.tsx
@@ -170,6 +170,7 @@ describe('SanityApp', () => {
 
   it('redirects to core if not inside iframe and not local url', async () => {
     const originalLocation = window.location
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
     const mockLocation = {
       replace: vi.fn(),
@@ -203,6 +204,7 @@ describe('SanityApp', () => {
       value: originalLocation,
       writable: true,
     })
+    consoleLogSpy.mockRestore()
   })
 
   it('does not redirect to core if not inside iframe and local url', async () => {

--- a/packages/react/src/context/ResourceProvider.test.tsx
+++ b/packages/react/src/context/ResourceProvider.test.tsx
@@ -1,5 +1,5 @@
 import {type SanityConfig, type SanityInstance} from '@sanity/sdk'
-import {render, screen} from '@testing-library/react'
+import {act, render, screen} from '@testing-library/react'
 import {StrictMode, use, useEffect} from 'react'
 import {describe, expect, it} from 'vitest'
 
@@ -36,7 +36,7 @@ describe('ResourceProvider', () => {
     expect(screen.getByTestId('test-child')).toBeInTheDocument()
   })
 
-  it('shows fallback during loading', () => {
+  it('shows fallback during loading', async () => {
     const {promise, resolve} = promiseWithResolvers()
     function SuspendingChild(): React.ReactNode {
       throw promise
@@ -49,7 +49,9 @@ describe('ResourceProvider', () => {
     )
 
     expect(screen.getByTestId('fallback')).toBeInTheDocument()
-    resolve()
+    act(() => {
+      resolve()
+    })
   })
 
   it('creates root instance when no parent context exists', async () => {
@@ -138,7 +140,7 @@ describe('ResourceProvider', () => {
     expect(instance?.isDisposed()).toBe(false)
   })
 
-  it('uses default fallback when none provided', () => {
+  it('uses default fallback when none provided', async () => {
     const {promise, resolve} = promiseWithResolvers()
     function SuspendingChild(): React.ReactNode {
       throw promise
@@ -152,6 +154,8 @@ describe('ResourceProvider', () => {
     )
 
     expect(screen.getByText(/Warning: No fallback provided/)).toBeInTheDocument()
-    resolve()
+    act(() => {
+      resolve()
+    })
   })
 })

--- a/packages/react/src/hooks/dashboard/useManageFavorite.test.ts
+++ b/packages/react/src/hooks/dashboard/useManageFavorite.test.ts
@@ -172,6 +172,7 @@ describe('useManageFavorite', () => {
 
   it('should throw error during favorite/unfavorite actions', async () => {
     const errorMessage = 'Failed to update favorite status'
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     mockFetch.mockImplementation(() => {
       throw new Error(errorMessage)
@@ -191,6 +192,7 @@ describe('useManageFavorite', () => {
     })
 
     expect(resolveFavoritesState).not.toHaveBeenCalled()
+    consoleErrorSpy.mockRestore()
   })
 
   it('should throw error when studio resource is missing projectId or dataset', () => {

--- a/packages/react/src/hooks/dashboard/useNavigateToStudioDocument.test.ts
+++ b/packages/react/src/hooks/dashboard/useNavigateToStudioDocument.test.ts
@@ -75,10 +75,12 @@ describe('useNavigateToStudioDocument', () => {
   })
 
   it('does not send message when no workspace is found', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockWorkspacesByProjectIdAndDataset = {}
     const {result} = renderHook(() => useNavigateToStudioDocument(mockDocumentHandle))
     result.current.navigateToStudioDocument()
     expect(mockSendMessage).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
   })
 
   it('warns when multiple workspaces are found', () => {

--- a/packages/react/src/hooks/dashboard/useRecordDocumentHistoryEvent.test.ts
+++ b/packages/react/src/hooks/dashboard/useRecordDocumentHistoryEvent.test.ts
@@ -45,6 +45,7 @@ describe('useRecordDocumentHistoryEvent', () => {
   })
 
   it('should handle errors when sending messages', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     mockSendMessage.mockImplementation(() => {
       throw new Error('Failed to send message')
     })
@@ -52,6 +53,7 @@ describe('useRecordDocumentHistoryEvent', () => {
     const {result} = renderHook(() => useRecordDocumentHistoryEvent(mockDocumentHandle))
 
     expect(() => result.current.recordEvent('viewed')).toThrow('Failed to send message')
+    consoleErrorSpy.mockRestore()
   })
 
   it('should throw error when resourceId is missing for non-studio resources', () => {


### PR DESCRIPTION
### Description

Improved test cleanup and mocking practices across the codebase to prevent test pollution and ensure more reliable test runs. This PR addresses several issues:

1. Added proper spy cleanup with `mockRestore()` after tests
2. Moved console spies into test setup to ensure they're properly initialized
3. Added missing `listen` mock in queryStore tests
4. Fixed async act warnings in React tests by wrapping promise resolutions in `act()`
5. Added missing `useRealTimers()` call to prevent timer leakage

### What to review

- Check that all console spies are properly restored after tests
- Verify that React component tests properly use `act()` for async operations
- Confirm that the queryStore tests now correctly mock the `listen` method

### Testing
- run `pnpm test` with `main` branch see stderr output
- run this branch `pnpm test` see less stderr output


### Fun gif

![quieter](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbjNoNHEzMXE4NGI0a2dybGRnbnhrajg2MXBzbXcxdTFtZHlpNWZ4NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iHskdY9SMLFZuQ2u5c/giphy.gif)