### PR TITLE
feat(core): allow a userId option for the user store

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -12,7 +12,7 @@ const baseConfig = {
         config: 'tsconfig.tsdoc.json',
       },
       // Knip doesn't support pnpm version
-      ignoreBinaries: ['version', 'sed'],
+      ignoreBinaries: ['version', 'sed', 'open'],
       entry: ['package.config.ts', 'vitest.config.mts'],
     },
     'scripts/*': {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "prepare": "husky",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:coverage:open": "open coverage/index.html",
     "test:e2e": "turbo run test:e2e",
     "test:watch": "vitest watch",
     "ts:check": "turbo run ts:check --filter='./packages/*' --filter='./apps/*'",

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -127,13 +127,24 @@ export {createSanityInstance, type SanityInstance} from '../store/createSanityIn
 export {type Selector, type StateSource} from '../store/createStateSourceAction'
 export {getUsersKey, parseUsersKey} from '../users/reducers'
 export {
+  type GetUserOptions,
   type GetUsersOptions,
   type Membership,
+  type ResolveUserOptions,
   type ResolveUsersOptions,
   type SanityUser,
+  type SanityUserResponse,
   type UserProfile,
+  type UsersGroupState,
+  type UsersStoreState,
 } from '../users/types'
-export {getUsersState, loadMoreUsers, resolveUsers} from '../users/usersStore'
+export {
+  getUsersState,
+  getUserState,
+  loadMoreUsers,
+  resolveUser,
+  resolveUsers,
+} from '../users/usersStore'
 export {type FetcherStore, type FetcherStoreState} from '../utils/createFetcherStore'
 export {createGroqSearchFilter} from '../utils/createGroqSearchFilter'
 export {CORE_SDK_VERSION} from '../version'

--- a/packages/core/src/users/reducers.ts
+++ b/packages/core/src/users/reducers.ts
@@ -12,11 +12,16 @@ export const getUsersKey = (
     organizationId,
     batchSize = DEFAULT_USERS_BATCH_SIZE,
     projectId = instance.config.projectId,
+    userId,
   }: GetUsersOptions = {},
 ): string =>
-  JSON.stringify({resourceType, organizationId, batchSize, projectId} satisfies ReturnType<
-    typeof parseUsersKey
-  >)
+  JSON.stringify({
+    resourceType,
+    organizationId,
+    batchSize,
+    projectId,
+    userId,
+  } satisfies ReturnType<typeof parseUsersKey>)
 
 /** @internal */
 export const parseUsersKey = (
@@ -26,6 +31,7 @@ export const parseUsersKey = (
   resourceType?: 'organization' | 'project'
   projectId?: string
   organizationId?: string
+  userId?: string
 } => JSON.parse(key)
 
 export const addSubscription =

--- a/packages/core/src/users/types.ts
+++ b/packages/core/src/users/types.ts
@@ -84,3 +84,19 @@ export interface UsersStoreState {
 export interface ResolveUsersOptions extends GetUsersOptions {
   signal?: AbortSignal
 }
+
+/**
+ * @public
+ */
+export interface GetUserOptions extends ProjectHandle {
+  userId: string
+  resourceType?: 'organization' | 'project'
+  organizationId?: string
+}
+
+/**
+ * @public
+ */
+export interface ResolveUserOptions extends GetUserOptions {
+  signal?: AbortSignal
+}

--- a/packages/core/src/users/types.ts
+++ b/packages/core/src/users/types.ts
@@ -46,6 +46,7 @@ export interface GetUsersOptions extends ProjectHandle {
   resourceType?: 'organization' | 'project'
   batchSize?: number
   organizationId?: string
+  userId?: string
 }
 
 /**

--- a/packages/core/src/users/usersConstants.ts
+++ b/packages/core/src/users/usersConstants.ts
@@ -1,5 +1,5 @@
 // NOTE: currently this API is only available on vX
 export const API_VERSION = 'vX'
-export const PROJECT_API_VERSION = 'v2021-06-07'
+export const PROJECT_API_VERSION = '2025-07-18'
 export const USERS_STATE_CLEAR_DELAY = 5000
 export const DEFAULT_USERS_BATCH_SIZE = 100

--- a/packages/core/src/users/usersConstants.ts
+++ b/packages/core/src/users/usersConstants.ts
@@ -1,4 +1,5 @@
 // NOTE: currently this API is only available on vX
 export const API_VERSION = 'vX'
+export const PROJECT_API_VERSION = 'v2021-06-07'
 export const USERS_STATE_CLEAR_DELAY = 5000
 export const DEFAULT_USERS_BATCH_SIZE = 100

--- a/packages/core/src/users/usersStore.test.ts
+++ b/packages/core/src/users/usersStore.test.ts
@@ -1,12 +1,12 @@
-import {type SanityClient} from '@sanity/client'
+import {type SanityClient, type SanityUser as SanityUserFromClient} from '@sanity/client'
 import {delay, filter, firstValueFrom, Observable, of} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {getClientState} from '../client/clientStore'
+import {getClient, getClientState} from '../client/clientStore'
 import {createSanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
 import {type GetUsersOptions, type SanityUser, type SanityUserResponse} from './types'
-import {getUsersState, loadMoreUsers, resolveUsers} from './usersStore'
+import {getUsersState, getUserState, loadMoreUsers, resolveUser, resolveUsers} from './usersStore'
 
 vi.mock('./usersConstants', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./usersConstants')>()),
@@ -64,13 +64,19 @@ describe('usersStore', () => {
   beforeEach(() => {
     request = vi.fn().mockReturnValue(of(mockResponse).pipe(delay(0)))
 
-    vi.mocked(getClientState).mockReturnValue({
-      observable: of({
-        observable: {
-          request,
-        },
-      } as SanityClient),
-    } as StateSource<SanityClient>)
+    vi.mocked(getClientState).mockImplementation(() => {
+      const client = {
+        observable: {request},
+      } as unknown as SanityClient
+      return {
+        observable: of(client),
+      } as StateSource<SanityClient>
+    })
+    vi.mocked(getClient).mockReturnValue({
+      observable: {
+        request,
+      },
+    } as unknown as SanityClient)
   })
 
   it('initializes users state and cleans up after unsubscribe', async () => {
@@ -390,5 +396,109 @@ describe('usersStore', () => {
 
     unsubscribe2()
     instance.dispose()
+  })
+
+  describe('getUserState', () => {
+    beforeEach(() => {
+      // Clear all mocks between tests
+      vi.clearAllMocks()
+    })
+
+    it('fetches a single user with a project-scoped ID', async () => {
+      const instance = createSanityInstance({projectId: 'test', dataset: 'test'})
+      const projectUserId = 'p12345'
+      const mockProjectUser: SanityUserFromClient = {
+        id: projectUserId,
+        displayName: 'Project User',
+        createdAt: '2023-01-01T00:00:00Z',
+        updatedAt: '2023-01-01T00:00:00Z',
+        isCurrentUser: false,
+        projectId: 'project1',
+        familyName: null,
+        givenName: null,
+        middleName: null,
+        imageUrl: null,
+      }
+
+      const specificRequest = vi.fn().mockReturnValue(of(mockProjectUser).pipe(delay(0)))
+      vi.mocked(getClient).mockReturnValue({
+        observable: {
+          request: specificRequest,
+        },
+      } as unknown as SanityClient)
+
+      const user$ = getUserState(instance, {userId: projectUserId, projectId: 'project1'})
+
+      const result = await firstValueFrom(user$.pipe(filter((i) => i !== undefined)))
+
+      expect(getClient).toHaveBeenCalledWith(
+        instance,
+        expect.objectContaining({
+          projectId: 'project1',
+          useProjectHostname: true,
+        }),
+      )
+      expect(specificRequest).toHaveBeenCalledWith({
+        method: 'GET',
+        uri: `/users/${projectUserId}`,
+      })
+
+      const expectedUser: SanityUser = {
+        sanityUserId: projectUserId,
+        profile: {
+          id: projectUserId,
+          displayName: 'Project User',
+          familyName: undefined,
+          givenName: undefined,
+          middleName: undefined,
+          imageUrl: undefined,
+          createdAt: '2023-01-01T00:00:00Z',
+          updatedAt: '2023-01-01T00:00:00Z',
+          isCurrentUser: false,
+          email: '',
+          provider: '',
+        },
+        memberships: [],
+      }
+      expect(result).toEqual(expectedUser)
+
+      instance.dispose()
+    })
+
+    it('fetches a single user with a global-scoped ID', async () => {
+      const instance = createSanityInstance({
+        projectId: 'test',
+        dataset: 'test',
+      })
+      const globalUserId = 'g12345'
+      const mockGlobalUser: SanityUser = {
+        sanityUserId: globalUserId,
+        profile: {
+          id: 'profile-g1',
+          displayName: 'Global User',
+          email: 'global@example.com',
+          provider: 'google',
+          createdAt: '2023-01-01T00:00:00Z',
+        },
+        memberships: [],
+      }
+      const mockGlobalUserResponse: SanityUserResponse = {
+        data: [mockGlobalUser],
+        totalCount: 1,
+        nextCursor: null,
+      }
+
+      // Mock the request to return the global user response
+      vi.mocked(request).mockReturnValue(of(mockGlobalUserResponse))
+
+      const result = await resolveUser(instance, {
+        userId: globalUserId,
+        projectId: 'project1',
+      })
+
+      expect(result).toEqual(mockGlobalUser)
+
+      instance.dispose()
+    })
   })
 })

--- a/packages/core/src/users/usersStore.ts
+++ b/packages/core/src/users/usersStore.ts
@@ -43,7 +43,9 @@ import {
   updateLastLoadMoreRequest,
 } from './reducers'
 import {
+  type GetUserOptions,
   type GetUsersOptions,
+  type ResolveUserOptions,
   type ResolveUsersOptions,
   type SanityUser,
   type SanityUserResponse,
@@ -407,5 +409,32 @@ export const loadMoreUsers = bindActionGlobally(
     state.set('updateLastLoadMoreRequest', updateLastLoadMoreRequest(timestamp, key))
 
     return await promise
+  },
+)
+
+/**
+ * @beta
+ */
+export const getUserState = bindActionGlobally(
+  usersStore,
+  ({instance}, {userId, ...options}: GetUserOptions) => {
+    return getUsersState(instance, {userId, ...options}).observable.pipe(
+      map((res) => res?.data[0]),
+      distinctUntilChanged((a, b) => a?.profile.updatedAt === b?.profile.updatedAt),
+    )
+  },
+)
+
+/**
+ * @beta
+ */
+export const resolveUser = bindActionGlobally(
+  usersStore,
+  async ({instance}, {signal, ...options}: ResolveUserOptions) => {
+    const result = await resolveUsers(instance, {
+      signal,
+      ...options,
+    })
+    return result?.data[0]
   },
 )

--- a/packages/core/src/users/usersStore.ts
+++ b/packages/core/src/users/usersStore.ts
@@ -108,7 +108,7 @@ const listenForLoadMoreAndFetch = ({state, instance}: StoreContext<UsersStoreSta
 
             if (userId) {
               // In the future we will be able to fetch a user from the global API using the resourceUserId,
-              // but for now we need to use the project subdomain to fetch a user
+              // but for now we need to use the project subdomain to fetch a user if the userId is a project user (starts with "p")
               if (userId.startsWith('p')) {
                 const client = getClient(instance, {
                   apiVersion: PROJECT_API_VERSION,

--- a/packages/core/src/users/usersStore.ts
+++ b/packages/core/src/users/usersStore.ts
@@ -237,22 +237,6 @@ const listenForLoadMoreAndFetch = ({state, instance}: StoreContext<UsersStoreSta
               filter((cursor) => cursor !== null),
             )
 
-            if (userId) {
-              return combineLatest([resource$, client$]).pipe(
-                switchMap(([resource, client]) =>
-                  client.observable.request<SanityUserResponse>({
-                    method: 'GET',
-                    uri: `access/${resource.type}/${resource.id}/users/${userId}`,
-                  }),
-                ),
-                catchError((error) => {
-                  state.set('setUsersError', setUsersError(group$.key, error))
-                  return EMPTY
-                }),
-                tap((response) => state.set('setUsersData', setUsersData(group$.key, response))),
-              )
-            }
-
             return combineLatest([resource$, client$, loadMore$]).pipe(
               withLatestFrom(cursor$),
               switchMap(([[resource, client], cursor]) =>


### PR DESCRIPTION
### Description

Added functionality to fetch and resolve individual users by ID in the users store. This includes support for both global-scoped and project-scoped user IDs, with appropriate API handling for each type. Also added a new `test:coverage:open` script to easily view coverage reports.

### What to review

- New exports in `packages/core/src/_exports/index.ts` for user-related functions and types
- Implementation of `getUserState` and `resolveUser` functions in `usersStore.ts`
- Updated types to support fetching individual users
- Tests for the new user fetching functionality
- Configuration updates to support the new coverage report script

### Testing

Added comprehensive tests for the new user fetching functionality, including tests for both global-scoped and project-scoped user IDs. The tests verify that the correct API endpoints are called and that the response is properly transformed.

### Fun gif
![chosen](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGRpNTJ1ZDJmbGs5bWthbXQxeTN1N3MyMGl4ZDVsa2JnbTFycHV2dSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZLoZLP9fiUYu0IPWvW/giphy.gif)