### PR TITLE
feat(react-internal): create react-internal package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "packages/core": "2.1.0",
-  "packages/react": "2.1.0"
+  "packages/react": "2.1.0",
+  "packages/react-internal": "0.1.0-alpha.0"
 }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -56,6 +56,15 @@ const baseConfig = {
       entry: ['package.bundle.ts'],
       ignoreDependencies: ['@sanity/browserslist-config', 'react-compiler-runtime'],
     },
+    'packages/react-internal': {
+      typescript: {
+        config: 'tsconfig.settings.json',
+      },
+      project,
+      entry: ['package.bundle.ts'],
+      // for now -- will be removed once actual hooks are added
+      ignoreDependencies: ['@sanity/sdk', '@sanity/sdk-react', '@sanity/browserslist-config'],
+    },
     'packages/@repo/e2e': {
       typescript: {
         config: 'tsconfig.json',
@@ -86,6 +95,7 @@ export const addBundlerEntries = async (config: KnipConfig): Promise<KnipConfig>
     'packages/@repo/package.config',
     'packages/core',
     'packages/react',
+    'packages/react-internal',
     'apps/kitchensink-react',
   ]
 

--- a/packages/react-internal/README.md
+++ b/packages/react-internal/README.md
@@ -1,0 +1,37 @@
+# @sanity/sdk-react-internal
+
+**⚠️ INTERNAL USE ONLY**
+
+This package is for internal Sanity teams only and is not intended for public consumption. It contains internal utilities and helpers.
+
+## Alpha Versioning
+
+This package follows a separate versioning scheme from the main SDK packages:
+
+- Starts at `0.1.0-alpha.0`
+- Uses alpha prereleases
+- Managed by release-please automation
+
+## Installation
+
+This package is published with restricted access. Internal teams should install it via:
+
+```bash
+npm install @sanity/sdk-react-internal@alpha
+```
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Development watch mode
+pnpm dev
+```

--- a/packages/react-internal/eslint.config.mjs
+++ b/packages/react-internal/eslint.config.mjs
@@ -1,0 +1,27 @@
+// @ts-check
+import baseESLintConfig from '@repo/config-eslint'
+import reactConfig from '@repo/config-eslint/react'
+
+export default [
+  {
+    ignores: [
+      '.DS_Store',
+      '**/node_modules',
+      '**/build',
+      '**/dist',
+      '**/coverage',
+      '**/public',
+      '**/docs',
+      '.env',
+      '.env.*',
+      '!.env.example',
+
+      // Ignore files for PNPM, NPM and YARN
+      'pnpm-lock.yaml',
+      'package-lock.json',
+      'yarn.lock',
+    ],
+  },
+  ...baseESLintConfig,
+  ...reactConfig,
+]

--- a/packages/react-internal/package.bundle.ts
+++ b/packages/react-internal/package.bundle.ts
@@ -1,0 +1,14 @@
+import {defaultConfig} from '@repo/package.bundle'
+import {defineConfig, mergeConfig} from 'vite'
+
+export default defineConfig(() => {
+  return mergeConfig(defaultConfig, {
+    build: {
+      lib: {
+        entry: {
+          index: './src/_exports/index.ts',
+        },
+      },
+    },
+  })
+})

--- a/packages/react-internal/package.config.ts
+++ b/packages/react-internal/package.config.ts
@@ -1,0 +1,28 @@
+import {basePackageConfig} from '@repo/package.config'
+import {defineConfig} from '@sanity/pkg-utils'
+import visualizer from 'rollup-plugin-visualizer'
+
+const enableVisualizer = process.env['VISUALIZER'] === 'true'
+
+export default defineConfig({
+  ...basePackageConfig,
+  tsconfig: 'tsconfig.dist.json',
+  babel: {
+    reactCompiler: true,
+  },
+  reactCompilerOptions: {
+    target: '18',
+  },
+  rollup: {
+    plugins: [
+      ...(enableVisualizer
+        ? [
+            visualizer({
+              filename: './stats/index.html',
+              open: false,
+            }),
+          ]
+        : []),
+    ],
+  },
+})

--- a/packages/react-internal/package.json
+++ b/packages/react-internal/package.json
@@ -1,0 +1,96 @@
+{
+  "name": "@sanity/sdk-react-internal",
+  "version": "0.1.0-alpha.0",
+  "private": false,
+  "description": "Internal Sanity SDK React toolkit - for internal use only",
+  "keywords": [
+    "sanity",
+    "sdk",
+    "internal",
+    "react"
+  ],
+  "homepage": "https://github.com/sanity-io/sdk/tree/main/packages/react-internal/README.md",
+  "bugs": {
+    "url": "https://github.com/sanity-io/sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/sanity-io/sdk.git"
+  },
+  "license": "MIT",
+  "author": "Sanity <developers@sanity.io>",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/_exports/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "pkg build --strict --clean --check",
+    "build:bundle": "vite build --configLoader runner --config package.bundle.ts",
+    "clean": "rimraf dist",
+    "dev": "pkg watch",
+    "docs": "typedoc --json docs/typedoc.json --tsconfig ./tsconfig.dist.json",
+    "format": "prettier --write --cache --ignore-unknown .",
+    "lint": "eslint .",
+    "prepublishOnly": "pnpm run build",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "ts:check": "tsc --noEmit"
+  },
+  "browserslist": "extends @sanity/browserslist-config",
+  "prettier": "@sanity/prettier-config",
+  "dependencies": {
+    "@sanity/sdk": "workspace:*",
+    "@sanity/sdk-react": "workspace:*"
+  },
+  "devDependencies": {
+    "@repo/config-eslint": "workspace:*",
+    "@repo/config-test": "workspace:*",
+    "@repo/package.bundle": "workspace:*",
+    "@repo/package.config": "workspace:*",
+    "@repo/tsconfig": "workspace:*",
+    "@sanity/browserslist-config": "^1.0.5",
+    "@sanity/pkg-utils": "^7.2.2",
+    "@sanity/prettier-config": "^1.0.3",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.3",
+    "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/coverage-v8": "3.1.2",
+    "eslint": "^9.22.0",
+    "jsdom": "^25.0.1",
+    "prettier": "^3.5.3",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "rollup-plugin-visualizer": "^5.14.0",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.4",
+    "vitest": "^3.1.2"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "packageManager": "pnpm@10.8.0",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "restricted",
+    "tag": "beta"
+  }
+}

--- a/packages/react-internal/src/_exports/index.ts
+++ b/packages/react-internal/src/_exports/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @internal
+ * This package is for internal use only and not intended for public consumption.
+ */
+
+// Add internal-specific exports here
+export {version} from '../version.js'

--- a/packages/react-internal/src/version.test.ts
+++ b/packages/react-internal/src/version.test.ts
@@ -1,0 +1,9 @@
+import {describe, expect, it} from 'vitest'
+
+import {version} from './version.js'
+
+describe('version', () => {
+  it('should be a string', () => {
+    expect(typeof version).toBe('string')
+  })
+})

--- a/packages/react-internal/src/version.ts
+++ b/packages/react-internal/src/version.ts
@@ -1,0 +1,5 @@
+/**
+ * The version of the internal SDK React package
+ * @internal
+ */
+export const version = '0.1.0-alpha.0'

--- a/packages/react-internal/test/setup.ts
+++ b/packages/react-internal/test/setup.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom/vitest'
+
+import {cleanup} from '@testing-library/react'
+import {afterEach} from 'vitest'
+
+// Automatically cleanup after each test
+afterEach(() => {
+  cleanup()
+})

--- a/packages/react-internal/test/test-utils.tsx
+++ b/packages/react-internal/test/test-utils.tsx
@@ -1,0 +1,18 @@
+import {render, type RenderOptions} from '@testing-library/react'
+import {type ReactElement} from 'react'
+
+// Re-export everything from React Testing Library
+export * from '@testing-library/react'
+
+// Custom render function that can be extended later
+const customRender = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>,
+): ReturnType<typeof render> =>
+  render(ui, {
+    // Add any default providers here if needed
+    // wrapper: AllTheProviders,
+    ...options,
+  })
+
+export {customRender as render}

--- a/packages/react-internal/tsconfig.dist.json
+++ b/packages/react-internal/tsconfig.dist.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.settings.json",
+  "include": ["./package.json", "./src"],
+  "exclude": [
+    "./src/**/__fixtures__",
+    "./src/**/__mocks__",
+    "./src/**/__workshop__",
+    "./src/**/*.test.ts",
+    "./src/**/*.test.tsx"
+  ]
+}

--- a/packages/react-internal/tsconfig.json
+++ b/packages/react-internal/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.settings.json",
+  "include": ["./package.json", "./src", "./test"],
+  "exclude": ["./node_modules"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  }
+}

--- a/packages/react-internal/tsconfig.settings.json
+++ b/packages/react-internal/tsconfig.settings.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@repo/tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    // For import.meta.env/import.meta.hot definitions and similar
+    "types": ["vite/client"],
+    "paths": {
+      "@sanity/sdk": ["./node_modules/@sanity/sdk/src/_exports/index.ts"],
+      "@sanity/sdk/*": ["./node_modules/@sanity/sdk/src/_exports/*"],
+      "@sanity/sdk-react": ["./node_modules/@sanity/sdk-react/src/_exports/index.ts"],
+      "@sanity/sdk-react/*": ["./node_modules/@sanity/sdk-react/src/_exports/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/react-internal/vitest.config.ts
+++ b/packages/react-internal/vitest.config.ts
@@ -1,0 +1,18 @@
+import {defineConfig} from '@repo/config-test/vitest'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./test/setup.ts'],
+    include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['**/*.{test,spec,stories}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,6 +542,85 @@ importers:
         specifier: ^3.1.2
         version: 3.1.2(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.7.1)
 
+  packages/react-internal:
+    dependencies:
+      '@sanity/sdk':
+        specifier: workspace:*
+        version: link:../core
+      '@sanity/sdk-react':
+        specifier: workspace:*
+        version: link:../react
+    devDependencies:
+      '@repo/config-eslint':
+        specifier: workspace:*
+        version: link:../@repo/config-eslint
+      '@repo/config-test':
+        specifier: workspace:*
+        version: link:../@repo/config-test
+      '@repo/package.bundle':
+        specifier: workspace:*
+        version: link:../@repo/package.bundle
+      '@repo/package.config':
+        specifier: workspace:*
+        version: link:../@repo/package.config
+      '@repo/tsconfig':
+        specifier: workspace:*
+        version: link:../@repo/tsconfig
+      '@sanity/browserslist-config':
+        specifier: ^1.0.5
+        version: 1.0.5
+      '@sanity/pkg-utils':
+        specifier: ^7.2.2
+        version: 7.9.6(@types/babel__core@7.20.5)(@types/node@22.13.9)(typescript@5.8.3)
+      '@sanity/prettier-config':
+        specifier: ^1.0.3
+        version: 1.0.3(prettier@3.6.2)
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@types/react':
+        specifier: ^19.1.2
+        version: 19.1.2
+      '@types/react-dom':
+        specifier: ^19.1.3
+        version: 19.1.3(@types/react@19.1.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.4.1
+        version: 4.4.1(vite@6.3.4(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@vitest/coverage-v8':
+        specifier: 3.1.2
+        version: 3.1.2(vitest@3.1.2(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.7.1))
+      eslint:
+        specifier: ^9.22.0
+        version: 9.25.1(jiti@2.4.2)
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      prettier:
+        specifier: ^3.5.3
+        version: 3.6.2
+      react:
+        specifier: ^19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
+      rollup-plugin-visualizer:
+        specifier: ^5.14.0
+        version: 5.14.0(rolldown@1.0.0-beta.27)(rollup@4.45.1)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^6.3.4
+        version: 6.3.4(@types/node@22.13.9)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.7.1)
+      vitest:
+        specifier: ^3.1.2
+        version: 3.1.2(@types/node@22.13.9)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.29.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.7.1)
+
 packages:
 
   '@actions/core@1.11.1':
@@ -7924,8 +8003,8 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
 
   '@asamuzakjp/css-color@3.1.5':
     dependencies:
@@ -8198,7 +8277,7 @@ snapshots:
     dependencies:
       '@babel/template': 7.27.0
       '@babel/traverse': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9530,7 +9609,7 @@ snapshots:
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.29
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -9538,8 +9617,8 @@ snapshots:
 
   '@jridgewell/source-map@0.3.6':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
@@ -10223,7 +10302,7 @@ snapshots:
       get-it: 8.6.7(debug@4.4.1)
       groq-js: 1.16.1
       pkg-dir: 5.0.0
-      prettier: 3.5.3
+      prettier: 3.6.2
       semver: 7.7.1
       validate-npm-package-name: 3.0.0
     transitivePeerDependencies:
@@ -10607,6 +10686,11 @@ snapshots:
       prettier: 3.5.3
       prettier-plugin-packagejson: 2.5.3(prettier@3.5.3)
 
+  '@sanity/prettier-config@1.0.3(prettier@3.6.2)':
+    dependencies:
+      prettier: 3.6.2
+      prettier-plugin-packagejson: 2.5.3(prettier@3.6.2)
+
   '@sanity/preview-url-secret@2.1.8(@sanity/client@6.29.1)':
     dependencies:
       '@sanity/client': 6.29.1(debug@4.4.1)
@@ -10862,7 +10946,7 @@ snapshots:
 
   '@testing-library/dom@10.4.0':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/runtime': 7.27.0
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -13484,7 +13568,7 @@ snapshots:
 
   istanbul-lib-source-maps@5.0.6:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.29
       debug: 4.4.1(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
@@ -13888,8 +13972,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.1
       source-map-js: 1.2.1
 
   make-dir@1.3.0:
@@ -14450,6 +14534,13 @@ snapshots:
       synckit: 0.9.2
     optionalDependencies:
       prettier: 3.5.3
+
+  prettier-plugin-packagejson@2.5.3(prettier@3.6.2):
+    dependencies:
+      sort-package-json: 2.10.1
+      synckit: 0.9.2
+    optionalDependencies:
+      prettier: 3.6.2
 
   prettier@3.5.3: {}
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -35,6 +35,13 @@
       "bump-patch-for-minor-pre-major": true,
       "bump-minor-pre-major": true,
       "versioning": "always-bump-patch"
+    },
+    "packages/react-internal": {
+      "component": "sdk-react-internal",
+      "release-type": "node",
+      "prerelease": true,
+      "prerelease-type": "alpha",
+      "versioning": "prerelease"
     }
   }
 }


### PR DESCRIPTION
### Description
Creates a new package specifically for React hooks to be used by internal teams to be published to a restricted org-only package. No content and most of the configuration is doubled from `@sanity/sdk-react`. 

This will be initially used for intent resolution logic to be used in Dashboard.

### What to review
Do we like this here or do we want a private repo? Are we okay with the naming? Does the release configuration look correct?

### Testing
This should hopefully build. Releasing it is another story.

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZjdjNDIwbGxhNXIyd3Q4bmc2bzUybWl6dGU0ejBmbW10YzZ0cjFoMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3orif0qMh9rE3rYc3C/giphy.gif)