### PR TITLE
feat(core): add defineIntent

### DIFF
--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -147,6 +147,7 @@ export {
 } from '../users/usersStore'
 export {type FetcherStore, type FetcherStoreState} from '../utils/createFetcherStore'
 export {createGroqSearchFilter} from '../utils/createGroqSearchFilter'
+export {defineIntent, type Intent, type IntentFilter} from '../utils/defineIntent'
 export {CORE_SDK_VERSION} from '../version'
 export {
   getIndexForKey,

--- a/packages/core/src/utils/defineIntent.test.ts
+++ b/packages/core/src/utils/defineIntent.test.ts
@@ -1,0 +1,477 @@
+import {describe, expect, test} from 'vitest'
+
+import {defineIntent, type Intent, type IntentFilter} from './defineIntent'
+
+describe('defineIntent', () => {
+  test('should return a valid intent object when all required fields are provided', () => {
+    const intent: Intent = {
+      id: 'viewHat',
+      action: 'view',
+      title: 'View a hat',
+      description: 'This lets you view a hat',
+      filters: [
+        {
+          projectId: 'some-project',
+          dataset: 'a-dataset',
+          types: ['hat'],
+        },
+      ],
+    }
+
+    const result = defineIntent(intent)
+
+    expect(result).toEqual(intent)
+    expect(result).toBe(intent)
+  })
+
+  test('should throw error when filters array is empty', () => {
+    const intent: Intent = {
+      id: 'globalIntent',
+      action: 'create',
+      title: 'Global Intent',
+      description: 'An intent with no filters',
+      filters: [],
+    }
+
+    expect(() => defineIntent(intent)).toThrow(
+      "Intent must have at least one filter. If you want to match everything, use {types: ['*']}",
+    )
+  })
+
+  test('should work with wildcard filter to match everything', () => {
+    const intent: Intent = {
+      id: 'globalIntent',
+      action: 'create',
+      title: 'Global Intent',
+      description: 'An intent that matches everything',
+      filters: [
+        {
+          types: ['*'],
+        },
+      ],
+    }
+
+    const result = defineIntent(intent)
+
+    expect(result).toEqual(intent)
+    expect(result.filters[0].types).toEqual(['*'])
+  })
+
+  test('should work with partial filters', () => {
+    const intent: Intent = {
+      id: 'partialFilter',
+      action: 'edit',
+      title: 'Partial Filter Intent',
+      description: 'An intent with partial filter criteria',
+      filters: [
+        {
+          projectId: 'some-project',
+          // No dataset or types specified
+        },
+        {
+          types: ['document'],
+          // No projectId or dataset specified
+        },
+      ],
+    }
+
+    const result = defineIntent(intent)
+
+    expect(result).toEqual(intent)
+  })
+
+  test('should throw error when id is missing', () => {
+    const intent = {
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [],
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Intent must have an id')
+  })
+
+  test('should throw error when id is empty string', () => {
+    const intent: Intent = {
+      id: '',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [],
+    }
+
+    expect(() => defineIntent(intent)).toThrow('Intent must have an id')
+  })
+
+  test('should throw error when action is missing', () => {
+    const intent = {
+      id: 'test',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [],
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Intent must have an action')
+  })
+
+  test('should throw error when action is empty string', () => {
+    const intent = {
+      id: 'test',
+      action: '',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [],
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Intent must have an action')
+  })
+
+  test('should throw error when title is missing', () => {
+    const intent = {
+      id: 'test',
+      action: 'view',
+      description: 'Test description',
+      filters: [],
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Intent must have a title')
+  })
+
+  test('should throw error when title is empty string', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: '',
+      description: 'Test description',
+      filters: [],
+    }
+
+    expect(() => defineIntent(intent)).toThrow('Intent must have a title')
+  })
+
+  test('should throw error when filters are missing', () => {
+    const intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Intent must have a filters array')
+  })
+
+  test('should throw error when filters are not an array', () => {
+    const intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: 'not an array',
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Intent must have a filters array')
+  })
+
+  test('should work with complex filter combinations', () => {
+    const intent: Intent = {
+      id: 'complexIntent',
+      action: 'edit',
+      title: 'Complex Intent',
+      description: 'An intent with multiple complex filters',
+      filters: [
+        {
+          projectId: 'project-1',
+          dataset: 'production',
+          types: ['article', 'blogPost'],
+        },
+        {
+          projectId: 'project-2',
+          dataset: 'staging',
+          types: ['product'],
+        },
+        {
+          // Filter with only types
+          types: ['global-document'],
+        },
+      ],
+    }
+
+    const result = defineIntent(intent)
+
+    expect(result).toEqual(intent)
+    expect(result.filters).toHaveLength(3)
+    expect(result.filters[0].types).toEqual(['article', 'blogPost'])
+    expect(result.filters[2].projectId).toBeUndefined()
+    expect(result.filters[2].dataset).toBeUndefined()
+  })
+
+  // Filter validation tests
+  test('should throw error for empty filter object', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow(
+      'Filter at index 0 must have at least one property (projectId, dataset, or types)',
+    )
+  })
+
+  test('should throw error for non-object filter', () => {
+    const intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: ['not an object'],
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0 must be an object')
+  })
+
+  test('should throw error for non-string projectId', () => {
+    const intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{projectId: 123}],
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: projectId must be a string')
+  })
+
+  test('should throw error for empty projectId', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{projectId: ''}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: projectId cannot be empty')
+  })
+
+  test('should throw error for whitespace-only projectId', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{projectId: '   '}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: projectId cannot be empty')
+  })
+
+  test('should throw error for non-string dataset', () => {
+    const intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{dataset: 123}],
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: dataset must be a string')
+  })
+
+  test('should throw error for empty dataset', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{dataset: ''}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: dataset cannot be empty')
+  })
+
+  test('should throw error when dataset is specified without projectId', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{dataset: 'production'}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow(
+      'Filter at index 0: dataset cannot be specified without projectId',
+    )
+  })
+
+  test('should throw error when dataset is specified with empty projectId', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{projectId: '', dataset: 'production'}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: projectId cannot be empty')
+  })
+
+  test('should work when dataset is specified with valid projectId', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{projectId: 'my-project', dataset: 'production'}],
+    }
+
+    const result = defineIntent(intent)
+    expect(result).toEqual(intent)
+  })
+
+  test('should throw error for non-array types', () => {
+    const intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{types: 'not-an-array'}],
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: types must be an array')
+  })
+
+  test('should throw error for empty types array', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{types: []}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: types array cannot be empty')
+  })
+
+  test('should throw error for non-string type in types array', () => {
+    const intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{types: ['valid', 123, 'also-valid']}],
+    } as unknown as Intent
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: types[1] must be a string')
+  })
+
+  test('should throw error for empty string in types array', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{types: ['valid', '', 'also-valid']}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: types[1] cannot be empty')
+  })
+
+  test('should throw error for whitespace-only string in types array', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{types: ['valid', '   ', 'also-valid']}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 0: types[1] cannot be empty')
+  })
+
+  test('should throw error when wildcard is mixed with other types', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{types: ['*', 'document']}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow(
+      "Filter at index 0: when using wildcard '*', it must be the only type in the array",
+    )
+  })
+
+  test('should throw error when wildcard appears with other types in different order', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [{types: ['document', 'article', '*']}],
+    }
+
+    expect(() => defineIntent(intent)).toThrow(
+      "Filter at index 0: when using wildcard '*', it must be the only type in the array",
+    )
+  })
+
+  test('should work with valid individual filter properties', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [
+        {projectId: 'my-project'},
+        {projectId: 'my-project', dataset: 'production'}, // Dataset with projectId
+        {types: ['document']},
+        {types: ['*']}, // Valid wildcard usage
+      ],
+    }
+
+    const result = defineIntent(intent)
+    expect(result).toEqual(intent)
+  })
+
+  test('should provide correct filter index in error messages for multiple filters', () => {
+    const intent: Intent = {
+      id: 'test',
+      action: 'view',
+      title: 'Test Intent',
+      description: 'Test description',
+      filters: [
+        {projectId: 'valid-project'},
+        {projectId: ''}, // This should be filter at index 1
+      ],
+    }
+
+    expect(() => defineIntent(intent)).toThrow('Filter at index 1: projectId cannot be empty')
+  })
+})
+
+describe('IntentFilter interface', () => {
+  test('should allow all optional properties', () => {
+    // This is more of a TypeScript compile-time test
+    // but we can verify the structure is as expected
+    const filter1: IntentFilter = {}
+    const filter2: IntentFilter = {projectId: 'test'}
+    const filter3: IntentFilter = {dataset: 'test'}
+    const filter4: IntentFilter = {types: ['test']}
+    const filter5: IntentFilter = {
+      projectId: 'test',
+      dataset: 'test',
+      types: ['test'],
+    }
+
+    // These should all be valid filter objects
+    expect(filter1).toBeDefined()
+    expect(filter2).toBeDefined()
+    expect(filter3).toBeDefined()
+    expect(filter4).toBeDefined()
+    expect(filter5).toBeDefined()
+  })
+})

--- a/packages/core/src/utils/defineIntent.test.ts
+++ b/packages/core/src/utils/defineIntent.test.ts
@@ -66,7 +66,7 @@ describe('defineIntent', () => {
       filters: [
         {
           projectId: 'some-project',
-          // No dataset or types specified
+          types: ['*'], // Add required types
         },
         {
           types: ['document'],
@@ -207,16 +207,16 @@ describe('defineIntent', () => {
 
   // Filter validation tests
   test('should throw error for empty filter object', () => {
-    const intent: Intent = {
+    const intent = {
       id: 'test',
       action: 'view',
       title: 'Test Intent',
       description: 'Test description',
       filters: [{}],
-    }
+    } as unknown as Intent
 
     expect(() => defineIntent(intent)).toThrow(
-      'Filter at index 0 must have at least one property (projectId, dataset, or types)',
+      "Filter at index 0 must have a types property. Use ['*'] to match all document types.",
     )
   })
 
@@ -238,7 +238,7 @@ describe('defineIntent', () => {
       action: 'view',
       title: 'Test Intent',
       description: 'Test description',
-      filters: [{projectId: 123}],
+      filters: [{projectId: 123, types: ['*']}],
     } as unknown as Intent
 
     expect(() => defineIntent(intent)).toThrow('Filter at index 0: projectId must be a string')
@@ -250,7 +250,7 @@ describe('defineIntent', () => {
       action: 'view',
       title: 'Test Intent',
       description: 'Test description',
-      filters: [{projectId: ''}],
+      filters: [{projectId: '', types: ['*']}],
     }
 
     expect(() => defineIntent(intent)).toThrow('Filter at index 0: projectId cannot be empty')
@@ -262,7 +262,7 @@ describe('defineIntent', () => {
       action: 'view',
       title: 'Test Intent',
       description: 'Test description',
-      filters: [{projectId: '   '}],
+      filters: [{projectId: '   ', types: ['*']}],
     }
 
     expect(() => defineIntent(intent)).toThrow('Filter at index 0: projectId cannot be empty')
@@ -274,7 +274,7 @@ describe('defineIntent', () => {
       action: 'view',
       title: 'Test Intent',
       description: 'Test description',
-      filters: [{dataset: 123}],
+      filters: [{projectId: 'test', dataset: 123, types: ['*']}],
     } as unknown as Intent
 
     expect(() => defineIntent(intent)).toThrow('Filter at index 0: dataset must be a string')
@@ -286,7 +286,7 @@ describe('defineIntent', () => {
       action: 'view',
       title: 'Test Intent',
       description: 'Test description',
-      filters: [{dataset: ''}],
+      filters: [{dataset: '', types: ['*']}],
     }
 
     expect(() => defineIntent(intent)).toThrow('Filter at index 0: dataset cannot be empty')
@@ -298,7 +298,7 @@ describe('defineIntent', () => {
       action: 'view',
       title: 'Test Intent',
       description: 'Test description',
-      filters: [{dataset: 'production'}],
+      filters: [{dataset: 'production', types: ['*']}],
     }
 
     expect(() => defineIntent(intent)).toThrow(
@@ -312,7 +312,7 @@ describe('defineIntent', () => {
       action: 'view',
       title: 'Test Intent',
       description: 'Test description',
-      filters: [{projectId: '', dataset: 'production'}],
+      filters: [{projectId: '', dataset: 'production', types: ['*']}],
     }
 
     expect(() => defineIntent(intent)).toThrow('Filter at index 0: projectId cannot be empty')
@@ -324,7 +324,7 @@ describe('defineIntent', () => {
       action: 'view',
       title: 'Test Intent',
       description: 'Test description',
-      filters: [{projectId: 'my-project', dataset: 'production'}],
+      filters: [{projectId: 'my-project', dataset: 'production', types: ['*']}],
     }
 
     const result = defineIntent(intent)
@@ -426,8 +426,8 @@ describe('defineIntent', () => {
       title: 'Test Intent',
       description: 'Test description',
       filters: [
-        {projectId: 'my-project'},
-        {projectId: 'my-project', dataset: 'production'}, // Dataset with projectId
+        {projectId: 'my-project', types: ['*']},
+        {projectId: 'my-project', dataset: 'production', types: ['*']},
         {types: ['document']},
         {types: ['*']}, // Valid wildcard usage
       ],
@@ -444,8 +444,8 @@ describe('defineIntent', () => {
       title: 'Test Intent',
       description: 'Test description',
       filters: [
-        {projectId: 'valid-project'},
-        {projectId: ''}, // This should be filter at index 1
+        {projectId: 'valid-project', types: ['*']},
+        {projectId: '', types: ['*']},
       ],
     }
 
@@ -454,12 +454,12 @@ describe('defineIntent', () => {
 })
 
 describe('IntentFilter interface', () => {
-  test('should allow all optional properties', () => {
+  test('should require types property', () => {
     // This is more of a TypeScript compile-time test
     // but we can verify the structure is as expected
-    const filter1: IntentFilter = {}
-    const filter2: IntentFilter = {projectId: 'test'}
-    const filter3: IntentFilter = {dataset: 'test'}
+    const filter1: IntentFilter = {types: ['*']} // types is now required
+    const filter2: IntentFilter = {projectId: 'test', types: ['*']} // types is now required
+    const filter3: IntentFilter = {dataset: 'test', types: ['*']} // types is now required
     const filter4: IntentFilter = {types: ['test']}
     const filter5: IntentFilter = {
       projectId: 'test',

--- a/packages/core/src/utils/defineIntent.ts
+++ b/packages/core/src/utils/defineIntent.ts
@@ -1,0 +1,249 @@
+/**
+ * Filter criteria for intent matching. Can be combined to create more specific intents.
+ *
+ * @example
+ * ```typescript
+ * // matches only geopoints in the travel-project project, production dataset
+ * const filter: IntentFilter = {
+ *   projectId: 'travel-project',
+ *   dataset: 'production',
+ *   types: ['geopoint']
+ * }
+ *
+ * // matches all documents in the travel-project project
+ * const filter: IntentFilter = {
+ *   projectId: 'travel-project',
+ *   types: ['*']
+ * }
+ *
+ * // matches geopoints in the travel-project production dataset and map pins in all projects in the org
+ * const filters: IntentFilter[] = [
+ *  {
+ *    projectId: 'travel-project',
+ *    dataset: 'production',
+ *    types: ['geopoint']
+ *  },
+ *  {
+ *    types: ['map-pin']
+ *  }
+ * ]
+ * ```
+ * @public
+ */
+export interface IntentFilter {
+  /**
+   * Project ID to match against
+   * @remarks When specified, the intent will only match for the specified project.
+   */
+  projectId?: string
+
+  /**
+   * Dataset to match against
+   * @remarks When specified, the intent will only match for the specified dataset. Requires projectId to be specified.
+   */
+  dataset?: string
+
+  /**
+   * Document types that this intent can handle
+   * @remarks When specified, the intent will only match for documents of these types.
+   * Use ['*'] to match all document types.
+   */
+  types?: string[]
+}
+
+/**
+ * Intent definition structure for registering user intents
+ * @public
+ */
+export interface Intent {
+  /**
+   * Unique identifier for this intent
+   * @remarks Should be unique across all registered intents in an org for proper matching
+   */
+  id: string
+
+  /**
+   * The action that this intent performs
+   * @remarks Examples: "view", "edit", "create", "delete"
+   */
+  action: 'view' | 'edit' | 'create' | 'delete'
+
+  /**
+   * Human-readable title for this intent
+   * @remarks Used for display purposes in UI or logs
+   */
+  title: string
+
+  /**
+   * Detailed description of what this intent does
+   * @remarks Helps users understand the purpose and behavior of the intent
+   */
+  description?: string
+
+  /**
+   * Array of filter criteria for intent matching
+   * @remarks At least one filter is required. Use `{types: ['*']}` to match everything
+   */
+  filters: IntentFilter[]
+}
+
+/**
+ * Creates a properly typed intent definition for registration with the backend
+ *
+ * This utility function provides TypeScript support and validation for intent declarations.
+ *
+ * @param intent - The intent definition object
+ * @returns The same intent object with proper typing
+ *
+ * @example
+ * ```typescript
+ * // Specific filter for a document type
+ * const viewGeopointInMapApp = defineIntent({
+ *   id: 'viewGeopointInMapApp',
+ *   action: 'view',
+ *   title: 'View a geopoint in the map app',
+ *   description: 'This lets you view a geopoint in the map app',
+ *   filters: [
+ *     {
+ *       projectId: 'travel-project',
+ *       dataset: 'production',
+ *       types: ['geopoint']
+ *     }
+ *   ]
+ * })
+ *
+ * export default viewGeopointInMapApp
+ * ```
+ *
+ * If your intent is asynchronous, resolve the promise before defining / returning the intent
+ * ```typescript
+ * async function createAsyncIntent() {
+ *   const currentProject = await asyncProjectFunction()
+ *   const currentDataset = await asyncDatasetFunction()
+ *
+ *   return defineIntent({
+ *     id: 'dynamicIntent',
+ *     action: 'view',
+ *     title: 'Dynamic Intent',
+ *     description: 'Intent with dynamically resolved values',
+ *     filters: [
+ *       {
+ *         projectId: currentProject,  // Resolved value
+ *         dataset: currentDataset,    // Resolved value
+ *         types: ['document']
+ *       }
+ *     ]
+ *   })
+ * }
+ *
+ * const intent = await createAsyncIntent()
+ * export default intent
+ * ```
+ *
+ * @public
+ */
+export function defineIntent(intent: Intent): Intent {
+  // Validate required fields
+  if (!intent.id) {
+    throw new Error('Intent must have an id')
+  }
+  if (!intent.action) {
+    throw new Error('Intent must have an action')
+  }
+  if (!intent.title) {
+    throw new Error('Intent must have a title')
+  }
+  if (!Array.isArray(intent.filters)) {
+    throw new Error('Intent must have a filters array')
+  }
+  if (intent.filters.length === 0) {
+    throw new Error(
+      "Intent must have at least one filter. If you want to match everything, use {types: ['*']}",
+    )
+  }
+
+  // Validate each filter
+  intent.filters.forEach((filter, index) => {
+    validateFilter(filter, index)
+  })
+
+  // Return the intent as-is, providing type safety and runtime validation
+  return intent
+}
+
+/**
+ * Validates an individual filter object
+ * @param filter - The filter to validate
+ * @param index - The filter's index in the array (for error messages)
+ * @internal
+ */
+function validateFilter(filter: IntentFilter, index: number): void {
+  const filterContext = `Filter at index ${index}`
+
+  // Check that filter is an object
+  if (!filter || typeof filter !== 'object') {
+    throw new Error(`${filterContext} must be an object`)
+  }
+
+  // Check that filter has at least one property
+  const hasProperties =
+    filter.projectId !== undefined || filter.dataset !== undefined || filter.types !== undefined
+
+  if (!hasProperties) {
+    throw new Error(
+      `${filterContext} must have at least one property (projectId, dataset, or types)`,
+    )
+  }
+
+  // Validate projectId
+  if (filter.projectId !== undefined) {
+    if (typeof filter.projectId !== 'string') {
+      throw new Error(`${filterContext}: projectId must be a string`)
+    }
+    if (filter.projectId.trim() === '') {
+      throw new Error(`${filterContext}: projectId cannot be empty`)
+    }
+  }
+
+  // Validate dataset
+  if (filter.dataset !== undefined) {
+    if (typeof filter.dataset !== 'string') {
+      throw new Error(`${filterContext}: dataset must be a string`)
+    }
+    if (filter.dataset.trim() === '') {
+      throw new Error(`${filterContext}: dataset cannot be empty`)
+    }
+    // Dataset requires projectId to be specified
+    if (filter.projectId === undefined) {
+      throw new Error(`${filterContext}: dataset cannot be specified without projectId`)
+    }
+  }
+
+  // Validate types
+  if (filter.types !== undefined) {
+    if (!Array.isArray(filter.types)) {
+      throw new Error(`${filterContext}: types must be an array`)
+    }
+    if (filter.types.length === 0) {
+      throw new Error(`${filterContext}: types array cannot be empty`)
+    }
+
+    // Validate each type
+    filter.types.forEach((type, typeIndex) => {
+      if (typeof type !== 'string') {
+        throw new Error(`${filterContext}: types[${typeIndex}] must be a string`)
+      }
+      if (type.trim() === '') {
+        throw new Error(`${filterContext}: types[${typeIndex}] cannot be empty`)
+      }
+    })
+
+    // Check for wildcard exclusivity
+    const hasWildcard = filter.types.includes('*')
+    if (hasWildcard && filter.types.length > 1) {
+      throw new Error(
+        `${filterContext}: when using wildcard '*', it must be the only type in the array`,
+      )
+    }
+  }
+}


### PR DESCRIPTION
### Description
FIXES SDK-525

This PR adds a `defineIntent` function. Like `defineType`, it's mostly there as a type helper for our users, but should also hopefully provider helpful validation and error states when intents are declared.

I also plan on using this in the CLI, to be used if people declare intents as bare objects (we can use this to validate / normalize).

### What to review
Mostly should be self-explanatory. Two questions:
1. are we happy where this is located (in core) and its place in the file structure (in utils?)
2. does the filters system make sense? Any gotchas there?

### Testing
100% test coverage, mostly for the error scenarios.

### Fun gif
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWl0ODJpMG8xb2Zrd3dtM3M1NXBmaHViYWQwb2s0Y2FwcTd6aGV6MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2Je66zG6mAAZxgqI/giphy.gif)
