### PR TITLE
docs: update README with viewport-based lazy loading example and event type clarification

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -297,6 +297,27 @@ function ArticleList() {
 
 ---
 
+### Viewport-Based Lazy Loading
+
+Pass a `ref` to `useDocumentProjection` to fetch only when the element enters the viewport. Wrap the component in Suspense like any other data hook:
+
+```tsx
+import {useRef} from 'react'
+
+function LazyArticleCard({handle}: {handle: DocumentHandle}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const {data} = useDocumentProjection({
+    ...handle,
+    ref, // Only fetches when element is visible
+    projection: '{ title }',
+  })
+
+  return <div ref={ref}>{data?.title}</div>
+}
+```
+
+---
+
 ### Draft/Published Model
 
 Sanity has two document states:
@@ -538,27 +559,6 @@ npx sanity deploy
 Add the resulting app ID to the `deployment` section of your `sanity.config.ts` file: `{deployment: { appId: "appbc1234", ... } }`.
 
 App appears in Sanity Dashboard alongside Studios. Requires `sanity.sdk.applications.deploy` permission.
-
----
-
-### Viewport-Based Lazy Loading
-
-Use a ref with `useDocumentProjection` to load content only when the element enters the viewport:
-
-```tsx
-import {useRef} from 'react'
-
-function LazyArticleCard({handle}: {handle: DocumentHandle}) {
-  const ref = useRef(null)
-  const {data} = useDocumentProjection({
-    ...handle,
-    ref, // Only fetches when element is visible
-    projection: '{ title, excerpt }',
-  })
-
-  return <div ref={ref}>{data?.title}</div>
-}
-```
 
 ---
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -146,7 +146,7 @@ await apply([publishDocument(handle1), publishDocument(handle2), deleteDocument(
 useDocumentEvent({
   ...handle,
   onEvent: (event) => {
-    // event.type: 'documentEdited' | 'documentPublished' | 'documentDeleted' | ...
+    // event.type: 'edited' | 'published' | 'deleted' | 'created' | 'unpublished' | 'discarded' | ...
     console.log(event.type, event.documentId)
   },
 })
@@ -538,6 +538,27 @@ npx sanity deploy
 Add the resulting app ID to the `deployment` section of your `sanity.config.ts` file: `{deployment: { appId: "appbc1234", ... } }`.
 
 App appears in Sanity Dashboard alongside Studios. Requires `sanity.sdk.applications.deploy` permission.
+
+---
+
+### Viewport-Based Lazy Loading
+
+Use a ref with `useDocumentProjection` to load content only when the element enters the viewport:
+
+```tsx
+import {useRef} from 'react'
+
+function LazyArticleCard({handle}: {handle: DocumentHandle}) {
+  const ref = useRef(null)
+  const {data} = useDocumentProjection({
+    ...handle,
+    ref, // Only fetches when element is visible
+    projection: '{ title, excerpt }',
+  })
+
+  return <div ref={ref}>{data?.title}</div>
+}
+```
 
 ---
 


### PR DESCRIPTION
### Description

This PR updates the React SDK documentation in two ways:

1. Updates the event type names in the `useDocumentEvent` example to match the actual event types returned by the API (`edited`, `published`, `deleted`, etc. instead of `documentEdited`, `documentPublished`, etc.)

2. Adds a new section demonstrating viewport-based lazy loading with `useDocumentProjection` using a ref to only fetch content when an element becomes visible in the viewport

### What to review

- Check that the event type names in the `useDocumentEvent` example are correct
- Review the new "Viewport-Based Lazy Loading" section for accuracy and clarity
- Ensure the code example for lazy loading with refs is properly formatted and follows best practices

### Testing

Documentation changes only, no functional changes to test.

### Fun gif
![Lazy loading cat](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExem5wdHB4aXc4eThqb2VpcG9xYzlidGlwNGQ2ZGFvbmEzMnBpbHp5ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mTxnhJyiVYTUA/giphy.gif)