### PR TITLE
chore: add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs
 .vitest-reports
 
 .auth
+.env


### PR DESCRIPTION
### Description

Added `.env` file to `.gitignore` to prevent environment variables from being committed to the repository. This helps maintain security by keeping sensitive configuration data out of version control.

### What to review

Verify that the `.env` file is now properly ignored by git and won't be tracked in future commits.

### Testing

Manually tested by creating a sample `.env` file and confirming it doesn't appear in git status.

### Fun gif
![shut door](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTd1OGNycDY4MXNiemk4bDk4cWhwdW95eXpiYjhhM3d3NGNrZzQwbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3ohs4x28LlTjNO2G8U/giphy.gif)