### PR TITLE
fix(e2e): temporarily run e2e tests outside of dashboard

### DIFF
--- a/apps/kitchensink-react/playwright.config.ts
+++ b/apps/kitchensink-react/playwright.config.ts
@@ -1,7 +1,7 @@
 import {createPlaywrightConfig} from '@repo/e2e'
 
-const isWebkitProject =
-  process.argv.includes('--project=webkit') || process.argv.some((arg) => arg.includes('webkit'))
+// const isWebkitProject =
+//   process.argv.includes('--project=webkit') || process.argv.some((arg) => arg.includes('webkit'))
 
 export default createPlaywrightConfig({
   testDir: './e2e',
@@ -9,7 +9,9 @@ export default createPlaywrightConfig({
     ? {} // In CI, don't start a webServer since it's started manually
     : {
         webServer: {
-          command: isWebkitProject ? 'pnpm exec vite --port 3333' : 'pnpm dev',
+          // Restore for Dashboard when we get secrets
+          // command: isWebkitProject ? 'pnpm exec vite --port 3333' : 'pnpm dev',
+          command: 'pnpm exec vite --port 3333',
           reuseExistingServer: true,
           stdout: 'pipe',
           env: {

--- a/packages/@repo/e2e/src/helpers/pageContext.ts
+++ b/packages/@repo/e2e/src/helpers/pageContext.ts
@@ -13,7 +13,8 @@ export type PageContext = Pick<Page, 'getByTestId' | 'getByText' | 'getByRole' |
 // Webkit is excluded from dashboard tests because webkit blocks script execution
 // in sandboxed iframes without 'allow-scripts', and the dashboard creates
 // sandboxed iframes that webkit cannot execute JavaScript in
-const DASHBOARD_PROJECTS = ['chromium', 'firefox']
+// const DASHBOARD_PROJECTS = ['chromium', 'firefox']
+const DASHBOARD_PROJECTS: string[] = []
 
 /**
  * Determines if we're in a dashboard context by checking the project name

--- a/packages/@repo/e2e/src/index.ts
+++ b/packages/@repo/e2e/src/index.ts
@@ -10,9 +10,10 @@ const SETUP_DIR = path.join(path.dirname(__dirname), 'src', 'setup')
 const TEARDOWN_DIR = path.join(path.dirname(__dirname), 'src', 'teardown')
 const AUTH_FILE = path.join(path.dirname(__dirname), '.auth', 'user.json')
 
-const {CI, SDK_E2E_ORGANIZATION_ID} = getE2EEnv()
-const BASE_URL = `https://www.sanity.work/@${SDK_E2E_ORGANIZATION_ID}/application/__dev/`
-
+const {CI} = getE2EEnv()
+// Restore for Dashboard when we get secrets
+// const BASE_URL = `https://www.sanity.work/@${SDK_E2E_ORGANIZATION_ID}/application/__dev/`
+const BASE_URL = 'http://localhost:3333/'
 /**
  * @internal
  * Base Playwright configuration

--- a/packages/@repo/e2e/src/setup/auth.setup.ts
+++ b/packages/@repo/e2e/src/setup/auth.setup.ts
@@ -49,38 +49,38 @@ const authenticateUser = async (context: BrowserContext, config: AuthConfig) => 
   await page.close()
 }
 
-const setDashboardRedirectCookie = async (context: BrowserContext) => {
-  const page = await context.newPage()
+// const setDashboardRedirectCookie = async (context: BrowserContext) => {
+//   const page = await context.newPage()
 
-  // visit the dashboard url to set the redirect cookie
-  await page.goto(
-    `https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}?dev=http://localhost:3333`,
-  )
+//   // visit the dashboard url to set the redirect cookie
+//   await page.goto(
+//     `https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}?dev=http://localhost:3333`,
+//   )
 
-  // wait until the url is /application/__dev (indicating the redirect cookie was set)
-  await page.waitForURL(`https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}/application/__dev`)
+//   // wait until the url is /application/__dev (indicating the redirect cookie was set)
+//   await page.waitForURL(`https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}/application/__dev`)
 
-  await page.close()
-}
+//   await page.close()
+// }
 
 setup('setup authentication', async ({browser}) => {
   // Create a single browser context that will be used for all authentication operations
   const context = await browser.newContext()
 
   try {
-    // Authenticate for standalone (webkit)
+    // Authenticate for standalone (all browsers at the moment)
     await authenticateUser(context, {
       origin: 'http://localhost:3333',
       expectedRedirectUrl: 'http://localhost:3333',
     })
-    // Authenticate for Dashboard (other browsers)
-    await authenticateUser(context, {
-      origin: 'https://www.sanity.work/api/dashboard/authenticate',
-      expectedRedirectUrl: `https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}`,
-    })
+    // Authenticate for Dashboard (restore for every browser but webkit when we get secrets)
+    // await authenticateUser(context, {
+    //   origin: 'https://www.sanity.work/api/dashboard/authenticate',
+    //   expectedRedirectUrl: `https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}`,
+    // })
 
-    // Set the dashboard redirect cookie
-    await setDashboardRedirectCookie(context)
+    // // Set the dashboard redirect cookie
+    // await setDashboardRedirectCookie(context)
 
     // Save the combined context state to the auth file
     // This will contain all cookies, localStorage, and sessionStorage from all operations


### PR DESCRIPTION
### Description
I don't have the permissions to create a `core-staging` secret to bypass Dashboard protection, and I'd rather not hold up in-flight work while we wait for one. This is a quick and dirty fix to continue e2e testing while we wait for the correct fix. That branch is mostly created, and this will be reverted in favor of that as soon as we can get it working.

### What to review
You can review my sincere apologies for this inelegant fix.

### Testing
If the e2e tests pass, this works.

### Fun gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWRjZGVjNG5mbDN3bWJuN2RkNnRsMmlpMm91OGhjbjhzYTNsbHhzbiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT5LMyHCWXvn3lvies/giphy.gif)
