### PR TITLE
feat: make applyDocumentActions more similar to the rest

### DIFF
--- a/packages/core/src/document/applyDocumentActions.test.ts
+++ b/packages/core/src/document/applyDocumentActions.test.ts
@@ -72,7 +72,8 @@ describe('applyDocumentActions', () => {
     }
 
     // Call applyDocumentActions with a fixed transactionId for reproducibility.
-    const applyPromise = applyDocumentActions(instance, action, {
+    const applyPromise = applyDocumentActions(instance, {
+      actions: [action],
       transactionId: 'txn-success',
     })
 
@@ -128,7 +129,8 @@ describe('applyDocumentActions', () => {
     }
 
     // Call applyDocumentActions with a fixed transactionId.
-    const applyPromise = applyDocumentActions(instance, action, {
+    const applyPromise = applyDocumentActions(instance, {
+      actions: [action],
       transactionId: 'txn-error',
     })
 
@@ -160,7 +162,8 @@ describe('applyDocumentActions', () => {
       dataset: 'd',
     }
     // Call applyDocumentActions with the context using childInstance, but with action requiring parent's config
-    const applyPromise = applyDocumentActions(childInstance, action, {
+    const applyPromise = applyDocumentActions(childInstance, {
+      actions: [action],
       transactionId: 'txn-child-match',
     })
 

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -281,16 +281,20 @@ export const getDocumentSyncStatus = bindActionByDataset(
   }),
 )
 
+type PermissionsStateOptions = {
+  actions: DocumentAction[]
+}
+
 /** @beta */
 export const getPermissionsState = bindActionByDataset(
   documentStore,
   createStateSourceAction({
     selector: calculatePermissions,
-    onSubscribe: (context, actions) =>
+    onSubscribe: (context, {actions}: PermissionsStateOptions) =>
       manageSubscriberIds(context, getDocumentIdsFromActions(actions)),
   }) as StoreAction<
     DocumentStoreState,
-    [DocumentAction | DocumentAction[]],
+    [PermissionsStateOptions],
     StateSource<ReturnType<typeof calculatePermissions>>
   >,
 )
@@ -298,9 +302,9 @@ export const getPermissionsState = bindActionByDataset(
 /** @beta */
 export const resolvePermissions = bindActionByDataset(
   documentStore,
-  ({instance}, actions: DocumentAction | DocumentAction[]) => {
+  ({instance}, options: PermissionsStateOptions) => {
     return firstValueFrom(
-      getPermissionsState(instance, actions).observable.pipe(filter((i) => i !== undefined)),
+      getPermissionsState(instance, options).observable.pipe(filter((i) => i !== undefined)),
     )
   },
 )

--- a/packages/core/src/document/permissions.test.ts
+++ b/packages/core/src/document/permissions.test.ts
@@ -75,7 +75,7 @@ describe('calculatePermissions', () => {
     const actions: DocumentAction[] = [
       {documentId: 'doc1', type: 'document.create', documentType: 'article'},
     ]
-    const result = calculatePermissions({instance, state}, actions)
+    const result = calculatePermissions({instance, state}, {actions})
     expect(result).toEqual({allowed: true})
   })
 
@@ -91,7 +91,7 @@ describe('calculatePermissions', () => {
     const actions: DocumentAction[] = [
       {documentId: 'doc1', type: 'document.create', documentType: 'article'},
     ]
-    expect(calculatePermissions({instance, state}, actions)).toBeUndefined()
+    expect(calculatePermissions({instance, state}, {actions})).toBeUndefined()
   })
 
   it('should catch PermissionActionError from processActions and return allowed false with a reason', () => {
@@ -107,7 +107,7 @@ describe('calculatePermissions', () => {
     const actions: DocumentAction[] = [
       {documentId: 'doc1', type: 'document.create', documentType: 'article'},
     ]
-    const result = calculatePermissions({instance, state}, actions)
+    const result = calculatePermissions({instance, state}, {actions})
     expect(result).toBeDefined()
     expect(result?.allowed).toBe(false)
     expect(result?.reasons).toEqual(
@@ -135,7 +135,7 @@ describe('calculatePermissions', () => {
     const actions: DocumentAction[] = [
       {documentId: 'doc1', documentType: 'book', type: 'document.edit'},
     ]
-    const result = calculatePermissions({instance, state}, actions)
+    const result = calculatePermissions({instance, state}, {actions})
     expect(result).toBeDefined()
     expect(result?.allowed).toBe(false)
     expect(result?.reasons).toEqual(
@@ -161,7 +161,7 @@ describe('calculatePermissions', () => {
     const actions: DocumentAction[] = [
       {documentId: 'doc1', documentType: 'book', type: 'document.edit'},
     ]
-    const result = calculatePermissions({instance, state}, actions)
+    const result = calculatePermissions({instance, state}, {actions})
     expect(result).toBeDefined()
     expect(result?.allowed).toBe(false)
     expect(result?.reasons).toEqual(
@@ -185,7 +185,7 @@ describe('calculatePermissions', () => {
     const actions: DocumentAction[] = [
       {documentId: 'doc1', type: 'document.create', documentType: 'article'},
     ]
-    expect(calculatePermissions({instance, state}, actions)).toBeUndefined()
+    expect(calculatePermissions({instance, state}, {actions})).toBeUndefined()
   })
 
   it('should catch ActionError from processActions and return a precondition error reason', () => {
@@ -200,7 +200,7 @@ describe('calculatePermissions', () => {
     const actions: DocumentAction[] = [
       {documentId: 'doc1', documentType: 'book', type: 'document.delete'},
     ]
-    const result = calculatePermissions({instance, state}, actions)
+    const result = calculatePermissions({instance, state}, {actions})
     expect(result).toBeDefined()
     expect(result?.allowed).toBe(false)
     expect(result?.reasons).toEqual(
@@ -228,8 +228,8 @@ describe('calculatePermissions', () => {
       documentType: 'article',
     }
     // notice how the action is a copy
-    const result1 = calculatePermissions({instance, state}, [{...action}])
-    const result2 = calculatePermissions({instance, state}, [{...action}])
+    const result1 = calculatePermissions({instance, state}, {actions: [{...action}]})
+    const result2 = calculatePermissions({instance, state}, {actions: [{...action}]})
     expect(result1).toBe(result2)
   })
 })

--- a/packages/core/src/document/permissions.ts
+++ b/packages/core/src/document/permissions.ts
@@ -58,15 +58,14 @@ const nullReplacer: object = {}
 const documentsSelector = createSelector(
   [
     ({state: {documentStates}}: SelectorContext<SyncTransactionState>) => documentStates,
-    (_context: SelectorContext<SyncTransactionState>, actions: DocumentAction | DocumentAction[]) =>
+    (_context: SelectorContext<SyncTransactionState>, {actions}: {actions: DocumentAction[]}) =>
       actions,
   ],
   (documentStates, actions) => {
-    const actionArray = Array.isArray(actions) ? actions : [actions]
     // Collect all document IDs needed for permission checks.
     // Important: liveEdit documents don't have drafts, so we only fetch the single document to avoid waiting for non-existent draft documents.
     const documentIds = new Set(
-      actionArray
+      actions
         .map((action) => {
           if (typeof action.documentId !== 'string') return []
           // For liveEdit documents, only fetch the single document
@@ -107,7 +106,7 @@ const documentsSelector = createSelector(
 const memoizedActionsSelector = createSelector(
   [
     documentsSelector,
-    (_state: SelectorContext<SyncTransactionState>, actions: DocumentAction | DocumentAction[]) =>
+    (_state: SelectorContext<SyncTransactionState>, {actions}: {actions: DocumentAction[]}) =>
       actions,
   ],
   (documents, actions) => {

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -587,8 +587,7 @@ export function manageSubscriberIds(
   }
 }
 
-export function getDocumentIdsFromActions(action: DocumentAction | DocumentAction[]): string[] {
-  const actions = Array.isArray(action) ? action : [action]
+export function getDocumentIdsFromActions(actions: DocumentAction[]): string[] {
   return Array.from(
     new Set(
       actions

--- a/packages/react/src/hooks/document/useApplyDocumentActions.test.ts
+++ b/packages/react/src/hooks/document/useApplyDocumentActions.test.ts
@@ -1,20 +1,135 @@
-import {applyDocumentActions} from '@sanity/sdk'
+import {applyDocumentActions, type SanityInstance} from '@sanity/sdk'
 import {describe, it} from 'vitest'
 
-import {createCallbackHook} from '../helpers/createCallbackHook'
+import {useSanityInstance} from '../context/useSanityInstance'
+import {useApplyDocumentActions} from './useApplyDocumentActions'
 
-vi.mock('../helpers/createCallbackHook', () => ({
-  createCallbackHook: vi.fn((cb) => () => cb),
-}))
 vi.mock('@sanity/sdk', async (importOriginal) => {
   const original = await importOriginal<typeof import('@sanity/sdk')>()
   return {...original, applyDocumentActions: vi.fn()}
 })
 
+vi.mock('../context/useSanityInstance')
+
+// These are quite fragile mocks, but they are useful enough for now.
+const instances: Record<string, SanityInstance | undefined> = {
+  'p123.d': {__id: 'p123.d'} as unknown as SanityInstance,
+  'p.d123': {__id: 'p.d123'} as unknown as SanityInstance,
+  'p123.d123': {__id: 'p123.d123'} as unknown as SanityInstance,
+}
+
+const instance = {
+  match({projectId = 'p', dataset = 'd'}): SanityInstance | undefined {
+    return instances[`${projectId}.${dataset}`]
+  },
+} as unknown as SanityInstance
+
 describe('useApplyDocumentActions', () => {
-  it('calls `createCallbackHook` with `applyActions`', async () => {
-    expect(createCallbackHook).not.toHaveBeenCalled()
-    await import('./useApplyDocumentActions')
-    expect(createCallbackHook).toHaveBeenCalledWith(applyDocumentActions)
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(useSanityInstance).mockReturnValueOnce(instance)
+  })
+
+  it('uses the SanityInstance', async () => {
+    const apply = useApplyDocumentActions()
+    apply({
+      type: 'document.edit',
+      documentType: 'post',
+      documentId: 'abc',
+    })
+
+    expect(applyDocumentActions).toHaveBeenCalledExactlyOnceWith(instance, {
+      actions: [
+        {
+          type: 'document.edit',
+          documentType: 'post',
+          documentId: 'abc',
+        },
+      ],
+    })
+  })
+
+  it('uses SanityInstance.match when projectId is overrideen', async () => {
+    const apply = useApplyDocumentActions()
+    apply({
+      type: 'document.edit',
+      documentType: 'post',
+      documentId: 'abc',
+
+      projectId: 'p123',
+    })
+
+    expect(applyDocumentActions).toHaveBeenCalledExactlyOnceWith(instances['p123.d'], {
+      actions: [
+        {
+          type: 'document.edit',
+          documentType: 'post',
+          documentId: 'abc',
+
+          projectId: 'p123',
+        },
+      ],
+    })
+  })
+
+  it('uses SanityInstance when dataset is overrideen', async () => {
+    const apply = useApplyDocumentActions()
+    apply({
+      type: 'document.edit',
+      documentType: 'post',
+      documentId: 'abc',
+
+      dataset: 'd123',
+    })
+
+    expect(applyDocumentActions).toHaveBeenCalledExactlyOnceWith(instance, {
+      actions: [
+        {
+          type: 'document.edit',
+          documentType: 'post',
+          documentId: 'abc',
+
+          dataset: 'd123',
+        },
+      ],
+    })
+  })
+
+  it('uses SanityInstance.amcth when projectId and dataset is overrideen', async () => {
+    const apply = useApplyDocumentActions()
+    apply({
+      type: 'document.edit',
+      documentType: 'post',
+      documentId: 'abc',
+
+      projectId: 'p123',
+      dataset: 'd123',
+    })
+
+    expect(applyDocumentActions).toHaveBeenCalledExactlyOnceWith(instances['p123.d123'], {
+      actions: [
+        {
+          type: 'document.edit',
+          documentType: 'post',
+          documentId: 'abc',
+
+          projectId: 'p123',
+          dataset: 'd123',
+        },
+      ],
+    })
+  })
+
+  it("throws if SanityInstance.match doesn't find anything", async () => {
+    const apply = useApplyDocumentActions()
+    expect(() => {
+      apply({
+        type: 'document.edit',
+        documentType: 'post',
+        documentId: 'abc',
+
+        projectId: 'other',
+      })
+    }).toThrow()
   })
 })

--- a/packages/react/src/hooks/document/useApplyDocumentActions.ts
+++ b/packages/react/src/hooks/document/useApplyDocumentActions.ts
@@ -6,7 +6,7 @@ import {
 } from '@sanity/sdk'
 import {type SanityDocument} from 'groq'
 
-import {createCallbackHook} from '../helpers/createCallbackHook'
+import {useSanityInstance} from '../context/useSanityInstance'
 // this import is used in an `{@link useEditDocument}`
 // eslint-disable-next-line unused-imports/no-unused-imports, import/consistent-type-specifier-style
 import type {useEditDocument} from './useEditDocument'
@@ -150,6 +150,46 @@ interface UseApplyDocumentActions {
  * }
  * ```
  */
-export const useApplyDocumentActions = createCallbackHook(
-  applyDocumentActions,
-) as UseApplyDocumentActions
+export const useApplyDocumentActions: UseApplyDocumentActions = () => {
+  const instance = useSanityInstance()
+
+  return (actionOrActions, options) => {
+    const actions = Array.isArray(actionOrActions) ? actionOrActions : [actionOrActions]
+
+    let projectId
+    let dataset
+    for (const action of actions) {
+      if (action.projectId) {
+        if (!projectId) projectId = action.projectId
+        if (action.projectId !== projectId) {
+          throw new Error(
+            `Mismatched project IDs found in actions. All actions must belong to the same project. Found "${action.projectId}" but expected "${projectId}".`,
+          )
+        }
+
+        if (action.dataset) {
+          if (!dataset) dataset = action.dataset
+          if (action.dataset !== dataset) {
+            throw new Error(
+              `Mismatched datasets found in actions. All actions must belong to the same dataset. Found "${action.dataset}" but expected "${dataset}".`,
+            )
+          }
+        }
+      }
+    }
+
+    if (projectId || dataset) {
+      const actualInstance = instance.match({projectId, dataset})
+      if (!actualInstance) {
+        throw new Error(
+          `Could not find a matching Sanity instance for the requested action: ${JSON.stringify({projectId, dataset}, null, 2)}.
+  Please ensure there is a ResourceProvider component with a matching configuration in the component hierarchy.`,
+        )
+      }
+
+      return applyDocumentActions(actualInstance, {actions, ...options})
+    }
+
+    return applyDocumentActions(instance, {actions, ...options})
+  }
+}

--- a/packages/react/src/hooks/document/useDocumentPermissions.test.tsx
+++ b/packages/react/src/hooks/document/useDocumentPermissions.test.tsx
@@ -97,7 +97,7 @@ describe('usePermissions', () => {
     })
 
     // ResourceProvider handles the instance configuration
-    expect(getPermissionsState).toHaveBeenCalledWith(expect.any(Object), mockAction)
+    expect(getPermissionsState).toHaveBeenCalledWith(expect.any(Object), {actions: [mockAction]})
     expect(result.current).toEqual(mockPermissionAllowed)
   })
 
@@ -140,7 +140,7 @@ describe('usePermissions', () => {
       ),
     })
 
-    expect(getPermissionsState).toHaveBeenCalledWith(expect.any(Object), actions)
+    expect(getPermissionsState).toHaveBeenCalledWith(expect.any(Object), {actions})
   })
 
   it('should throw an error if actions have mismatched project IDs', () => {
@@ -226,7 +226,7 @@ describe('usePermissions', () => {
 
     // Now it should render properly
     await waitFor(() => {
-      expect(getPermissionsState).toHaveBeenCalledWith(expect.any(Object), mockAction)
+      expect(getPermissionsState).toHaveBeenCalledWith(expect.any(Object), {actions: [mockAction]})
     })
   })
 

--- a/packages/react/src/hooks/document/useDocumentPermissions.ts
+++ b/packages/react/src/hooks/document/useDocumentPermissions.ts
@@ -84,7 +84,10 @@ import {useSanityInstance} from '../context/useSanityInstance'
 export function useDocumentPermissions(
   actionOrActions: DocumentAction | DocumentAction[],
 ): DocumentPermissionsResult {
-  const actions = Array.isArray(actionOrActions) ? actionOrActions : [actionOrActions]
+  const actions = useMemo(
+    () => (Array.isArray(actionOrActions) ? actionOrActions : [actionOrActions]),
+    [actionOrActions],
+  )
   // if actions is an array, we need to check that all actions belong to the same project and dataset
   let projectId
   let dataset
@@ -111,20 +114,20 @@ export function useDocumentPermissions(
 
   const instance = useSanityInstance({projectId, dataset})
   const isDocumentReady = useCallback(
-    () => getPermissionsState(instance, actionOrActions).getCurrent() !== undefined,
-    [actionOrActions, instance],
+    () => getPermissionsState(instance, {actions}).getCurrent() !== undefined,
+    [actions, instance],
   )
   if (!isDocumentReady()) {
     throw firstValueFrom(
-      getPermissionsState(instance, actionOrActions).observable.pipe(
+      getPermissionsState(instance, {actions}).observable.pipe(
         filter((result) => result !== undefined),
       ),
     )
   }
 
   const {subscribe, getCurrent} = useMemo(
-    () => getPermissionsState(instance, actionOrActions),
-    [actionOrActions, instance],
+    () => getPermissionsState(instance, {actions}),
+    [actions, instance],
   )
 
   return useSyncExternalStore(subscribe, getCurrent) as DocumentPermissionsResult


### PR DESCRIPTION
### Description

`applyDocumentActions` was the only function in the `core` package which interpreted the `SanityInstance` as a tree, automatically traversing the tree to find a matching instance. This is inconsistent with the other stores (e.g. query store) which assumes that it's being called with the right instance.

In addition, this changes `applyDocumentActions` to only accept actions as an array (so we don't have to check if it's an array or not) and also it places the `actions` as part of option. This is consistent with e.g. `getQueryState` which has a required `query` field in its options. This now means that all functions which are wrapped in `bindActionByDataset` are now consistently getting passed an object as their first argument. This is going to be key so that we later can modify this function to consider the options (instead of the instance).

There should be no breaking changes in the React package.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
