### PR TITLE
test: do not wait for network idle when logging in during e2e auth

### DIFF
--- a/apps/kitchensink-react/playwright.config.ts
+++ b/apps/kitchensink-react/playwright.config.ts
@@ -3,11 +3,13 @@ import {createPlaywrightConfig} from '@repo/e2e'
 export default createPlaywrightConfig({
   testDir: './e2e',
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: process.env['CI']
-      ? 'pnpm build --mode e2e && pnpm preview --mode e2e --port 3333'
-      : 'pnpm dev --mode e2e',
-    reuseExistingServer: true,
-    stdout: 'pipe',
-  },
+  ...(process.env['CI']
+    ? {} // In CI, don't start a webServer since it's started manually
+    : {
+        webServer: {
+          command: 'pnpm dev --mode e2e',
+          reuseExistingServer: true,
+          stdout: 'pipe',
+        },
+      }),
 })

--- a/packages/@repo/e2e/src/setup/auth.setup.ts
+++ b/packages/@repo/e2e/src/setup/auth.setup.ts
@@ -44,10 +44,7 @@ const authenticateUser = async (context: BrowserContext, config: AuthConfig) => 
   await page.goto(loginUrl.toString())
 
   // Wait for the redirect to complete AND network to be idle
-  await Promise.all([
-    page.waitForURL(config.expectedRedirectUrl),
-    page.waitForLoadState('networkidle'),
-  ])
+  await Promise.all([page.waitForURL(config.expectedRedirectUrl)])
 
   await page.close()
 }


### PR DESCRIPTION
### Description

The Dashboard has changed and is no longer idle (probably has an open connection). This removes an unnecessary wait for an idle network during authenticating to the Dashboard for Dashboard e2e tests.

Although this wasn't the problem, this also removes an unnecessary server startup in CI, since we start the server manually. (The original reason for having a separate step for preview was because the playwright tests would start running before the server was ready to respond.)

### What to review
Any gotchas? Is this making things opaque?

### Testing
Not quite sure what to additionally test here.

### Fun gif
![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)
