### PR TITLE
fix(core): ensure first event is always present

### DIFF
--- a/packages/core/src/favorites/favorites.test.ts
+++ b/packages/core/src/favorites/favorites.test.ts
@@ -146,8 +146,9 @@ describe('favoritesStore', () => {
       await firstValueFrom(state.observable)
       expect(mockFetch).toHaveBeenCalledTimes(1)
       // Second subscriber should use cached response
-      const sub2 = state.subscribe()
-      await firstValueFrom(state.observable)
+      const state2 = getFavoritesState(instance!, mockContext)
+      const sub2 = state2.subscribe()
+      await firstValueFrom(state2.observable)
       expect(mockFetch).toHaveBeenCalledTimes(1)
       // Cleanup
       sub1()

--- a/packages/core/src/projection/getProjectionState.test.ts
+++ b/packages/core/src/projection/getProjectionState.test.ts
@@ -126,7 +126,7 @@ describe('getProjectionState', () => {
     expect(state.get().subscriptions).toEqual({})
     expect(state.get().documentProjections).toEqual({})
 
-    const unsubscribe1 = projectionState1.subscribe(vi.fn()) // Should use ID 3
+    const unsubscribe1 = projectionState1.subscribe(vi.fn()) // Should use ID 2
     expect(state.get().subscriptions).toEqual({
       [docHandle.documentId]: {[hash1]: {testSubId_2: true}},
     })
@@ -134,7 +134,7 @@ describe('getProjectionState', () => {
       [docHandle.documentId]: {[hash1]: projection1},
     })
 
-    const unsubscribe2 = projectionState2.subscribe(vi.fn()) // Should use ID 4
+    const unsubscribe2 = projectionState2.subscribe(vi.fn()) // Should use ID 3
     expect(state.get().subscriptions).toEqual({
       [docHandle.documentId]: {
         [hash1]: {testSubId_2: true},
@@ -148,10 +148,12 @@ describe('getProjectionState', () => {
       },
     })
 
-    const unsubscribe3 = projectionState1.subscribe(vi.fn()) // Should use ID 5
+    // should share ID 2 from the first subscription -- we only care if ANY subscription exists
+    // so we can include the document / projection in a bulk fetch
+    const unsubscribe3 = projectionState1.subscribe(vi.fn())
     expect(state.get().subscriptions).toEqual({
       [docHandle.documentId]: {
-        [hash1]: {testSubId_2: true, testSubId_4: true},
+        [hash1]: {testSubId_2: true},
         [hash2]: {testSubId_3: true},
       },
     })
@@ -165,23 +167,20 @@ describe('getProjectionState', () => {
     })
 
     // --- Test Unsubscribe ---
-    unsubscribe1() // Unsubscribes ID 3
-    expect(state.get().subscriptions[docHandle.documentId]?.[hash1]).toEqual({
-      testSubId_2: true,
-      testSubId_4: true,
-    })
+    unsubscribe1() // Unsubscribes first subscription consumer
+    expect(state.get().subscriptions[docHandle.documentId]?.[hash1]).toEqual({testSubId_2: true})
     vi.advanceTimersByTime(PROJECTION_STATE_CLEAR_DELAY)
-    expect(state.get().subscriptions[docHandle.documentId]?.[hash1]).toEqual({testSubId_4: true})
+    expect(state.get().subscriptions[docHandle.documentId]?.[hash1]).toEqual({testSubId_2: true})
     expect(state.get().documentProjections[docHandle.documentId]?.[hash1]).toEqual(projection1)
 
-    unsubscribe3() // Unsubscribes ID 5
+    unsubscribe3() // Also unsubscibes first projection subscription, should be removed
     vi.advanceTimersByTime(PROJECTION_STATE_CLEAR_DELAY)
     expect(state.get().subscriptions[docHandle.documentId]?.[hash1]).toBeUndefined()
     expect(state.get().documentProjections[docHandle.documentId]?.[hash1]).toBeUndefined()
     expect(state.get().subscriptions[docHandle.documentId]?.[hash2]).toEqual({testSubId_3: true})
     expect(state.get().documentProjections[docHandle.documentId]?.[hash2]).toEqual(projection2)
 
-    unsubscribe2() // Unsubscribes ID 4
+    unsubscribe2() // Unsubscribes second projection subscription, should be removed
     vi.advanceTimersByTime(PROJECTION_STATE_CLEAR_DELAY)
     expect(state.get().subscriptions[docHandle.documentId]).toBeUndefined()
     expect(state.get().documentProjections[docHandle.documentId]).toBeUndefined()
@@ -203,14 +202,14 @@ describe('getProjectionState', () => {
     }))
 
     const unsubscribe1 = projectionState.subscribe(vi.fn()) // Should use ID 2
-    const unsubscribe2 = projectionState.subscribe(vi.fn()) // Should use ID 3
+    const unsubscribe2 = projectionState.subscribe(vi.fn()) // Should reuse ID 2
 
     expect(state.get().values[docHandle.documentId]?.[hash]).toEqual({
       data: initialData,
       isPending: true,
     })
 
-    unsubscribe1() // Unsubscribes ID 2
+    unsubscribe1() // Unsubscribes first subscription consumer
     vi.advanceTimersByTime(PROJECTION_STATE_CLEAR_DELAY)
     expect(state.get().values[docHandle.documentId]?.[hash]).toEqual({
       data: initialData,
@@ -219,9 +218,10 @@ describe('getProjectionState', () => {
     expect(Object.keys(state.get().subscriptions[docHandle.documentId]?.[hash] ?? {}).length).toBe(
       1,
     )
-    expect(state.get().subscriptions[docHandle.documentId]?.[hash]).toEqual({testSubId_3: true})
+    // should still have the same subscription ID since we're not unsubscribing the second consumer
+    expect(state.get().subscriptions[docHandle.documentId]?.[hash]).toEqual({testSubId_2: true})
 
-    unsubscribe2() // Unsubscribes ID 3
+    unsubscribe2() // Unsubscribes second subscription consumer
     expect(state.get().values[docHandle.documentId]?.[hash]).toEqual({
       data: initialData,
       isPending: true,

--- a/packages/core/src/store/createStateSourceAction.ts
+++ b/packages/core/src/store/createStateSourceAction.ts
@@ -1,4 +1,4 @@
-import {defer, distinctUntilChanged, finalize, map, Observable, share, skip} from 'rxjs'
+import {defer, distinctUntilChanged, finalize, map, Observable, shareReplay, skip} from 'rxjs'
 
 import {type StoreAction} from './createActionBinder'
 import {type SanityInstance} from './createSanityInstance'
@@ -215,7 +215,11 @@ export function createStateSourceAction<TState, TParams extends unknown[], TRetu
       values = withSubscribeHook(values, () => subscribeHandler(context, ...params))
     }
 
-    const sharedValues = values.pipe(share())
+    // Share but replay the latest value so every subscriber gets an
+    // initial synchronous emission, matching `state.observable`. That keeps
+    // `skip(1)` in `subscribe()` aligned with "skip current snapshot" rather than
+    // silently eating the first real update after multicasting.
+    const sharedValues = values.pipe(shareReplay({bufferSize: 1, refCount: true}))
 
     const subscribe = (onStoreChanged?: () => void) => {
       const subscription = sharedValues.pipe(skip(1)).subscribe({

--- a/packages/core/src/utils/createFetcherStore.test.ts
+++ b/packages/core/src/utils/createFetcherStore.test.ts
@@ -127,8 +127,9 @@ describe('createFetcherStore', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1)
 
     // Second subscription within throttle interval
-    const sub2 = stateSource.subscribe()
-    await firstValueFrom(stateSource.observable)
+    const stateSource2 = store.getState(instance, 1)
+    const sub2 = stateSource2.subscribe()
+    await firstValueFrom(stateSource2.observable)
     expect(fetchSpy).toHaveBeenCalledTimes(1)
 
     // Advance past throttle interval
@@ -136,8 +137,9 @@ describe('createFetcherStore', () => {
     await vi.advanceTimersByTimeAsync(1000)
 
     // Third subscription after throttle interval
-    const sub3 = stateSource.subscribe()
-    await firstValueFrom(stateSource.observable)
+    const stateSource3 = store.getState(instance, 1)
+    const sub3 = stateSource3.subscribe()
+    await firstValueFrom(stateSource3.observable)
     expect(fetchSpy).toHaveBeenCalledTimes(2)
 
     sub1()


### PR DESCRIPTION
### Description
The Claude review in #643 called out a legitimate bug. The original code:

`const subscription = sharedValues.pipe(skip(1)).subscribe...`

took in a `sharedValues` observable that _should_ have always been composed of a first snapshot event and then subsequent change events: `pipe(map(getCurrent), distinctUntilChanged(isEqual))` 

This would then be shared with `share`. `subscribe`, by design should always skip the initial snapshot.

This could be problematic if there are two subscribers at the same time, and we saw this in the failing tests on that branch:

```ts
// packages/core/src/utils/createFetcherStore.test.ts
const stateSource1 = store.getState(instance, 1)
const sub1 = stateSource1.subscribe()
sub1()


const stateSource2 = store.getState(instance, 1)
const sub2 = stateSource2.subscribe()
// times out, waits forever because it skipped a legitimate state change from its own onSubscribe fetch event
await firstValueFrom(stateSource2.observable.pipe(filter((data) => data !== undefined)))
```

This PR ensures that the first event is always the snapshot (via `shareReplay` with a refCount to ensure we don't keep a stale pipeline), and thus always there for observables and skipped for subscribers.

### What to review
The only actual behavioral change is a one-line change in `createStateSourceAction` which hopefully makes sense.

### Testing
`getProjectionState` tests were updated now that they share a subscription; we didn't really need to keep individual subscriber identities, since we only care if there's _anything_ subscribing to a document / projection.

`getFetcherStore` also has one update for the shared subscription behavior -- the test change actually makes it more consistent with the test directly above it. It was previously tracking the same call to `subscribe` as a "new subscriber" when arguably it is more correct that a new `getState` subscribe call is the new subscriber, triggering the new fetch.

`favorites.test.ts` received a similar update so it's testing the correct situation.

### Fun gif
There are still no fun GIFs about RxJS.