### PR TITLE
feat(core): respect __SANITY_STAGING__ global variable if present for apiHost

### DIFF
--- a/packages/core/src/auth/authStore.test.ts
+++ b/packages/core/src/auth/authStore.test.ts
@@ -73,6 +73,35 @@ describe('authStore', () => {
       instance?.dispose()
     })
 
+    it('uses staging apiHost when __SANITY_STAGING__ is true and no explicit apiHost', () => {
+      vi.stubGlobal('__SANITY_STAGING__', true)
+
+      instance = createSanityInstance({
+        projectId: 'p',
+        dataset: 'd',
+      })
+
+      const {options} = authStore.getInitialState(instance, null)
+      expect(options.apiHost).toBe('https://api.sanity.work')
+
+      vi.unstubAllGlobals()
+    })
+
+    it('prefers explicit apiHost over __SANITY_STAGING__', () => {
+      vi.stubGlobal('__SANITY_STAGING__', true)
+
+      instance = createSanityInstance({
+        projectId: 'p',
+        dataset: 'd',
+        auth: {apiHost: 'https://custom.host'},
+      })
+
+      const {options} = authStore.getInitialState(instance, null)
+      expect(options.apiHost).toBe('https://custom.host')
+
+      vi.unstubAllGlobals()
+    })
+
     it('sets initial options onto state', () => {
       const apiHost = 'test-api-host'
       const callbackUrl = '/login/callback'

--- a/packages/core/src/auth/authStore.ts
+++ b/packages/core/src/auth/authStore.ts
@@ -5,6 +5,7 @@ import {type AuthConfig, type AuthProvider} from '../config/authConfig'
 import {bindActionGlobally} from '../store/createActionBinder'
 import {createStateSourceAction} from '../store/createStateSourceAction'
 import {defineStore} from '../store/defineStore'
+import {getStagingApiHost} from '../utils/getStagingApiHost'
 import {resolveAuthMode} from './authMode'
 import {AuthStateType} from './authStateType'
 import {type AuthStrategyOptions} from './authStrategy'
@@ -102,7 +103,7 @@ export const authStore = defineStore<AuthStoreState>({
 
   getInitialState(instance) {
     const {
-      apiHost,
+      apiHost: configApiHost,
       callbackUrl,
       providers: customProviders,
       token: providedToken,
@@ -110,6 +111,7 @@ export const authStore = defineStore<AuthStoreState>({
       initialLocationHref = getDefaultLocation(),
     } = instance.config.auth ?? {}
 
+    const apiHost = configApiHost ?? getStagingApiHost()
     const authConfig = instance.config.auth ?? {}
 
     // Build login URL (used by standalone mode, but always computed for the

--- a/packages/core/src/client/clientStore.test.ts
+++ b/packages/core/src/client/clientStore.test.ts
@@ -68,6 +68,20 @@ describe('clientStore', () => {
       })
     })
 
+    it('should pass staging apiHost when __SANITY_STAGING__ is true and no explicit apiHost', () => {
+      vi.stubGlobal('__SANITY_STAGING__', true)
+
+      getClient(instance, {apiVersion: '2024-11-12'})
+
+      expect(vi.mocked(createClient)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiHost: 'https://api.sanity.work',
+        }),
+      )
+
+      vi.unstubAllGlobals()
+    })
+
     it('should throw when using disallowed configuration keys', () => {
       expect(() =>
         getClient(instance, {

--- a/packages/core/src/client/clientStore.ts
+++ b/packages/core/src/client/clientStore.ts
@@ -11,6 +11,7 @@ import {
 import {bindActionGlobally} from '../store/createActionBinder'
 import {createStateSourceAction} from '../store/createStateSourceAction'
 import {defineStore, type StoreContext} from '../store/defineStore'
+import {getStagingApiHost} from '../utils/getStagingApiHost'
 
 const DEFAULT_API_VERSION = '2024-11-12'
 const DEFAULT_REQUEST_TAG_PREFIX = 'sanity.sdk'
@@ -195,7 +196,7 @@ export const getClient = bindActionGlobally(
 
     const projectId = options.projectId ?? instance.config.projectId
     const dataset = options.dataset ?? instance.config.dataset
-    const apiHost = options.apiHost ?? instance.config.auth?.apiHost
+    const apiHost = options.apiHost ?? instance.config.auth?.apiHost ?? getStagingApiHost()
 
     const effectiveOptions: ClientOptions = {
       ...DEFAULT_CLIENT_CONFIG,

--- a/packages/core/src/utils/getStagingApiHost.test.ts
+++ b/packages/core/src/utils/getStagingApiHost.test.ts
@@ -1,0 +1,21 @@
+import {describe, expect, it, vi} from 'vitest'
+
+import {getStagingApiHost} from './getStagingApiHost'
+
+describe('getStagingApiHost', () => {
+  it('returns staging host when __SANITY_STAGING__ is true', () => {
+    vi.stubGlobal('__SANITY_STAGING__', true)
+    expect(getStagingApiHost()).toBe('https://api.sanity.work')
+    vi.unstubAllGlobals()
+  })
+
+  it('returns undefined when __SANITY_STAGING__ is false', () => {
+    vi.stubGlobal('__SANITY_STAGING__', false)
+    expect(getStagingApiHost()).toBeUndefined()
+    vi.unstubAllGlobals()
+  })
+
+  it('returns undefined when __SANITY_STAGING__ is not defined', () => {
+    expect(getStagingApiHost()).toBeUndefined()
+  })
+})

--- a/packages/core/src/utils/getStagingApiHost.ts
+++ b/packages/core/src/utils/getStagingApiHost.ts
@@ -1,0 +1,14 @@
+declare const __SANITY_STAGING__: boolean | undefined
+
+/**
+ * Returns the staging API host if the `__SANITY_STAGING__` build-time flag is
+ * set to `true` (mirroring how Sanity Studio detects staging builds).
+ *
+ * @internal
+ */
+export function getStagingApiHost(): string | undefined {
+  if (typeof __SANITY_STAGING__ !== 'undefined' && __SANITY_STAGING__ === true) {
+    return 'https://api.sanity.work'
+  }
+  return undefined
+}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

`__SANITY_STAGING__` is a global variable the CLI sets for studios & apps, if it's true we can set the `apiHost` for the client & auth to be `api.sanity.work`, its implemented the same way studio does which means that applications e..g studio/media-library when setting that variable have their SDK code automatically infer the correct host without setting specific settings – one place for everything :)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Are the tests sufficient to give us confidence in this change?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

As a user I should be able to run `SANITY_INTERNAL_ENV=staging sanity dev` and have the SDK infer the correct API hosts

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->

<img width="480" height="272" alt="the-sopranos-columbus-gif" src="https://github.com/user-attachments/assets/683dd2aa-a262-454c-97af-0e6e75219ffa" />
