### PR TITLE
chore(e2e): remove e2e build from prepare

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,8 +102,8 @@ jobs:
       # dataset names (SDK_E2E_DATASET_0/1) into the bundle at compile time.
       - name: 🚀 Build & start preview server
         run: |
-          cd apps/kitchensink-react
-          pnpm build && pnpm run preview --port 3333 &
+          pnpm build --filter=@sanity/kitchensink-react
+          cd apps/kitchensink-react && pnpm run preview --port 3333 &
           timeout 60 bash -c 'until curl -f -s http://localhost:3333 > /dev/null; do echo "Waiting for server..."; sleep 2; done'
           echo "Server is ready!"
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -23,6 +23,9 @@ const baseConfig = {
     },
     'apps/kitchensink-react': {
       entry: ['src/main.tsx', 'src/css/css.config.js'],
+      // disable playwright plugin: playwright.config.ts imports @repo/e2e which
+      // may not be built yet, and knip crashes trying to load it as an entry file
+      playwright: false,
       typescript: {
         config: 'tsconfig.json',
       },
@@ -64,15 +67,13 @@ const baseConfig = {
       entry: ['src/index.ts', 'src/setup/**/*.ts', 'src/teardown/**/*.ts'],
       ignoreDependencies: ['@repo/tsconfig'],
     },
-    // TODO: Remove this once we have presence fully implemented in the SDK
     'packages/core': {
       typescript: {
         config: 'tsconfig.settings.json',
       },
       project,
       entry: ['package.bundle.ts'],
-      ignore: ['src/presence/bifurTransport.ts', 'src/presence/types.ts'],
-      ignoreDependencies: ['@sanity/bifur-client', '@sanity/browserslist-config'],
+      ignoreDependencies: ['@sanity/browserslist-config'],
     },
   },
 } satisfies KnipConfig

--- a/packages/@repo/e2e/package.json
+++ b/packages/@repo/e2e/package.json
@@ -30,8 +30,7 @@
     "build": "pkg build --strict --clean --check",
     "cleanup": "tsx src/scripts/cleanup-datasets.ts",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "prepare": "pnpm build"
+    "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "@sanity/client": "^7.14.1",


### PR DESCRIPTION
### Description
This was likely left in the e2e package's `package.json` probably to stop depcheck from erroring: knip tries to load `playwright.config.ts` but the e2e package hasn't been built yet. It had the annoying side effect of running a build with every `pnpm install`.

Turns out there's a built in plugin for that. Turbo should handle the sequencing required to ensure that the e2e package is built before e2e testing.

It wasn't caught because our verbose schema extraction on `pnpm install` was also noisy, but I noticed it on `next`, where we don't have that.

### What to review
Hopefully not much!

### Testing
If the CI e2e tests run, this works. 

### Fun gif
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExd3N0OTZvdm10dTJ2dDE4bWRhZmF0b3Bzb2drNG42M3F6ZHl4ZDhhMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1iHDjCqdmDJOqZFYAX/giphy.gif)

FIXES SDK-1207
