### PR TITLE
fix(react): find correct instance for hooks that use config

### DIFF
--- a/apps/kitchensink-react/e2e/multi-resource.spec.ts
+++ b/apps/kitchensink-react/e2e/multi-resource.spec.ts
@@ -1,0 +1,127 @@
+import {expect, test} from '@repo/e2e'
+
+test.describe('Multi Resource Route', () => {
+  test('can view and edit documents from multiple resources', async ({
+    page,
+    getClient,
+    createDocuments,
+    getPageContext,
+  }) => {
+    // create an author document in dataset 0
+    const {
+      documentIds: [authorId],
+    } = await createDocuments(
+      [
+        {
+          _type: 'author',
+          name: 'Test Author Multi Resource',
+          role: 'developer',
+          awards: ['Best Code Award', 'Innovation Prize'],
+        },
+      ],
+      {asDraft: false}, // Create as published document
+      process.env['SDK_E2E_DATASET_0'], // First dataset
+    )
+
+    // Create a player document in dataset 1
+    const {
+      documentIds: [playerId],
+    } = await createDocuments(
+      [
+        {
+          _type: 'player',
+          name: 'Test Player Multi Resource',
+          slackUserId: 'U1234567890',
+        },
+      ],
+      {asDraft: false}, // Create as published document
+      process.env['SDK_E2E_DATASET_1'], // Second dataset
+    )
+
+    await page.goto('./multi-resource')
+
+    // get the page context for iframe/page detection
+    const pageContext = await getPageContext(page)
+
+    // Wait for both document cards to be visible
+    await expect(pageContext.getByTestId(/^author-document-/)).toBeVisible()
+    await expect(pageContext.getByTestId(/^player-document-/)).toBeVisible()
+
+    // Verify author document content is displayed
+    await expect(pageContext.getByTestId('author-name-display')).toHaveText(
+      'Test Author Multi Resource',
+    )
+
+    // Verify player document content is displayed
+    await expect(pageContext.getByTestId('player-name-display')).toHaveText(
+      'Test Player Multi Resource',
+    )
+
+    // Test author projection data
+    await expect(pageContext.getByTestId('author-projection-name')).toContainText(
+      'Test Author Multi Resource',
+    )
+    await expect(pageContext.getByTestId('author-projection-role')).toContainText('developer')
+    await expect(pageContext.getByTestId('author-projection-award-count')).toContainText('2')
+    await expect(pageContext.getByTestId('author-projection-first-award')).toContainText(
+      'Best Code Award',
+    )
+
+    // Test player projection data
+    await expect(pageContext.getByTestId('player-projection-name')).toContainText(
+      'Test Player Multi Resource',
+    )
+    await expect(pageContext.getByTestId('player-projection-slack-id')).toContainText('U1234567890')
+    await expect(pageContext.getByTestId('player-projection-has-slack')).toContainText('Yes')
+
+    // Test editing the author document
+    const authorNameInput = pageContext.getByTestId('author-name-input')
+    await authorNameInput.fill('Updated Author Name')
+    await authorNameInput.press('Enter')
+
+    // Verify the change is reflected in the display
+    await expect(pageContext.getByTestId('author-name-display')).toHaveText('Updated Author Name')
+
+    // Verify the change is also reflected in the projection
+    await expect(pageContext.getByTestId('author-projection-name')).toContainText(
+      'Updated Author Name',
+    )
+
+    // Test editing the player document
+    const playerNameInput = pageContext.getByTestId('player-name-input')
+    await playerNameInput.fill('Updated Player Name')
+    await playerNameInput.press('Enter')
+
+    // Verify the change is reflected in the display
+    await expect(pageContext.getByTestId('player-name-display')).toHaveText('Updated Player Name')
+
+    // Verify the change is also reflected in the projection
+    await expect(pageContext.getByTestId('player-projection-name')).toContainText(
+      'Updated Player Name',
+    )
+
+    // Test that external changes are reflected (simulating real-time updates)
+    const authorClient = getClient(process.env['SDK_E2E_DATASET_0'])
+    await authorClient.patch(`drafts.${authorId}`).set({name: 'Externally Updated Author'}).commit()
+
+    // Test external change for player
+    const playerClient = getClient(process.env['SDK_E2E_DATASET_1'])
+    await playerClient.patch(`drafts.${playerId}`).set({name: 'Externally Updated Player'}).commit()
+
+    // Verify external change is reflected
+    await expect(async () => {
+      const authorDisplay = await pageContext.getByTestId('author-name-display').textContent()
+      const authorProjection = await pageContext.getByTestId('author-projection-name').textContent()
+      expect(authorDisplay).toBe('Externally Updated Author')
+      expect(authorProjection).toContain('Externally Updated Author')
+    }).toPass({timeout: 5000})
+
+    // Verify external change is reflected
+    await expect(async () => {
+      const playerDisplay = await pageContext.getByTestId('player-name-display').textContent()
+      const playerProjection = await pageContext.getByTestId('player-projection-name').textContent()
+      expect(playerDisplay).toBe('Externally Updated Player')
+      expect(playerProjection).toContain('Externally Updated Player')
+    }).toPass({timeout: 5000})
+  })
+})

--- a/apps/kitchensink-react/src/DocumentCollection/MultiResourceRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/MultiResourceRoute.tsx
@@ -1,28 +1,194 @@
-import {type DocumentHandle, useDocument, useDocuments, useEditDocument} from '@sanity/sdk-react'
+import {
+  type DocumentHandle,
+  useDocument,
+  useDocumentPreview,
+  useDocumentProjection,
+  useDocuments,
+  useEditDocument,
+} from '@sanity/sdk-react'
 import {Box, TextInput} from '@sanity/ui'
-import {JSX} from 'react'
+import {defineProjection} from 'groq'
+import {JSX, Suspense, useRef} from 'react'
 
+import {
+  type MultiResourceAuthorProjectionProjectionResult,
+  type MultiResourcePlayerProjectionProjectionResult,
+} from '../../sanity.types'
 import {devConfigs, e2eConfigs} from '../sanityConfigs'
+
+function LoadingFallback({message = 'Loading...'}: {message?: string}) {
+  return (
+    <div style={{padding: '1rem', opacity: 0.6, fontStyle: 'italic', fontSize: '0.9rem'}}>
+      {message}
+    </div>
+  )
+}
+
+interface DemoCardProps {
+  title: string
+  projectInfo: string
+  backgroundColor: string
+  borderColor: string
+  textColor?: string
+  children: React.ReactNode
+  forwardedRef?: React.RefObject<HTMLDivElement | null>
+}
+
+const multiResourceAuthorProjection = defineProjection(`{
+  name,
+  role,
+  "awardCount": count(awards),
+  "firstAward": awards[0]
+}`)
+
+const multiResourcePlayerProjection = defineProjection(`{
+  name,
+  slackUserId,
+  "hasSlackId": defined(slackUserId)
+  }`)
+
+interface ProjectionCardProps<TData = unknown> {
+  docHandle: DocumentHandle
+  projection: string
+  title: string
+  backgroundColor: string
+  borderColor: string
+  textColor?: string
+  renderData: (data: TData | undefined, isPending: boolean) => React.ReactNode
+}
+
+function ProjectionCard<TData = unknown>({
+  docHandle,
+  projection,
+  title,
+  backgroundColor,
+  borderColor,
+  textColor,
+  renderData,
+}: ProjectionCardProps<TData>) {
+  const ref = useRef<HTMLDivElement>(null)
+  const {data, isPending} = useDocumentProjection({
+    ...docHandle,
+    ref,
+    projection: projection as `{${string}}`,
+  })
+
+  return (
+    <DemoCard
+      title={title}
+      projectInfo={`${docHandle.projectId}.${docHandle.dataset}`}
+      backgroundColor={backgroundColor}
+      borderColor={borderColor}
+      textColor={textColor}
+      forwardedRef={ref}
+    >
+      <div style={{fontSize: '0.9rem', lineHeight: '1.6'}}>
+        {isPending && <p style={{opacity: 0.6, fontStyle: 'italic'}}>Loading projection data...</p>}
+        {renderData(data as TData | undefined, isPending)}
+      </div>
+    </DemoCard>
+  )
+}
+
+interface PreviewCardProps {
+  docHandle: DocumentHandle
+  title: string
+  backgroundColor: string
+  borderColor: string
+  textColor?: string
+}
+
+function PreviewCard({
+  docHandle,
+  title,
+  backgroundColor,
+  borderColor,
+  textColor,
+}: PreviewCardProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const {data: preview, isPending} = useDocumentPreview({
+    ...docHandle,
+    ref,
+  })
+
+  return (
+    <DemoCard
+      title={title}
+      projectInfo={`${docHandle.projectId}.${docHandle.dataset}`}
+      backgroundColor={backgroundColor}
+      borderColor={borderColor}
+      textColor={textColor}
+      forwardedRef={ref}
+    >
+      <div style={{fontSize: '0.9rem', lineHeight: '1.6'}}>
+        {isPending && <p style={{opacity: 0.6, fontStyle: 'italic'}}>Loading preview data...</p>}
+        <p style={{opacity: isPending ? 0.5 : 1}}>
+          <strong>Title:</strong> {preview?.title ?? 'No title'}
+        </p>
+        <p style={{opacity: isPending ? 0.5 : 1}}>
+          <strong>Subtitle:</strong> {preview?.subtitle ?? 'No subtitle'}
+        </p>
+        <p style={{opacity: isPending ? 0.5 : 1}}>
+          <strong>Media Type:</strong> {preview?.media?.type ?? 'No media'}
+        </p>
+        {preview?.media?.type === 'image-asset' && preview.media.url && (
+          <div style={{marginTop: '0.5rem', opacity: isPending ? 0.5 : 1}}>
+            <img
+              src={preview.media.url}
+              alt="Preview"
+              style={{maxWidth: '100px', height: 'auto', borderRadius: '4px'}}
+            />
+          </div>
+        )}
+      </div>
+    </DemoCard>
+  )
+}
+
+function DemoCard({
+  title,
+  projectInfo,
+  backgroundColor,
+  borderColor,
+  textColor = '#fff',
+  children,
+  forwardedRef,
+}: DemoCardProps) {
+  const testId = title.toLowerCase().replace(/\s+/g, '-')
+  return (
+    <div
+      ref={forwardedRef}
+      data-testid={`${testId}-${projectInfo.replace('.', '-')}`}
+      style={{
+        padding: '1.5rem',
+        borderRadius: '8px',
+        backgroundColor,
+        boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+        minWidth: '280px',
+        flex: 1,
+        color: textColor,
+        border: `2px solid ${borderColor}`,
+      }}
+    >
+      <h3 style={{marginBottom: '1rem', color: textColor === '#fff' ? '#e0b3ff' : '#2a2a2a'}}>
+        {title} ({projectInfo})
+      </h3>
+      {children}
+    </div>
+  )
+}
 
 function AuthorEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
   const {data: author} = useDocument(docHandle)
   const setAuthorName = useEditDocument({...docHandle, path: 'name'})
 
   return (
-    <div
-      style={{
-        padding: '2rem',
-        borderRadius: '8px',
-        backgroundColor: '#3f0067',
-        boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-        minWidth: '300px',
-        flex: 1,
-        color: '#fff',
-      }}
+    <DemoCard
+      title="Author Document"
+      projectInfo={`${docHandle.projectId}.${docHandle.dataset}`}
+      backgroundColor="#3f0067"
+      borderColor="#3f0067"
     >
-      <h2 style={{marginBottom: '1rem'}}>
-        Author Document ({docHandle.projectId}.{docHandle.dataset})
-      </h2>
       <a
         style={{display: 'block', marginBottom: '1rem', color: '#3e41e7'}}
         href={`https://test-studio.sanity.build/${docHandle.dataset}/structure/author;${author?._id}`}
@@ -31,8 +197,11 @@ function AuthorEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
       >
         View in Studio →
       </a>
-      <h3 style={{fontSize: '1.5rem', marginBottom: '0.5rem'}}>{author?.name}</h3>
+      <h4 data-testid="author-name-display" style={{fontSize: '1.5rem', marginBottom: '0.5rem'}}>
+        {author?.name}
+      </h4>
       <TextInput
+        data-testid="author-name-input"
         label="Name"
         type="text"
         value={author?.name}
@@ -41,7 +210,7 @@ function AuthorEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
       {author?.role && <p style={{color: '#fff', marginBottom: '1rem'}}>Role: {author.role}</p>}
       {author?.awards && author.awards.length > 0 && (
         <div>
-          <h4 style={{marginBottom: '0.5rem'}}>Awards</h4>
+          <h5 style={{marginBottom: '0.5rem'}}>Awards</h5>
           <ul style={{paddingLeft: '1.5rem'}}>
             {author.awards.map((award: string, index: number) => (
               <li key={index}>{award}</li>
@@ -49,7 +218,7 @@ function AuthorEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
           </ul>
         </div>
       )}
-    </div>
+    </DemoCard>
   )
 }
 
@@ -58,20 +227,13 @@ function PlayerEditor({docHandle}: {docHandle: DocumentHandle<'player'>}) {
   const setPlayerName = useEditDocument({...docHandle, path: 'name'})
 
   return (
-    <div
-      style={{
-        padding: '2rem',
-        borderRadius: '8px',
-        backgroundColor: '#b4e6ef',
-        boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-        minWidth: '300px',
-        flex: 1,
-        color: '#444',
-      }}
+    <DemoCard
+      title="Player Document"
+      projectInfo={`${docHandle.projectId}.${docHandle.dataset}`}
+      backgroundColor="#b4e6ef"
+      borderColor="#4fb3c0"
+      textColor="#444"
     >
-      <h2 style={{marginBottom: '1rem', color: '#2a2a2a'}}>
-        Player Document ({docHandle.projectId}.{docHandle.dataset})
-      </h2>
       <a
         style={{display: 'block', marginBottom: '1rem', color: '#3e41e7'}}
         href={`https://autofoos.com/structure/player;${player?._id}`}
@@ -80,9 +242,11 @@ function PlayerEditor({docHandle}: {docHandle: DocumentHandle<'player'>}) {
       >
         View in Studio →
       </a>
-
-      <h3 style={{fontSize: '1.5rem', marginBottom: '0.5rem'}}>{player?.name}</h3>
+      <h4 data-testid="player-name-display" style={{fontSize: '1.5rem', marginBottom: '0.5rem'}}>
+        {player?.name}
+      </h4>
       <TextInput
+        data-testid="player-name-input"
         label="Name"
         type="text"
         value={player?.name}
@@ -91,7 +255,86 @@ function PlayerEditor({docHandle}: {docHandle: DocumentHandle<'player'>}) {
       <div style={{color: '#444', marginBottom: '1rem'}}>
         {player?.slackUserId && `Slack User ID: ${player.slackUserId}`}
       </div>
-    </div>
+    </DemoCard>
+  )
+}
+
+function AuthorProjection({docHandle}: {docHandle: DocumentHandle<'author'>}) {
+  return (
+    <ProjectionCard<MultiResourceAuthorProjectionProjectionResult>
+      docHandle={docHandle}
+      projection={multiResourceAuthorProjection}
+      title="Author Projection"
+      backgroundColor="#1a0033"
+      borderColor="#3f0067"
+      renderData={(data, isPending) => (
+        <div data-testid="author-projection-data">
+          <p data-testid="author-projection-name" style={{opacity: isPending ? 0.5 : 1}}>
+            <strong>Name:</strong> {data?.name ?? 'No name'}
+          </p>
+          <p data-testid="author-projection-role" style={{opacity: isPending ? 0.5 : 1}}>
+            <strong>Role:</strong> {data?.role ?? 'No role'}
+          </p>
+          <p data-testid="author-projection-award-count" style={{opacity: isPending ? 0.5 : 1}}>
+            <strong>Award Count:</strong> {data?.awardCount ?? 0}
+          </p>
+          {data?.firstAward && (
+            <p data-testid="author-projection-first-award" style={{opacity: isPending ? 0.5 : 1}}>
+              <strong>First Award:</strong> {data.firstAward}
+            </p>
+          )}
+        </div>
+      )}
+    />
+  )
+}
+
+function PlayerProjection({docHandle}: {docHandle: DocumentHandle<'player'>}) {
+  return (
+    <ProjectionCard<MultiResourcePlayerProjectionProjectionResult>
+      docHandle={docHandle}
+      projection={multiResourcePlayerProjection}
+      title="Player Projection"
+      backgroundColor="#7fc7d1"
+      borderColor="#4fb3c0"
+      textColor="#1a1a1a"
+      renderData={(data, isPending) => (
+        <div data-testid="player-projection-data">
+          <p data-testid="player-projection-name" style={{opacity: isPending ? 0.5 : 1}}>
+            <strong>Name:</strong> {data?.name ?? 'No name'}
+          </p>
+          <p data-testid="player-projection-slack-id" style={{opacity: isPending ? 0.5 : 1}}>
+            <strong>Slack User ID:</strong> {data?.slackUserId ?? 'Not set'}
+          </p>
+          <p data-testid="player-projection-has-slack" style={{opacity: isPending ? 0.5 : 1}}>
+            <strong>Has Slack ID:</strong> {data?.hasSlackId ? 'Yes' : 'No'}
+          </p>
+        </div>
+      )}
+    />
+  )
+}
+
+function AuthorPreview({docHandle}: {docHandle: DocumentHandle<'author'>}) {
+  return (
+    <PreviewCard
+      docHandle={docHandle}
+      title="Author Preview"
+      backgroundColor="#4d1a75"
+      borderColor="#6b2d96"
+    />
+  )
+}
+
+function PlayerPreview({docHandle}: {docHandle: DocumentHandle<'player'>}) {
+  return (
+    <PreviewCard
+      docHandle={docHandle}
+      title="Player Preview"
+      backgroundColor="#5ca8b5"
+      borderColor="#4a929e"
+      textColor="#1a1a1a"
+    />
   )
 }
 
@@ -130,9 +373,31 @@ export function MultiResourceRoute(): JSX.Element {
         Note you must have access to both resources ({configs[0].projectId}.{configs[0].dataset} and{' '}
         {configs[1].projectId}.{configs[1].dataset}) to see the documents.
       </p>
-      <div style={{display: 'flex', gap: '2rem', flexWrap: 'wrap'}}>
+
+      <h2 style={{marginBottom: '1rem'}}>Document Editors</h2>
+      <div style={{display: 'flex', gap: '2rem', flexWrap: 'wrap', marginBottom: '3rem'}}>
         <AuthorEditor docHandle={authorHandle} />
         <PlayerEditor docHandle={playerHandle} />
+      </div>
+
+      <h2 style={{marginBottom: '1rem'}}>Document Projections</h2>
+      <div style={{display: 'flex', gap: '2rem', flexWrap: 'wrap', marginBottom: '3rem'}}>
+        <Suspense fallback={<LoadingFallback message="Loading author projection..." />}>
+          <AuthorProjection docHandle={authorHandle} />
+        </Suspense>
+        <Suspense fallback={<LoadingFallback message="Loading player projection..." />}>
+          <PlayerProjection docHandle={playerHandle} />
+        </Suspense>
+      </div>
+
+      <h2 style={{marginBottom: '1rem'}}>Document Previews</h2>
+      <div style={{display: 'flex', gap: '2rem', flexWrap: 'wrap'}}>
+        <Suspense fallback={<LoadingFallback message="Loading author preview..." />}>
+          <AuthorPreview docHandle={authorHandle} />
+        </Suspense>
+        <Suspense fallback={<LoadingFallback message="Loading player preview..." />}>
+          <PlayerPreview docHandle={playerHandle} />
+        </Suspense>
       </div>
     </div>
   )

--- a/packages/react/src/hooks/preview/useDocumentPreview.tsx
+++ b/packages/react/src/hooks/preview/useDocumentPreview.tsx
@@ -83,7 +83,7 @@ export function useDocumentPreview({
   ref,
   ...docHandle
 }: useDocumentPreviewOptions): useDocumentPreviewResults {
-  const instance = useSanityInstance()
+  const instance = useSanityInstance(docHandle)
   const stateSource = getPreviewState(instance, docHandle)
 
   // Create subscribe function for useSyncExternalStore

--- a/packages/react/src/hooks/projection/useDocumentProjection.ts
+++ b/packages/react/src/hooks/projection/useDocumentProjection.ts
@@ -181,7 +181,7 @@ export function useDocumentProjection<TData extends object>({
   projection,
   ...docHandle
 }: useDocumentProjectionOptions): useDocumentProjectionResults<TData> {
-  const instance = useSanityInstance()
+  const instance = useSanityInstance(docHandle)
   const stateSource = getProjectionState<TData>(instance, {...docHandle, projection})
 
   if (stateSource.getCurrent()?.data === null) {


### PR DESCRIPTION
### Description
There was some crossed wires / oversight in a few hooks, so passing in a `documentHandle` with a specific `projectId` or `dataset` wouldn't necessarily pull up the correct `SanityInstance`.

This PR fixes that and adds those hooks to the MultiResourceRoute and an e2e test. 

### What to review
The actual important changes are in the react package -- it's a 2 line change. The rest is just future-proofing :)

### Testing
Added e2e tests/

### Fun gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExajJiemJvbGMwbGk3YWk2YjkzcHBqYWExemtia205NWZ6M3YyYWYwNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/pdSncNyYgaH0wqaCqp/giphy.gif)