### PR TITLE
fix(core): correctly handle state changes during onSubscribe in createStateSourceAction

### DIFF
--- a/packages/core/src/favorites/favorites.test.ts
+++ b/packages/core/src/favorites/favorites.test.ts
@@ -146,8 +146,9 @@ describe('favoritesStore', () => {
       await firstValueFrom(state.observable)
       expect(mockFetch).toHaveBeenCalledTimes(1)
       // Second subscriber should use cached response
-      const sub2 = state.subscribe()
-      await firstValueFrom(state.observable)
+      const state2 = getFavoritesState(instance!, mockContext)
+      const sub2 = state2.subscribe()
+      await firstValueFrom(state2.observable)
       expect(mockFetch).toHaveBeenCalledTimes(1)
       // Cleanup
       sub1()

--- a/packages/core/src/projection/getProjectionState.test.ts
+++ b/packages/core/src/projection/getProjectionState.test.ts
@@ -126,7 +126,7 @@ describe('getProjectionState', () => {
     expect(state.get().subscriptions).toEqual({})
     expect(state.get().documentProjections).toEqual({})
 
-    const unsubscribe1 = projectionState1.subscribe(vi.fn()) // Should use ID 3
+    const unsubscribe1 = projectionState1.subscribe(vi.fn()) // Should use ID 2
     expect(state.get().subscriptions).toEqual({
       [docHandle.documentId]: {[hash1]: {testSubId_2: true}},
     })
@@ -134,7 +134,7 @@ describe('getProjectionState', () => {
       [docHandle.documentId]: {[hash1]: projection1},
     })
 
-    const unsubscribe2 = projectionState2.subscribe(vi.fn()) // Should use ID 4
+    const unsubscribe2 = projectionState2.subscribe(vi.fn()) // Should use ID 3
     expect(state.get().subscriptions).toEqual({
       [docHandle.documentId]: {
         [hash1]: {testSubId_2: true},
@@ -148,10 +148,12 @@ describe('getProjectionState', () => {
       },
     })
 
-    const unsubscribe3 = projectionState1.subscribe(vi.fn()) // Should use ID 5
+    // should share ID 2 from the first subscription -- we only care if ANY subscription exists
+    // so we can include the document / projection in a bulk fetch
+    const unsubscribe3 = projectionState1.subscribe(vi.fn())
     expect(state.get().subscriptions).toEqual({
       [docHandle.documentId]: {
-        [hash1]: {testSubId_2: true, testSubId_4: true},
+        [hash1]: {testSubId_2: true},
         [hash2]: {testSubId_3: true},
       },
     })
@@ -165,23 +167,20 @@ describe('getProjectionState', () => {
     })
 
     // --- Test Unsubscribe ---
-    unsubscribe1() // Unsubscribes ID 3
-    expect(state.get().subscriptions[docHandle.documentId]?.[hash1]).toEqual({
-      testSubId_2: true,
-      testSubId_4: true,
-    })
+    unsubscribe1() // Unsubscribes first subscription consumer
+    expect(state.get().subscriptions[docHandle.documentId]?.[hash1]).toEqual({testSubId_2: true})
     vi.advanceTimersByTime(PROJECTION_STATE_CLEAR_DELAY)
-    expect(state.get().subscriptions[docHandle.documentId]?.[hash1]).toEqual({testSubId_4: true})
+    expect(state.get().subscriptions[docHandle.documentId]?.[hash1]).toEqual({testSubId_2: true})
     expect(state.get().documentProjections[docHandle.documentId]?.[hash1]).toEqual(projection1)
 
-    unsubscribe3() // Unsubscribes ID 5
+    unsubscribe3() // Also unsubscibes first projection subscription, should be removed
     vi.advanceTimersByTime(PROJECTION_STATE_CLEAR_DELAY)
     expect(state.get().subscriptions[docHandle.documentId]?.[hash1]).toBeUndefined()
     expect(state.get().documentProjections[docHandle.documentId]?.[hash1]).toBeUndefined()
     expect(state.get().subscriptions[docHandle.documentId]?.[hash2]).toEqual({testSubId_3: true})
     expect(state.get().documentProjections[docHandle.documentId]?.[hash2]).toEqual(projection2)
 
-    unsubscribe2() // Unsubscribes ID 4
+    unsubscribe2() // Unsubscribes second projection subscription, should be removed
     vi.advanceTimersByTime(PROJECTION_STATE_CLEAR_DELAY)
     expect(state.get().subscriptions[docHandle.documentId]).toBeUndefined()
     expect(state.get().documentProjections[docHandle.documentId]).toBeUndefined()
@@ -203,14 +202,14 @@ describe('getProjectionState', () => {
     }))
 
     const unsubscribe1 = projectionState.subscribe(vi.fn()) // Should use ID 2
-    const unsubscribe2 = projectionState.subscribe(vi.fn()) // Should use ID 3
+    const unsubscribe2 = projectionState.subscribe(vi.fn()) // Should reuse ID 2
 
     expect(state.get().values[docHandle.documentId]?.[hash]).toEqual({
       data: initialData,
       isPending: true,
     })
 
-    unsubscribe1() // Unsubscribes ID 2
+    unsubscribe1() // Unsubscribes first subscription consumer
     vi.advanceTimersByTime(PROJECTION_STATE_CLEAR_DELAY)
     expect(state.get().values[docHandle.documentId]?.[hash]).toEqual({
       data: initialData,
@@ -219,9 +218,10 @@ describe('getProjectionState', () => {
     expect(Object.keys(state.get().subscriptions[docHandle.documentId]?.[hash] ?? {}).length).toBe(
       1,
     )
-    expect(state.get().subscriptions[docHandle.documentId]?.[hash]).toEqual({testSubId_3: true})
+    // should still have the same subscription ID since we're not unsubscribing the second consumer
+    expect(state.get().subscriptions[docHandle.documentId]?.[hash]).toEqual({testSubId_2: true})
 
-    unsubscribe2() // Unsubscribes ID 3
+    unsubscribe2() // Unsubscribes second subscription consumer
     expect(state.get().values[docHandle.documentId]?.[hash]).toEqual({
       data: initialData,
       isPending: true,

--- a/packages/core/src/store/createStateSourceAction.test.ts
+++ b/packages/core/src/store/createStateSourceAction.test.ts
@@ -1,3 +1,4 @@
+import {filter, firstValueFrom, timeout} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createSanityInstance, type SanityInstance} from './createSanityInstance'
@@ -193,5 +194,66 @@ describe('createStateSourceAction', () => {
     expect(context1).not.toBe(context2)
     expect(context1.instance).toBe(instance)
     expect(context2.instance).toBe(secondInstance)
+  })
+
+  it('correctly observes values defined in the onSubscribe', async () => {
+    const selector = vi.fn(({state: s}: SelectorContext<CountStoreState>) => s.count)
+    const source = createStateSourceAction({
+      selector: selector,
+      onSubscribe() {
+        state.set('update', {count: 1})
+      },
+    })({state, instance, key: null})
+
+    const value = await firstValueFrom(
+      source.observable.pipe(
+        filter((i) => i === 1),
+        timeout(10),
+      ),
+    )
+    expect(value).toBe(1)
+  })
+
+  it('only invokes selector once on changes', () => {
+    const selector = vi.fn(({state: s}: SelectorContext<CountStoreState>) => s.count)
+    const source = createStateSourceAction({selector: selector})({state, instance, key: null})
+
+    expect(selector).toBeCalledTimes(0)
+
+    // Now it should be called once:
+    const sub = source.observable.subscribe()
+    expect(selector).toBeCalledTimes(1)
+
+    // The observable should be shared so this shouldn't invoke it first.
+    const sub2 = source.observable.subscribe()
+    expect(selector).toBeCalledTimes(1)
+
+    // Updating the value should only invoke it once:
+    state.set('update', {count: 1})
+    expect(selector).toBeCalledTimes(2)
+
+    sub2.unsubscribe()
+    sub.unsubscribe()
+
+    // Once everyone has unsubscribed it should be invoked again.
+    const sub3 = source.observable.subscribe()
+    expect(selector).toBeCalledTimes(3)
+    sub3.unsubscribe()
+  })
+
+  it('only subscribes once when mixing subscribe/observable', () => {
+    const selector = vi.fn(({state: s}: SelectorContext<CountStoreState>) => s.count)
+    const source = createStateSourceAction({selector: selector})({state, instance, key: null})
+
+    expect(selector).toBeCalledTimes(0)
+
+    const sub = source.observable.subscribe()
+    expect(selector).toBeCalledTimes(1)
+
+    const sub2 = source.subscribe()
+    expect(selector).toBeCalledTimes(1)
+
+    sub.unsubscribe()
+    sub2()
   })
 })

--- a/packages/core/src/store/createStateSourceAction.ts
+++ b/packages/core/src/store/createStateSourceAction.ts
@@ -1,4 +1,4 @@
-import {defer, distinctUntilChanged, finalize, map, Observable, share, skip} from 'rxjs'
+import {defer, distinctUntilChanged, finalize, map, Observable, shareReplay, skip} from 'rxjs'
 
 import {type StoreAction} from './createActionBinder'
 import {type SanityInstance} from './createSanityInstance'
@@ -215,7 +215,11 @@ export function createStateSourceAction<TState, TParams extends unknown[], TRetu
       values = withSubscribeHook(values, () => subscribeHandler(context, ...params))
     }
 
-    const sharedValues = values.pipe(share())
+    // Share but replay the latest value so every subscriber gets an
+    // initial synchronous emission, matching `state.observable`. That keeps
+    // `skip(1)` in `subscribe()` aligned with "skip current snapshot" rather than
+    // silently eating the first real update after multicasting.
+    const sharedValues = values.pipe(shareReplay({bufferSize: 1, refCount: true}))
 
     const subscribe = (onStoreChanged?: () => void) => {
       const subscription = sharedValues.pipe(skip(1)).subscribe({

--- a/packages/core/src/store/createStateSourceAction.ts
+++ b/packages/core/src/store/createStateSourceAction.ts
@@ -1,4 +1,4 @@
-import {distinctUntilChanged, map, Observable, share, skip} from 'rxjs'
+import {defer, distinctUntilChanged, finalize, map, Observable, share, skip} from 'rxjs'
 
 import {type StoreAction} from './createActionBinder'
 import {type SanityInstance} from './createSanityInstance'
@@ -187,8 +187,7 @@ export function createStateSourceAction<TState, TParams extends unknown[], TRetu
   function stateSourceAction(context: StoreContext<TState, TKey>, ...params: TParams) {
     const {state, instance} = context
 
-    const getCurrent = () => {
-      const currentState = state.get()
+    const getCurrent = (currentState: TState) => {
       if (typeof currentState !== 'object' || currentState === null) {
         throw new Error(
           `Expected store state to be an object but got "${typeof currentState}" instead`,
@@ -208,53 +207,45 @@ export function createStateSourceAction<TState, TParams extends unknown[], TRetu
       return selector(selectorContext, ...params)
     }
 
-    // Subscription manager handles both RxJS and direct subscriptions
-    const subscribe = (onStoreChanged?: () => void) => {
-      // Run setup handler if provided
-      const cleanup = subscribeHandler?.(context, ...params)
+    // `state.observable` will emit the current value immediately and
+    // hence we inherit the same behavior here.
+    let values = state.observable.pipe(map(getCurrent), distinctUntilChanged(isEqual))
 
-      // Set up state change subscription
-      const subscription = state.observable
-        .pipe(
-          // Derive value from current state
-          map(getCurrent),
-          // Filter unchanged values using custom equality check
-          distinctUntilChanged(isEqual),
-          // Skip initial emission since we only want changes
-          skip(1),
-        )
-        .subscribe({
-          next: () => onStoreChanged?.(),
-          // Propagate selector errors to both subscription types
-          error: () => onStoreChanged?.(),
-        })
+    if (subscribeHandler) {
+      values = withSubscribeHook(values, () => subscribeHandler(context, ...params))
+    }
+
+    const sharedValues = values.pipe(share())
+
+    const subscribe = (onStoreChanged?: () => void) => {
+      const subscription = sharedValues.pipe(skip(1)).subscribe({
+        next: () => onStoreChanged?.(),
+        // Propagate selector errors to both subscription types
+        error: () => onStoreChanged?.(),
+      })
 
       return () => {
         subscription.unsubscribe()
-        cleanup?.()
       }
     }
 
-    // Create shared observable that handles multiple subscribers efficiently
-    const observable = new Observable<TReturn>((observer) => {
-      const emitCurrent = () => {
-        try {
-          observer.next(getCurrent())
-        } catch (error) {
-          observer.error(error)
-        }
-      }
-      // Emit immediately on subscription
-      emitCurrent()
-      return subscribe(emitCurrent)
-    }).pipe(share())
-
     return {
-      getCurrent,
+      getCurrent: () => getCurrent(state.get()),
       subscribe,
-      observable,
+      observable: sharedValues,
     }
   }
 
   return stateSourceAction
+}
+
+/**
+ * Creates a new Observable which wraps an existing Observable which will invoke
+ * the function when a new subscriber appears.
+ */
+function withSubscribeHook<T>(obs: Observable<T>, fn: () => void | (() => void)): Observable<T> {
+  return defer(() => {
+    const cleanup = fn()
+    return cleanup ? obs.pipe(finalize(() => cleanup())) : obs
+  })
 }

--- a/packages/core/src/utils/createFetcherStore.test.ts
+++ b/packages/core/src/utils/createFetcherStore.test.ts
@@ -127,8 +127,9 @@ describe('createFetcherStore', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1)
 
     // Second subscription within throttle interval
-    const sub2 = stateSource.subscribe()
-    await firstValueFrom(stateSource.observable)
+    const stateSource2 = store.getState(instance, 1)
+    const sub2 = stateSource2.subscribe()
+    await firstValueFrom(stateSource2.observable)
     expect(fetchSpy).toHaveBeenCalledTimes(1)
 
     // Advance past throttle interval
@@ -136,8 +137,9 @@ describe('createFetcherStore', () => {
     await vi.advanceTimersByTimeAsync(1000)
 
     // Third subscription after throttle interval
-    const sub3 = stateSource.subscribe()
-    await firstValueFrom(stateSource.observable)
+    const stateSource3 = store.getState(instance, 1)
+    const sub3 = stateSource3.subscribe()
+    await firstValueFrom(stateSource3.observable)
     expect(fetchSpy).toHaveBeenCalledTimes(2)
 
     sub1()


### PR DESCRIPTION
### Description

This fixes a quite subtle bug: Any state changes happening in `onSubscribe` would be not be part of the source.observable. The reason for this is that the implementation would do:

1. First emit the current value by looking at state.get()
2. Invoke the onSubscribe hook.
3. Listen to the observable of state, but skip the first value because we expect it to emit the current state first.

However, this means that if (2) actually _changes_ the state synchronously then that's the value that is skipped in (3) happens to be the new state.

We're using this pattern in `getDocumentSyncStatus`.

This changes the implementation to be based around an observable which contains the actual values. This is both shorter in code and also happens to avoid calling `getCurrent` multiple times. Previously `getCurrent` would be invoked twice: Once for detecting that a value had changed and once again when producing the value.

### What to review

- Try to determine if there's some edge cases scenarios where this new (more correct IMO) behavior could happen.
- Also wondering if there's a better pattern for `withSubscribeHook`.

### Testing

- I've added new unit tests for this behavior.

### Fun gif

Sorry, I couldn't find any fun gifs about RxJS.
