### PR TITLE
docs: fix docs typo

### DIFF
--- a/packages/react/src/hooks/users/useUsers.ts
+++ b/packages/react/src/hooks/users/useUsers.ts
@@ -62,7 +62,7 @@ export interface UsersResult {
  *         <address>{user.profile.email}</address>
  *       </figure>
  *     ))}
- *     {hasMore && <button onClick={loadMore}>{isPending ? 'Loading...' : 'Load More'</button>}
+ *     {hasMore && <button onClick={loadMore}>{isPending ? 'Loading...' : 'Load More'}</button>}
  *   </div>
  * )
  * ```


### PR DESCRIPTION
### Description
Fixing a small typo that gets displayed [here](https://reference.sanity.io/_sanity/sdk-react/exports/useUsers/), making the example not run.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

The typo


