### PR TITLE
feat(access): if a project user can't be found envoke dashboard request-access flow

### DIFF
--- a/packages/react/src/components/auth/AuthBoundary.test.tsx
+++ b/packages/react/src/components/auth/AuthBoundary.test.tsx
@@ -22,6 +22,9 @@ vi.mock('../../hooks/auth/useHandleAuthCallback', () => ({
 vi.mock('../../hooks/auth/useLogOut', () => ({
   useLogOut: vi.fn(() => async () => {}),
 }))
+vi.mock('../../hooks/comlink/useWindowConnection', () => ({
+  useWindowConnection: vi.fn(() => ({fetch: vi.fn()})),
+}))
 
 // Mock AuthError throwing scenario
 vi.mock('./AuthError', async (importOriginal) => {

--- a/packages/react/src/components/auth/LoginError.test.tsx
+++ b/packages/react/src/components/auth/LoginError.test.tsx
@@ -9,6 +9,10 @@ vi.mock('../../hooks/auth/useLogOut', () => ({
   useLogOut: vi.fn(() => async () => {}),
 }))
 
+vi.mock('../../hooks/comlink/useWindowConnection', () => ({
+  useWindowConnection: vi.fn(() => ({fetch: vi.fn()})),
+}))
+
 describe('LoginError', () => {
   it('shows authentication error and retry button', async () => {
     const mockReset = vi.fn()
@@ -21,6 +25,7 @@ describe('LoginError', () => {
     )
 
     expect(screen.getByText('Authentication Error')).toBeInTheDocument()
+
     const retryButton = screen.getByRole('button', {name: 'Retry'})
     fireEvent.click(retryButton)
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

In #651 we added a nice fallback for if the project user couldn't be found, with the addition of https://github.com/sanity-io/ada/pull/2013 any app can summon the request access flow for a particular few type of resources. Currently quite restricted i've not made a dedicated hook for users to consume yet but inlined the work as a POC.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

* Should I have made a new hook?
* Is calling the `useWindowConnection` hook in the `LoginError` okay? my understanding is that the hook will suspend the app until a connection is found...

### Related Issue

* resolves SDK-789

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->

![Eric Andre GIF](https://media0.giphy.com/media/yx400dIdkwWdsCgWYp/giphy.gif)