### PR TITLE
feat: add bifur dependency and presence events

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -64,6 +64,16 @@ const baseConfig = {
       entry: ['src/index.ts', 'src/setup/**/*.ts', 'src/teardown/**/*.ts'],
       ignoreDependencies: ['@repo/tsconfig'],
     },
+    // TODO: Remove this once we have presence fully implemented in the SDK
+    'packages/core': {
+      typescript: {
+        config: 'tsconfig.settings.json',
+      },
+      project,
+      entry: ['package.bundle.ts'],
+      ignore: ['src/presence/bifurTransport.ts', 'src/presence/types.ts'],
+      ignoreDependencies: ['@sanity/bifur-client', '@sanity/browserslist-config'],
+    },
   },
 } satisfies KnipConfig
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
   "browserslist": "extends @sanity/browserslist-config",
   "prettier": "@sanity/prettier-config",
   "dependencies": {
+    "@sanity/bifur-client": "^0.4.1",
     "@sanity/client": "^7.2.1",
     "@sanity/comlink": "^3.0.4",
     "@sanity/diff-match-patch": "^3.2.0",

--- a/packages/core/src/presence/bifurTransport.test.ts
+++ b/packages/core/src/presence/bifurTransport.test.ts
@@ -1,0 +1,257 @@
+import {fromUrl} from '@sanity/bifur-client'
+import {type SanityClient} from '@sanity/client'
+import {of, Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {createBifurTransport} from './bifurTransport'
+import {type PresenceLocation, type TransportEvent} from './types'
+
+vi.mock('@sanity/bifur-client', () => ({
+  fromUrl: vi.fn(),
+}))
+
+const fromUrlMock = fromUrl as Mock
+
+type BifurStateMessage = {
+  type: 'state'
+  i: string
+  m: {
+    sessionId: string
+    locations: PresenceLocation[]
+  }
+}
+
+type BifurDisconnectMessage = {
+  type: 'disconnect'
+  i: string
+  m: {session: string}
+}
+
+type BifurRollCallEvent = {
+  type: 'rollCall'
+  i: string
+  session: string
+}
+
+type IncomingBifurEvent = BifurRollCallEvent | BifurStateMessage | BifurDisconnectMessage
+
+describe('createBifurTransport', () => {
+  let mockBifurClient: {
+    listen: Mock
+    request: Mock
+  }
+  let mockSanityClient: SanityClient
+  let token$: Subject<string | null>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockBifurClient = {
+      listen: vi.fn(() => new Subject<never>()),
+      request: vi.fn(() => of(undefined)),
+    }
+    fromUrlMock.mockReturnValue(mockBifurClient)
+
+    mockSanityClient = {
+      config: () => ({
+        dataset: 'test-dataset',
+        url: 'http://localhost:3333',
+        requestTagPrefix: 'test-tag',
+      }),
+      withConfig: vi.fn().mockReturnThis(),
+    } as unknown as SanityClient
+
+    token$ = new Subject<string | null>()
+  })
+
+  it('constructs the bifur client with the correct URL', () => {
+    createBifurTransport({
+      client: mockSanityClient,
+      token$,
+      sessionId: 'session-id-123',
+    })
+
+    expect(fromUrlMock).toHaveBeenCalledWith(
+      'ws://localhost:3333/socket/test-dataset?tag=test-tag',
+      {
+        token$,
+      },
+    )
+  })
+
+  it('handles incoming rollCall events', () => {
+    const incomingBifurEvents$ = new Subject<IncomingBifurEvent>()
+    mockBifurClient.listen.mockReturnValue(incomingBifurEvents$)
+
+    const [incomingEvents$] = createBifurTransport({
+      client: mockSanityClient,
+      token$,
+      sessionId: 'session-id-123',
+    })
+
+    const receivedEvents: TransportEvent[] = []
+    incomingEvents$.subscribe((event) => receivedEvents.push(event))
+
+    incomingBifurEvents$.next({
+      type: 'rollCall',
+      i: 'user-1',
+      session: 'session-id-456',
+    })
+
+    expect(receivedEvents).toEqual([
+      {
+        type: 'rollCall',
+        userId: 'user-1',
+        sessionId: 'session-id-456',
+      },
+    ])
+  })
+
+  it('handles incoming state events', () => {
+    const date = new Date('2024-01-01T12:00:00.000Z')
+    vi.setSystemTime(date)
+
+    const incomingBifurEvents$ = new Subject<IncomingBifurEvent>()
+    mockBifurClient.listen.mockReturnValue(incomingBifurEvents$)
+
+    const [incomingEvents$] = createBifurTransport({
+      client: mockSanityClient,
+      token$,
+      sessionId: 'session-id-123',
+    })
+
+    const receivedEvents: TransportEvent[] = []
+    incomingEvents$.subscribe((event) => receivedEvents.push(event))
+
+    const locations: PresenceLocation[] = [
+      {type: 'document', documentId: 'doc1', path: ['a'], lastActiveAt: new Date().toISOString()},
+    ]
+    incomingBifurEvents$.next({
+      type: 'state',
+      i: 'user-1',
+      m: {
+        sessionId: 'session-id-456',
+        locations,
+      },
+    })
+
+    expect(receivedEvents).toEqual([
+      {
+        type: 'state',
+        userId: 'user-1',
+        sessionId: 'session-id-456',
+        timestamp: date.toISOString(),
+        locations,
+      },
+    ])
+  })
+
+  it('handles incoming disconnect events', () => {
+    const date = new Date('2024-01-01T12:00:00.000Z')
+    vi.setSystemTime(date)
+
+    const incomingBifurEvents$ = new Subject<IncomingBifurEvent>()
+    mockBifurClient.listen.mockReturnValue(incomingBifurEvents$)
+
+    const [incomingEvents$] = createBifurTransport({
+      client: mockSanityClient,
+      token$,
+      sessionId: 'session-id-123',
+    })
+
+    const receivedEvents: TransportEvent[] = []
+    incomingEvents$.subscribe((event) => receivedEvents.push(event))
+
+    incomingBifurEvents$.next({
+      type: 'disconnect',
+      i: 'user-1',
+      m: {
+        session: 'session-id-456',
+      },
+    })
+
+    expect(receivedEvents).toEqual([
+      {
+        type: 'disconnect',
+        userId: 'user-1',
+        sessionId: 'session-id-456',
+        timestamp: date.toISOString(),
+      },
+    ])
+  })
+
+  it('throws an error for unknown incoming events', () => {
+    const incomingBifurEvents$ = new Subject<IncomingBifurEvent>()
+    mockBifurClient.listen.mockReturnValue(incomingBifurEvents$)
+
+    const [incomingEvents$] = createBifurTransport({
+      client: mockSanityClient,
+      token$,
+      sessionId: 'session-id-123',
+    })
+
+    const errors: Error[] = []
+    incomingEvents$.subscribe({
+      error: (err) => errors.push(err),
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    incomingBifurEvents$.next({type: 'unknown'} as any)
+
+    expect(errors.length).toBe(1)
+    expect(errors[0]).toBeInstanceOf(Error)
+    expect(errors[0].message).toContain('Got unknown presence event')
+  })
+
+  describe('dispatchMessage', () => {
+    it('sends a "rollCall" message', () => {
+      const [, dispatchMessage] = createBifurTransport({
+        client: mockSanityClient,
+        token$,
+        sessionId: 'my-session',
+      })
+      dispatchMessage({type: 'rollCall'})
+      expect(mockBifurClient.request).toHaveBeenCalledWith('presence_rollcall', {
+        session: 'my-session',
+      })
+    })
+
+    it('sends a "state" message', () => {
+      const [, dispatchMessage] = createBifurTransport({
+        client: mockSanityClient,
+        token$,
+        sessionId: 'my-session',
+      })
+      const locations: PresenceLocation[] = [
+        {type: 'document', documentId: 'doc1', path: ['a'], lastActiveAt: new Date().toISOString()},
+      ]
+      dispatchMessage({type: 'state', locations})
+      expect(mockBifurClient.request).toHaveBeenCalledWith('presence_announce', {
+        data: {locations, sessionId: 'my-session'},
+      })
+    })
+
+    it('sends a "disconnect" message', () => {
+      const [, dispatchMessage] = createBifurTransport({
+        client: mockSanityClient,
+        token$,
+        sessionId: 'my-session',
+      })
+      dispatchMessage({type: 'disconnect'})
+      expect(mockBifurClient.request).toHaveBeenCalledWith('presence_disconnect', {
+        session: 'my-session',
+      })
+    })
+
+    it('does nothing for unknown message types', () => {
+      const [, dispatchMessage] = createBifurTransport({
+        client: mockSanityClient,
+        token$,
+        sessionId: 'my-session',
+      })
+      // The type assertion is needed to test this case
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dispatchMessage({type: 'unknown'} as any)
+      expect(mockBifurClient.request).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/presence/bifurTransport.ts
+++ b/packages/core/src/presence/bifurTransport.ts
@@ -1,0 +1,102 @@
+import {type BifurClient, fromUrl} from '@sanity/bifur-client'
+import {type SanityClient} from '@sanity/client'
+import {EMPTY, type Observable} from 'rxjs'
+import {map, share} from 'rxjs/operators'
+
+import {
+  type BifurTransportOptions,
+  type PresenceLocation,
+  type PresenceTransport,
+  type TransportEvent,
+  type TransportMessage,
+} from './types'
+
+type BifurStateMessage = {
+  type: 'state'
+  i: string
+  m: {
+    sessionId: string
+    locations: PresenceLocation[]
+  }
+}
+
+type BifurDisconnectMessage = {
+  type: 'disconnect'
+  i: string
+  m: {session: string}
+}
+
+type RollCallEvent = {
+  type: 'rollCall'
+  i: string
+  session: string
+}
+
+type IncomingBifurEvent = RollCallEvent | BifurStateMessage | BifurDisconnectMessage
+
+function getBifurClient(client: SanityClient, token$: Observable<string | null>): BifurClient {
+  const bifurVersionedClient = client.withConfig({apiVersion: '2022-06-30'})
+  const {dataset, url: baseUrl, requestTagPrefix = 'sanity.studio'} = bifurVersionedClient.config()
+  const url = `${baseUrl.replace(/\/+$/, '')}/socket/${dataset}`.replace(/^http/, 'ws')
+  const urlWithTag = `${url}?tag=${requestTagPrefix}`
+
+  return fromUrl(urlWithTag, {token$})
+}
+
+const handleIncomingMessage = (event: IncomingBifurEvent): TransportEvent => {
+  switch (event.type) {
+    case 'rollCall':
+      return {
+        type: 'rollCall',
+        userId: event.i,
+        sessionId: event.session,
+      }
+    case 'state': {
+      const {sessionId, locations} = event.m
+      return {
+        type: 'state',
+        userId: event.i,
+        sessionId,
+        timestamp: new Date().toISOString(),
+        locations,
+      }
+    }
+    case 'disconnect':
+      return {
+        type: 'disconnect',
+        userId: event.i,
+        sessionId: event.m.session,
+        timestamp: new Date().toISOString(),
+      }
+    default: {
+      throw new Error(`Got unknown presence event: ${JSON.stringify(event)}`)
+    }
+  }
+}
+
+export const createBifurTransport = (options: BifurTransportOptions): PresenceTransport => {
+  const {client, token$, sessionId} = options
+  const bifur = getBifurClient(client, token$)
+
+  const incomingEvents$: Observable<TransportEvent> = bifur
+    .listen<IncomingBifurEvent>('presence')
+    .pipe(map(handleIncomingMessage))
+
+  const dispatchMessage = (message: TransportMessage): Observable<void> => {
+    switch (message.type) {
+      case 'rollCall':
+        return bifur.request('presence_rollcall', {session: sessionId})
+      case 'state':
+        return bifur.request('presence_announce', {
+          data: {locations: message.locations, sessionId},
+        })
+      case 'disconnect':
+        return bifur.request('presence_disconnect', {session: sessionId})
+      default: {
+        return EMPTY
+      }
+    }
+  }
+
+  return [incomingEvents$.pipe(share()), dispatchMessage]
+}

--- a/packages/core/src/presence/types.ts
+++ b/packages/core/src/presence/types.ts
@@ -1,0 +1,62 @@
+import {type SanityClient} from '@sanity/client'
+import {type Observable} from 'rxjs'
+
+/** @public */
+export interface PresenceLocation {
+  type: 'document'
+  documentId: string
+  path: string[]
+  lastActiveAt: string
+}
+
+/** @public */
+export type PresenceTransport = [
+  incomingEvents$: Observable<TransportEvent>,
+  dispatchMessage: (message: TransportMessage) => Observable<void>,
+]
+
+/** @public */
+export type TransportEvent = RollCallEvent | StateEvent | DisconnectEvent
+
+/** @public */
+export interface RollCallEvent {
+  type: 'rollCall'
+  userId: string
+  sessionId: string
+}
+
+/** @public */
+export interface StateEvent {
+  type: 'state'
+  userId: string
+  sessionId: string
+  timestamp: string
+  locations: PresenceLocation[]
+}
+
+/** @public */
+export interface DisconnectEvent {
+  type: 'disconnect'
+  userId: string
+  sessionId: string
+  timestamp: string
+}
+
+/** @public */
+export type TransportMessage =
+  | {type: 'rollCall'}
+  | {type: 'state'; locations: PresenceLocation[]}
+  | {type: 'disconnect'}
+
+/** @public */
+export interface BifurTransportOptions {
+  client: SanityClient
+  token$: Observable<string | null>
+  sessionId: string
+}
+
+/** @public */
+export interface PresenceStore {
+  locations$: Observable<PresenceLocation[]>
+  reportPresence: (locations: PresenceLocation[]) => void
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@sanity/bifur-client':
+        specifier: ^0.4.1
+        version: 0.4.1
       '@sanity/client':
         specifier: ^7.2.1
         version: 7.2.1(debug@4.4.0)
@@ -11186,7 +11189,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11208,7 +11211,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
### Description

Added a new Bifur transport implementation for presence functionality. This implementation uses the `@sanity/bifur-client` package to establish WebSocket connections for real-time presence updates. The transport handles various presence events including state changes, disconnects, and roll calls.

### What to review

- The new `bifurTransport.ts` file which implements the `PresenceTransport` interface
- The handling of different message types (state, disconnect, rollCall)
- The WebSocket connection setup and configuration
- The transformation of Bifur messages to transport events

### Testing

The implementation follows the existing transport interface pattern. Tests should verify:
- Proper connection to the Bifur client
- Correct handling of incoming messages
- Proper dispatching of outgoing messages
- Session management

### Fun gif
![bifur](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ3JqcGFhMW9hdnd1cWRyMmduajIzc3JlbDlzemU3emJtbTFnNHc5NCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MN6SKta7jRsNa/giphy.gif)