### PR TITLE
fix!: rename and clarify exports

### DIFF
--- a/apps/kitchensink-react/src/DocumentCollection/DocumentDashboardInteractionsRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentDashboardInteractionsRoute.tsx
@@ -1,10 +1,10 @@
 import {
   DatasetResource,
   DocumentHandle,
+  useDispatchDocumentHistoryEvent,
   useDocuments,
   useManageFavorite,
   useNavigateToStudioDocument,
-  useRecordDocumentHistoryEvent,
   useResource,
 } from '@sanity/sdk-react'
 import {Box, Button, Flex, Heading} from '@sanity/ui'
@@ -61,13 +61,13 @@ function FavoriteButton({docHandle}: {docHandle: DocumentHandle}) {
 }
 
 const ViewButton = ({docHandle}: {docHandle: DocumentHandle}) => {
-  const {recordEvent} = useRecordDocumentHistoryEvent({
+  const {dispatchHistoryEvent} = useDispatchDocumentHistoryEvent({
     ...docHandle,
     resourceType: 'studio',
   })
   return (
     <ErrorBoundary fallbackRender={({error}) => <ButtonError error={error} />}>
-      <Button mode="ghost" onClick={() => recordEvent('viewed')} text="Record view" />
+      <Button mode="ghost" onClick={() => dispatchHistoryEvent('viewed')} text="Record view" />
     </ErrorBoundary>
   )
 }

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -14,7 +14,7 @@ export {
   type LoggingInAuthState,
   setAuthToken,
 } from '../auth/authStore'
-export {observeOrganizationVerificationState} from '../auth/getOrganizationVerificationState'
+export {getOrganizationVerificationState} from '../auth/getOrganizationVerificationState'
 export {handleAuthCallback} from '../auth/handleAuthCallback'
 export {logout} from '../auth/logout'
 export type {ClientStoreState as ClientState} from '../client/clientStore'
@@ -77,9 +77,9 @@ export {
   getDocumentState,
   getDocumentSyncStatus,
   getPermissionsState,
+  onDocumentEvent,
   resolveDocument,
   resolvePermissions,
-  subscribeDocumentEvents,
 } from '../document/documentStore'
 export {
   type ActionErrorEvent,
@@ -96,7 +96,7 @@ export {
 export {type DocumentPermissionsResult, type PermissionDeniedReason} from '../document/permissions'
 export type {FavoriteStatusResponse} from '../favorites/favorites'
 export {getFavoritesState, resolveFavoritesState} from '../favorites/favorites'
-export {getPresence} from '../presence/presenceStore'
+export {getPresenceState} from '../presence/presenceStore'
 export type {
   DisconnectEvent,
   PresenceLocation,
@@ -106,7 +106,7 @@ export type {
   UserPresence,
 } from '../presence/types'
 export type {PreviewMedia, PreviewQueryResult, PreviewValue} from '../preview/types'
-export {type OrgVerificationResult} from '../project/organizationVerification'
+export {type OrganizationVerificationResult} from '../project/organizationVerification'
 export {getProjectState, type ProjectHandle, resolveProject} from '../project/project'
 export {getProjectionState} from '../projection/getProjectionState'
 export {resolveProjection} from '../projection/resolveProjection'

--- a/packages/core/src/auth/getOrganizationVerificationState.test.ts
+++ b/packages/core/src/auth/getOrganizationVerificationState.test.ts
@@ -1,16 +1,17 @@
-import {type Observable} from 'rxjs'
+import {type SanityProject} from '@sanity/client'
+import {NEVER, type Observable} from 'rxjs'
 import {TestScheduler} from 'rxjs/testing'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {
   compareProjectOrganization,
-  type OrgVerificationResult,
+  type OrganizationVerificationResult,
 } from '../project/organizationVerification'
 import {getProjectState} from '../project/project'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
 import {getDashboardOrganizationId} from './dashboardUtils'
-import {observeOrganizationVerificationState} from './getOrganizationVerificationState'
+import {getOrganizationVerificationState} from './getOrganizationVerificationState'
 
 // Mock dependencies
 vi.mock('./dashboardUtils', () => ({
@@ -20,16 +21,12 @@ vi.mock('../project/project', () => ({
   getProjectState: vi.fn(),
 }))
 // Mock the comparison function to check its inputs
-vi.mock('../project/organizationVerification', async (importOriginal) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const original = await importOriginal<any>()
-  return {
-    ...original,
-    compareProjectOrganization: vi.fn(),
-  }
-})
+vi.mock('../project/organizationVerification', (importOriginal) => ({
+  ...importOriginal(),
+  compareProjectOrganization: vi.fn(),
+}))
 
-describe('observeOrganizationVerificationState', () => {
+describe('getOrganizationVerificationState', () => {
   let testScheduler: TestScheduler
 
   // Mock instance with studio.projectId
@@ -50,21 +47,20 @@ describe('observeOrganizationVerificationState', () => {
       observable,
       getCurrent: () => undefined,
       subscribe: observable.subscribe.bind(observable),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any) // Cast to any to bypass strict type checking in mock
+    } as unknown as StateSource<string | undefined>)
   }
 
   // Helper to mock getProjectState
   const mockProjectOrgId = (observable: Observable<{organizationId: string | null} | null>) => {
     vi.mocked(getProjectState).mockReturnValue({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      observable: observable as any, // Cast needed due to complex type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as StateSource<any>)
+      observable: observable as unknown as Observable<SanityProject | undefined>,
+      getCurrent: () => null,
+      subscribe: () => () => {},
+    } as unknown as StateSource<SanityProject | undefined>)
   }
 
   // Helper to mock compareProjectOrganization result
-  const mockComparisonResult = (result: OrgVerificationResult) => {
+  const mockComparisonResult = (result: OrganizationVerificationResult) => {
     vi.mocked(compareProjectOrganization).mockReturnValue(result)
   }
 
@@ -79,10 +75,10 @@ describe('observeOrganizationVerificationState', () => {
       const expectedMarble = '--a' // Corrected: combineLatest emits at frame 2
       const expectedValues = {a: {error: null}}
 
-      const result$ = observeOrganizationVerificationState(mockInstance, [
+      const result = getOrganizationVerificationState(mockInstance, [
         mockInstance.config.studio!.projectId!,
       ])
-      expectObservable(result$).toBe(expectedMarble, expectedValues)
+      expectObservable(result.observable).toBe(expectedMarble, expectedValues)
     })
     expect(compareProjectOrganization).not.toHaveBeenCalled()
   })
@@ -105,8 +101,8 @@ describe('observeOrganizationVerificationState', () => {
       const expectedMarble = '-a' // Corrected: Emit at frame 1
       const expectedValues = {a: {error: null}}
 
-      const result$ = observeOrganizationVerificationState(instanceWithoutProjectId, [])
-      expectObservable(result$).toBe(expectedMarble, expectedValues)
+      const result = getOrganizationVerificationState(instanceWithoutProjectId, [])
+      expectObservable(result.observable).toBe(expectedMarble, expectedValues)
     })
     // No project fetch or comparison should occur
     expect(getProjectState).not.toHaveBeenCalled()
@@ -137,10 +133,10 @@ describe('observeOrganizationVerificationState', () => {
       const expectedMarble = '---r' // Should emit { error: null }
       const expectedValues = {r: {error: null}} // Expect null error
 
-      const result$ = observeOrganizationVerificationState(mockInstance, [
+      const result = getOrganizationVerificationState(mockInstance, [
         mockInstance.config.studio!.projectId!,
       ])
-      expectObservable(result$).toBe(expectedMarble, expectedValues)
+      expectObservable(result.observable).toBe(expectedMarble, expectedValues)
     })
     // Comparison should NOT be called because projectData.orgId is null
     expect(compareProjectOrganization).not.toHaveBeenCalled()
@@ -161,15 +157,73 @@ describe('observeOrganizationVerificationState', () => {
       const expectedMarble = '--r' // Emits when projectOrgId$ emits
       const expectedValues = {r: comparisonResult}
 
-      const result$ = observeOrganizationVerificationState(mockInstance, [
+      const result = getOrganizationVerificationState(mockInstance, [
         mockInstance.config.studio!.projectId!,
       ])
-      expectObservable(result$).toBe(expectedMarble, expectedValues)
+      expectObservable(result.observable).toBe(expectedMarble, expectedValues)
     })
 
     // Check that comparison was called with correct values after observables emit
     expect(compareProjectOrganization).toHaveBeenCalledTimes(1)
     expect(compareProjectOrganization).toHaveBeenCalledWith('proj-1', 'org-match', 'org-match')
+  })
+
+  describe('getCurrent()', () => {
+    const setupMocks = ({
+      dashboardOrgId,
+      projectOrgId,
+    }: {
+      dashboardOrgId: string | null | undefined
+      projectOrgId: string | null
+    }) => {
+      vi.mocked(getDashboardOrganizationId).mockReturnValue({
+        getCurrent: () => dashboardOrgId,
+        observable: NEVER,
+        subscribe: () => () => {},
+      } as StateSource<string | undefined>)
+      vi.mocked(getProjectState).mockReturnValue({
+        getCurrent: () => (projectOrgId !== null ? {organizationId: projectOrgId} : null),
+        observable: NEVER as Observable<SanityProject | undefined>,
+        subscribe: () => () => {},
+      } as StateSource<SanityProject | undefined>)
+    }
+
+    it('returns {error: null} when dashboardOrgId is null', () => {
+      setupMocks({dashboardOrgId: null, projectOrgId: 'org-real'})
+      const result = getOrganizationVerificationState(mockInstance, ['proj-1'])
+      expect(result.getCurrent()).toEqual({error: null})
+      expect(compareProjectOrganization).not.toHaveBeenCalled()
+    })
+
+    it('returns {error: null} when projectIds is empty', () => {
+      setupMocks({dashboardOrgId: 'org-dash', projectOrgId: 'org-real'})
+      const result = getOrganizationVerificationState(mockInstance, [])
+      expect(result.getCurrent()).toEqual({error: null})
+      expect(compareProjectOrganization).not.toHaveBeenCalled()
+    })
+
+    it('returns {error: null} when project has no orgId', () => {
+      setupMocks({dashboardOrgId: 'org-dash', projectOrgId: null})
+      const result = getOrganizationVerificationState(mockInstance, ['proj-1'])
+      expect(result.getCurrent()).toEqual({error: null})
+      expect(compareProjectOrganization).not.toHaveBeenCalled()
+    })
+
+    it('returns {error: null} when org IDs match', () => {
+      setupMocks({dashboardOrgId: 'org-match', projectOrgId: 'org-match'})
+      vi.mocked(compareProjectOrganization).mockReturnValue({error: null})
+      const result = getOrganizationVerificationState(mockInstance, ['proj-1'])
+      expect(result.getCurrent()).toEqual({error: null})
+      expect(compareProjectOrganization).toHaveBeenCalledWith('proj-1', 'org-match', 'org-match')
+    })
+
+    it('returns error when org IDs mismatch', () => {
+      const mismatchError = {error: 'Mismatch'}
+      setupMocks({dashboardOrgId: 'org-dash', projectOrgId: 'org-proj'})
+      vi.mocked(compareProjectOrganization).mockReturnValue(mismatchError)
+      const result = getOrganizationVerificationState(mockInstance, ['proj-1'])
+      expect(result.getCurrent()).toEqual(mismatchError)
+    })
   })
 
   it('should call compareProjectOrganization and emit its result when IDs mismatch', () => {
@@ -185,10 +239,10 @@ describe('observeOrganizationVerificationState', () => {
       const expectedMarble = '--r'
       const expectedValues = {r: comparisonResult}
 
-      const result$ = observeOrganizationVerificationState(mockInstance, [
+      const result = getOrganizationVerificationState(mockInstance, [
         mockInstance.config.studio!.projectId!,
       ])
-      expectObservable(result$).toBe(expectedMarble, expectedValues)
+      expectObservable(result.observable).toBe(expectedMarble, expectedValues)
     })
     expect(compareProjectOrganization).toHaveBeenCalledTimes(1)
     expect(compareProjectOrganization).toHaveBeenCalledWith('proj-1', 'org-proj', 'org-dash')

--- a/packages/core/src/auth/getOrganizationVerificationState.ts
+++ b/packages/core/src/auth/getOrganizationVerificationState.ts
@@ -1,24 +1,48 @@
-import {combineLatest, distinctUntilChanged, map, type Observable, of, switchMap} from 'rxjs'
+import {combineLatest, distinctUntilChanged, map, of, share, skip, switchMap} from 'rxjs'
 
 import {
   compareProjectOrganization,
-  type OrgVerificationResult,
+  type OrganizationVerificationResult,
 } from '../project/organizationVerification'
 import {getProjectState} from '../project/project'
 import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
 import {getDashboardOrganizationId} from './dashboardUtils'
 
 /**
- * Creates an observable that emits the organization verification state for a given instance.
+ * Gets the organization verification state for a given instance.
  * It combines the dashboard organization ID (from auth context) with the
  * project's actual organization ID (fetched via getProjectState) and compares them.
  * @public
  */
-export function observeOrganizationVerificationState(
+export function getOrganizationVerificationState(
   instance: SanityInstance,
   projectIds: string[],
-): Observable<OrgVerificationResult> {
-  // Observable for the dashboard org ID (potentially null)
+): StateSource<OrganizationVerificationResult> {
+  const computeResult = (): OrganizationVerificationResult => {
+    const dashboardOrgId = getDashboardOrganizationId(instance).getCurrent()
+    const projectOrgDataArray = projectIds.map((id) => {
+      const project = getProjectState(instance, {projectId: id}).getCurrent()
+      return {projectId: id, orgId: project?.organizationId ?? null}
+    })
+
+    if (!dashboardOrgId || projectOrgDataArray.length === 0) {
+      return {error: null}
+    }
+
+    for (const projectData of projectOrgDataArray) {
+      if (!projectData.orgId) continue
+      const result = compareProjectOrganization(
+        projectData.projectId,
+        projectData.orgId,
+        dashboardOrgId,
+      )
+      if (result.error) return result
+    }
+
+    return {error: null}
+  }
+
   const dashboardOrgId$ =
     getDashboardOrganizationId(instance).observable.pipe(distinctUntilChanged())
 
@@ -35,39 +59,42 @@ export function observeOrganizationVerificationState(
   const allProjectOrgIds$ =
     projectOrgIdObservables.length > 0 ? combineLatest(projectOrgIdObservables) : of([])
 
-  // Combine the sources
-  return combineLatest([dashboardOrgId$, allProjectOrgIds$]).pipe(
-    switchMap(([dashboardOrgId, projectOrgDataArray]) => {
-      // If no dashboard org ID is set, or no project IDs provided, verification isn't applicable/possible
-      if (!dashboardOrgId || projectOrgDataArray.length === 0) {
-        return of<OrgVerificationResult>({error: null}) // Return success (no error)
-      }
-
-      // Iterate through all projects and check organization IDs
-      for (const projectData of projectOrgDataArray) {
-        // If a project doesn't have an orgId, we can't verify, treat as non-blocking for now
-        // (Matches original logic where null projectOrgId resulted in {error: null})
-        if (!projectData.orgId) {
-          continue
+  const orgVerificationPipeline = () =>
+    combineLatest([dashboardOrgId$, allProjectOrgIds$]).pipe(
+      switchMap(([dashboardOrgId, projectOrgDataArray]) => {
+        if (!dashboardOrgId || projectOrgDataArray.length === 0) {
+          return of<OrganizationVerificationResult>({error: null})
         }
 
-        // Perform the comparison for the current project
-        const result = compareProjectOrganization(
-          projectData.projectId,
-          projectData.orgId,
-          dashboardOrgId,
-        )
-
-        // If any project fails verification, immediately return the error
-        if (result.error) {
-          return of(result)
+        for (const projectData of projectOrgDataArray) {
+          // If a project doesn't have an orgId, we can't verify, treat as non-blocking for now
+          if (!projectData.orgId) continue
+          const result = compareProjectOrganization(
+            projectData.projectId,
+            projectData.orgId,
+            dashboardOrgId,
+          )
+          // If any project fails verification, immediately return the error
+          if (result.error) return of(result)
         }
-      }
 
-      // If all projects passed verification (or had no orgId to check)
-      return of<OrgVerificationResult>({error: null})
-    }),
-    // Only emit when the overall error status actually changes
-    distinctUntilChanged((prev, curr) => prev.error === curr.error),
-  )
+        return of<OrganizationVerificationResult>({error: null})
+      }),
+      distinctUntilChanged((prev, curr) => prev.error === curr.error),
+    )
+
+  // Shared for efficient multicasting when multiple consumers subscribe to .observable
+  const observable = orgVerificationPipeline().pipe(share())
+
+  // Uses a fresh pipeline so skip(1) always has an initial emission to discard,
+  // regardless of whether .observable already has active subscribers
+  const subscribe = (onStoreChanged?: () => void): (() => void) => {
+    const sub = orgVerificationPipeline()
+      // the initial emission is the current state (see getCurrent), so we skip it
+      .pipe(skip(1))
+      .subscribe(() => onStoreChanged?.())
+    return () => sub.unsubscribe()
+  }
+
+  return {getCurrent: computeResult, subscribe, observable}
 }

--- a/packages/core/src/document/documentStore.test.ts
+++ b/packages/core/src/document/documentStore.test.ts
@@ -35,9 +35,9 @@ import {
   getDocumentState,
   getDocumentSyncStatus,
   getPermissionsState,
+  onDocumentEvent,
   resolveDocument,
   resolvePermissions,
-  subscribeDocumentEvents,
 } from './documentStore'
 import {type ActionErrorEvent, type TransactionRevertedEvent} from './events'
 import {type DatasetAcl} from './permissions'
@@ -541,7 +541,7 @@ it('reverts failed outgoing transaction locally', async () => {
   })
 
   const revertedEventPromise = new Promise<TransactionRevertedEvent>((resolve) => {
-    const unsubscribe = subscribeDocumentEvents(instance, {
+    const unsubscribe = onDocumentEvent(instance, {
       resource,
       eventHandler: (e) => {
         if (e.type === 'reverted') {
@@ -609,7 +609,7 @@ it('reverts failed outgoing transaction locally', async () => {
 
 it('removes a queued transaction if it fails to apply', async () => {
   const actionErrorEventPromise = new Promise<ActionErrorEvent>((resolve) => {
-    const unsubscribe = subscribeDocumentEvents(instance, {
+    const unsubscribe = onDocumentEvent(instance, {
       resource,
       eventHandler: (e) => {
         if (e.type === 'error') {
@@ -833,7 +833,7 @@ it('returns a promise that resolves when a document has been loaded in the store
 
 it('emits an event for each action after an outgoing transaction has been accepted', async () => {
   const handler = vi.fn()
-  const unsubscribe = subscribeDocumentEvents(instance, {resource, eventHandler: handler})
+  const unsubscribe = onDocumentEvent(instance, {resource, eventHandler: handler})
 
   const documentId = DocumentId(crypto.randomUUID())
   const doc = createDocumentHandle({documentId, documentType: 'article', resource})

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -298,7 +298,7 @@ export const resolvePermissions = bindActionByResource(
 )
 
 /** @beta */
-export const subscribeDocumentEvents = bindActionByResource(
+export const onDocumentEvent = bindActionByResource(
   documentStore,
   ({state}, options: {resource: DocumentResource; eventHandler: (e: DocumentEvent) => void}) => {
     const {events} = state.get()

--- a/packages/core/src/presence/presenceStore.test.ts
+++ b/packages/core/src/presence/presenceStore.test.ts
@@ -8,7 +8,7 @@ import {createSanityInstance, type SanityInstance} from '../store/createSanityIn
 import {type SanityUser} from '../users/types'
 import {getUserState} from '../users/usersStore'
 import {createBifurTransport} from './bifurTransport'
-import {getPresence} from './presenceStore'
+import {getPresenceState} from './presenceStore'
 import {type PresenceLocation, type TransportEvent} from './types'
 
 vi.mock('../auth/authStore')
@@ -79,10 +79,10 @@ describe('presenceStore', () => {
     instance.dispose()
   })
 
-  describe('getPresence', () => {
+  describe('getPresenceState', () => {
     const key = {resource: {projectId: 'test-project', dataset: 'test-dataset'}}
     it('creates bifur transport with correct parameters', () => {
-      getPresence(instance, key)
+      getPresenceState(instance, key)
 
       expect(getClient).toHaveBeenCalledWith(instance, {
         apiVersion: '2026-03-30',
@@ -99,18 +99,18 @@ describe('presenceStore', () => {
     })
 
     it('sends rollCall message on initialization', () => {
-      getPresence(instance, key)
+      getPresenceState(instance, key)
 
       expect(mockDispatchMessage).toHaveBeenCalledWith({type: 'rollCall'})
     })
 
     it('returns empty array when no users present', () => {
-      const source = getPresence(instance, key)
+      const source = getPresenceState(instance, key)
       expect(source.getCurrent()).toEqual([])
     })
 
     it('handles state events from other users', async () => {
-      const source = getPresence(instance, key)
+      const source = getPresenceState(instance, key)
 
       // Subscribe to initialize the store
       const unsubscribe = source.subscribe(() => {})
@@ -147,7 +147,7 @@ describe('presenceStore', () => {
     })
 
     it('ignores events from own session', async () => {
-      const source = getPresence(instance, key)
+      const source = getPresenceState(instance, key)
       const unsubscribe = source.subscribe(() => {})
 
       await firstValueFrom(of(null).pipe(delay(10)))
@@ -169,7 +169,7 @@ describe('presenceStore', () => {
     })
 
     it('handles disconnect events', async () => {
-      const source = getPresence(instance, key)
+      const source = getPresenceState(instance, key)
       const unsubscribe = source.subscribe(() => {})
 
       await firstValueFrom(of(null).pipe(delay(10)))
@@ -201,7 +201,7 @@ describe('presenceStore', () => {
     })
 
     it('fetches user data for present users', async () => {
-      const source = getPresence(instance, key)
+      const source = getPresenceState(instance, key)
       const unsubscribe = source.subscribe(() => {})
 
       await firstValueFrom(of(null).pipe(delay(10)))
@@ -233,7 +233,7 @@ describe('presenceStore', () => {
     })
 
     it('handles presence events correctly', async () => {
-      const source = getPresence(instance, key)
+      const source = getPresenceState(instance, key)
       const unsubscribe = source.subscribe(() => {})
 
       await firstValueFrom(of(null).pipe(delay(10)))
@@ -259,7 +259,7 @@ describe('presenceStore', () => {
       const mediaLibraryResource = {mediaLibraryId: 'ml123'}
 
       expect(() => {
-        getPresence(instance, {resource: mediaLibraryResource})
+        getPresenceState(instance, {resource: mediaLibraryResource})
       }).toThrow('Presence is not supported for media library resources.')
     })
 
@@ -267,7 +267,7 @@ describe('presenceStore', () => {
       const datasetResource = {projectId: 'test-project', dataset: 'test-dataset'}
 
       expect(() => {
-        getPresence(instance, {resource: datasetResource})
+        getPresenceState(instance, {resource: datasetResource})
       }).not.toThrow()
     })
 
@@ -275,12 +275,12 @@ describe('presenceStore', () => {
       const canvasResource = {canvasId: 'canvas123'}
 
       expect(() => {
-        getPresence(instance, {resource: canvasResource})
+        getPresenceState(instance, {resource: canvasResource})
       }).not.toThrow()
     })
 
     it('creates a project-hostname client for dataset resources', () => {
-      getPresence(instance, {resource: {projectId: 'my-project', dataset: 'my-dataset'}})
+      getPresenceState(instance, {resource: {projectId: 'my-project', dataset: 'my-dataset'}})
 
       expect(getClient).toHaveBeenCalledWith(instance, {
         apiVersion: '2026-03-30',
@@ -292,7 +292,7 @@ describe('presenceStore', () => {
 
     it('creates a resource client for canvas resources', () => {
       const canvasResource = {canvasId: 'canvas123'}
-      getPresence(instance, {resource: canvasResource})
+      getPresenceState(instance, {resource: canvasResource})
 
       expect(getClient).toHaveBeenCalledWith(instance, {
         apiVersion: '2026-03-30',
@@ -302,7 +302,7 @@ describe('presenceStore', () => {
 
     it('fetches organizationId from canvas endpoint for canvas resources', () => {
       const canvasResource = {canvasId: 'canvas123'}
-      getPresence(instance, {resource: canvasResource})
+      getPresenceState(instance, {resource: canvasResource})
 
       expect(mockClient.observable.request).toHaveBeenCalledWith({
         uri: '/canvases/canvas123',
@@ -310,13 +310,13 @@ describe('presenceStore', () => {
     })
 
     it('does not fetch organizationId for dataset resources', () => {
-      getPresence(instance, key)
+      getPresenceState(instance, key)
 
       expect(mockClient.observable.request).not.toHaveBeenCalled()
     })
 
     it('fetches user data for canvas users', async () => {
-      const source = getPresence(instance, {resource: {canvasId: 'canvas123'}})
+      const source = getPresenceState(instance, {resource: {canvasId: 'canvas123'}})
       const unsubscribe = source.subscribe(() => {})
 
       await firstValueFrom(of(null).pipe(delay(10)))

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -156,7 +156,7 @@ const selectPresence = createSelector(
 )
 
 /** @beta */
-export const getPresence = bindActionByResource(
+export const getPresenceState = bindActionByResource(
   presenceStore,
   createStateSourceAction({
     selector: (context: SelectorContext<PresenceStoreState>): UserPresence[] =>

--- a/packages/core/src/project/organizationVerification.test.ts
+++ b/packages/core/src/project/organizationVerification.test.ts
@@ -1,6 +1,9 @@
 import {describe, expect, it} from 'vitest'
 
-import {compareProjectOrganization, type OrgVerificationResult} from './organizationVerification'
+import {
+  compareProjectOrganization,
+  type OrganizationVerificationResult,
+} from './organizationVerification'
 
 describe('compareProjectOrganization', () => {
   const projectId = 'proj-1'
@@ -9,7 +12,7 @@ describe('compareProjectOrganization', () => {
   it('should return error null when project orgId matches expected orgId', () => {
     const projectOrgId = 'org-abc'
     const result = compareProjectOrganization(projectId, projectOrgId, expectedOrgId)
-    expect(result).toEqual<OrgVerificationResult>({error: null})
+    expect(result).toEqual<OrganizationVerificationResult>({error: null})
   })
 
   it('should return an error message when project orgId does not match expected orgId', () => {

--- a/packages/core/src/project/organizationVerification.ts
+++ b/packages/core/src/project/organizationVerification.ts
@@ -2,7 +2,7 @@
  * Error message returned by the organization verification
  * @public
  */
-export interface OrgVerificationResult {
+export interface OrganizationVerificationResult {
   error: string | null
 }
 
@@ -14,7 +14,7 @@ export function compareProjectOrganization(
   projectId: string,
   projectOrganizationId: string | null | undefined,
   currentDashboardOrgId: string,
-): OrgVerificationResult {
+): OrganizationVerificationResult {
   if (projectOrganizationId !== currentDashboardOrgId) {
     return {
       error:

--- a/packages/react/guides/0-Migration-Guide.md
+++ b/packages/react/guides/0-Migration-Guide.md
@@ -81,7 +81,8 @@ The following hooks support `resourceName` / `resource`:
 - `usePaginatedDocuments`
 - `usePerspective`
 - `useActiveReleases`
-- `usePresence` (dataset resources only)
+- `usePresence` (dataset / canvas resources only)
+- `useProject`
 
 **`ResourceProvider` uses `resource` prop**
 
@@ -108,7 +109,7 @@ The following hooks support `resourceName` / `resource`:
 The following APIs were deprecated in v2 and have been removed in v3:
 
 | Removed                                       | Replacement                                                |
-| --------------------------------------------  | ---------------------------------------------------------- |
+| --------------------------------------------- | ---------------------------------------------------------- |
 | `getPreviewState` / `GetPreviewStateOptions`  | `getProjectionState` with an explicit `projection`         |
 | `resolvePreview` / `ResolvePreviewOptions`    | `resolveProjection` with an explicit `projection`          |
 | `PreviewStoreState` type                      | Use the return type of `getProjectionState`                |
@@ -118,6 +119,7 @@ The following APIs were deprecated in v2 and have been removed in v3:
 | `sanityConfigs` prop on `<SanityApp>`         | `resources` prop                                           |
 | `SanityProject` type                          | Import from `@sanity/client`                               |
 | `scope` / `~experimental_resource` on clients | `useProjectHostname` and `resource` prop                   |
+| `observeOrganizationVerificationState`        | `getOrganizationVerificationState.observable`              |
 
 **`getPreviewState`**
 
@@ -192,7 +194,19 @@ const config: SanityConfig = {
 }
 ```
 
-#### 4. `@sanity/sdk` agent and comlink utilities moved to sub-entries
+#### 4. Renamed APIs
+
+Some APIs have been renamed, mostly for consistency and clarity:
+
+| Original name                                  | New name                                                  |
+| ---------------------------------------------- | --------------------------------------------------------- |
+| `useRecordDocumentHistoryEvent`, `recordEvent` | `useDispatchDocumentHistoryEvent`, `dispatchHistoryEvent` |
+| `getPresence`                                  | `getPresenceState`                                        |
+| `OrgVerificationResult`                        | `OrganizationVerificationResult`                          |
+| `useVerifyOrgProjects`                         | `useOrganizationVerification`                             |
+| `subscribeDocumentEvents`                      | `onDocumentEvent`                                         |
+
+#### 5. `@sanity/sdk` agent and comlink utilities moved to sub-entries
 
 Agent and comlink utilities are now available only from dedicated sub-entry points:
 
@@ -213,7 +227,7 @@ import {type FrameMessage} from '@sanity/sdk/comlink'
 
 `@sanity/sdk-react` previously re-exported all core utilities, but these two subdomains are now excluded. Make the above code changes to get access to these.
 
-#### 5. Explicit `projectId` required for `getDatasetsState` / `useDatasets`
+#### 6. Explicit `projectId` required for `getDatasetsState` / `useDatasets`
 
 `getDatasetsState` and `useDatasets` now require an explicit `projectId` argument. They no longer infer it from instance config:
 
@@ -229,7 +243,7 @@ const datasets = useDatasets()
 const datasets = useDatasets({projectId: 'abc123'})
 ```
 
-#### 6. Experimental typegen and groq dependency removed
+#### 7. Experimental typegen and groq dependency removed
 
 The `groq` package is no longer a dependency. `defineQuery` and `defineProjection` are no longer needed or exported. Pass plain strings to `query` and `projection` parameters:
 
@@ -250,7 +264,7 @@ const {data} = useQuery({query: '*[_type == $type]', params: {type: 'book'}})
 
 You can safely remove the `groq` package from your dependencies if you were only using it for `defineQuery` / `defineProjection`.
 
-#### 7. Stackable perspectives disallowed
+#### 8. Stackable perspectives disallowed
 
 `PerspectiveHandle` no longer accepts array-based (stackable) perspectives. Only single perspectives are allowed:
 
@@ -285,9 +299,9 @@ For example, providing a specific perspective that reflects one of your Content 
 
 This way, previous changes will be incorporated into your selected perspective.
 
-#### 8. Presence refactored to use resources
+#### 9. Presence refactored to use resources
 
-`usePresence` now accepts `resource` / `resourceName` options. It only supports dataset resources — passing a media library or canvas resource will throw an error:
+`usePresence` now accepts `resource` / `resourceName` options. It only supports dataset and canvas resources — passing a media library will throw an error:
 
 ```typescript
 const {locations} = usePresence({resourceName: 'marketing-site'})

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -34,7 +34,7 @@ export {useDashboardOrganizationId} from '../hooks/auth/useDashboardOrganization
 export {useHandleAuthCallback} from '../hooks/auth/useHandleAuthCallback'
 export {useLoginUrl} from '../hooks/auth/useLoginUrl'
 export {useLogOut} from '../hooks/auth/useLogOut'
-export {useVerifyOrgProjects} from '../hooks/auth/useVerifyOrgProjects'
+export {useOrganizationVerification} from '../hooks/auth/useOrganizationVerification'
 export {useClient} from '../hooks/client/useClient'
 export {
   type FrameConnection,
@@ -51,13 +51,13 @@ export {
 export {useResource} from '../hooks/context/useDefaultResource'
 export {useSanityInstance} from '../hooks/context/useSanityInstance'
 export {useDashboardNavigate} from '../hooks/dashboard/useDashboardNavigate'
+export {useDispatchDocumentHistoryEvent} from '../hooks/dashboard/useDispatchDocumentHistoryEvent'
 export {useDispatchIntent} from '../hooks/dashboard/useDispatchIntent'
 export {useManageFavorite} from '../hooks/dashboard/useManageFavorite'
 export {
   type NavigateToStudioResult,
   useNavigateToStudioDocument,
 } from '../hooks/dashboard/useNavigateToStudioDocument'
-export {useRecordDocumentHistoryEvent} from '../hooks/dashboard/useRecordDocumentHistoryEvent'
 export {useStudioWorkspacesByProjectIdDataset} from '../hooks/dashboard/useStudioWorkspacesByProjectIdDataset'
 export {useDatasets} from '../hooks/datasets/useDatasets'
 export {useApplyDocumentActions} from '../hooks/document/useApplyDocumentActions'

--- a/packages/react/src/components/auth/AuthBoundary.test.tsx
+++ b/packages/react/src/components/auth/AuthBoundary.test.tsx
@@ -7,7 +7,7 @@ import {beforeEach, describe, expect, it, type MockInstance, vi} from 'vitest'
 import {ResourceProvider} from '../../context/ResourceProvider'
 import {useAuthState} from '../../hooks/auth/useAuthState'
 import {useLoginUrl} from '../../hooks/auth/useLoginUrl'
-import {useVerifyOrgProjects} from '../../hooks/auth/useVerifyOrgProjects'
+import {useOrganizationVerification} from '../../hooks/auth/useOrganizationVerification'
 import {AuthBoundary} from './AuthBoundary'
 
 // Mock hooks
@@ -15,7 +15,7 @@ vi.mock('../../hooks/auth/useAuthState', () => ({
   useAuthState: vi.fn(() => 'logged-out'),
 }))
 vi.mock('../../hooks/auth/useLoginUrl')
-vi.mock('../../hooks/auth/useVerifyOrgProjects')
+vi.mock('../../hooks/auth/useOrganizationVerification')
 vi.mock('../../hooks/auth/useHandleAuthCallback', () => ({
   useHandleAuthCallback: vi.fn(() => async () => {}),
 }))
@@ -107,7 +107,7 @@ describe('AuthBoundary', () => {
   let consoleErrorSpy: MockInstance
   const mockUseAuthState = vi.mocked(useAuthState)
   const mockUseLoginUrl = vi.mocked(useLoginUrl)
-  const mockUseVerifyOrgProjects = vi.mocked(useVerifyOrgProjects)
+  const mockUseVerifyOrganizationProjects = vi.mocked(useOrganizationVerification)
   const testProjectIds = ['proj-test'] // Example project ID for tests
 
   beforeEach(() => {
@@ -117,8 +117,8 @@ describe('AuthBoundary', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockUseAuthState.mockReturnValue({type: AuthStateType.LOGGED_IN} as any)
     mockUseLoginUrl.mockReturnValue('http://example.com/login')
-    // Default mock for useVerifyOrgProjects - returns null (no error)
-    mockUseVerifyOrgProjects.mockImplementation(() => null)
+    // Default mock for useOrganizationVerification - returns null (no error)
+    mockUseVerifyOrganizationProjects.mockImplementation(() => null)
   })
 
   afterEach(() => {
@@ -208,7 +208,7 @@ describe('AuthBoundary', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockUseAuthState.mockReturnValue({type: AuthStateType.LOGGED_IN} as any)
     // Mock specific return value for this test
-    mockUseVerifyOrgProjects.mockImplementation((disabled, pIds) => {
+    mockUseVerifyOrganizationProjects.mockImplementation((disabled, pIds) => {
       // Expect verification to be enabled (disabled=false) and projectIds to match
       if (!disabled && pIds === testProjectIds) {
         return orgErrorMessage
@@ -240,7 +240,7 @@ describe('AuthBoundary', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockUseAuthState.mockReturnValue({type: AuthStateType.LOGGED_IN} as any)
     // Mock specific return value for this test
-    mockUseVerifyOrgProjects.mockImplementation((disabled, pIds) => {
+    mockUseVerifyOrganizationProjects.mockImplementation((disabled, pIds) => {
       // Expect verification to be disabled (disabled=true) and projectIds to match
       if (disabled && pIds === testProjectIds) {
         // Hook should return null when disabled, but we mock based on call
@@ -271,8 +271,8 @@ describe('AuthBoundary', () => {
       error: new Error(authErrorMessage),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)
-    mockUseVerifyOrgProjects.mockReturnValue(null) // Org verification passes or is irrelevant
-    mockUseVerifyOrgProjects.mockImplementation(() => null)
+    mockUseVerifyOrganizationProjects.mockReturnValue(null) // Org verification passes or is irrelevant
+    mockUseVerifyOrganizationProjects.mockImplementation(() => null)
 
     render(
       <ResourceProvider resource={{projectId: 'p', dataset: 'd'}} fallback={null}>

--- a/packages/react/src/components/auth/AuthBoundary.tsx
+++ b/packages/react/src/components/auth/AuthBoundary.tsx
@@ -7,7 +7,7 @@ import {ErrorBoundary, type FallbackProps} from 'react-error-boundary'
 import {ComlinkTokenRefreshProvider} from '../../context/ComlinkTokenRefresh'
 import {useAuthState} from '../../hooks/auth/useAuthState'
 import {useLoginUrl} from '../../hooks/auth/useLoginUrl'
-import {useVerifyOrgProjects} from '../../hooks/auth/useVerifyOrgProjects'
+import {useOrganizationVerification} from '../../hooks/auth/useOrganizationVerification'
 import {useSanityInstance} from '../../hooks/context/useSanityInstance'
 import {CorsErrorComponent} from '../errors/CorsErrorComponent'
 import {isInIframe} from '../utils'
@@ -160,7 +160,7 @@ function AuthSwitch({
   const isStudio = isStudioConfig(instance.config)
   const disableVerifyOrg =
     !verifyOrganization || isStudio || authState.type !== AuthStateType.LOGGED_IN
-  const orgError = useVerifyOrgProjects(disableVerifyOrg, projectIds)
+  const orgError = useOrganizationVerification(disableVerifyOrg, projectIds)
 
   const isLoggedOut = authState.type === AuthStateType.LOGGED_OUT && !authState.isDestroyingSession
   const loginUrl = useLoginUrl()

--- a/packages/react/src/hooks/auth/useOrganizationVerification.test.tsx
+++ b/packages/react/src/hooks/auth/useOrganizationVerification.test.tsx
@@ -1,22 +1,22 @@
-import {observeOrganizationVerificationState, type OrgVerificationResult} from '@sanity/sdk'
+import {getOrganizationVerificationState, type OrganizationVerificationResult} from '@sanity/sdk'
 import {act, renderHook, waitFor} from '@testing-library/react'
 import {Subject} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
 import {ResourceProvider} from '../../context/ResourceProvider'
-import {useVerifyOrgProjects} from './useVerifyOrgProjects'
+import {useOrganizationVerification} from './useOrganizationVerification'
 
 // Mock dependencies
 vi.mock('@sanity/sdk', async (importOriginal) => {
   const original = await importOriginal<typeof import('@sanity/sdk')>()
   return {
     ...original,
-    observeOrganizationVerificationState: vi.fn(),
+    getOrganizationVerificationState: vi.fn(),
   }
 })
 
-describe('useVerifyOrgProjects', () => {
-  const mockObserve = vi.mocked(observeOrganizationVerificationState)
+describe('useOrganizationVerification', () => {
+  const mockObserve = vi.mocked(getOrganizationVerificationState)
   const testProjectIds = ['proj-1']
 
   beforeEach(() => {
@@ -24,7 +24,7 @@ describe('useVerifyOrgProjects', () => {
   })
 
   it('should return null and not observe state if disabled', () => {
-    const {result} = renderHook(() => useVerifyOrgProjects(true, testProjectIds), {
+    const {result} = renderHook(() => useOrganizationVerification(true, testProjectIds), {
       wrapper: ({children}) => (
         <ResourceProvider
           resource={{projectId: 'test-project', dataset: 'test-dataset'}}
@@ -40,20 +40,23 @@ describe('useVerifyOrgProjects', () => {
   })
 
   it('should return null and not observe state if projectIds is missing or empty', () => {
-    const {result: resultUndefined} = renderHook(() => useVerifyOrgProjects(false, undefined), {
-      wrapper: ({children}) => (
-        <ResourceProvider
-          resource={{projectId: 'test-project', dataset: 'test-dataset'}}
-          fallback={null}
-        >
-          {children}
-        </ResourceProvider>
-      ),
-    })
+    const {result: resultUndefined} = renderHook(
+      () => useOrganizationVerification(false, undefined),
+      {
+        wrapper: ({children}) => (
+          <ResourceProvider
+            resource={{projectId: 'test-project', dataset: 'test-dataset'}}
+            fallback={null}
+          >
+            {children}
+          </ResourceProvider>
+        ),
+      },
+    )
     expect(resultUndefined.current).toBeNull()
     expect(mockObserve).not.toHaveBeenCalled()
 
-    const {result: resultEmpty} = renderHook(() => useVerifyOrgProjects(false, []), {
+    const {result: resultEmpty} = renderHook(() => useOrganizationVerification(false, []), {
       wrapper: ({children}) => (
         <ResourceProvider
           resource={{projectId: 'test-project', dataset: 'test-dataset'}}
@@ -68,10 +71,14 @@ describe('useVerifyOrgProjects', () => {
   })
 
   it('should return null initially when not disabled and projectIds provided', () => {
-    const subject = new Subject<OrgVerificationResult>()
-    mockObserve.mockReturnValue(subject.asObservable())
+    const subject = new Subject<OrganizationVerificationResult>()
+    mockObserve.mockReturnValue({
+      observable: subject.asObservable(),
+      getCurrent: () => ({error: null}),
+      subscribe: () => () => {},
+    })
 
-    const {result} = renderHook(() => useVerifyOrgProjects(false, testProjectIds), {
+    const {result} = renderHook(() => useOrganizationVerification(false, testProjectIds), {
       wrapper: ({children}) => (
         <ResourceProvider
           resource={{projectId: 'test-project', dataset: 'test-dataset'}}
@@ -87,10 +94,14 @@ describe('useVerifyOrgProjects', () => {
   })
 
   it('should return null if observable emits { error: null }', async () => {
-    const subject = new Subject<OrgVerificationResult>()
-    mockObserve.mockReturnValue(subject.asObservable())
+    const subject = new Subject<OrganizationVerificationResult>()
+    mockObserve.mockReturnValue({
+      observable: subject.asObservable(),
+      getCurrent: () => ({error: null}),
+      subscribe: () => () => {},
+    })
 
-    const {result} = renderHook(() => useVerifyOrgProjects(false, testProjectIds), {
+    const {result} = renderHook(() => useOrganizationVerification(false, testProjectIds), {
       wrapper: ({children}) => (
         <ResourceProvider
           resource={{projectId: 'test-project', dataset: 'test-dataset'}}
@@ -111,11 +122,15 @@ describe('useVerifyOrgProjects', () => {
   })
 
   it('should return error string if observable emits { error: string }', async () => {
-    const subject = new Subject<OrgVerificationResult>()
+    const subject = new Subject<OrganizationVerificationResult>()
     const errorMessage = 'Org mismatch'
-    mockObserve.mockReturnValue(subject.asObservable())
+    mockObserve.mockReturnValue({
+      observable: subject.asObservable(),
+      getCurrent: () => ({error: null}),
+      subscribe: () => () => {},
+    })
 
-    const {result} = renderHook(() => useVerifyOrgProjects(false, testProjectIds), {
+    const {result} = renderHook(() => useOrganizationVerification(false, testProjectIds), {
       wrapper: ({children}) => (
         <ResourceProvider
           resource={{projectId: 'test-project', dataset: 'test-dataset'}}
@@ -136,11 +151,15 @@ describe('useVerifyOrgProjects', () => {
   })
 
   it('should unsubscribe on unmount', () => {
-    const subject = new Subject<OrgVerificationResult>()
+    const subject = new Subject<OrganizationVerificationResult>()
     const unsubscribeSpy = vi.spyOn(subject, 'unsubscribe')
-    mockObserve.mockReturnValue(subject)
+    mockObserve.mockReturnValue({
+      observable: subject,
+      getCurrent: () => ({error: null}),
+      subscribe: () => () => {},
+    })
 
-    const {unmount} = renderHook(() => useVerifyOrgProjects(false, testProjectIds), {
+    const {unmount} = renderHook(() => useOrganizationVerification(false, testProjectIds), {
       wrapper: ({children}) => (
         <ResourceProvider
           resource={{projectId: 'test-project', dataset: 'test-dataset'}}
@@ -164,12 +183,16 @@ describe('useVerifyOrgProjects', () => {
   })
 
   it('should clear the error if disabled becomes true', async () => {
-    const subject = new Subject<OrgVerificationResult>()
+    const subject = new Subject<OrganizationVerificationResult>()
     const errorMessage = 'Org mismatch'
-    mockObserve.mockReturnValue(subject.asObservable())
+    mockObserve.mockReturnValue({
+      observable: subject.asObservable(),
+      getCurrent: () => ({error: null}),
+      subscribe: () => () => {},
+    })
 
     const {result, rerender} = renderHook(
-      ({disabled, pIds}) => useVerifyOrgProjects(disabled, pIds),
+      ({disabled, pIds}) => useOrganizationVerification(disabled, pIds),
       {
         initialProps: {disabled: false, pIds: testProjectIds},
         wrapper: ({children}) => (

--- a/packages/react/src/hooks/auth/useOrganizationVerification.tsx
+++ b/packages/react/src/hooks/auth/useOrganizationVerification.tsx
@@ -1,4 +1,4 @@
-import {observeOrganizationVerificationState, type OrgVerificationResult} from '@sanity/sdk'
+import {getOrganizationVerificationState, type OrganizationVerificationResult} from '@sanity/sdk'
 import {useEffect, useState} from 'react'
 
 import {useSanityInstance} from '../context/useSanityInstance'
@@ -13,7 +13,7 @@ import {useSanityInstance} from '../context/useSanityInstance'
  * @example
  * ```tsx
  * function OrgVerifier() {
- *   const error = useVerifyOrgProjects()
+ *   const error = useOrganizationVerification()
  *
  *   if (error) {
  *     return <div className="error">{error}</div>
@@ -23,7 +23,10 @@ import {useSanityInstance} from '../context/useSanityInstance'
  * }
  * ```
  */
-export function useVerifyOrgProjects(disabled = false, projectIds?: string[]): string | null {
+export function useOrganizationVerification(
+  disabled = false,
+  projectIds?: string[],
+): string | null {
   const instance = useSanityInstance()
   const [error, setError] = useState<string | null>(null)
 
@@ -33,9 +36,10 @@ export function useVerifyOrgProjects(disabled = false, projectIds?: string[]): s
       return
     }
 
-    const verificationObservable$ = observeOrganizationVerificationState(instance, projectIds)
-
-    const subscription = verificationObservable$.subscribe((result: OrgVerificationResult) => {
+    const subscription = getOrganizationVerificationState(
+      instance,
+      projectIds,
+    ).observable.subscribe((result: OrganizationVerificationResult) => {
       setError(result.error)
     })
 

--- a/packages/react/src/hooks/dashboard/useDispatchDocumentHistoryEvent.test.ts
+++ b/packages/react/src/hooks/dashboard/useDispatchDocumentHistoryEvent.test.ts
@@ -2,13 +2,13 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {renderHook} from '../../../test/test-utils'
 import {useWindowConnection} from '../comlink/useWindowConnection'
-import {useRecordDocumentHistoryEvent} from './useRecordDocumentHistoryEvent'
+import {useDispatchDocumentHistoryEvent} from './useDispatchDocumentHistoryEvent'
 
 vi.mock('../comlink/useWindowConnection', () => ({
   useWindowConnection: vi.fn(),
 }))
 
-describe('useRecordDocumentHistoryEvent', () => {
+describe('useDispatchDocumentHistoryEvent', () => {
   let mockSendMessage = vi.fn()
   const mockDocumentHandle = {
     documentId: 'mock-id',
@@ -28,10 +28,10 @@ describe('useRecordDocumentHistoryEvent', () => {
     })
   })
 
-  it('should send correct message when recording events', () => {
-    const {result} = renderHook(() => useRecordDocumentHistoryEvent(mockDocumentHandle))
+  it('should send correct message when dispatching events', () => {
+    const {result} = renderHook(() => useDispatchDocumentHistoryEvent(mockDocumentHandle))
 
-    result.current.recordEvent('viewed')
+    result.current.dispatchHistoryEvent('viewed')
     expect(mockSendMessage).toHaveBeenCalledWith('dashboard/v1/events/history', {
       eventType: 'viewed',
       document: {
@@ -51,9 +51,9 @@ describe('useRecordDocumentHistoryEvent', () => {
       throw new Error('Failed to send message')
     })
 
-    const {result} = renderHook(() => useRecordDocumentHistoryEvent(mockDocumentHandle))
+    const {result} = renderHook(() => useDispatchDocumentHistoryEvent(mockDocumentHandle))
 
-    expect(() => result.current.recordEvent('viewed')).toThrow('Failed to send message')
+    expect(() => result.current.dispatchHistoryEvent('viewed')).toThrow('Failed to send message')
     consoleErrorSpy.mockRestore()
   })
 
@@ -66,8 +66,8 @@ describe('useRecordDocumentHistoryEvent', () => {
       resource: {mediaLibraryId: 'mock-media-library-id'},
     }
 
-    expect(() => renderHook(() => useRecordDocumentHistoryEvent(mockMediaDocumentHandle))).toThrow(
-      'resourceId is required for media-library and canvas resources',
-    )
+    expect(() =>
+      renderHook(() => useDispatchDocumentHistoryEvent(mockMediaDocumentHandle)),
+    ).toThrow('resourceId is required for media-library and canvas resources')
   })
 })

--- a/packages/react/src/hooks/dashboard/useDispatchDocumentHistoryEvent.ts
+++ b/packages/react/src/hooks/dashboard/useDispatchDocumentHistoryEvent.ts
@@ -12,14 +12,14 @@ import {useCallback} from 'react'
 import {type DocumentHandle} from '../../config/handles'
 import {useWindowConnection} from '../comlink/useWindowConnection'
 
-interface DocumentInteractionHistory {
-  recordEvent: (eventType: 'viewed' | 'edited' | 'created' | 'deleted') => void
+interface DocumentHistoryEventDispatcher {
+  dispatchHistoryEvent: (eventType: 'viewed' | 'edited' | 'created' | 'deleted') => void
 }
 
 /**
  * @internal
  */
-interface UseRecordDocumentHistoryEventProps extends DocumentHandle {
+interface UseDispatchDocumentHistoryEventProps extends DocumentHandle {
   resourceType: StudioResource['type'] | MediaResource['type'] | CanvasResource['type']
   resourceId?: string
   /**
@@ -32,21 +32,21 @@ interface UseRecordDocumentHistoryEventProps extends DocumentHandle {
 /**
  * @internal
  * Hook for managing document interaction history in Sanity Studio.
- * This hook provides functionality to record document interactions.
+ * This hook provides functionality to dispatch document history events.
  * @category History
  * @param documentHandle - The document handle containing document ID and type, like `{_id: '123', _type: 'book'}`
  * @returns An object containing:
- * - `recordEvent` - Function to record document interactions
+ * - `dispatchHistoryEvent` - Function to dispatch document history events
  *
  * @example
  * ```tsx
- * import {useRecordDocumentHistoryEvent} from '@sanity/sdk-react'
+ * import {useDispatchDocumentHistoryEvent} from '@sanity/sdk-react'
  * import {Button} from '@sanity/ui'
  * import {Suspense} from 'react'
  *
- * function RecordEventButton(props: DocumentActionProps) {
+ * function DispatchEventButton(props: DocumentActionProps) {
  *   const {documentId, documentType, resourceType, resourceId} = props
- *   const {recordEvent} = useRecordDocumentHistoryEvent({
+ *   const {dispatchHistoryEvent} = useDispatchDocumentHistoryEvent({
  *     documentId,
  *     documentType,
  *     resourceType,
@@ -54,7 +54,7 @@ interface UseRecordDocumentHistoryEventProps extends DocumentHandle {
  *   })
  *   return (
  *     <Button
- *       onClick={() => recordEvent('viewed')}
+ *       onClick={() => dispatchHistoryEvent('viewed')}
  *       text="Viewed"
  *     />
  *   )
@@ -64,19 +64,19 @@ interface UseRecordDocumentHistoryEventProps extends DocumentHandle {
  * function MyDocumentAction(props: DocumentActionProps) {
  *   return (
  *     <Suspense fallback={<Button text="Loading..." disabled />}>
- *       <RecordEventButton {...props} />
+ *       <DispatchEventButton {...props} />
  *     </Suspense>
  *   )
  * }
  * ```
  */
-export function useRecordDocumentHistoryEvent({
+export function useDispatchDocumentHistoryEvent({
   documentId,
   documentType,
   resourceType,
   resourceId,
   schemaName,
-}: UseRecordDocumentHistoryEventProps): DocumentInteractionHistory {
+}: UseDispatchDocumentHistoryEventProps): DocumentHistoryEventDispatcher {
   const {sendMessage} = useWindowConnection<Events.HistoryMessage, FrameMessage>({
     name: SDK_NODE_NAME,
     connectTo: SDK_CHANNEL_NAME,
@@ -86,7 +86,7 @@ export function useRecordDocumentHistoryEvent({
     throw new Error('resourceId is required for media-library and canvas resources')
   }
 
-  const recordEvent = useCallback(
+  const dispatchHistoryEvent = useCallback(
     (eventType: 'viewed' | 'edited' | 'created' | 'deleted') => {
       try {
         const message: Events.HistoryMessage = {
@@ -108,7 +108,7 @@ export function useRecordDocumentHistoryEvent({
         sendMessage(message.type, message.data)
       } catch (error) {
         // eslint-disable-next-line no-console
-        console.error('Failed to record history event:', error)
+        console.error('Failed to dispatch history event:', error)
         throw error
       }
     },
@@ -116,6 +116,6 @@ export function useRecordDocumentHistoryEvent({
   )
 
   return {
-    recordEvent,
+    dispatchHistoryEvent,
   }
 }

--- a/packages/react/src/hooks/document/useDocumentEvent.test.tsx
+++ b/packages/react/src/hooks/document/useDocumentEvent.test.tsx
@@ -1,5 +1,5 @@
 // tests/useDocumentEvent.test.ts
-import {type DocumentEvent, type DocumentHandle, subscribeDocumentEvents} from '@sanity/sdk'
+import {type DocumentEvent, type DocumentHandle, onDocumentEvent} from '@sanity/sdk'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {renderHook} from '../../../test/test-utils'
@@ -7,7 +7,7 @@ import {useDocumentEvent} from './useDocumentEvent'
 
 vi.mock('@sanity/sdk', async (importOriginal) => {
   const original = await importOriginal<typeof import('@sanity/sdk')>()
-  return {...original, subscribeDocumentEvents: vi.fn()}
+  return {...original, onDocumentEvent: vi.fn()}
 })
 
 const docHandle: DocumentHandle = {
@@ -21,17 +21,17 @@ describe('useDocumentEvent hook', () => {
     vi.resetAllMocks()
   })
 
-  it('calls subscribeDocumentEvents with instance and a stable handler', () => {
+  it('calls onDocumentEvent with instance and a stable handler', () => {
     const handleEvent = vi.fn()
     const unsubscribe = vi.fn()
-    vi.mocked(subscribeDocumentEvents).mockReturnValue(unsubscribe)
+    vi.mocked(onDocumentEvent).mockReturnValue(unsubscribe)
 
     renderHook(() => useDocumentEvent({...docHandle, onEvent: handleEvent}))
 
-    expect(vi.mocked(subscribeDocumentEvents)).toHaveBeenCalledTimes(1)
-    expect(vi.mocked(subscribeDocumentEvents).mock.calls[0][0]).toEqual(expect.any(Object))
+    expect(vi.mocked(onDocumentEvent)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(onDocumentEvent).mock.calls[0][0]).toEqual(expect.any(Object))
 
-    const options = vi.mocked(subscribeDocumentEvents).mock.calls[0][1]
+    const options = vi.mocked(onDocumentEvent).mock.calls[0][1]
     expect(typeof options.eventHandler).toBe('function')
 
     const event = {type: 'edited', documentId: 'doc1', outgoing: {}} as DocumentEvent
@@ -42,7 +42,7 @@ describe('useDocumentEvent hook', () => {
   it('calls the unsubscribe function on unmount', () => {
     const handleEvent = vi.fn()
     const unsubscribe = vi.fn()
-    vi.mocked(subscribeDocumentEvents).mockReturnValue(unsubscribe)
+    vi.mocked(onDocumentEvent).mockReturnValue(unsubscribe)
 
     const {unmount} = renderHook(() => useDocumentEvent({...docHandle, onEvent: handleEvent}))
     unmount()

--- a/packages/react/src/hooks/document/useDocumentEvent.ts
+++ b/packages/react/src/hooks/document/useDocumentEvent.ts
@@ -1,4 +1,4 @@
-import {type DocumentEvent, subscribeDocumentEvents} from '@sanity/sdk'
+import {type DocumentEvent, onDocumentEvent} from '@sanity/sdk'
 import {useCallback, useEffect, useInsertionEffect, useRef} from 'react'
 
 import {type ResourceHandle} from '../../config/handles'
@@ -88,7 +88,7 @@ export function useDocumentEvent<
 
   const instance = useSanityInstance()
   useEffect(() => {
-    return subscribeDocumentEvents(instance, {
+    return onDocumentEvent(instance, {
       eventHandler: stableHandler,
       resource: datasetHandle.resource,
     })

--- a/packages/react/src/hooks/presence/usePresence.test.tsx
+++ b/packages/react/src/hooks/presence/usePresence.test.tsx
@@ -1,4 +1,4 @@
-import {getPresence, type SanityUser, type UserPresence} from '@sanity/sdk'
+import {getPresenceState, type SanityUser, type UserPresence} from '@sanity/sdk'
 import {act, renderHook} from '@testing-library/react'
 import {NEVER} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
@@ -10,7 +10,7 @@ vi.mock('@sanity/sdk', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sanity/sdk')>()
   return {
     ...actual,
-    getPresence: vi.fn(),
+    getPresenceState: vi.fn(),
     createSanityInstance: vi.fn(() => ({
       isDisposed: vi.fn(() => false),
       dispose: vi.fn(),
@@ -58,7 +58,7 @@ describe('usePresence', () => {
       }),
       observable: NEVER,
     }
-    vi.mocked(getPresence).mockReturnValue(mockPresenceSource)
+    vi.mocked(getPresenceState).mockReturnValue(mockPresenceSource)
 
     const {result, unmount} = renderHook(() => usePresence(), {
       wrapper: ({children}) => (
@@ -108,7 +108,7 @@ describe('usePresence', () => {
       subscribe: vi.fn(() => () => {}),
       observable: NEVER,
     }
-    vi.mocked(getPresence).mockReturnValue(mockPresenceSource)
+    vi.mocked(getPresenceState).mockReturnValue(mockPresenceSource)
 
     const {result, unmount} = renderHook(
       () => usePresence({resource: {projectId: 'test-project', dataset: 'test-dataset'}}),

--- a/packages/react/src/hooks/presence/usePresence.ts
+++ b/packages/react/src/hooks/presence/usePresence.ts
@@ -1,4 +1,4 @@
-import {getPresence, isMediaLibraryResource, type UserPresence} from '@sanity/sdk'
+import {getPresenceState, isMediaLibraryResource, type UserPresence} from '@sanity/sdk'
 import {useCallback, useMemo, useSyncExternalStore} from 'react'
 
 import {type ResourceHandle} from '../../config/handles'
@@ -21,7 +21,7 @@ export function usePresence(options: ResourceHandle = {}): {
 
   const sanityInstance = useSanityInstance()
   const source = useMemo(
-    () => getPresence(sanityInstance, normalizedOptions),
+    () => getPresenceState(sanityInstance, normalizedOptions),
     [sanityInstance, normalizedOptions],
   )
   const subscribe = useCallback((callback: () => void) => source.subscribe(callback), [source])


### PR DESCRIPTION
### Description
While we're working through breaking changes for SDK v3, we received some feedback about certain APIs that were inconsistent or confusingly named. This PR attempts to address those changes by doing the following (for the source of this feedback, please see the attached Linear ticket):

- `observeOrganizationVerificationState` - turned into a `StateSource`, including an observable, to match other utils.
- `subscribeDocumentEvents` - name implies it returns something subscribable. Updated to `onDocumentEvent` which matches the "event handler" pattern we have elsewhere (`onMessage` for Comlink, for example)
- `getPresence` - it's a reactive accessor and `StateSource`, updated to `getPresenceState` like the others.
- `useRecordDocumentHistoryEvent` - name implied it records on mount. Updated to `useDispatchDocumentHistoryEvent` which (I think?) better implies it returns a `dispatch` function.
- `useVerifyOrgProjects` - the presence of `Verify` implies that it returns an action, but it's actually reactive state. Updated to `useOrganizationVerification` (moving `Org` to `Organization` was also part of this).

### What to review
I'm least sure about `getOrganizationVerificationState` and would love a second eye on that.

### Testing
Tests were updated with the new names and also for the new functionality needed by changing the above to a `StateSource`.

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExM2czZ2x4NXVzbGMxc3ZvbWUzNWhkbGV5bjlzaDRsNTBlbDM1ZWs2NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1xdHOdXcFAeMpURJeM/giphy.gif)
