### PR TITLE
fix(core): use mutations endpoint for liveEdit documents

### DIFF
--- a/apps/kitchensink-react/e2e/live-edit-document-editor.spec.ts
+++ b/apps/kitchensink-react/e2e/live-edit-document-editor.spec.ts
@@ -1,3 +1,5 @@
+import {randomUUID} from 'node:crypto'
+
 import {expect, test} from '@repo/e2e'
 
 test.describe('Live edit document editor', () => {
@@ -7,7 +9,7 @@ test.describe('Live edit document editor', () => {
     getPageContext,
   }) => {
     const client = getClient()
-    const liveDocId = `live-e2e-crud-${Date.now()}`
+    const liveDocId = `live-edit-${randomUUID()}`
     // not actually used -- we're checking for non-existence of draft
     const draftId = `drafts.${liveDocId}`
 

--- a/apps/kitchensink-react/e2e/live-edit-document-editor.spec.ts
+++ b/apps/kitchensink-react/e2e/live-edit-document-editor.spec.ts
@@ -1,0 +1,94 @@
+import {expect, test} from '@repo/e2e'
+
+test.describe('Live edit document editor', () => {
+  test('creates, edits, and deletes a published author via editor actions (no draft)', async ({
+    page,
+    getClient,
+    getPageContext,
+  }) => {
+    const client = getClient()
+    const liveDocId = `live-e2e-crud-${Date.now()}`
+    // not actually used -- we're checking for non-existence of draft
+    const draftId = `drafts.${liveDocId}`
+
+    // Navigate to the document editor
+    await page.goto('./document-editor')
+
+    // we may be in an iframe or just a page -- get the right locators
+    const pageContext = await getPageContext(page)
+
+    const liveEditCheckbox = pageContext.getByTestId('live-edit-checkbox')
+    await expect(liveEditCheckbox).toBeVisible()
+    await liveEditCheckbox.check()
+
+    const documentIdInput = pageContext.getByTestId('document-id-input')
+    await expect(documentIdInput).toBeVisible()
+    await documentIdInput.fill(liveDocId)
+
+    await pageContext.getByTestId('load-document-button').click()
+
+    await expect(pageContext.getByTestId('live-edit-mode-badge')).toBeVisible({timeout: 10000})
+    await expect(pageContext.getByTestId('live-edit-mode-badge')).toHaveText('Live Edit Mode')
+
+    const createButton = pageContext.getByTestId('document-editor-action-create')
+    await expect(createButton).toBeEnabled({timeout: 15000})
+    await createButton.click()
+
+    const documentContent = pageContext.getByTestId('document-content')
+    await expect(documentContent).toBeVisible({timeout: 15000})
+    await expect(async () => {
+      const content = await documentContent.textContent()
+      const doc = JSON.parse(content || '{}')
+      expect(doc._id).toBe(liveDocId)
+      expect(doc._type).toBe('author')
+    }).toPass({timeout: 15000})
+
+    await expect(async () => {
+      expect(
+        await client.fetch<number>('count(*[_id == $publishedId])', {publishedId: liveDocId}),
+      ).toBe(1)
+      expect(await client.fetch<number>('count(*[_id == $draftId])', {draftId})).toBe(0)
+    }).toPass({timeout: 15000})
+
+    const nameInput = pageContext.getByTestId('name-input')
+    await expect(nameInput).toBeVisible({timeout: 10000})
+    await nameInput.fill('Live edit CRUD updated')
+    await nameInput.press('Enter')
+
+    await expect(nameInput).toHaveValue('Live edit CRUD updated', {timeout: 10000})
+
+    await expect(async () => {
+      const content = await documentContent.textContent()
+      const doc = JSON.parse(content || '{}')
+      expect(doc.name).toBe('Live edit CRUD updated')
+    }).toPass({timeout: 15000})
+
+    await expect(async () => {
+      expect(
+        await client.fetch<string | null>('*[_id == $publishedId][0].name', {
+          publishedId: liveDocId,
+        }),
+      ).toBe('Live edit CRUD updated')
+      expect(await client.fetch<number>('count(*[_id == $draftId])', {draftId})).toBe(0)
+    }).toPass({timeout: 15000})
+
+    const deleteButton = pageContext.getByTestId('document-editor-action-delete')
+    await expect(deleteButton).toBeEnabled({timeout: 15000})
+    await deleteButton.click()
+
+    await expect(async () => {
+      expect(
+        await client.fetch<number>('count(*[_id == $publishedId])', {publishedId: liveDocId}),
+      ).toBe(0)
+      expect(await client.fetch<number>('count(*[_id == $draftId])', {draftId})).toBe(0)
+    }).toPass({timeout: 15000})
+
+    // manual delete here since we created the document directly in the editor
+    await client
+      .delete({
+        query: '*[_id in $ids]',
+        params: {ids: [liveDocId, draftId]},
+      })
+      .catch(() => {})
+  })
+})

--- a/apps/kitchensink-react/src/DocumentCollection/DocumentEditorRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentEditorRoute.tsx
@@ -58,7 +58,11 @@ function DocumentEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
         <Card padding={3} radius={2} shadow={1}>
           <Flex gap={3} align="center" justify="space-between">
             <Flex gap={2} align="center">
-              <Badge tone={docHandle.liveEdit ? 'primary' : 'default'} fontSize={2}>
+              <Badge
+                tone={docHandle.liveEdit ? 'primary' : 'default'}
+                fontSize={2}
+                data-testid="live-edit-mode-badge"
+              >
                 {docHandle.liveEdit ? 'Live Edit Mode' : 'Draft/Published Mode'}
               </Badge>
               {docHandle.liveEdit && (
@@ -112,6 +116,7 @@ function DocumentEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
                     text="Create"
                     tone="positive"
                     fontSize={1}
+                    data-testid="document-editor-action-create"
                   />
                 </Box>
               </Tooltip>
@@ -132,6 +137,7 @@ function DocumentEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
                     text="Create with Initial Values"
                     tone="positive"
                     fontSize={1}
+                    data-testid="document-editor-action-create-with-initial-values"
                   />
                 </Box>
               </Tooltip>
@@ -183,6 +189,7 @@ function DocumentEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
                     text="Delete"
                     tone="critical"
                     fontSize={1}
+                    data-testid="document-editor-action-delete"
                   />
                 </Box>
               </Tooltip>
@@ -204,7 +211,16 @@ function DocumentEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
             {document && (
               <>
                 {/* Hidden element for e2e tests */}
-                <Box style={{display: 'none'}} data-testid="document-content">
+                <Box
+                  style={{
+                    position: 'absolute',
+                    width: 1,
+                    height: 1,
+                    overflow: 'hidden',
+                    left: -9999,
+                  }}
+                  data-testid="document-content"
+                >
                   {JSON.stringify(document)}
                 </Box>
                 <JsonDocumentEditor
@@ -268,10 +284,6 @@ function Editor() {
     // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [liveEditMode])
-
-  if (!documents.length) {
-    return <Box padding={4}>No documents found</Box>
-  }
 
   return (
     <Box padding={4}>

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -141,6 +141,7 @@ export {
   type DocumentEditedEvent,
   type DocumentEvent,
   type DocumentPublishedEvent,
+  type DocumentTransactionSubmissionResult,
   type DocumentUnpublishedEvent,
   type TransactionAcceptedEvent,
   type TransactionRevertedEvent,

--- a/packages/core/src/document/applyDocumentActions.ts
+++ b/packages/core/src/document/applyDocumentActions.ts
@@ -1,4 +1,3 @@
-import {type SanityClient} from '@sanity/client'
 import {type SanityDocument} from 'groq'
 import {distinctUntilChanged, filter, first, firstValueFrom, map, race} from 'rxjs'
 
@@ -8,6 +7,7 @@ import {type SanityInstance} from '../store/createSanityInstance'
 import {type StoreContext} from '../store/defineStore'
 import {type DocumentAction} from './actions'
 import {documentStore, type DocumentStoreState} from './documentStore'
+import {type DocumentTransactionSubmissionResult} from './events'
 import {type DocumentSet} from './processMutations'
 import {type AppliedTransaction, type QueuedTransaction, queueTransaction} from './reducers'
 
@@ -20,7 +20,7 @@ export interface ActionsResult<TDocument extends SanityDocument = SanityDocument
   appeared: string[]
   updated: string[]
   disappeared: string[]
-  submitted: () => ReturnType<SanityClient['action']>
+  submitted: () => Promise<DocumentTransactionSubmissionResult>
 }
 
 /** @beta */

--- a/packages/core/src/document/documentStore.test.ts
+++ b/packages/core/src/document/documentStore.test.ts
@@ -501,7 +501,7 @@ it('submits liveEdit document edits through observable.mutate', async () => {
     visibility: 'async',
     returnDocuments: false,
     returnFirst: false,
-    tag: 'live-edit.mutate',
+    tag: 'document.mutate',
     skipCrossDatasetReferenceValidation: true,
   })
   expect(mutationList.length).toBeGreaterThan(0)
@@ -1266,7 +1266,9 @@ beforeEach(() => {
             continue
           }
           default: {
-            throw new Error(`Unsupported action for mock backend: ${i.actionType}`)
+            throw new Error(
+              `Unsupported action for mock backend: ${(i as {actionType: string}).actionType}`,
+            )
           }
         }
       }

--- a/packages/core/src/document/documentStore.test.ts
+++ b/packages/core/src/document/documentStore.test.ts
@@ -1,8 +1,10 @@
 import {
   type BaseActionOptions,
+  type BaseMutationOptions,
   type FilteredResponseQueryOptions,
   type ListenEvent,
   type MultipleActionResult,
+  type MultipleMutationResult,
   type MutationEvent,
   type RawQueryResponse,
   type ResponseQueryOptions,
@@ -469,6 +471,52 @@ it('batches edit transaction into one outgoing transaction', async () => {
   unsubscribe()
 })
 
+it('submits liveEdit document edits through observable.mutate', async () => {
+  const liveDoc = createDocumentHandle({
+    documentId: 'live-edit-test-doc',
+    documentType: 'article',
+    liveEdit: true,
+  })
+  const state = getDocumentState(instance, liveDoc)
+  const unsubscribe = state.subscribe()
+
+  await firstValueFrom(state.observable.pipe(first((doc) => doc !== undefined)))
+  expect(state.getCurrent()).toMatchObject({
+    _id: 'live-edit-test-doc',
+    title: 'live initial',
+  })
+
+  const callCountBefore = mutateSubmission.mock.calls.length
+
+  const result = await applyDocumentActions(instance, {
+    actions: [editDocument(liveDoc, {set: {title: 'patched via mutate'}})],
+    source,
+  })
+  await result.submitted()
+
+  expect(mutateSubmission.mock.calls.length).toBe(callCountBefore + 1)
+  const [mutationList, mutateOptions] = mutateSubmission.mock.calls[callCountBefore]!
+  expect(mutateOptions).toMatchObject({
+    transactionId: result.transactionId,
+    visibility: 'async',
+    returnDocuments: false,
+    returnFirst: false,
+    tag: 'live-edit.mutate',
+    skipCrossDatasetReferenceValidation: true,
+  })
+  expect(mutationList.length).toBeGreaterThan(0)
+  expect(
+    mutationList.every(
+      (m) => 'patch' in m && (m as {patch: {id: string}}).patch.id === liveDoc.documentId,
+    ),
+  ).toBe(true)
+
+  expect(state.getCurrent()?.title).toBe('patched via mutate')
+  expect(client.action).not.toHaveBeenCalled()
+
+  unsubscribe()
+})
+
 it('provides the consistency status via `getDocumentSyncStatus`', async () => {
   const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
 
@@ -859,7 +907,21 @@ vi.mock('./documentConstants.ts', async (importOriginal) => {
 
 let client: SanityClient
 
+/** Mock for `client.observable.mutate` (liveEdit submission path); implementation reset in `beforeEach`. */
+const mutateSubmission = vi.fn(
+  async (
+    _mutations: Mutation[],
+    _options?: BaseMutationOptions,
+  ): Promise<MultipleMutationResult> => ({
+    transactionId: '',
+    documentIds: [],
+    results: [],
+  }),
+)
+
 beforeEach(() => {
+  mutateSubmission.mockReset()
+
   const client$ = (getClientState as () => StateSource<SanityClient>)()
     .observable as ReplaySubject<SanityClient>
   const sharedListener = (
@@ -878,6 +940,122 @@ beforeEach(() => {
       _type: 'book',
       title: 'existing doc',
     },
+    'live-edit-test-doc': {
+      _id: 'live-edit-test-doc',
+      _type: 'article',
+      _createdAt: '2025-02-06T06:43:46.236Z',
+      _updatedAt: '2025-02-06T06:43:46.236Z',
+      _rev: 'rev-live-initial',
+      title: 'live initial',
+    },
+  }
+
+  const emitDatasetChangeEvents = (
+    prior: DocumentSet,
+    next: DocumentSet,
+    transactionId: string,
+    timestamp: string,
+  ) => {
+    const existingIds = new Set(
+      Object.entries(prior)
+        .filter(([, value]) => !!value)
+        .map(([key]) => key),
+    )
+    const resultingIds = new Set(
+      Object.entries(next)
+        .filter(([, value]) => !!value)
+        .map(([key]) => key),
+    )
+    const allKeys = new Set([...existingIds, ...resultingIds])
+
+    const {appeared, disappeared, updated} = Array.from(allKeys).reduce<{
+      updated: string[]
+      appeared: string[]
+      disappeared: string[]
+    }>(
+      (acc, id) => {
+        if (existingIds.has(id) && resultingIds.has(id)) {
+          acc.updated.push(id)
+        } else if (!existingIds.has(id) && resultingIds.has(id)) {
+          acc.appeared.push(id)
+        } else if (!resultingIds.has(id) && existingIds.has(id)) {
+          acc.disappeared.push(id)
+        }
+        return acc
+      },
+      {updated: [], appeared: [], disappeared: []},
+    )
+
+    const transactionTotalEvents = appeared.length + disappeared.length + updated.length
+    let transactionCurrentEvent = 0
+
+    const mutationEvents: MutationEvent[] = []
+
+    for (const id of appeared) {
+      transactionCurrentEvent++
+      const nextDoc = next[id]!
+      mutationEvents.push({
+        type: 'mutation',
+        documentId: id,
+        eventId: `${transactionId}#${id}`,
+        identity: 'example-user',
+        mutations: [{create: nextDoc}],
+        timestamp,
+        transactionId,
+        transactionCurrentEvent,
+        transactionTotalEvents,
+        transition: 'appear',
+        visibility: 'query',
+        resultRev: transactionId,
+      })
+    }
+
+    for (const id of updated) {
+      transactionCurrentEvent++
+      const prevDoc = prior[id]!
+      const nextDoc = next[id]!
+
+      mutationEvents.push({
+        type: 'mutation',
+        documentId: id,
+        eventId: `${transactionId}#${id}`,
+        identity: 'example-user',
+        mutations: diffValue(prevDoc, nextDoc).map((patch): Mutation => ({patch: {...patch, id}})),
+        timestamp,
+        transactionCurrentEvent,
+        transactionTotalEvents,
+        transactionId,
+        transition: 'update',
+        visibility: 'query',
+        previousRev: prevDoc._rev,
+        resultRev: transactionId,
+      })
+    }
+
+    for (const id of disappeared) {
+      transactionCurrentEvent++
+      const prevDoc = prior[id]!
+      mutationEvents.push({
+        type: 'mutation',
+        documentId: id,
+        eventId: `${transactionId}#${id}`,
+        identity: 'example-user',
+        mutations: [{delete: {id}}],
+        timestamp,
+        transactionId,
+        transactionCurrentEvent,
+        transactionTotalEvents,
+        transition: 'disappear',
+        visibility: 'query',
+        previousRev: prevDoc._rev,
+      })
+    }
+
+    documents = next
+
+    for (const mutationEvent of mutationEvents) {
+      sharedListener.events.next(mutationEvent)
+    }
   }
 
   vi.mocked(createFetchDocument).mockReturnValue(
@@ -887,6 +1065,33 @@ beforeEach(() => {
         delay(0),
       ),
     ),
+  )
+
+  mutateSubmission.mockImplementation(
+    async (
+      mutations: Mutation[],
+      options: BaseMutationOptions = {},
+    ): Promise<MultipleMutationResult> => {
+      const transactionId = options.transactionId ?? crypto.randomUUID()
+      const timestamp = new Date().toISOString()
+      const prior = {...documents}
+      let next = {...documents}
+      next = processMutations({documents: next, mutations, transactionId, timestamp})
+
+      if (!options.dryRun) {
+        emitDatasetChangeEvents(prior, next, transactionId, timestamp)
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      return {
+        transactionId,
+        documentIds: Object.entries(next)
+          .filter(([, v]) => !!v)
+          .map(([k]) => k),
+        results: [],
+      }
+    },
   )
 
   const isNonNullable = <T>(t: T): t is NonNullable<T> => !!t
@@ -1067,108 +1272,7 @@ beforeEach(() => {
       }
 
       if (!dryRun) {
-        const existingIds = new Set(
-          Object.entries(documents)
-            .filter(([, value]) => !!value)
-            .map(([key]) => key),
-        )
-        const resultingIds = new Set(
-          Object.entries(next)
-            .filter(([, value]) => !!value)
-            .map(([key]) => key),
-        )
-        const allKeys = new Set([...existingIds, ...resultingIds])
-
-        const {appeared, disappeared, updated} = Array.from(allKeys).reduce<{
-          updated: string[]
-          appeared: string[]
-          disappeared: string[]
-        }>(
-          (acc, id) => {
-            if (existingIds.has(id) && resultingIds.has(id)) {
-              acc.updated.push(id)
-            } else if (!existingIds.has(id) && resultingIds.has(id)) {
-              acc.appeared.push(id)
-            } else if (!resultingIds.has(id) && existingIds.has(id)) {
-              acc.disappeared.push(id)
-            }
-            return acc
-          },
-          {updated: [], appeared: [], disappeared: []},
-        )
-
-        const transactionTotalEvents = appeared.length + disappeared.length + updated.length
-        let transactionCurrentEvent = 0
-
-        const mutationEvents: MutationEvent[] = []
-
-        for (const id of appeared) {
-          transactionCurrentEvent++ // index seems to start at 1
-          const nextDoc = next[id]!
-          mutationEvents.push({
-            type: 'mutation',
-            documentId: id,
-            eventId: `${transactionId}#${id}`,
-            identity: 'example-user',
-            mutations: [{create: nextDoc}],
-            timestamp,
-            transactionId,
-            transactionCurrentEvent,
-            transactionTotalEvents,
-            transition: 'appear',
-            visibility: 'query',
-            resultRev: transactionId,
-          })
-        }
-
-        for (const id of updated) {
-          transactionCurrentEvent++
-          const prevDoc = documents[id]!
-          const nextDoc = next[id]!
-
-          mutationEvents.push({
-            type: 'mutation',
-            documentId: id,
-            eventId: `${transactionId}#${id}`,
-            identity: 'example-user',
-            mutations: diffValue(prevDoc, nextDoc).map(
-              (patch): Mutation => ({patch: {...patch, id}}),
-            ),
-            timestamp,
-            transactionCurrentEvent,
-            transactionTotalEvents,
-            transactionId,
-            transition: 'update',
-            visibility: 'query',
-            previousRev: prevDoc._rev,
-            resultRev: transactionId,
-          })
-        }
-
-        for (const id of disappeared) {
-          transactionCurrentEvent++
-          const prevDoc = documents[id]!
-          mutationEvents.push({
-            type: 'mutation',
-            documentId: id,
-            eventId: `${transactionId}#${id}`,
-            identity: 'example-user',
-            mutations: [{delete: {id}}],
-            timestamp,
-            transactionId,
-            transactionCurrentEvent,
-            transactionTotalEvents,
-            transition: 'disappear',
-            visibility: 'query',
-            previousRev: prevDoc._rev,
-          })
-        }
-
-        documents = next
-
-        for (const mutationEvent of mutationEvents) {
-          sharedListener.events.next(mutationEvent)
-        }
+        emitDatasetChangeEvents(documents, next, transactionId, timestamp)
       }
 
       // add a tick for realism
@@ -1195,6 +1299,7 @@ beforeEach(() => {
       action: (...args: Parameters<typeof action>) => from(action(...args)),
       fetch: (...args: Parameters<typeof fetch>) => from(fetch(...args)),
       request: (...args: Parameters<typeof request>) => from(request(...args)),
+      mutate: (...args: Parameters<typeof mutateSubmission>) => from(mutateSubmission(...args)),
     },
   } as SanityClient
   client$.next(client)

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -411,28 +411,15 @@ const subscribeToAppliedAndSubmitNextTransaction = ({
           return EMPTY
         })
 
-        // Draft/published flow -- send actions and return
-        if (outgoing.outgoingActions.length > 0) {
-          return client.observable
-            .action(outgoing.outgoingActions as Action[], {
-              transactionId: outgoing.transactionId,
-              skipCrossDatasetReferenceValidation: true,
-              tag: 'document.action',
-            })
-            .pipe(
-              revertOnError,
-              map((result) => ({
-                result: result as DocumentTransactionSubmissionResult,
-                outgoing,
-              })),
-            )
-        }
+        const toResult = map((result: unknown) => ({
+          result: result as DocumentTransactionSubmissionResult,
+          outgoing,
+        }))
 
-        // liveEdit edits: mutations API and return
-        if (
-          outgoing.actions.every((action) => action.liveEdit) &&
-          outgoing.outgoingMutations.length > 0
-        ) {
+        // Any liveEdit action in the batch routes to the mutations API. For mixed batches
+        // non-liveEdit operations (e.g. publish) lose atomicity, but that is acceptable
+        // given how rare mixed batches are.
+        if (outgoing.actions.some((action) => action.liveEdit)) {
           return client.observable
             .mutate(outgoing.outgoingMutations as Mutation[], {
               transactionId: outgoing.transactionId,
@@ -442,16 +429,17 @@ const subscribeToAppliedAndSubmitNextTransaction = ({
               tag: 'document.mutate',
               skipCrossDatasetReferenceValidation: true,
             })
-            .pipe(
-              revertOnError,
-              map((result) => ({
-                result: result as DocumentTransactionSubmissionResult,
-                outgoing,
-              })),
-            )
+            .pipe(revertOnError, toResult)
         }
 
-        return EMPTY
+        // Pure non-liveEdit transactions use the actions API.
+        return client.observable
+          .action(outgoing.outgoingActions as Action[], {
+            transactionId: outgoing.transactionId,
+            skipCrossDatasetReferenceValidation: true,
+            tag: 'document.action',
+          })
+          .pipe(revertOnError, toResult)
       }),
       tap(({outgoing, result}) => {
         state.set('cleanupOutgoingTransaction', cleanupOutgoingTransaction)

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -411,7 +411,7 @@ const subscribeToAppliedAndSubmitNextTransaction = ({
           return EMPTY
         })
 
-        // Draft/published flow and liveEdit create/delete -- use actions and return
+        // Draft/published flow -- send actions and return
         if (outgoing.outgoingActions.length > 0) {
           return client.observable
             .action(outgoing.outgoingActions as Action[], {

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -1,4 +1,4 @@
-import {type Action} from '@sanity/client'
+import {type Action, type Mutation} from '@sanity/client'
 import {getPublishedId} from '@sanity/client/csm'
 import {jsonMatch} from '@sanity/json-match'
 import {type SanityDocument} from 'groq'
@@ -45,7 +45,11 @@ import {defineStore, type StoreContext} from '../store/defineStore'
 import {getDraftId} from '../utils/ids'
 import {type DocumentAction} from './actions'
 import {API_VERSION, INITIAL_OUTGOING_THROTTLE_TIME} from './documentConstants'
-import {type DocumentEvent, getDocumentEvents} from './events'
+import {
+  type DocumentEvent,
+  type DocumentTransactionSubmissionResult,
+  getDocumentEvents,
+} from './events'
 import {listen, OutOfSyncError} from './listen'
 import {type JsonMatch} from './patchOperations'
 import {
@@ -399,20 +403,55 @@ const subscribeToAppliedAndSubmitNextTransaction = ({
       ),
       concatMap(([outgoing, client]) => {
         if (!outgoing) return EMPTY
-        return client.observable
-          .action(outgoing.outgoingActions as Action[], {
-            transactionId: outgoing.transactionId,
-            skipCrossDatasetReferenceValidation: true,
-            tag: 'document.action',
-          })
-          .pipe(
-            catchError((error) => {
-              state.set('revertOutgoingTransaction', revertOutgoingTransaction)
-              events.next({type: 'reverted', message: error.message, outgoing, error})
-              return EMPTY
-            }),
-            map((result) => ({result, outgoing})),
-          )
+
+        const revertOnError = catchError((error: unknown) => {
+          state.set('revertOutgoingTransaction', revertOutgoingTransaction)
+          const message = error instanceof Error ? error.message : 'Request failed'
+          events.next({type: 'reverted', message, outgoing, error})
+          return EMPTY
+        })
+
+        // Draft/published flow and liveEdit create/delete -- use actions and return
+        if (outgoing.outgoingActions.length > 0) {
+          return client.observable
+            .action(outgoing.outgoingActions as Action[], {
+              transactionId: outgoing.transactionId,
+              skipCrossDatasetReferenceValidation: true,
+              tag: 'document.action',
+            })
+            .pipe(
+              revertOnError,
+              map((result) => ({
+                result: result as DocumentTransactionSubmissionResult,
+                outgoing,
+              })),
+            )
+        }
+
+        // liveEdit edits: mutations API and return
+        if (
+          outgoing.actions.every((action) => action.liveEdit) &&
+          outgoing.outgoingMutations.length > 0
+        ) {
+          return client.observable
+            .mutate(outgoing.outgoingMutations as Mutation[], {
+              transactionId: outgoing.transactionId,
+              visibility: 'async',
+              returnDocuments: false,
+              returnFirst: false,
+              tag: 'document.mutate',
+              skipCrossDatasetReferenceValidation: true,
+            })
+            .pipe(
+              revertOnError,
+              map((result) => ({
+                result: result as DocumentTransactionSubmissionResult,
+                outgoing,
+              })),
+            )
+        }
+
+        return EMPTY
       }),
       tap(({outgoing, result}) => {
         state.set('cleanupOutgoingTransaction', cleanupOutgoingTransaction)

--- a/packages/core/src/document/events.ts
+++ b/packages/core/src/document/events.ts
@@ -1,7 +1,12 @@
-import {type SanityClient} from '@sanity/client'
+import {type MultipleMutationResult, type SanityClient} from '@sanity/client'
 
 import {type DocumentAction} from './actions'
 import {type OutgoingTransaction} from './reducers'
+
+/** @beta Response body from submitting an outgoing transaction (actions or mutations API). */
+export type DocumentTransactionSubmissionResult =
+  | Awaited<ReturnType<SanityClient['action']>>
+  | MultipleMutationResult
 
 /** @beta */
 export type DocumentEvent =
@@ -35,7 +40,7 @@ export interface ActionErrorEvent {
 export interface TransactionAcceptedEvent {
   type: 'accepted'
   outgoing: OutgoingTransaction
-  result: Awaited<ReturnType<SanityClient['action']>>
+  result: DocumentTransactionSubmissionResult
 }
 /**
  * @beta

--- a/packages/core/src/document/processActions.test.ts
+++ b/packages/core/src/document/processActions.test.ts
@@ -1,4 +1,4 @@
-import {type Reference, type SanityDocument} from '@sanity/types'
+import {type CreateMutation, type Reference, type SanityDocument} from '@sanity/types'
 import {parse} from 'groq-js'
 import {describe, expect, it} from 'vitest'
 
@@ -885,17 +885,12 @@ describe('processActions', () => {
         expect(doc?._type).toBe('liveArticle')
         expect(doc?._rev).toBe(transactionId)
 
-        // Should use document.create action, not version.create
-        expect(result.outgoingActions).toHaveLength(1)
-        const action = result.outgoingActions[0]
-        expect(action.actionType).toBe('sanity.action.document.create')
-        if ('attributes' in action && 'publishedId' in action) {
-          expect(action.publishedId).toBe('live1')
-          expect(action.attributes._id).toBe('live1')
-          expect(action.attributes._type).toBe('liveArticle')
-        } else {
-          throw new Error('Expected action to have attributes and publishedId')
-        }
+        // Should not use actions
+        expect(result.outgoingActions).toHaveLength(0)
+        expect(result.outgoingMutations).toHaveLength(1)
+        const mutation = result.outgoingMutations[0] as CreateMutation
+        expect(mutation.create._id).toBe('live1')
+        expect(mutation.create._type).toBe('liveArticle')
       })
 
       it('should throw an error if liveEdit document already exists', () => {

--- a/packages/core/src/document/processActions.test.ts
+++ b/packages/core/src/document/processActions.test.ts
@@ -946,12 +946,15 @@ describe('processActions', () => {
         expect(editedDoc?.['title']).toBe('Updated Title')
         expect(editedDoc?._id).toBe('live1')
 
-        // Should use document.edit action with draftId prefixed (for server validation) but publishedId as the actual doc
-        expect(result.outgoingActions[0]).toMatchObject({
-          actionType: 'sanity.action.document.edit',
-          draftId: 'drafts.live1',
-          publishedId: 'live1',
+        expect(result.outgoingMutations[0]).toEqual({
+          patch: {
+            id: 'live1',
+            diffMatchPatch: {
+              title: '@@ -1,12 +1,11 @@\n-Original\n+Updated\n  Tit\n',
+            },
+          },
         })
+        expect(result.outgoingActions).toHaveLength(0)
       })
 
       it('should throw an error if liveEdit document does not exist', () => {

--- a/packages/core/src/document/processActions.test.ts
+++ b/packages/core/src/document/processActions.test.ts
@@ -893,6 +893,37 @@ describe('processActions', () => {
         expect(mutation.create._type).toBe('liveArticle')
       })
 
+      it('should apply initialValue when creating a liveEdit document', () => {
+        const base: DocumentSet = {}
+        const working: DocumentSet = {}
+        const actions: DocumentAction[] = [
+          {
+            documentId: 'live1',
+            type: 'document.create',
+            documentType: 'liveArticle',
+            liveEdit: true,
+            initialValue: {title: 'Initial Title', count: 42},
+          },
+        ]
+
+        const result = processActions({
+          actions,
+          transactionId,
+          base,
+          working,
+          timestamp,
+          grants: defaultGrants,
+        })
+
+        const doc = result.working['live1']
+        expect(doc?.['title']).toBe('Initial Title')
+        expect(doc?.['count']).toBe(42)
+
+        const mutation = result.outgoingMutations[0] as CreateMutation
+        expect(mutation.create['title']).toBe('Initial Title')
+        expect(mutation.create['count']).toBe(42)
+      })
+
       it('should throw an error if liveEdit document already exists', () => {
         const existingDoc = createLiveEditDoc('live1', 'Existing')
         const base: DocumentSet = {live1: existingDoc}
@@ -996,12 +1027,9 @@ describe('processActions', () => {
 
         expect(result.working['live1']).toBeNull()
 
-        expect(result.outgoingActions).toEqual([
-          {
-            actionType: 'sanity.action.document.delete',
-            publishedId: 'live1',
-          },
-        ])
+        expect(result.outgoingActions).toHaveLength(0)
+        expect(result.outgoingMutations).toHaveLength(1)
+        expect(result.outgoingMutations[0]).toEqual({delete: {id: 'live1'}})
       })
 
       it('should throw an error if liveEdit document does not exist', () => {

--- a/packages/core/src/document/processActions.ts
+++ b/packages/core/src/document/processActions.ts
@@ -176,12 +176,8 @@ export function processActions({
             })
           }
 
+          // liveEdit documents use the mutation endpoint directly -- we don't send actions
           outgoingMutations.push(...mutations)
-          outgoingActions.push({
-            actionType: 'sanity.action.document.create',
-            publishedId: documentId,
-            attributes: newDocWorking,
-          })
           continue
         }
 

--- a/packages/core/src/document/processActions.ts
+++ b/packages/core/src/document/processActions.ts
@@ -151,8 +151,12 @@ export function processActions({
             })
           }
 
-          const newDocBase = {_type: action.documentType, _id: documentId}
-          const newDocWorking = {_type: action.documentType, _id: documentId}
+          const newDocBase = {_type: action.documentType, _id: documentId, ...action.initialValue}
+          const newDocWorking = {
+            _type: action.documentType,
+            _id: documentId,
+            ...action.initialValue,
+          }
           const mutations: Mutation[] = [{create: newDocWorking}]
 
           base = processMutations({
@@ -264,11 +268,10 @@ export function processActions({
           base = processMutations({documents: base, transactionId, mutations, timestamp})
           working = processMutations({documents: working, transactionId, mutations, timestamp})
 
+          // although liveEdit documents can use the actions API for deletion,
+          // having this be an action while other operations are mutations creates an inconsistency
+          // (and a possible race condition in document store where mutations might get skipped)
           outgoingMutations.push(...mutations)
-          outgoingActions.push({
-            actionType: 'sanity.action.document.delete',
-            publishedId: documentId,
-          })
           continue
         }
 

--- a/packages/core/src/document/processActions.ts
+++ b/packages/core/src/document/processActions.ts
@@ -408,19 +408,8 @@ export function processActions({
             timestamp,
           })
 
+          // liveEdit documents use the mutation endpoint directly -- we don't send actions
           outgoingMutations.push(...workingMutations)
-          outgoingActions.push(
-            ...patches.map(
-              (patch): HttpAction => ({
-                actionType: 'sanity.action.document.edit',
-                // Server requires draftId to have drafts. prefix for validation, even for liveEdit
-                draftId: getDraftId(documentId),
-                publishedId: documentId,
-                patch: patch as PatchOperations,
-              }),
-            ),
-          )
-
           continue
         }
 

--- a/packages/core/src/document/reducers.test.ts
+++ b/packages/core/src/document/reducers.test.ts
@@ -350,6 +350,67 @@ describe('batchAppliedTransactions', () => {
     // The actions array should be the same as the input's.
     expect(result?.actions).toEqual(appliedTx.actions)
   })
+
+  it('does not batch a liveEdit edit with a non-liveEdit edit', () => {
+    const nonLiveEditTx: AppliedTransaction = {
+      transactionId: 'txn-nonlive',
+      actions: [
+        {
+          type: 'document.edit',
+          documentId: 'doc1',
+          documentType: 'article',
+          patches: [{set: {foo: 'a'}}],
+        },
+      ],
+      disableBatching: false,
+      outgoingActions: [
+        {
+          actionType: 'sanity.action.document.edit',
+          draftId: getDraftId('doc1'),
+          publishedId: getPublishedId('doc1'),
+          patch: {set: {foo: 'a'}},
+        },
+      ],
+      outgoingMutations: [],
+      base: {[getDraftId('doc1')]: {...exampleDoc, _id: getDraftId('doc1'), _rev: 'rev1'}},
+      working: {[getDraftId('doc1')]: {...exampleDoc, _id: getDraftId('doc1'), _rev: 'rev2'}},
+      previous: {[getDraftId('doc1')]: {...exampleDoc, _id: getDraftId('doc1'), _rev: 'rev1'}},
+      previousRevs: {[getDraftId('doc1')]: 'rev1'},
+      timestamp: '2025-02-06T00:00:00.000Z',
+    }
+    const liveEditTx: AppliedTransaction = {
+      transactionId: 'txn-live',
+      actions: [
+        {
+          type: 'document.edit',
+          documentId: 'doc2',
+          documentType: 'liveArticle',
+          liveEdit: true,
+          patches: [{set: {bar: 'b'}}],
+        },
+      ],
+      disableBatching: false,
+      outgoingActions: [],
+      outgoingMutations: [{patch: {id: 'doc2', set: {bar: 'b'}}}],
+      base: {doc2: {...exampleDoc, _id: 'doc2', _rev: 'rev1'}},
+      working: {doc2: {...exampleDoc, _id: 'doc2', _rev: 'rev2'}},
+      previous: {doc2: {...exampleDoc, _id: 'doc2', _rev: 'rev1'}},
+      previousRevs: {doc2: 'rev1'},
+      timestamp: '2025-02-06T00:01:00.000Z',
+    }
+
+    // liveEdit first: should return only the liveEdit transaction
+    const resultLiveFirst = batchAppliedTransactions([liveEditTx, nonLiveEditTx])
+    expect(resultLiveFirst?.batchedTransactionIds).toEqual(['txn-live'])
+    expect(resultLiveFirst?.outgoingMutations).toEqual(liveEditTx.outgoingMutations)
+    expect(resultLiveFirst?.outgoingActions).toHaveLength(0)
+
+    // non-liveEdit first: should return only the non-liveEdit transaction
+    const resultNonLiveFirst = batchAppliedTransactions([nonLiveEditTx, liveEditTx])
+    expect(resultNonLiveFirst?.batchedTransactionIds).toEqual(['txn-nonlive'])
+    expect(resultNonLiveFirst?.outgoingActions).toEqual(nonLiveEditTx.outgoingActions)
+    expect(resultNonLiveFirst?.outgoingMutations).toHaveLength(0)
+  })
 })
 
 describe('transitionAppliedTransactionsToOutgoing', () => {

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -116,9 +116,9 @@ export interface AppliedTransaction extends QueuedTransaction {
   outgoingActions: HttpAction[]
 
   /**
-   * similar to `outgoingActions` but comprised of mutations instead of action.
-   * this left here for debugging purposes but could be used to send mutations
-   * to Content Lake instead of actions.
+   * similar to `outgoingActions` but comprised of mutations instead of actions.
+   * Useful for debugging, and is also used by liveEdit documents to send mutations,
+   * since they can't use the Actions API which is pretty dependent on the draft model.
    */
   outgoingMutations: Mutation[]
 }
@@ -265,6 +265,9 @@ export function batchAppliedTransactions([curr, ...rest]: AppliedTransaction[]):
   const next = batchAppliedTransactions(rest)
   if (!next) return undefined
   if (next.disableBatching) return editAction
+
+  // Don't batch a liveEdit edit with a non-liveEdit edit — they route to different APIs
+  if (!!action.liveEdit !== !!next.actions[0]?.liveEdit) return editAction
 
   return {
     disableBatching: false,

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -21,7 +21,6 @@ export type SyncTransactionState = Pick<
 
 type ActionMap = {
   create: 'sanity.action.document.version.create'
-  createLiveEdit: 'sanity.action.document.create'
   discard: 'sanity.action.document.version.discard'
   unpublish: 'sanity.action.document.unpublish'
   delete: 'sanity.action.document.delete'
@@ -36,7 +35,6 @@ type OptimisticLock = {
 
 export type HttpAction =
   | {actionType: ActionMap['create']; publishedId: string; attributes: SanityDocumentLike}
-  | {actionType: ActionMap['createLiveEdit']; publishedId: string; attributes: SanityDocumentLike}
   | {actionType: ActionMap['discard']; versionId: string; purge?: boolean}
   | {actionType: ActionMap['unpublish']; draftId: string; publishedId: string}
   | {actionType: ActionMap['delete']; publishedId: string; includeDrafts?: string[]}


### PR DESCRIPTION
### Description
It's my understanding that the Actions API doesn't really work well with `liveEdit` documents -- an explanation in our [internal thread](https://sanity-io.slack.com/archives/C06D0L2HJ94/p1713210390615989) says that it doesn't quite sit well with the draft model. Our current implementation attempts to use the Actions API but ends up creating a draft -- see the below GIF:
<img width="2020" height="1180" alt="2026-04-16 18 51 12" src="https://github.com/user-attachments/assets/b19a541f-fe3c-4010-83f0-2d8735322224" />

Everything looks correct in the optimistic store in the SDK, but the draft is still being created remotely (we just don't see it, as it's not being listened to).

Additionally -- this also errors with the Create action. If you click `Live Edit` in that same interface and click `Create` you'll get the following error:
```
"action index 0: \"attributes._id\" must be prefixed with either \"drafts.\" or \"versions.{bundleId}\""
```
 
This PR updates the document store to use mutations when working with a `liveEdit` document, which is the same strategy the Studio uses.

I also added an initial value affordance there.

### What to review
The most important changes are in the document store itself -- adding a mutations endpoint to the remote change mechanism. `processActions` is also updated not to create `outgoingActions` if it's a `liveEdit` document. (internal actions are fine, since that's the mechanism used to update the optimistic store).

There were some additional guards / tests to avoid batching and dropping things silently.

### Testing
Logic was added to handle mutations in `documentStore.test.ts` and tests were added for this logic. I also added e2e tests to prevent further regressions.

### Fun gif
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2xtZ2EzOXN0Zm0yM2Y1ejhrbG43M3hkbWx1cDUwc3BxNzl2am4zMyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/mWnDeIKilkwDcrM2VT/giphy.gif)