### PR TITLE
fix(e2e): add vercel bypass headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ SDK_E2E_ORGANIZATION_ID=oFvj4MZWQ
 SDK_E2E_USER_ID=sdk+e2e@sanity.io
 SDK_E2E_USER_PASSWORD=
 RECAPTCHA_E2E_STAGING_KEY=
+# This can be found in the "Deployment Protection" settings section of the sanity-io Vercel project.
+VERCEL_AUTOMATION_BYPASS_SECRET=
 
 
 # we test with multiple Resource configurations at once. For now, these are in the same project
@@ -34,4 +36,3 @@ SDK_E2E_SESSION_TOKEN=
 # This is generated on the org admin page. If you are a user with media library permissions, you can just
 # use the same user session token you used above.
 SDK_E2E_MEDIA_LIBRARY_TOKEN=
-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,6 +69,7 @@ jobs:
       SDK_E2E_USER_ID: ${{ secrets.SDK_E2E_USER_ID }}
       SDK_E2E_USER_PASSWORD: ${{ secrets.SDK_E2E_USER_PASSWORD }}
       RECAPTCHA_E2E_STAGING_KEY: ${{ secrets.RECAPTCHA_E2E_STAGING_KEY }}
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
     steps:
       - name: 📥 Checkout repository

--- a/apps/kitchensink-react/playwright.config.ts
+++ b/apps/kitchensink-react/playwright.config.ts
@@ -1,7 +1,7 @@
 import {createPlaywrightConfig} from '@repo/e2e'
 
-// const isWebkitProject =
-//   process.argv.includes('--project=webkit') || process.argv.some((arg) => arg.includes('webkit'))
+const isWebkitProject =
+  process.argv.includes('--project=webkit') || process.argv.some((arg) => arg.includes('webkit'))
 
 export default createPlaywrightConfig({
   testDir: './e2e',
@@ -9,9 +9,7 @@ export default createPlaywrightConfig({
     ? {} // In CI, don't start a webServer since it's started manually
     : {
         webServer: {
-          // Restore for Dashboard when we get secrets
-          // command: isWebkitProject ? 'pnpm exec vite --port 3333' : 'pnpm dev',
-          command: 'pnpm exec vite --port 3333',
+          command: isWebkitProject ? 'pnpm exec vite --port 3333' : 'pnpm dev',
           reuseExistingServer: true,
           stdout: 'pipe',
           env: {

--- a/packages/@repo/e2e/src/fixtures.ts
+++ b/packages/@repo/e2e/src/fixtures.ts
@@ -54,5 +54,3 @@ export const test = base.extend<SanityFixtures>({
     await use(getPageContext)
   },
 })
-
-export {expect} from '@playwright/test'

--- a/packages/@repo/e2e/src/helpers/getE2EEnv.ts
+++ b/packages/@repo/e2e/src/helpers/getE2EEnv.ts
@@ -19,6 +19,8 @@ interface E2EEnv {
   SDK_E2E_USER_PASSWORD: string
   /** E2E test recaptcha key for CI */
   RECAPTCHA_E2E_STAGING_KEY: string
+  /** Vercel bypass secret for Dashboard deployment protection */
+  VERCEL_AUTOMATION_BYPASS_SECRET: string
   /** The media library ID for media library tests */
   SDK_E2E_MEDIA_LIBRARY_ID: string
   /** The media library token for media library tests */
@@ -68,6 +70,7 @@ export function getE2EEnv(): E2EEnv {
   const SDK_E2E_USER_ID = readEnv('SDK_E2E_USER_ID')
   const SDK_E2E_USER_PASSWORD = readEnv('SDK_E2E_USER_PASSWORD')
   const RECAPTCHA_E2E_STAGING_KEY = readEnv('RECAPTCHA_E2E_STAGING_KEY')
+  const VERCEL_AUTOMATION_BYPASS_SECRET = readEnv('VERCEL_AUTOMATION_BYPASS_SECRET')
   const SDK_E2E_MEDIA_LIBRARY_ID = readEnv('SDK_E2E_MEDIA_LIBRARY_ID')
   const SDK_E2E_MEDIA_LIBRARY_TOKEN = readEnv('SDK_E2E_MEDIA_LIBRARY_TOKEN')
   return {
@@ -80,6 +83,7 @@ export function getE2EEnv(): E2EEnv {
     SDK_E2E_USER_ID,
     SDK_E2E_USER_PASSWORD,
     RECAPTCHA_E2E_STAGING_KEY,
+    VERCEL_AUTOMATION_BYPASS_SECRET,
     SDK_E2E_MEDIA_LIBRARY_ID,
     SDK_E2E_MEDIA_LIBRARY_TOKEN,
   }

--- a/packages/@repo/e2e/src/helpers/pageContext.ts
+++ b/packages/@repo/e2e/src/helpers/pageContext.ts
@@ -13,8 +13,7 @@ export type PageContext = Pick<Page, 'getByTestId' | 'getByText' | 'getByRole' |
 // Webkit is excluded from dashboard tests because webkit blocks script execution
 // in sandboxed iframes without 'allow-scripts', and the dashboard creates
 // sandboxed iframes that webkit cannot execute JavaScript in
-// const DASHBOARD_PROJECTS = ['chromium', 'firefox']
-const DASHBOARD_PROJECTS: string[] = []
+const DASHBOARD_PROJECTS = ['chromium', 'firefox']
 
 /**
  * Determines if we're in a dashboard context by checking the project name

--- a/packages/@repo/e2e/src/index.ts
+++ b/packages/@repo/e2e/src/index.ts
@@ -10,10 +10,9 @@ const SETUP_DIR = path.join(path.dirname(__dirname), 'src', 'setup')
 const TEARDOWN_DIR = path.join(path.dirname(__dirname), 'src', 'teardown')
 const AUTH_FILE = path.join(path.dirname(__dirname), '.auth', 'user.json')
 
-const {CI} = getE2EEnv()
-// Restore for Dashboard when we get secrets
-// const BASE_URL = `https://www.sanity.work/@${SDK_E2E_ORGANIZATION_ID}/application/__dev/`
-const BASE_URL = 'http://localhost:3333/'
+const {CI, SDK_E2E_ORGANIZATION_ID, VERCEL_AUTOMATION_BYPASS_SECRET} = getE2EEnv()
+const BASE_URL = `https://www.sanity.work/@${SDK_E2E_ORGANIZATION_ID}/application/__dev/`
+
 /**
  * @internal
  * Base Playwright configuration
@@ -38,6 +37,12 @@ export const basePlaywrightConfig: PlaywrightTestConfig = {
     navigationTimeout: 15000,
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    extraHTTPHeaders: {
+      // bypass deployment protection on sanity.work
+      'x-vercel-protection-bypass': VERCEL_AUTOMATION_BYPASS_SECRET,
+      // we're running Chromium and Firefox tests in an iframe
+      'x-vercel-set-bypass-cookie': 'samesitenone',
+    },
   },
   /* Increase expect timeout for async operations like mutations and subscriptions */
   expect: {
@@ -99,4 +104,5 @@ export const createPlaywrightConfig = (
 }
 
 // Export test fixtures
-export {expect, test} from './fixtures'
+export {test} from './fixtures'
+export {expect} from '@playwright/test'

--- a/packages/@repo/e2e/src/setup/auth.setup.ts
+++ b/packages/@repo/e2e/src/setup/auth.setup.ts
@@ -45,42 +45,48 @@ const authenticateUser = async (context: BrowserContext, config: AuthConfig) => 
 
   // Wait for the redirect to complete AND network to be idle
   await page.waitForURL(config.expectedRedirectUrl)
+  await page.close()
+}
+
+const setDashboardRedirectCookie = async (context: BrowserContext) => {
+  const page = await context.newPage()
+
+  // visit the dashboard url to set the redirect cookie
+  await page.goto(
+    `https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}?dev=http://localhost:3333`,
+  )
+
+  // wait until the url is /application/__dev (indicating the redirect cookie was set)
+  await page.waitForURL(`https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}/application/__dev`)
 
   await page.close()
 }
 
-// const setDashboardRedirectCookie = async (context: BrowserContext) => {
-//   const page = await context.newPage()
-
-//   // visit the dashboard url to set the redirect cookie
-//   await page.goto(
-//     `https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}?dev=http://localhost:3333`,
-//   )
-
-//   // wait until the url is /application/__dev (indicating the redirect cookie was set)
-//   await page.waitForURL(`https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}/application/__dev`)
-
-//   await page.close()
-// }
-
 setup('setup authentication', async ({browser}) => {
   // Create a single browser context that will be used for all authentication operations
-  const context = await browser.newContext()
+  const context = await browser.newContext({
+    extraHTTPHeaders: {
+      // bypass deployment protection on sanity.work
+      'x-vercel-protection-bypass': env.VERCEL_AUTOMATION_BYPASS_SECRET,
+      // we're running Chromium and Firefox tests in an iframe
+      'x-vercel-set-bypass-cookie': 'samesitenone',
+    },
+  })
 
   try {
-    // Authenticate for standalone (all browsers at the moment)
+    // Authenticate for standalone (webkit)
     await authenticateUser(context, {
       origin: 'http://localhost:3333',
       expectedRedirectUrl: 'http://localhost:3333',
     })
     // Authenticate for Dashboard (restore for every browser but webkit when we get secrets)
-    // await authenticateUser(context, {
-    //   origin: 'https://www.sanity.work/api/dashboard/authenticate',
-    //   expectedRedirectUrl: `https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}`,
-    // })
+    await authenticateUser(context, {
+      origin: 'https://www.sanity.work/api/dashboard/authenticate',
+      expectedRedirectUrl: `https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}`,
+    })
 
     // // Set the dashboard redirect cookie
-    // await setDashboardRedirectCookie(context)
+    await setDashboardRedirectCookie(context)
 
     // Save the combined context state to the auth file
     // This will contain all cookies, localStorage, and sessionStorage from all operations

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,9 @@
     "NPM_CONFIG_PROVENANCE",
     "CI",
     "SDK_E2E_*",
-    "RECAPTCHA_E2E_STAGING_KEY"
+    "SANITY_INTERNAL_ENV",
+    "RECAPTCHA_E2E_STAGING_KEY",
+    "VERCEL_AUTOMATION_BYPASS_SECRET"
   ],
   "tasks": {
     "build": {
@@ -64,7 +66,12 @@
     },
     "test:e2e": {
       "cache": false,
-      "env": ["SDK_E2E_*", "NODE_ENV", "RECAPTCHA_E2E_STAGING_KEY"],
+      "env": [
+        "SDK_E2E_*",
+        "SANITY_INTERNAL_ENV",
+        "RECAPTCHA_E2E_STAGING_KEY",
+        "VERCEL_AUTOMATION_BYPASS_SECRET"
+      ],
       "dependsOn": ["@repo/e2e#build"],
       "outputs": ["e2e/test-results/**", "e2e/test-report/**"]
     },


### PR DESCRIPTION
### Description
Use the Vercel Deployment headers to be able to test the SDK within Dashboard.

### What to review
Anything I missed?

### Testing
Hopefully functional e2e tests speak for themselves.

### Fun gif
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExM3o4b3FldnZ0NXlvNGs2bXA5Mzd6c3R2b3J5N2h0MmZ4em11c3k1MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/A7XLVY8QoE3n8KzpjP/giphy.gif)
