### PR TITLE
fix(core): add perspective to query cache key to avoid collisions

### DIFF
--- a/apps/kitchensink-react/e2e/perspectives.spec.ts
+++ b/apps/kitchensink-react/e2e/perspectives.spec.ts
@@ -1,0 +1,46 @@
+import {expect, test} from '@repo/e2e'
+
+test.describe('Perspectives route', () => {
+  test('published panel does not show draft content', async ({page, getClient, getPageContext}) => {
+    const client = getClient()
+
+    // Create a published author
+    const published = await client.create({
+      _type: 'author',
+      name: 'Author Base Name',
+    })
+
+    // Create a draft overlay for the same document id
+    await client.createOrReplace({
+      _id: `drafts.${published._id}`,
+      _type: 'author',
+      name: 'Author Draft Name',
+    })
+
+    // Navigate to the perspectives demo
+    await page.goto('./perspectives')
+
+    const pageContext = await getPageContext(page)
+
+    // Wait for both panels to render
+    const left = pageContext.getByRole('heading', {name: 'Drafts Resource Provider'})
+    const right = pageContext.getByRole('heading', {name: 'Published Resource Provider'})
+    await expect(left).toBeVisible()
+    await expect(right).toBeVisible()
+
+    // Panels render JSON with stable test ids
+    const draftsPanel = pageContext.getByTestId('panel-drafts-json')
+    const publishedPanel = pageContext.getByTestId('panel-published-json')
+
+    // Validate content eventually reflects correct perspectives
+    await expect(async () => {
+      const draftsText = await draftsPanel.textContent()
+      const publishedText = await publishedPanel.textContent()
+      // Drafts subtree should show the draft overlay
+      expect(draftsText).toContain('Author Draft Name')
+      // Published subtree should not show draft name
+      expect(publishedText).toContain('Author Base Name')
+      expect(publishedText).not.toContain('Author Draft Name')
+    }).toPass({timeout: 5000})
+  })
+})

--- a/apps/kitchensink-react/src/AppRoutes.tsx
+++ b/apps/kitchensink-react/src/AppRoutes.tsx
@@ -18,6 +18,7 @@ import {DashboardContextRoute} from './routes/DashboardContextRoute'
 import {DashboardWorkspacesRoute} from './routes/DashboardWorkspacesRoute'
 import ExperimentalResourceClientRoute from './routes/ExperimentalResourceClientRoute'
 import {ProjectsRoute} from './routes/ProjectsRoute'
+import {PerspectivesRoute} from './routes/PerspectivesRoute'
 import {ReleasesRoute} from './routes/releases/ReleasesRoute'
 import {UserDetailRoute} from './routes/UserDetailRoute'
 import {UsersRoute} from './routes/UsersRoute'
@@ -109,6 +110,10 @@ export function AppRoutes(): JSX.Element {
                     path: 'projects',
                     element: <ProjectsRoute />,
                   },
+                  {
+                    path: 'perspectives',
+                    element: <PerspectivesRoute />,
+                  },
                 ]}
               />
             }
@@ -120,6 +125,7 @@ export function AppRoutes(): JSX.Element {
           <Route path="comlink-demo" element={<ParentApp />} />
           <Route path="releases" element={<ReleasesRoute />} />
           <Route path="projects" element={<ProjectsRoute />} />
+          <Route path="perspectives" element={<PerspectivesRoute />} />
         </Route>
         <Route path="comlink-demo">
           {frameRoutes.map((route) => (

--- a/apps/kitchensink-react/src/routes/PerspectivesRoute.tsx
+++ b/apps/kitchensink-react/src/routes/PerspectivesRoute.tsx
@@ -1,0 +1,96 @@
+import {ResourceProvider, useQuery} from '@sanity/sdk-react'
+import {Box, Card, Code, Flex, Heading, Stack, Text} from '@sanity/ui'
+import {type JSX, Suspense} from 'react'
+
+function QueryPanel({
+  title,
+  docId,
+  testId,
+}: {
+  title: string
+  docId: string
+  testId: string
+}): JSX.Element {
+  const {data} = useQuery<Record<string, unknown> | null>({
+    query: '*[_id == $id][0]',
+    params: {id: docId},
+  })
+
+  return (
+    <Card padding={4} radius={3} shadow={1} tone="transparent" data-testid={`panel-${testId}`}>
+      <Stack space={3}>
+        <Heading size={2} as="h2">
+          {title}
+        </Heading>
+        <Box>
+          <Text size={1} weight="semibold">
+            Document
+          </Text>
+          <Card padding={3} radius={2} tone="transparent">
+            <Code data-testid={`panel-${testId}-json`}>
+              {JSON.stringify(data ?? null, null, 2)}
+            </Code>
+          </Card>
+        </Box>
+      </Stack>
+    </Card>
+  )
+}
+
+export function PerspectivesRoute(): JSX.Element {
+  // Get the latest published author document id once, outside the nested providers,
+  // so both subtrees use the same document id.
+  const {data: latest} = useQuery<{_id: string} | null>({
+    query: '*[_type == "author"] | order(_updatedAt desc)[0]{_id}',
+    // may not always return a draft result, but usually does in test dataset
+    perspective: 'published',
+  })
+
+  const docId = latest?._id
+
+  return (
+    <Box padding={4}>
+      <Stack space={4}>
+        <Heading as="h1" size={5}>
+          Perspectives Demo (Key Collision)
+        </Heading>
+        <Text size={1} muted>
+          This nests ResourceProviders with the same project/dataset but different implicit
+          perspectives (drafts vs published). Both panels run the same useQuery for the same
+          document id without passing a perspective option.
+        </Text>
+        <Text size={1} muted>
+          Latest published author id: <Code>{docId ?? 'Loading…'}</Code>
+        </Text>
+
+        {/* ResourceProvider with drafts perspective */}
+        <ResourceProvider perspective="drafts" fallback={null}>
+          <Flex gap={4} wrap="wrap">
+            <Box style={{minWidth: 320, flex: 1}}>
+              <Suspense>
+                {docId ? (
+                  <QueryPanel title="Drafts Resource Provider" docId={docId} testId="drafts" />
+                ) : null}
+              </Suspense>
+            </Box>
+
+            {/* ResourceProvider with published perspective */}
+            <ResourceProvider perspective="published" fallback={null}>
+              <Box style={{minWidth: 320, flex: 1}}>
+                <Suspense>
+                  {docId ? (
+                    <QueryPanel
+                      title="Published Resource Provider"
+                      docId={docId}
+                      testId="published"
+                    />
+                  ) : null}
+                </Suspense>
+              </Box>
+            </ResourceProvider>
+          </Flex>
+        </ResourceProvider>
+      </Stack>
+    </Box>
+  )
+}

--- a/apps/kitchensink-react/src/routes/releases/ReleasesRoute.tsx
+++ b/apps/kitchensink-react/src/routes/releases/ReleasesRoute.tsx
@@ -114,16 +114,16 @@ export function ReleasesRoute(): JSX.Element {
     () => ({...selectedDocument, perspective: selectedPerspective.perspective}),
     [selectedDocument, selectedPerspective],
   )
-
+  const documentProjectionOptions = useMemo(
+    () => ({
+      ...documentOptions,
+      projection: `{name, "bestFriend": bestFriend->name}` as `{${string}}`,
+    }),
+    [documentOptions],
+  )
   const documentResult = useDocument(documentOptions)
   const previewResult = useDocumentPreview(documentOptions)
-  const projectionResult = useDocumentProjection({
-    ...documentOptions,
-    projection: `{
-      name,
-      "bestFriend": bestFriend->name
-    }`,
-  })
+  const projectionResult = useDocumentProjection(documentProjectionOptions)
 
   return (
     <Box padding={4}>

--- a/packages/core/src/query/queryStoreConstants.ts
+++ b/packages/core/src/query/queryStoreConstants.ts
@@ -7,3 +7,4 @@
  */
 export const QUERY_STATE_CLEAR_DELAY = 1000
 export const QUERY_STORE_API_VERSION = 'v2025-05-06'
+export const QUERY_STORE_DEFAULT_PERSPECTIVE = 'drafts'


### PR DESCRIPTION
### Description
There was a subtle bug that could happen if you used a nested `ResourceProvider` with a perspective (or any other way of implicitly getting a perspective) that pointed to the same project and dataset as another `ResourceProvider`, wherein you might get the wrong query result. You can see this if you run this branch  and check the new route in Kitchensink without the queryStore fix, as below:

![Screenshot 2025-09-02 at 3.26.59 PM.png](https://app.graphite.dev/user-attachments/assets/dbb95119-7170-4e8c-8723-02f1b93556b0.png)

Every query store is instanced to a project and dataset, and it caches the results of a query. If you were to make the exact same query in a different provider with a different perspective, your "new" perspective would not be saved in the query key, and you would be served the old cached query result with from the "wrong" perspective, because neither query saved their perspective as part of their query key.

(this wasn't a problem with something like `useDocument({...documentHandle, perspective})` because all options got memoized into the key)

This PR rectifies this by forcing every query key to have a perspective. It also adds tests and e2e tests. New results below:

![Screenshot 2025-09-02 at 3.32.19 PM.png](https://app.graphite.dev/user-attachments/assets/85181fad-14db-44b3-a7f0-131e8280881e.png)

### What to review
The only significant logic change is in `queryStore.ts`. Everything else is testing / future-proofing.

- The new `PerspectivesRoute` component that demonstrates nested `ResourceProvider` components with different perspectives
- The updated query store implementation that now properly separates cache entries by perspective
- The new e2e test that verifies published panels don't show draft content

### Testing

Added a comprehensive e2e test that:
- Creates a published author document
- Creates a draft overlay with modified content
- Verifies that the drafts panel shows the draft content
- Verifies that the published panel shows only the published content

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExemtpdzJneGsxbG1qaWs4OHZtaWtvNWJ2ZzhqdW12Zm9qYndwZTIyNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oz8xCXOMwPF1J4BBC/giphy.gif)