### PR TITLE
fix(projects): properly type the includeMembers option

### DIFF
--- a/apps/kitchensink-react/src/AppRoutes.tsx
+++ b/apps/kitchensink-react/src/AppRoutes.tsx
@@ -17,6 +17,7 @@ import {ProtectedRoute} from './ProtectedRoute'
 import {DashboardContextRoute} from './routes/DashboardContextRoute'
 import {DashboardWorkspacesRoute} from './routes/DashboardWorkspacesRoute'
 import ExperimentalResourceClientRoute from './routes/ExperimentalResourceClientRoute'
+import {ProjectsRoute} from './routes/ProjectsRoute'
 import {ReleasesRoute} from './routes/releases/ReleasesRoute'
 import {UserDetailRoute} from './routes/UserDetailRoute'
 import {UsersRoute} from './routes/UsersRoute'
@@ -104,6 +105,10 @@ export function AppRoutes(): JSX.Element {
                     path: 'releases',
                     element: <ReleasesRoute />,
                   },
+                  {
+                    path: 'projects',
+                    element: <ProjectsRoute />,
+                  },
                 ]}
               />
             }
@@ -114,6 +119,7 @@ export function AppRoutes(): JSX.Element {
           <Route path="users/:userId" element={<UserDetailRoute />} />
           <Route path="comlink-demo" element={<ParentApp />} />
           <Route path="releases" element={<ReleasesRoute />} />
+          <Route path="projects" element={<ProjectsRoute />} />
         </Route>
         <Route path="comlink-demo">
           {frameRoutes.map((route) => (

--- a/apps/kitchensink-react/src/routes/ProjectsRoute.tsx
+++ b/apps/kitchensink-react/src/routes/ProjectsRoute.tsx
@@ -1,0 +1,70 @@
+import {useProjects} from '@sanity/sdk-react'
+import {Box, Card, Checkbox, Flex, Label, Text} from '@sanity/ui'
+import {ChangeEvent, type JSX, Suspense, useState} from 'react'
+
+import {PageLayout} from '../components/PageLayout'
+
+export function ProjectsRoute(): JSX.Element {
+  const [organizationId, setOrganizationId] = useState<string | undefined>(undefined)
+  const [includeMembers, setIncludeMembers] = useState<boolean>(false)
+  return (
+    <PageLayout title="Organization Projects" subtitle={`projects available for your user`}>
+      <Label htmlFor="organizationId" size={1}>
+        Organization ID
+      </Label>
+      <input
+        value={organizationId}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => setOrganizationId(e.currentTarget.value)}
+        style={{width: '100%', border: '1px solid #ccc', padding: '8px', borderRadius: '4px'}}
+      />
+      <Label htmlFor="includeMembers" size={1}>
+        Include members
+      </Label>
+      <Checkbox
+        checked={includeMembers}
+        label="Include members"
+        id="includeMembers"
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+          setIncludeMembers(e.currentTarget.checked)
+        }}
+      />
+
+      <Suspense fallback={<Text>Loading projects...</Text>}>
+        <ProjectsList organizationId={organizationId} includeMembers={includeMembers} />
+      </Suspense>
+    </PageLayout>
+  )
+}
+
+function ProjectsList({
+  organizationId,
+  includeMembers,
+}: {
+  organizationId: string | undefined
+  includeMembers: boolean
+}) {
+  const projects = useProjects({organizationId, includeMembers})
+
+  return (
+    <ol className="DocumentListLayout list-none" style={{gap: 2}}>
+      {projects.map((project) => (
+        <li key={project.id}>
+          <Card width="fill" marginBottom={2} style={{cursor: 'pointer'}} tone="inherit">
+            <Flex align="center" gap={2} padding={2}>
+              <Box paddingY={2}>
+                <Flex direction="column" gap={1}>
+                  <Text>{project.displayName}</Text>
+                  <Text muted>Project ID: {project.id}</Text>
+                  <Text muted>Organization ID: {project.organizationId}</Text>
+                  {includeMembers && 'members' in project && (
+                    <Text muted>Members: {project.members?.length}</Text>
+                  )}
+                </Flex>
+              </Box>
+            </Flex>
+          </Card>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/packages/react/src/hooks/projects/useProjects.ts
+++ b/packages/react/src/hooks/projects/useProjects.ts
@@ -10,31 +10,38 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
  */
 export type ProjectWithoutMembers = Omit<SanityProject, 'members'>
 
-type UseProjects = {
-  /**
-   *
-   * Returns metadata for each project you have access to.
-   *
-   * @category Projects
-   * @returns An array of metadata (minus the projects’ members) for each project
-   * @example
-   * ```tsx
-   * const projects = useProjects()
-   *
-   * return (
-   *   <select>
-   *     {projects.map((project) => (
-   *       <option key={project.id}>{project.displayName}</option>
-   *     ))}
-   *   </select>
-   * )
-   * ```
-   */
-  (options?: {organizationId?: string; includeMembers?: true}): SanityProject[]
-  (options: {organizationId?: string; includeMembers?: false}): ProjectWithoutMembers[]
-}
+/**
+ * @public
+ * @category Types
+ */
+type UseProjects = <TIncludeMembers extends boolean = false>(options?: {
+  organizationId?: string
+  includeMembers?: TIncludeMembers
+}) => TIncludeMembers extends true ? SanityProject[] : ProjectWithoutMembers[]
 
 /**
+ * Returns metadata for each project you have access to.
+ *
+ * @category Projects
+ * @param options - Configuration options
+ * @returns An array of project metadata. If includeMembers is true, returns full SanityProject objects. Otherwise, returns ProjectWithoutMembers objects.
+ * @example
+ * ```tsx
+ * const projects = useProjects()
+ *
+ * return (
+ *   <select>
+ *     {projects.map((project) => (
+ *       <option key={project.id}>{project.displayName}</option>
+ *     ))}
+ *   </select>
+ * )
+ * ```
+ * @example
+ * ```tsx
+ * const projectsWithMembers = useProjects({ includeMembers: true })
+ * const projectsWithoutMembers = useProjects({ includeMembers: false })
+ * ```
  * @public
  * @function
  */


### PR DESCRIPTION
### Description
Improved the `useProjects` hook documentation and type definitions to better support the `includeMembers` parameter, making it clearer when the hook returns projects with or without member information.

Also added a new Projects route to the kitchensink-react app that displays projects available to the current user. The route allows filtering projects by organization ID and toggling the inclusion of member information.

### What to review
- The improved type definitions and documentation for the `useProjects` hook
- The new `ProjectsRoute.tsx` component that displays project information
- The route registration in `AppRoutes.tsx`


### Testing

Tested the new route by verifying:
- Projects display correctly with and without the organization filter
- The member information toggle works as expected
- The route is accessible from both the main navigation and dashboard

### Fun gif
![type](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExanB5aGxxMTVmbDJuMWN4eTUwOThlMTljaWszaWwxejRheTF0YTgyMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/f16wgrNYaKkBcvOu5r/giphy.gif)