### PR TITLE
chore: deploy kitchensink app on merge to main

### DIFF
--- a/.github/workflows/deploy-kitchensink.yml
+++ b/.github/workflows/deploy-kitchensink.yml
@@ -1,0 +1,41 @@
+name: Deploy Kitchensink
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-kitchensink
+  cancel-in-progress: false
+
+jobs:
+  deploy-kitchensink:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Check pnpm
+        run: pnpm -v
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy Sanity App
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN_DEPLOY }}
+        run: pnpm run deploy:kitchensink

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev": "pnpm dev:kitchensink",
     "dev:kitchensink": "turbo run dev --filter=@sanity/kitchensink-react",
     "dev:e2e": "turbo run dev --filter=@sanity/kitchensink-react -- --mode=e2e",
+    "deploy:kitchensink": "turbo run deploy --filter=@sanity/kitchensink-react",
     "format": "prettier --write --cache --ignore-unknown .",
     "lint": "turbo run lint -- --fix && eslint . --fix",
     "prepare": "husky",

--- a/turbo.json
+++ b/turbo.json
@@ -90,6 +90,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
       "cache": true
+    },
+    "deploy": {
+      "cache": false,
+      "dependsOn": ["^build"]
     }
   }
 }


### PR DESCRIPTION
### Description

Added a GitHub workflow to automatically deploy the Kitchensink app when changes are pushed to the main branch. This workflow sets up the necessary environment, installs dependencies, and runs the deployment process using a Sanity authentication token.

To support this deployment process, added a new `deploy:kitchensink` script to the root package.json and configured a new `deploy` task in turbo.json with appropriate dependencies.

### What to review

- The GitHub workflow configuration in `.github/workflows/deploy-kitchensink.yml`
- The new `deploy:kitchensink` script in package.json
- The `deploy` task configuration in turbo.json that depends on build tasks

### Testing

The workflow can be tested by either pushing to main or manually triggering it through the GitHub Actions UI. The deployment process relies on the `SANITY_AUTH_TOKEN_DEPLOY` secret being properly configured in the repository settings.

### Fun gif
![send](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmVpNngwemtveWNvNWNpejk4bmNjN294OG5pMDVxZ3UzNmVzNWo1eiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/qrfjUqL8RPqmNB5LQM/giphy.gif)