### PR TITLE
fix: change versioning strategy to "default"

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,12 +3,36 @@
   "bootstrap-sha": "a077f3907000535b74f6cebb32585d857776d029",
   "always-link-local": true,
   "changelog-sections": [
-    {"type": "feat", "section": "Features", "hidden": false},
-    {"type": "fix", "section": "Bug Fixes", "hidden": false},
-    {"type": "perf", "section": "Performance Improvements", "hidden": false},
-    {"type": "revert", "section": "Reverts", "hidden": false},
-    {"type": "docs", "section": "Documentation", "hidden": false},
-    {"type": "chore", "section": "Miscellaneous", "hidden": true}
+    {
+      "type": "feat",
+      "section": "Features",
+      "hidden": false
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes",
+      "hidden": false
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements",
+      "hidden": false
+    },
+    {
+      "type": "revert",
+      "section": "Reverts",
+      "hidden": false
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": false
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous",
+      "hidden": true
+    }
   ],
   "plugins": [
     {
@@ -27,14 +51,14 @@
       "release-type": "node",
       "bump-patch-for-minor-pre-major": true,
       "bump-minor-pre-major": true,
-      "versioning": "always-bump-patch"
+      "versioning": "default"
     },
     "packages/core": {
       "component": "sdk",
       "release-type": "node",
       "bump-patch-for-minor-pre-major": true,
       "bump-minor-pre-major": true,
-      "versioning": "always-bump-patch"
+      "versioning": "default"
     }
   }
 }


### PR DESCRIPTION
### Description

Changed the versioning strategy in release-please-config.json from "always-bump-patch" to "default" for both the API and core packages. This allows for more standard semantic versioning behavior rather than always incrementing the patch version.

### What to review

- Verify that changing from "always-bump-patch" to "default" versioning is the intended behavior for both packages

### Testing

The release-please tool will use these settings during the next release cycle.

### Fun gif
![strategy](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExNjVpcTNxaTAwMzB3NGYzOXF6YnZzanloeXJwczNuNGQ2dDdqYW5iYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26hkhHMHwnnUqL8TC/giphy.gif)