### PR TITLE
chore: fix pnpm install on kitchensink deploy

### DIFF
--- a/.github/workflows/deploy-kitchensink.yml
+++ b/.github/workflows/deploy-kitchensink.yml
@@ -25,9 +25,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: false
 
       - name: Check pnpm
         run: pnpm -v


### PR DESCRIPTION
### Description

This PR fixes the pnpm install on the kitchensink deploy workflow. Previously it [threw an error](https://github.com/sanity-io/sdk/actions/runs/17675443740/job/50236342256) because multiple versions of pnpm were being installed

### Fun gif
![fixing CI/CD](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExaWsybnByc2cxbGhtaG4wZW9lbXdkbHN2OXp6ZWg1enVvcTl4N3R2biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/LpkBAUDg53FI8xLmg1/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
