### PR TITLE
chore: merge kitchensink's Vite config into CLI config

### DIFF
--- a/apps/kitchensink-react/sanity.cli.ts
+++ b/apps/kitchensink-react/sanity.cli.ts
@@ -1,9 +1,87 @@
 import {defineCliConfig} from 'sanity/cli'
+import {
+  type ConfigEnv,
+  type Plugin,
+  type PluginOption,
+  type UserConfig,
+  type UserConfigExport,
+} from 'vite'
 
 export default defineCliConfig({
   app: {
     organizationId: 'oblZgbTFj',
     entry: './src/App.tsx',
     id: 'wkyoigmzawwnnwx458zgoh46',
+  },
+  // Extend Sanity CLI's internal Vite config with the app's Vite config
+  vite: async (prev: UserConfig) => {
+    const {default: viteConfigFactory} = (await import('./vite.config.ts')) as {
+      default: UserConfigExport
+    }
+
+    const mode = process.env['NODE_ENV'] === 'production' ? 'production' : 'development'
+    const env: ConfigEnv = {mode, command: 'serve'}
+
+    const projectConfigMaybe =
+      typeof viteConfigFactory === 'function' ? viteConfigFactory(env) : viteConfigFactory
+    const projectConfig = (await Promise.resolve(projectConfigMaybe)) as UserConfig
+
+    // Merge plugins without duplicates and avoid double React Refresh injection
+    const flattenPlugins = (
+      input: PluginOption | PluginOption[] | undefined,
+    ): import('vite').Plugin[] => {
+      const result: import('vite').Plugin[] = []
+      const push = (value: unknown) => {
+        if (!value) return
+        if (Array.isArray(value)) {
+          value.forEach(push)
+          return
+        }
+        const maybe = value as Partial<Plugin>
+        if (typeof maybe === 'object' && maybe && 'name' in maybe) {
+          result.push(maybe as Plugin)
+        }
+      }
+      push(input as unknown)
+      return result
+    }
+
+    const prevPlugins = flattenPlugins(prev.plugins)
+    const projectPlugins = flattenPlugins(projectConfig.plugins)
+
+    const projectHasReact = projectPlugins.some((p) => /react|refresh/i.test(p.name))
+    const filteredPrev = projectHasReact
+      ? prevPlugins.filter((p) => !/react|refresh/i.test(p.name))
+      : prevPlugins
+
+    const seen = new Set<string>()
+    const mergedPlugins = [...projectPlugins, ...filteredPrev].filter((p) => {
+      if (!p.name) return true
+      if (seen.has(p.name)) return false
+      seen.add(p.name)
+      return true
+    })
+
+    return {
+      ...prev,
+      ...projectConfig,
+      plugins: mergedPlugins,
+      resolve: {
+        ...prev.resolve,
+        ...projectConfig.resolve,
+        alias: {
+          ...(prev.resolve?.alias ?? {}),
+          ...(projectConfig.resolve?.alias ?? {}),
+        },
+      },
+      define: {
+        ...prev.define,
+        ...(projectConfig.define ?? {}),
+      },
+      server: {
+        ...prev.server,
+        ...(projectConfig.server ?? {}),
+      },
+    }
   },
 })

--- a/apps/kitchensink-react/sanity.cli.ts
+++ b/apps/kitchensink-react/sanity.cli.ts
@@ -20,7 +20,8 @@ export default defineCliConfig({
     }
 
     const mode = process.env['NODE_ENV'] === 'production' ? 'production' : 'development'
-    const env: ConfigEnv = {mode, command: 'serve'}
+    const command: ConfigEnv['command'] = mode === 'production' ? 'build' : 'serve'
+    const env: ConfigEnv = {mode, command}
 
     const projectConfigMaybe =
       typeof viteConfigFactory === 'function' ? viteConfigFactory(env) : viteConfigFactory


### PR DESCRIPTION
### Description

This PR extends the Sanity CLI configuration in the kitchensink-react app to integrate with the app's Vite configuration. It adds a `vite` function that merges the app's Vite config with Sanity CLI's internal Vite config, handling plugin deduplication and ensuring React Refresh isn't injected twice. The implementation carefully merges plugins, resolve aliases, define variables, and server settings.

### What to review

- The plugin merging logic that prevents duplicates and avoids double React Refresh injection
- The resolution of the app's Vite config and proper merging with Sanity CLI's config
- The handling of different configuration sections (plugins, resolve, define, server)
- The TypeScript types imported from Vite

### Testing

This change should be tested by running the kitchensink-react app in both development and production modes to ensure that:
- The app builds and runs correctly
- Vite plugins from both configs are properly applied
- React Refresh works as expected in development mode
- No console errors related to duplicate plugins or configurations

### Fun gif
![drift merge](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExY3g2ZzdlODhjZ2Z4NWR5d21jajc4MDNzam45ZHRmOWp6eGJyYmZ5NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mNT2zQTgAEY5q/giphy.gif)