### PR TITLE
fix: do not redirect to the Dashboard if studioMode is specified

### DIFF
--- a/packages/react/src/components/SanityApp.test.tsx
+++ b/packages/react/src/components/SanityApp.test.tsx
@@ -170,7 +170,7 @@ describe('SanityApp', () => {
 
   it('redirects to core if not inside iframe and not local url', async () => {
     const originalLocation = window.location
-    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const mockLocation = {
       replace: vi.fn(),
@@ -204,7 +204,7 @@ describe('SanityApp', () => {
       value: originalLocation,
       writable: true,
     })
-    consoleLogSpy.mockRestore()
+    consoleWarnSpy.mockRestore()
   })
 
   it('does not redirect to core if not inside iframe and local url', async () => {
@@ -242,5 +242,45 @@ describe('SanityApp', () => {
       value: originalLocation,
       writable: true,
     })
+  })
+
+  it('does not redirect to core if studioMode is enabled', async () => {
+    const originalLocation = window.location
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const mockLocation = {
+      replace: vi.fn(),
+      href: 'http://sanity-test.app',
+    }
+
+    const mockSanityConfig: SanityConfig = {
+      projectId: 'test-project',
+      dataset: 'test-dataset',
+      studioMode: {enabled: true},
+    }
+
+    Object.defineProperty(window, 'location', {
+      value: mockLocation,
+      writable: true,
+    })
+
+    render(
+      <SanityApp config={[mockSanityConfig]} fallback={<div>Fallback</div>}>
+        <div>Test Child</div>
+      </SanityApp>,
+    )
+
+    // Wait for 1 second
+    await new Promise((resolve) => setTimeout(resolve, 1010))
+
+    // Add assertions based on your iframe-specific behavior
+    expect(mockLocation.replace).not.toHaveBeenCalled()
+
+    // Clean up the mock
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    })
+    consoleWarnSpy.mockRestore()
   })
 })

--- a/packages/react/src/components/SanityApp.tsx
+++ b/packages/react/src/components/SanityApp.tsx
@@ -86,8 +86,9 @@ export function SanityApp({
 }: SanityAppProps): ReactElement {
   useEffect(() => {
     let timeout: NodeJS.Timeout | undefined
+    const primaryConfig = Array.isArray(config) ? config[0] : config
 
-    if (!isInIframe() && !isLocalUrl(window)) {
+    if (!isInIframe() && !isLocalUrl(window) && !primaryConfig?.studioMode?.enabled) {
       // If the app is not running in an iframe and is not a local url, redirect to core.
       timeout = setTimeout(() => {
         // eslint-disable-next-line no-console
@@ -96,7 +97,7 @@ export function SanityApp({
       }, 1000)
     }
     return () => clearTimeout(timeout)
-  }, [])
+  }, [config])
 
   return (
     <SDKProvider {...props} fallback={fallback} config={config}>


### PR DESCRIPTION
### Description

This PR adds support for disabling the automatic redirect to core when the app is not running in an iframe by introducing a `studioMode.enabled` configuration option. When this option is set to `true`, the app will not redirect to core even if it's not running in an iframe and is not a local URL.

### What to review

- The updated redirect logic in `SanityApp.tsx` that now checks for `primaryConfig?.studioMode?.enabled`
- The new test case that verifies the app doesn't redirect when `studioMode.enabled` is true


### Testing

Added a new test case that specifically tests the behavior when `studioMode.enabled` is set to `true`. The test verifies that no redirect occurs in this scenario, even when the app is not in an iframe and not on a local URL.

### Fun gif
![redirect](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGRrdWNjZnV6dHJ4M28xbDY3eTBsa201ZzY0ajd0Zmd3bjM5cjhoMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT1Ra20Z38XnTRdFte/giphy.gif)