### PR TITLE
feat: support arbitrary sources in useQuery

### DIFF
--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -52,11 +52,13 @@ export {
 export {
   type DatasetHandle,
   type DocumentHandle,
+  type DocumentSource,
   type DocumentTypeHandle,
   type PerspectiveHandle,
   type ProjectHandle,
   type ReleasePerspective,
   type SanityConfig,
+  sourceFor,
 } from '../config/sanityConfig'
 export {getDatasetsState, resolveDatasets} from '../datasets/datasets'
 export {

--- a/packages/core/src/config/sanityConfig.ts
+++ b/packages/core/src/config/sanityConfig.ts
@@ -81,3 +81,32 @@ export interface SanityConfig extends DatasetHandle, PerspectiveHandle {
     enabled: boolean
   }
 }
+
+/**
+ * Represents a source which can be used by various functionality.
+ *
+ * @see sourceFor For how to initialize a new source for a dataset.
+ * @public
+ */
+export type DocumentSource = {
+  [__sourceData]: {
+    projectId: string
+    dataset: string
+  }
+}
+
+/**
+ * An internal symbol to avoid users to access data inside here.
+ *
+ * @internal
+ */
+export const __sourceData = Symbol('Sanity.DocumentSource')
+
+/**
+ * Creates a new {@link DocumentSource} object based on a projectId and dataset.
+ *
+ * @public
+ */
+export function sourceFor(data: {projectId: string; dataset: string}): DocumentSource {
+  return {[__sourceData]: data}
+}

--- a/packages/core/src/preview/subscribeToStateAndFetchBatches.ts
+++ b/packages/core/src/preview/subscribeToStateAndFetchBatches.ts
@@ -14,6 +14,7 @@ import {
   tap,
 } from 'rxjs'
 
+import {sourceFor} from '../config/sanityConfig'
 import {getQueryState, resolveQuery} from '../query/queryStore'
 import {type BoundDatasetKey} from '../store/createActionBinder'
 import {type StoreContext} from '../store/defineStore'
@@ -66,8 +67,7 @@ export const subscribeToStateAndFetchBatches = ({
             params,
             tag: PREVIEW_TAG,
             perspective: PREVIEW_PERSPECTIVE,
-            projectId,
-            dataset,
+            source: sourceFor({projectId, dataset}),
           })
           const source$ = defer(() => {
             if (getCurrent() === undefined) {
@@ -78,8 +78,7 @@ export const subscribeToStateAndFetchBatches = ({
                   tag: PREVIEW_TAG,
                   perspective: PREVIEW_PERSPECTIVE,
                   signal: controller.signal,
-                  projectId,
-                  dataset,
+                  source: sourceFor({projectId, dataset}),
                 }),
               ).pipe(switchMap(() => observable))
             }

--- a/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
+++ b/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
@@ -16,6 +16,7 @@ import {
   tap,
 } from 'rxjs'
 
+import {sourceFor} from '../config/sanityConfig'
 import {getQueryState, resolveQuery} from '../query/queryStore'
 import {type BoundDatasetKey} from '../store/createActionBinder'
 import {type StoreContext} from '../store/defineStore'
@@ -96,8 +97,7 @@ export const subscribeToStateAndFetchBatches = ({
           const {getCurrent, observable} = getQueryState<ProjectionQueryResult[]>(instance, {
             query,
             params,
-            projectId,
-            dataset,
+            source: sourceFor({projectId, dataset}),
             tag: PROJECTION_TAG,
             perspective: PROJECTION_PERSPECTIVE,
           })
@@ -108,8 +108,7 @@ export const subscribeToStateAndFetchBatches = ({
                 resolveQuery<ProjectionQueryResult[]>(instance, {
                   query,
                   params,
-                  projectId,
-                  dataset,
+                  source: sourceFor({projectId, dataset}),
                   tag: PROJECTION_TAG,
                   perspective: PROJECTION_PERSPECTIVE,
                   signal: controller.signal,

--- a/packages/core/src/query/queryStoreConstants.ts
+++ b/packages/core/src/query/queryStoreConstants.ts
@@ -7,4 +7,3 @@
  */
 export const QUERY_STATE_CLEAR_DELAY = 1000
 export const QUERY_STORE_API_VERSION = 'v2025-05-06'
-export const QUERY_STORE_DEFAULT_PERSPECTIVE = 'drafts'

--- a/packages/core/src/store/createActionBinder.ts
+++ b/packages/core/src/store/createActionBinder.ts
@@ -1,3 +1,4 @@
+import {__sourceData, type DocumentSource} from '../config/sanityConfig'
 import {type SanityInstance} from './createSanityInstance'
 import {createStoreInstance, type StoreInstance} from './createStoreInstance'
 import {type StoreState} from './createStoreState'
@@ -138,10 +139,11 @@ export function createActionBinder<
  */
 export const bindActionByDataset = createActionBinder<
   BoundDatasetKey,
-  [object & {projectId?: string; dataset?: string}]
+  [object & {projectId?: string; dataset?: string; source?: DocumentSource}]
 >((instance, options) => {
-  const projectId = options.projectId ?? instance.config.projectId
-  const dataset = options.dataset ?? instance.config.dataset
+  const sourceData = options.source?.[__sourceData]
+  const projectId = sourceData?.projectId ?? options.projectId ?? instance.config.projectId
+  const dataset = sourceData?.dataset ?? options.dataset ?? instance.config.dataset
   if (!projectId || !dataset) {
     throw new Error('This API requires a project ID and dataset configured.')
   }

--- a/packages/react/src/hooks/documents/useDocuments.ts
+++ b/packages/react/src/hooks/documents/useDocuments.ts
@@ -1,9 +1,4 @@
-import {
-  createGroqSearchFilter,
-  type DatasetHandle,
-  type DocumentHandle,
-  type QueryOptions,
-} from '@sanity/sdk'
+import {createGroqSearchFilter, type DatasetHandle, type DocumentHandle} from '@sanity/sdk'
 import {type SortOrderingItem} from '@sanity/types'
 import {pick} from 'lodash-es'
 import {useCallback, useEffect, useMemo, useState} from 'react'
@@ -23,8 +18,7 @@ export interface DocumentsOptions<
   TDocumentType extends string = string,
   TDataset extends string = string,
   TProjectId extends string = string,
-> extends DatasetHandle<TDataset, TProjectId>,
-    Pick<QueryOptions, 'perspective' | 'params'> {
+> extends DatasetHandle<TDataset, TProjectId> {
   /**
    * Filter documents by their `_type`. Can be a single type or an array of types.
    */
@@ -45,6 +39,8 @@ export interface DocumentsOptions<
    * Text search query to filter results
    */
   search?: string
+
+  params?: Record<string, unknown>
 }
 
 /**

--- a/packages/react/src/hooks/errors/useCorsOriginError.ts
+++ b/packages/react/src/hooks/errors/useCorsOriginError.ts
@@ -2,17 +2,20 @@ import {CorsOriginError} from '@sanity/client'
 import {clearQueryError, getCorsErrorProjectId, getQueryErrorState} from '@sanity/sdk'
 import {useCallback, useMemo, useSyncExternalStore} from 'react'
 
-import {useSanityInstance} from '../context/useSanityInstance'
+import {useSanityInstanceAndSource} from '../context/useSanityInstance'
 
 export function useCorsOriginError(): {
   error: Error | null
   projectId: string | null
   clear: () => void
 } {
-  const instance = useSanityInstance()
-  const {getCurrent, subscribe} = useMemo(() => getQueryErrorState(instance), [instance])
+  const [instance, source] = useSanityInstanceAndSource({})
+  const {getCurrent, subscribe} = useMemo(
+    () => getQueryErrorState(instance, {source}),
+    [instance, source],
+  )
   const error = useSyncExternalStore(subscribe, getCurrent)
-  const clear = useCallback(() => clearQueryError(instance), [instance])
+  const clear = useCallback(() => clearQueryError(instance, {source}), [instance, source])
   const value = useMemo(() => {
     if (!(error instanceof CorsOriginError)) return {error: null, projectId: null}
 

--- a/packages/react/src/hooks/paginatedDocuments/usePaginatedDocuments.ts
+++ b/packages/react/src/hooks/paginatedDocuments/usePaginatedDocuments.ts
@@ -1,10 +1,10 @@
-import {createGroqSearchFilter, type DocumentHandle, type QueryOptions} from '@sanity/sdk'
+import {createGroqSearchFilter, type DocumentHandle} from '@sanity/sdk'
 import {type SortOrderingItem} from '@sanity/types'
 import {pick} from 'lodash-es'
 import {useCallback, useEffect, useMemo, useState} from 'react'
 
 import {useSanityInstance} from '../context/useSanityInstance'
-import {useQuery} from '../query/useQuery'
+import {useQuery, type UseQueryOptions} from '../query/useQuery'
 
 /**
  * Configuration options for the usePaginatedDocuments hook
@@ -12,11 +12,8 @@ import {useQuery} from '../query/useQuery'
  * @public
  * @category Types
  */
-export interface PaginatedDocumentsOptions<
-  TDocumentType extends string = string,
-  TDataset extends string = string,
-  TProjectId extends string = string,
-> extends Omit<QueryOptions<TDocumentType, TDataset, TProjectId>, 'query'> {
+export interface PaginatedDocumentsOptions<TDocumentType extends string = string>
+  extends Omit<UseQueryOptions<TDocumentType>, 'query'> {
   documentType?: TDocumentType | TDocumentType[]
   /**
    * GROQ filter expression to apply to the query
@@ -232,7 +229,7 @@ export function usePaginatedDocuments<
   orderings,
   search,
   ...options
-}: PaginatedDocumentsOptions<TDocumentType, TDataset, TProjectId>): PaginatedDocumentsResponse<
+}: PaginatedDocumentsOptions<TDocumentType>): PaginatedDocumentsResponse<
   TDocumentType,
   TDataset,
   TProjectId

--- a/packages/react/src/type.ts
+++ b/packages/react/src/type.ts
@@ -1,0 +1,27 @@
+import {type DocumentSource} from '@sanity/sdk'
+
+/**
+ * Option which can be used for deciding which source to traget.
+ *
+ * This uses the following strategy:
+ *
+ * 1. If `source` is given it will use this source and ignore the other parameters.
+ * 2. If `dataset` or `projectId` is given it will look inside the current Sanity instances for them.
+ * 3. Otherwise, it uses the current projectId/dataset on the current Sanity instances.
+ */
+export type SourceOptions = {
+  /**
+   * The source (e.g. dataset) which will be queried.
+   */
+  source?: DocumentSource
+
+  /**
+   * Overrides the project ID for this query.
+   */
+  projectId?: string
+
+  /**
+   * Overrides the project ID for this query.
+   */
+  dataset?: string
+}


### PR DESCRIPTION
### Description

This contains a non-breaking change to `useQuery` (and other hooks which uses this under the hood) of accepting a `source` parameter. This can be used to query datasets which are not part of the current context.

However, this has lead to some breaking changes to the `core` package:

- The QueryOptions no longer takes an _optional_ projectId/dataset, but  rather a _required_ `source`. This will always represent the resource we'll be querying.
- The same applies to `perspective`. This is part of the work of decoupling the perspective setting from the SanityInstace.
- However, since we still want `useQuery` to have the same options we've now introduced a new UseQueryOptions. This could potentially be considered a breaking change.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
