### PR TITLE
fix: handle projectUserNotFoundErrors and display the error message

### DIFF
--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -24,6 +24,13 @@ export {
 export {observeOrganizationVerificationState} from '../auth/getOrganizationVerificationState'
 export {handleAuthCallback} from '../auth/handleAuthCallback'
 export {logout} from '../auth/logout'
+export {
+  type ApiErrorBody,
+  getClientErrorApiBody,
+  getClientErrorApiDescription,
+  getClientErrorApiType,
+  isProjectUserNotFoundClientError,
+} from '../auth/utils'
 export type {ClientStoreState as ClientState} from '../client/clientStore'
 export {type ClientOptions, getClient, getClientState} from '../client/clientStore'
 export {

--- a/packages/core/src/auth/utils.ts
+++ b/packages/core/src/auth/utils.ts
@@ -1,3 +1,4 @@
+import {type ClientError} from '@sanity/client'
 import {EMPTY, fromEvent, Observable} from 'rxjs'
 
 import {AUTH_CODE_PARAM, DEFAULT_BASE} from './authConstants'
@@ -133,4 +134,39 @@ export function getCleanedUrl(locationUrl: string): string {
   loc.searchParams.delete('sid')
   loc.searchParams.delete('url')
   return loc.toString()
+}
+
+// -----------------------------------------------------------------------------
+// ClientError helpers (shared)
+// -----------------------------------------------------------------------------
+
+/** @internal */
+export type ApiErrorBody = {
+  error?: {type?: string; description?: string}
+  type?: string
+  description?: string
+  message?: string
+}
+
+/** @internal Extracts the structured API error body from a ClientError, if present. */
+export function getClientErrorApiBody(error: ClientError): ApiErrorBody | undefined {
+  const body: unknown = (error as ClientError).response?.body
+  return body && typeof body === 'object' ? (body as ApiErrorBody) : undefined
+}
+
+/** @internal Returns the error type string from an API error body, if available. */
+export function getClientErrorApiType(error: ClientError): string | undefined {
+  const body = getClientErrorApiBody(error)
+  return body?.error?.type ?? body?.type
+}
+
+/** @internal Returns the error description string from an API error body, if available. */
+export function getClientErrorApiDescription(error: ClientError): string | undefined {
+  const body = getClientErrorApiBody(error)
+  return body?.error?.description ?? body?.description
+}
+
+/** @internal True if the error represents a projectUserNotFoundError. */
+export function isProjectUserNotFoundClientError(error: ClientError): boolean {
+  return getClientErrorApiType(error) === 'projectUserNotFoundError'
 }


### PR DESCRIPTION
### Description

This PR adds utility functions for handling client errors in the authentication flow. It exports several functions from the auth/utils module to help extract and interpret error information from ClientError objects. The main additions include:


- Added a function to specifically detect "projectUserNotFoundError" errors
- Updated the LoginError component to use these new utilities for better error handling
- Improved the user experience by conditionally showing retry CTAs based on the error type
- Exported utility functions for extracting API error bodies, types, and descriptions from ClientError objects

<img width="1562" height="542" alt="CleanShot 2025-10-22 at 14 25 59@2x" src="https://github.com/user-attachments/assets/fdf87885-76dc-4d33-85fc-322419de592a" />


### What to review

- The new utility functions in `auth/utils.ts` for handling ClientError objects
- The exports added to the core package
- The implementation in LoginError component that uses these utilities to provide better error messages
- The conditional rendering of the retry CTA based on error type

### Testing

Test by:
1. Change the Kitchensink config to `{
    projectId: 'txacgfm1',
    dataset: 'production' },`
2. Set `verifyOrganization={false}` prop on the `SDKProvider` component in the `SanityApp`
3. Run `pnpm run deploy:kitchensink`
4. Visit https://www.sanity.io/@oblZgbTFj/application/wkyoigmzawwnnwx458zgoh46/document-list
5. Observe error message instead of endless rerendering and token refreshing
    

### Fun gif
![not found](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzB0ZjI2ano0cjZlZmh6eGl1cXZjOW9ubTh5d214ZGN4MWEyZDBiMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/hEc4k5pN17GZq/giphy.gif)
