### PR TITLE
fix(document): ensure document store works for versions

### DIFF
--- a/apps/kitchensink-react/e2e/version-document-editor.spec.ts
+++ b/apps/kitchensink-react/e2e/version-document-editor.spec.ts
@@ -1,0 +1,71 @@
+import {expect, test} from '@repo/e2e'
+
+test.describe('Version Document Editor', () => {
+  test('can create and edit a version document in a release', async ({
+    page,
+    getClient,
+    getPageContext,
+  }) => {
+    const client = getClient()
+
+    // Create a content release to test against
+    const {releaseId} = await client.releases.create({
+      metadata: {
+        title: 'Version Editor Test Release',
+        releaseType: 'undecided',
+      },
+    })
+
+    await page.goto('./releases')
+    const pageContext = await getPageContext(page)
+
+    // Wait for the route to be ready
+    const heading = pageContext.getByText('Releases', {exact: true}).first()
+    await expect(heading).toBeVisible({timeout: 30000})
+
+    // Select the release in the autocomplete
+    const autocompleteInput = pageContext.locator('input[placeholder="Type to find release …"]')
+    await expect(autocompleteInput).toBeVisible()
+    await autocompleteInput.click()
+    await autocompleteInput.fill('Version Editor Test Release')
+
+    const releaseButton = pageContext.getByRole('button', {
+      name: new RegExp(`Version Editor Test Release.*Release ID: ${releaseId}`),
+    })
+    await expect(releaseButton).toBeVisible({timeout: 10000})
+    await releaseButton.click()
+
+    await expect(autocompleteInput).toHaveValue('Version Editor Test Release', {timeout: 10000})
+
+    // Enter a new (unique) document ID to create as a version document in this release
+    const newDocumentId = `test-version-doc-${Date.now()}`
+    const documentIdInput = pageContext.locator('input[placeholder="Enter document ID"]')
+    await expect(documentIdInput).toBeVisible()
+    await documentIdInput.fill(newDocumentId)
+    await pageContext.getByRole('button', {name: 'View Document'}).click()
+
+    // Open the document editor dialog (release perspective is now active)
+    const editDocumentButton = pageContext.getByRole('button', {name: 'Edit Document'})
+    await expect(editDocumentButton).toBeVisible()
+    await editDocumentButton.click()
+
+    // Wait for the dialog to appear
+    const dialog = pageContext.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    // The document doesn't exist in the release yet — wait for permissions to
+    // resolve, then click Create to create the version document
+    const createButton = dialog.getByRole('button', {name: 'Create'})
+    await expect(createButton).toBeEnabled({timeout: 10000})
+    await createButton.click()
+
+    // Update the name field once the version document has been created
+    const nameInput = dialog.getByTestId('name-input')
+    await expect(nameInput).toBeVisible({timeout: 10000})
+    await nameInput.fill('My Release Document')
+    await nameInput.press('Enter')
+
+    // Verify the name change is reflected in the live-bound name input
+    await expect(nameInput).toHaveValue('My Release Document', {timeout: 10000})
+  })
+})

--- a/apps/kitchensink-react/src/DocumentCollection/DocumentEditorRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentEditorRoute.tsx
@@ -1,53 +1,34 @@
 /* eslint-disable no-console */
 import {
-  createDocument,
   createDocumentHandle,
-  deleteDocument,
-  discardDocument,
   type DocumentHandle,
-  editDocument,
-  publishDocument,
-  unpublishDocument,
-  useApplyDocumentActions,
   useDocument,
   useDocumentEvent,
-  useDocumentPermissions,
   useDocuments,
   useDocumentSyncStatus,
-  useEditDocument,
 } from '@sanity/sdk-react'
-import {
-  Badge,
-  Box,
-  Button,
-  Card,
-  Checkbox,
-  Flex,
-  Label,
-  Stack,
-  Text,
-  TextInput,
-  Tooltip,
-} from '@sanity/ui'
+import {Badge, Box, Button, Card, Checkbox, Flex, Label, Stack, Text, TextInput} from '@sanity/ui'
 import {type JSX, useEffect, useState} from 'react'
 
+import {DocumentEditorPanel} from '../components/DocumentEditorPanel'
 import {JsonDocumentEditor} from '../components/JsonDocumentEditor'
 import {devConfigs, e2eConfigs} from '../sanityConfigs'
 
-function DocumentEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
+const AUTHOR_INITIAL_VALUES = {
+  name: 'New Author',
+  role: 'developer',
+  awards: ['Quick Creator Award'],
+}
+
+function DocumentEditor({
+  docHandle,
+  onDocumentIdChange,
+}: {
+  docHandle: DocumentHandle<'author'>
+  onDocumentIdChange: (id: string) => void
+}) {
   useDocumentEvent({...docHandle, onEvent: (e) => console.log(e)})
   const synced = useDocumentSyncStatus(docHandle)
-  const apply = useApplyDocumentActions()
-
-  const canEdit = useDocumentPermissions(editDocument(docHandle))
-  const canCreate = useDocumentPermissions(createDocument(docHandle))
-  const canPublish = useDocumentPermissions(publishDocument(docHandle))
-  const canDelete = useDocumentPermissions(deleteDocument(docHandle))
-  const canUnpublish = useDocumentPermissions(unpublishDocument(docHandle))
-  const canDiscard = useDocumentPermissions(discardDocument(docHandle))
-
-  const {data: name = ''} = useDocument({...docHandle, path: 'name'})
-  const setName = useEditDocument({...docHandle, path: 'name'})
 
   const {data: document} = useDocument(docHandle)
 
@@ -77,130 +58,11 @@ function DocumentEditor({docHandle}: {docHandle: DocumentHandle<'author'>}) {
           </Flex>
         </Card>
 
-        {/* Document Info Section */}
-        <Card padding={3} radius={2} shadow={1}>
-          <Stack space={3}>
-            <Text size={1} weight="semibold">
-              Document Information
-            </Text>
-            <Flex gap={3}>
-              <Box flex={1}>
-                <TextInput fontSize={1} label="Document ID" value={docHandle.documentId} readOnly />
-              </Box>
-              <Box flex={1}>
-                <TextInput
-                  fontSize={1}
-                  label="Name"
-                  type="text"
-                  value={name}
-                  onChange={(e) => setName(e.currentTarget.value)}
-                  data-testid="name-input"
-                />
-              </Box>
-            </Flex>
-          </Stack>
-        </Card>
-
-        {/* Actions Section */}
-        <Card padding={3} radius={2} shadow={1}>
-          <Stack space={3}>
-            <Text size={1} weight="semibold">
-              Document Actions
-            </Text>
-            <Flex gap={2} wrap="wrap">
-              <Tooltip content={canCreate.message}>
-                <Box>
-                  <Button
-                    disabled={!canCreate.allowed}
-                    onClick={() => apply(createDocument(docHandle))}
-                    text="Create"
-                    tone="positive"
-                    fontSize={1}
-                    data-testid="document-editor-action-create"
-                  />
-                </Box>
-              </Tooltip>
-
-              <Tooltip content={canCreate.message}>
-                <Box>
-                  <Button
-                    disabled={!canCreate.allowed}
-                    onClick={() =>
-                      apply(
-                        createDocument(docHandle, {
-                          name: 'New Author',
-                          role: 'developer',
-                          awards: ['Quick Creator Award'],
-                        }),
-                      )
-                    }
-                    text="Create with Initial Values"
-                    tone="positive"
-                    fontSize={1}
-                    data-testid="document-editor-action-create-with-initial-values"
-                  />
-                </Box>
-              </Tooltip>
-
-              {!docHandle.liveEdit && (
-                <>
-                  <Tooltip content={canPublish.message}>
-                    <Box>
-                      <Button
-                        disabled={!canPublish.allowed}
-                        onClick={async () => {
-                          const response = await apply(publishDocument(docHandle))
-                          await response.submitted()
-                        }}
-                        text="Publish"
-                        tone="positive"
-                        fontSize={1}
-                      />
-                    </Box>
-                  </Tooltip>
-                  <Tooltip content={canDiscard.message}>
-                    <Box>
-                      <Button
-                        disabled={!canDiscard.allowed}
-                        onClick={() => apply(discardDocument(docHandle))}
-                        text="Discard Draft"
-                        fontSize={1}
-                      />
-                    </Box>
-                  </Tooltip>
-                  <Tooltip content={canUnpublish.message}>
-                    <Box>
-                      <Button
-                        disabled={!canUnpublish.allowed}
-                        onClick={() => apply(unpublishDocument(docHandle))}
-                        text="Unpublish"
-                        fontSize={1}
-                      />
-                    </Box>
-                  </Tooltip>
-                </>
-              )}
-
-              <Tooltip content={canDelete.message}>
-                <Box>
-                  <Button
-                    disabled={!canDelete.allowed}
-                    onClick={() => apply(deleteDocument(docHandle))}
-                    text="Delete"
-                    tone="critical"
-                    fontSize={1}
-                    data-testid="document-editor-action-delete"
-                  />
-                </Box>
-              </Tooltip>
-            </Flex>
-            {canEdit.message && (
-              <Text size={1} muted>
-                Permissions: {canEdit.message}
-              </Text>
-            )}
-          </Stack>
-        </Card>
+        <DocumentEditorPanel
+          docHandle={docHandle}
+          createInitialValues={AUTHOR_INITIAL_VALUES}
+          onDocumentIdChange={onDocumentIdChange}
+        />
 
         {/* JSON Editor Section */}
         <Card padding={4} radius={2} shadow={1}>
@@ -262,6 +124,16 @@ function Editor() {
         }),
       )
     }
+  }
+
+  const handleDocumentIdChange = (newId: string) => {
+    setDocHandle(
+      createDocumentHandle({
+        documentType: 'author',
+        documentId: newId,
+        liveEdit: liveEditMode,
+      }),
+    )
   }
 
   const updateDocHandle = (newValue: string) => {
@@ -349,6 +221,7 @@ function Editor() {
           <DocumentEditor
             key={`${docHandle.documentId}-${docHandle.liveEdit}`}
             docHandle={docHandle}
+            onDocumentIdChange={handleDocumentIdChange}
           />
         )}
       </Stack>

--- a/apps/kitchensink-react/src/components/DocumentEditorPanel.tsx
+++ b/apps/kitchensink-react/src/components/DocumentEditorPanel.tsx
@@ -1,0 +1,213 @@
+import {
+  createDocument,
+  deleteDocument,
+  discardDocument,
+  type DocumentHandle,
+  editDocument,
+  publishDocument,
+  unpublishDocument,
+  useApplyDocumentActions,
+  useDocument,
+  useDocumentPermissions,
+  useEditDocument,
+  useSanityInstance,
+} from '@sanity/sdk-react'
+import {Box, Button, Card, Flex, Stack, Text, TextInput, Tooltip} from '@sanity/ui'
+import React, {useEffect, useState} from 'react'
+
+interface DocumentEditorPanelProps {
+  docHandle: DocumentHandle
+  /**
+   * The document field path to use for the editable text input.
+   * Defaults to 'name'.
+   */
+  nameField?: string
+  /**
+   * The label shown above the editable text input.
+   * Defaults to 'Name'.
+   */
+  nameLabel?: string
+  /**
+   * If provided, shows a "Create with Initial Values" button pre-populated with these values.
+   * If omitted, that button is hidden.
+   */
+  createInitialValues?: Record<string, unknown>
+  /**
+   * If provided, the Document ID input becomes editable. Called when the user commits
+   * a new ID (on blur or Enter). The parent is responsible for updating docHandle.
+   */
+  onDocumentIdChange?: (id: string) => void
+}
+
+/*
+ * This component is used to test document actions and single-field "real-time" edits
+ */
+export function DocumentEditorPanel({
+  docHandle,
+  nameField = 'name',
+  nameLabel = 'Name',
+  createInitialValues,
+  onDocumentIdChange,
+}: DocumentEditorPanelProps): React.JSX.Element {
+  const apply = useApplyDocumentActions()
+  const instance = useSanityInstance()
+
+  // document actions (editDocument, createDocument, publishDocument, etc.) come from core and require resource to be passed in
+  const strictHandle = {
+    ...docHandle,
+    projectId: instance.config.projectId,
+    dataset: instance.config.dataset,
+  }
+
+  const canEdit = useDocumentPermissions(editDocument(strictHandle))
+  const canCreate = useDocumentPermissions(createDocument(strictHandle))
+  const canPublish = useDocumentPermissions(publishDocument(strictHandle))
+  const canDelete = useDocumentPermissions(deleteDocument(strictHandle))
+  const canUnpublish = useDocumentPermissions(unpublishDocument(strictHandle))
+  const canDiscard = useDocumentPermissions(discardDocument(strictHandle))
+  const [inputId, setInputId] = useState(docHandle.documentId)
+
+  useEffect(() => {
+    setInputId(docHandle.documentId)
+  }, [docHandle.documentId])
+
+  const commitId = () => {
+    if (inputId !== docHandle.documentId) {
+      onDocumentIdChange?.(inputId)
+    }
+  }
+  const {data} = useDocument<string>({...docHandle, path: nameField})
+  const setName = useEditDocument<string>({...docHandle, path: nameField})
+
+  return (
+    <Stack space={4}>
+      {/* Document Info Section */}
+      <Card padding={3} radius={2} shadow={1}>
+        <Stack space={3}>
+          <Text size={1} weight="semibold">
+            Document Information
+          </Text>
+          <Flex gap={3}>
+            <Box flex={1}>
+              <TextInput
+                fontSize={1}
+                label="Document ID"
+                value={inputId}
+                readOnly={!onDocumentIdChange}
+                onChange={(e) => setInputId(e.currentTarget.value)}
+                onBlur={commitId}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitId()
+                }}
+              />
+            </Box>
+            <Box flex={1}>
+              <TextInput
+                fontSize={1}
+                label={nameLabel}
+                type="text"
+                value={data ?? ''}
+                onChange={(e) => setName(e.currentTarget.value)}
+                data-testid="name-input"
+              />
+            </Box>
+          </Flex>
+        </Stack>
+      </Card>
+
+      {/* Actions Section */}
+      <Card padding={3} radius={2} shadow={1}>
+        <Stack space={3}>
+          <Text size={1} weight="semibold">
+            Document Actions
+          </Text>
+          <Flex gap={2} wrap="wrap">
+            <Tooltip content={canCreate.message}>
+              <Box>
+                <Button
+                  disabled={!canCreate.allowed}
+                  onClick={() => apply(createDocument(strictHandle))}
+                  text="Create"
+                  tone="positive"
+                  fontSize={1}
+                  data-testid="document-editor-action-create"
+                />
+              </Box>
+            </Tooltip>
+
+            {createInitialValues && (
+              <Tooltip content={canCreate.message}>
+                <Box>
+                  <Button
+                    disabled={!canCreate.allowed}
+                    onClick={() => apply(createDocument(strictHandle, createInitialValues))}
+                    text="Create with Initial Values"
+                    tone="positive"
+                    fontSize={1}
+                  />
+                </Box>
+              </Tooltip>
+            )}
+
+            {!docHandle.liveEdit && (
+              <>
+                <Tooltip content={canPublish.message}>
+                  <Box>
+                    <Button
+                      disabled={!canPublish.allowed}
+                      onClick={async () => {
+                        const response = await apply(publishDocument(strictHandle))
+                        await response.submitted()
+                      }}
+                      text="Publish"
+                      tone="positive"
+                      fontSize={1}
+                    />
+                  </Box>
+                </Tooltip>
+                <Tooltip content={canDiscard.message}>
+                  <Box>
+                    <Button
+                      disabled={!canDiscard.allowed}
+                      onClick={() => apply(discardDocument(strictHandle))}
+                      text="Discard Draft"
+                      fontSize={1}
+                    />
+                  </Box>
+                </Tooltip>
+                <Tooltip content={canUnpublish.message}>
+                  <Box>
+                    <Button
+                      disabled={!canUnpublish.allowed}
+                      onClick={() => apply(unpublishDocument(strictHandle))}
+                      text="Unpublish"
+                      fontSize={1}
+                    />
+                  </Box>
+                </Tooltip>
+              </>
+            )}
+
+            <Tooltip content={canDelete.message}>
+              <Box>
+                <Button
+                  disabled={!canDelete.allowed}
+                  onClick={() => apply(deleteDocument(strictHandle))}
+                  text="Delete"
+                  tone="critical"
+                  fontSize={1}
+                  data-testid="document-editor-action-delete"
+                />
+              </Box>
+            </Tooltip>
+          </Flex>
+          {canEdit.message && (
+            <Text size={1} muted>
+              Permissions: {canEdit.message}
+            </Text>
+          )}
+        </Stack>
+      </Card>
+    </Stack>
+  )
+}

--- a/apps/kitchensink-react/src/components/JsonDocumentEditor.tsx
+++ b/apps/kitchensink-react/src/components/JsonDocumentEditor.tsx
@@ -11,7 +11,7 @@ import {ErrorBoundary} from 'react-error-boundary'
 
 interface JsonDocumentEditorProps {
   /** Document handle for the document being edited */
-  documentHandle: Pick<DocumentHandle, 'documentId' | 'documentType'>
+  documentHandle: Pick<DocumentHandle, 'documentId' | 'documentType' | 'perspective'>
 
   /** Optional minimum height (defaults to 400px) */
   minHeight?: string

--- a/apps/kitchensink-react/src/routes/MediaLibraryRoute.tsx
+++ b/apps/kitchensink-react/src/routes/MediaLibraryRoute.tsx
@@ -4,10 +4,11 @@ import {
   useDocumentSyncStatus,
   useQuery,
 } from '@sanity/sdk-react'
-import {Box, Button, Card, Dialog, Flex, Spinner, Text} from '@sanity/ui'
+import {Box, Button, Card, Dialog, Flex, Spinner, Stack, Text} from '@sanity/ui'
 import {type JSX, Suspense, useState} from 'react'
 import {SanityDocument} from 'sanity'
 
+import {DocumentEditorPanel} from '../components/DocumentEditorPanel'
 import {JsonDocumentEditor} from '../components/JsonDocumentEditor'
 
 // Modal dialog for editing media assets
@@ -36,7 +37,12 @@ function MediaAssetEditorDialog({
       width={2}
     >
       <Box padding={4}>
-        <JsonDocumentEditor documentHandle={docHandle} minHeight="500px" maxHeight="70vh" />
+        <Suspense fallback={<Spinner />}>
+          <Stack space={4}>
+            <DocumentEditorPanel docHandle={docHandle} nameField="title" nameLabel="Title" />
+            <JsonDocumentEditor documentHandle={docHandle} minHeight="500px" maxHeight="70vh" />
+          </Stack>
+        </Suspense>
         <Flex justify="flex-end" gap={2} marginTop={4}>
           <Button text={synced ? 'Close' : 'Syncing...'} onClick={onClose} tone="primary" />
         </Flex>

--- a/apps/kitchensink-react/src/routes/releases/ReleasesRoute.tsx
+++ b/apps/kitchensink-react/src/routes/releases/ReleasesRoute.tsx
@@ -9,10 +9,12 @@ import {
   useDocuments,
   usePerspective,
 } from '@sanity/sdk-react'
-import {Box, Button, Card, Flex, Heading, Spinner, Stack, Text, TextInput} from '@sanity/ui'
+import {Box, Button, Card, Dialog, Flex, Heading, Spinner, Stack, Text, TextInput} from '@sanity/ui'
 import {type JSX, Suspense, useMemo, useState} from 'react'
 
+import {DocumentEditorPanel} from '../../components/DocumentEditorPanel'
 import {DocumentListLayout} from '../../components/DocumentListLayout/DocumentListLayout'
+import {JsonDocumentEditor} from '../../components/JsonDocumentEditor'
 import {DocumentPreview} from '../../DocumentCollection/DocumentPreview'
 import {ReleasesAutocomplete} from './ReleasesAutocomplete'
 import {isReleasePerspective} from './util'
@@ -295,6 +297,8 @@ export function ReleasesRoute(): JSX.Element {
     documentType: 'author',
   })
 
+  const [isEditorOpen, setIsEditorOpen] = useState(false)
+
   const handlePerspectiveSelect = (perspective: PerspectiveHandle) => {
     setSelectedPerspective(perspective)
   }
@@ -317,6 +321,44 @@ export function ReleasesRoute(): JSX.Element {
             onDocumentIdSubmit={handleDocumentIdSubmit}
           />
         </Suspense>
+
+        {selectedDocument && (
+          <Button
+            text="Edit Document"
+            tone="primary"
+            fontSize={1}
+            onClick={() => setIsEditorOpen(true)}
+          />
+        )}
+
+        {isEditorOpen && (
+          <Dialog
+            header={`Edit Document: ${selectedDocument.documentId}`}
+            id="releases-document-editor"
+            onClose={() => setIsEditorOpen(false)}
+            open={isEditorOpen}
+            width={2}
+          >
+            <Box padding={4}>
+              <Suspense fallback={<Spinner />}>
+                <Stack space={4}>
+                  <DocumentEditorPanel
+                    docHandle={{...selectedDocument, perspective: selectedPerspective.perspective}}
+                    onDocumentIdChange={handleDocumentIdSubmit}
+                  />
+                  <JsonDocumentEditor
+                    documentHandle={{
+                      ...selectedDocument,
+                      perspective: selectedPerspective.perspective,
+                    }}
+                    minHeight="400px"
+                    maxHeight="60vh"
+                  />
+                </Stack>
+              </Suspense>
+            </Box>
+          </Dialog>
+        )}
       </Stack>
     </Box>
   )

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,7 +71,7 @@
     "@sanity/image-url": "^2.0.3",
     "@sanity/json-match": "^1.0.5",
     "@sanity/message-protocol": "^0.18.0",
-    "@sanity/mutate": "^0.12.4",
+    "@sanity/mutate": "^0.16.1",
     "@sanity/telemetry": "^1.0.0",
     "@sanity/types": "^5.2.0",
     "groq": "3.88.1-typegen-experimental.0",

--- a/packages/core/src/document/actions.ts
+++ b/packages/core/src/document/actions.ts
@@ -4,7 +4,7 @@ import {type PatchMutation, type PatchOperations} from '@sanity/types'
 import {type SanityDocument} from 'groq'
 
 import {type DocumentHandle, type DocumentTypeHandle} from '../config/sanityConfig'
-import {getPublishedId} from '../utils/ids'
+import {getEffectiveDocumentId} from './util'
 
 const isSanityMutatePatch = (value: unknown): value is SanityMutatePatchMutation => {
   if (typeof value !== 'object' || !value) return false
@@ -140,12 +140,15 @@ export function createDocument<
     >
   >,
 ): CreateDocumentAction<TDocumentType, TDataset, TProjectId> {
+  // users may pass in an explicit documentId -- make sure we format it correctly for the action
+  let effectiveDocumentId
+  if (typeof doc.documentId === 'string') {
+    effectiveDocumentId = getEffectiveDocumentId({...doc, documentId: doc.documentId})
+  }
   return {
     type: 'document.create',
     ...doc,
-    ...(doc.documentId && {
-      documentId: doc.liveEdit ? doc.documentId : getPublishedId(doc.documentId),
-    }),
+    ...(effectiveDocumentId && {documentId: effectiveDocumentId}),
     ...(initialValue && {initialValue}),
   }
 }
@@ -163,10 +166,11 @@ export function deleteDocument<
 >(
   doc: DocumentHandle<TDocumentType, TDataset, TProjectId>,
 ): DeleteDocumentAction<TDocumentType, TDataset, TProjectId> {
+  const effectiveDocumentId = getEffectiveDocumentId(doc)
   return {
     type: 'document.delete',
     ...doc,
-    documentId: doc.liveEdit ? doc.documentId : getPublishedId(doc.documentId),
+    documentId: effectiveDocumentId,
   }
 }
 
@@ -230,14 +234,14 @@ export function editDocument<
   doc: DocumentHandle<TDocumentType, TDataset, TProjectId>,
   patches?: PatchOperations | PatchOperations[] | SanityMutatePatchMutation,
 ): EditDocumentAction<TDocumentType, TDataset, TProjectId> {
-  const documentId = doc.liveEdit ? doc.documentId : getPublishedId(doc.documentId)
+  const effectiveDocumentId = getEffectiveDocumentId(doc)
 
   if (isSanityMutatePatch(patches)) {
     const converted = convertSanityMutatePatch(patches) ?? []
     return {
       ...doc,
       type: 'document.edit',
-      documentId,
+      documentId: effectiveDocumentId,
       patches: converted,
     }
   }
@@ -245,7 +249,7 @@ export function editDocument<
   return {
     ...doc,
     type: 'document.edit',
-    documentId,
+    documentId: effectiveDocumentId,
     ...(patches && {patches: Array.isArray(patches) ? patches : [patches]}),
   }
 }
@@ -263,10 +267,11 @@ export function publishDocument<
 >(
   doc: DocumentHandle<TDocumentType, TDataset, TProjectId>,
 ): PublishDocumentAction<TDocumentType, TDataset, TProjectId> {
+  const effectiveDocumentId = getEffectiveDocumentId(doc)
   return {
     type: 'document.publish',
     ...doc,
-    documentId: doc.liveEdit ? doc.documentId : getPublishedId(doc.documentId),
+    documentId: effectiveDocumentId,
   }
 }
 
@@ -283,10 +288,11 @@ export function unpublishDocument<
 >(
   doc: DocumentHandle<TDocumentType, TDataset, TProjectId>,
 ): UnpublishDocumentAction<TDocumentType, TDataset, TProjectId> {
+  const effectiveDocumentId = getEffectiveDocumentId(doc)
   return {
     type: 'document.unpublish',
     ...doc,
-    documentId: doc.liveEdit ? doc.documentId : getPublishedId(doc.documentId),
+    documentId: effectiveDocumentId,
   }
 }
 
@@ -303,9 +309,10 @@ export function discardDocument<
 >(
   doc: DocumentHandle<TDocumentType, TDataset, TProjectId>,
 ): DiscardDocumentAction<TDocumentType, TDataset, TProjectId> {
+  const effectiveDocumentId = getEffectiveDocumentId(doc)
   return {
     type: 'document.discard',
     ...doc,
-    documentId: doc.liveEdit ? doc.documentId : getPublishedId(doc.documentId),
+    documentId: effectiveDocumentId,
   }
 }

--- a/packages/core/src/document/applyDocumentActions.test.ts
+++ b/packages/core/src/document/applyDocumentActions.test.ts
@@ -1,11 +1,9 @@
-// applyDocumentActions.test.ts
 import {type SanityDocument} from '@sanity/types'
 import {Subject} from 'rxjs'
 import {describe, expect, it} from 'vitest'
 
 import {bindActionBySource} from '../store/createActionBinder'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
-import {} from '../store/createStateSourceAction'
 import {createStoreState, type StoreState} from '../store/createStoreState'
 import {type DocumentAction} from './actions'
 import {type DocumentStoreState} from './documentStore'

--- a/packages/core/src/document/documentStore.test.ts
+++ b/packages/core/src/document/documentStore.test.ts
@@ -14,6 +14,7 @@ import {
   type WelcomeEvent,
 } from '@sanity/client'
 import {diffValue} from '@sanity/diff-patch'
+import {DocumentId, getDraftId, getPublishedId} from '@sanity/id-utils'
 import {type Mutation, type SanityDocument} from '@sanity/types'
 import {evaluate, parse} from 'groq-js'
 import {delay, first, firstValueFrom, from, Observable, of, ReplaySubject, Subject} from 'rxjs'
@@ -23,7 +24,6 @@ import {getClientState} from '../client/clientStore'
 import {createDocumentHandle} from '../config/handles'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {getDraftId, getPublishedId} from '../utils/ids'
 import {
   createDocument,
   deleteDocument,
@@ -87,8 +87,9 @@ afterEach(() => {
 })
 
 it('creates, edits, and publishes a document', async () => {
-  const doc = createDocumentHandle({documentId: 'doc-single', documentType: 'article'})
-  const documentState = getDocumentState(instance, doc)
+  const documentId = DocumentId('doc-single')
+  const doc = createDocumentHandle({documentId, documentType: 'article'})
+  const documentState = getDocumentState<TestDocument>(instance, doc)
 
   // Initially the document is undefined
   expect(documentState.getCurrent()).toBeUndefined()
@@ -100,10 +101,10 @@ it('creates, edits, and publishes a document', async () => {
     actions: [createDocument(doc)],
     source,
   })
-  expect(appeared).toContain(getDraftId(doc.documentId))
+  expect(appeared).toContain(getDraftId(documentId))
 
   let currentDoc = documentState.getCurrent()
-  expect(currentDoc?._id).toEqual(getDraftId(doc.documentId))
+  expect(currentDoc?._id).toEqual(getDraftId(documentId))
 
   // Edit the document – add a title
   await applyDocumentActions(instance, {
@@ -121,13 +122,14 @@ it('creates, edits, and publishes a document', async () => {
   await submitted()
   currentDoc = documentState.getCurrent()
 
-  expect(currentDoc).toMatchObject({_id: doc.documentId, _rev: transactionId})
+  expect(currentDoc).toMatchObject({_id: documentId, _rev: transactionId})
   unsubscribe()
 })
 
 it('creates a document with initial values', async () => {
-  const doc = createDocumentHandle({documentId: 'doc-with-initial', documentType: 'article'})
-  const documentState = getDocumentState(instance, doc)
+  const documentId = DocumentId('doc-with-initial')
+  const doc = createDocumentHandle({documentId, documentType: 'article'})
+  const documentState = getDocumentState<TestDocument>(instance, doc)
 
   expect(documentState.getCurrent()).toBeUndefined()
 
@@ -144,10 +146,10 @@ it('creates a document with initial values', async () => {
     ],
     source,
   })
-  expect(appeared).toContain(getDraftId(doc.documentId))
+  expect(appeared).toContain(getDraftId(documentId))
 
   const currentDoc = documentState.getCurrent()
-  expect(currentDoc?._id).toEqual(getDraftId(doc.documentId))
+  expect(currentDoc?._id).toEqual(getDraftId(documentId))
   expect(currentDoc?.title).toEqual('Article with Initial Values')
   expect(currentDoc?.['author']).toEqual('Jane Doe')
   expect(currentDoc?.['count']).toEqual(42)
@@ -156,8 +158,9 @@ it('creates a document with initial values', async () => {
 })
 
 it('edits existing documents', async () => {
-  const doc = createDocumentHandle({documentId: 'existing-doc', documentType: 'article'})
-  const state = getDocumentState(instance, doc)
+  const documentId = DocumentId('existing-doc')
+  const doc = createDocumentHandle({documentId, documentType: 'article'})
+  const state = getDocumentState<TestDocument>(instance, doc)
 
   // not subscribed yet so the value is undefined
   expect(state.getCurrent()).toBeUndefined()
@@ -168,7 +171,7 @@ it('edits existing documents', async () => {
   await firstValueFrom(state.observable.pipe(first((i) => !!i)))
 
   expect(state.getCurrent()).toMatchObject({
-    _id: getDraftId(doc.documentId),
+    _id: getDraftId(documentId),
     title: 'existing doc',
   })
 
@@ -177,7 +180,7 @@ it('edits existing documents', async () => {
     source,
   })
   expect(state.getCurrent()).toMatchObject({
-    _id: getDraftId(doc.documentId),
+    _id: getDraftId(documentId),
     title: 'updated title',
   })
 
@@ -185,23 +188,30 @@ it('edits existing documents', async () => {
 })
 
 it('sets optimistic changes synchronously', async () => {
-  const doc = createDocumentHandle({documentId: 'optimistic', documentType: 'article'})
+  const doc1 = {
+    documentId: DocumentId('optimistic'),
+    documentType: 'article',
+  }
+  const doc2 = {
+    documentId: DocumentId('optimistic'),
+    documentType: 'article',
+  }
 
-  const state1 = getDocumentState(instance1, doc)
-  const state2 = getDocumentState(instance2, doc)
+  const state1 = getDocumentState(instance1, doc1)
+  const state2 = getDocumentState(instance2, doc2)
 
   const unsubscribe1 = state1.subscribe()
   const unsubscribe2 = state2.subscribe()
 
   // wait until the value is primed in the store
-  await resolveDocument(instance1, doc)
+  await resolveDocument(instance1, doc1)
 
   // then the actions are synchronous
   expect(state1.getCurrent()).toBeNull()
-  applyDocumentActions(instance1, {actions: [createDocument(doc)], source: source1})
-  expect(state1.getCurrent()).toMatchObject({_id: getDraftId(doc.documentId)})
+  applyDocumentActions(instance1, {actions: [createDocument(doc1)], source: source1})
+  expect(state1.getCurrent()).toMatchObject({_id: getDraftId(doc1.documentId)})
   const actionResult1Promise = applyDocumentActions(instance1, {
-    actions: [editDocument(doc, {set: {title: 'initial title'}})],
+    actions: [editDocument(doc1, {set: {title: 'initial title'}})],
     source: source1,
   })
   expect(state1.getCurrent()?.title).toBe('initial title')
@@ -222,7 +232,7 @@ it('sets optimistic changes synchronously', async () => {
 
   // synchronous for state 2
   const actionResult2Promise = applyDocumentActions(instance2, {
-    actions: [editDocument(doc, {set: {title: 'updated title'}})],
+    actions: [editDocument(doc2, {set: {title: 'updated title'}})],
     source: source2,
   })
   expect(state2.getCurrent()?.title).toBe('updated title')
@@ -252,8 +262,8 @@ it('propagates changes between two instances', async () => {
 
   const doc1 = state1.getCurrent()
   const doc2 = state2.getCurrent()
-  expect(doc1?._id).toEqual(getDraftId(doc.documentId))
-  expect(doc2?._id).toEqual(getDraftId(doc.documentId))
+  expect(doc1?._id).toEqual(getDraftId(DocumentId(doc.documentId)))
+  expect(doc2?._id).toEqual(getDraftId(DocumentId(doc.documentId)))
 
   // Now, edit the document from instance2.
   await applyDocumentActions(instance2, {
@@ -315,8 +325,9 @@ it('handles concurrent edits and resolves conflicts', async () => {
 })
 
 it('unpublishes and discards a document', async () => {
-  const doc = createDocumentHandle({documentId: 'doc-pub-unpub', documentType: 'article'})
-  const documentState = getDocumentState(instance, doc)
+  const documentId = DocumentId('doc-pub-unpub')
+  const doc = createDocumentHandle({documentId, documentType: 'article'})
+  const documentState = getDocumentState<TestDocument>(instance, doc)
   const unsubscribe = documentState.subscribe()
 
   // Create and publish the document.
@@ -327,7 +338,7 @@ it('unpublishes and discards a document', async () => {
   })
   const publishedDoc = documentState.getCurrent()
   expect(publishedDoc).toMatchObject({
-    _id: getPublishedId(doc.documentId),
+    _id: getPublishedId(documentId),
     _rev: afterPublish.transactionId,
   })
 
@@ -335,7 +346,7 @@ it('unpublishes and discards a document', async () => {
   await applyDocumentActions(instance, {actions: [unpublishDocument(doc)], source})
   const afterUnpublish = documentState.getCurrent()
   // In our mock implementation the _id remains the same but the published copy is removed.
-  expect(afterUnpublish?._id).toEqual(getDraftId(doc.documentId))
+  expect(afterUnpublish?._id).toEqual(getDraftId(documentId))
 
   // Discard the draft (which deletes the draft version).
   await applyDocumentActions(instance, {actions: [discardDocument(doc)], source})
@@ -346,7 +357,8 @@ it('unpublishes and discards a document', async () => {
 })
 
 it('deletes a document', async () => {
-  const doc = createDocumentHandle({documentId: 'doc-delete', documentType: 'article'})
+  const documentId = DocumentId('doc-delete')
+  const doc = createDocumentHandle({documentId, documentType: 'article'})
 
   const documentState = getDocumentState(instance, doc)
   const unsubscribe = documentState.subscribe()
@@ -367,8 +379,9 @@ it('deletes a document', async () => {
 })
 
 it('cleans up document state when there are no subscribers', async () => {
-  const doc = createDocumentHandle({documentId: 'doc-cleanup', documentType: 'article'})
-  const documentState = getDocumentState(instance, doc)
+  const documentId = DocumentId('doc-cleanup')
+  const doc = createDocumentHandle({documentId, documentType: 'article'})
+  const documentState = getDocumentState<TestDocument>(instance, doc)
 
   // Subscribe to the document state.
   const unsubscribe = documentState.subscribe()
@@ -573,7 +586,8 @@ it('reverts failed outgoing transaction locally', async () => {
     })
   })
 
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const documentId = DocumentId(crypto.randomUUID())
+  const doc = createDocumentHandle({documentId, documentType: 'article'})
 
   const {getCurrent, subscribe} = getDocumentState(instance, doc)
   const unsubscribe = subscribe()
@@ -803,7 +817,8 @@ it('fetches ACL for CanvasSource', async () => {
 })
 
 it('returns a promise that resolves when a document has been loaded in the store (useful for suspense)', async () => {
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const documentId = DocumentId(crypto.randomUUID())
+  const doc = createDocumentHandle({documentId, documentType: 'article'})
 
   expect(await resolveDocument(instance, doc)).toBe(null)
 
@@ -816,7 +831,7 @@ it('returns a promise that resolves when a document has been loaded in the store
   await result.submitted() // wait till submitted to server before resolving
 
   await expect(resolveDocument(instance, doc)).resolves.toMatchObject({
-    _id: getDraftId(doc.documentId),
+    _id: getDraftId(documentId),
     _type: 'article',
     title: 'initial title',
   })
@@ -827,7 +842,7 @@ it('emits an event for each action after an outgoing transaction has been accept
   const handler = vi.fn()
   const unsubscribe = subscribeDocumentEvents(instance, {source, eventHandler: handler})
 
-  const documentId = crypto.randomUUID()
+  const documentId = DocumentId(crypto.randomUUID())
   const doc = createDocumentHandle({documentId, documentType: 'article'})
   expect(handler).toHaveBeenCalledTimes(0)
 
@@ -867,6 +882,122 @@ it('emits an event for each action after an outgoing transaction has been accept
   await applyDocumentActions(instance, {actions: [deleteDocument(doc)], source})
 
   unsubscribe()
+})
+
+it('creates and edits a version document with a release perspective', async () => {
+  const documentId = DocumentId('doc-release')
+  const releaseName = 'test-release'
+  const doc = createDocumentHandle({
+    documentId,
+    documentType: 'article',
+    perspective: {releaseName},
+  })
+  const versionId = `versions.${releaseName}.${documentId}`
+
+  const documentState = getDocumentState<TestDocument>(instance, doc)
+  expect(documentState.getCurrent()).toBeUndefined()
+
+  const unsubscribe = documentState.subscribe()
+
+  // Create a version document for the release
+  const {appeared} = await applyDocumentActions(instance, {
+    actions: [createDocument(doc)],
+  })
+  expect(appeared).toContain(versionId)
+
+  let currentDoc = documentState.getCurrent()
+  expect(currentDoc?._id).toEqual(versionId)
+  expect(currentDoc?._type).toEqual('article')
+
+  // Edit the version document
+  await applyDocumentActions(instance, {
+    actions: [editDocument(doc, {set: {title: 'Release Version Title'}})],
+  })
+  currentDoc = documentState.getCurrent()
+  expect(currentDoc?.title).toEqual('Release Version Title')
+  expect(currentDoc?._id).toEqual(versionId)
+
+  unsubscribe()
+})
+
+it('creates a version document with initial values and then discards it', async () => {
+  const documentId = DocumentId('doc-release-discard')
+  const releaseName = 'test-release-discard'
+  const doc = createDocumentHandle({
+    documentId,
+    documentType: 'article',
+    perspective: {releaseName},
+  })
+  const versionId = `versions.${releaseName}.${documentId}`
+
+  const documentState = getDocumentState<TestDocument>(instance, doc)
+  const unsubscribe = documentState.subscribe()
+
+  // Create a version document with initial values
+  await applyDocumentActions(instance, {
+    actions: [createDocument(doc, {title: 'Initial Release Title'})],
+  })
+
+  let currentDoc = documentState.getCurrent()
+  expect(currentDoc?._id).toEqual(versionId)
+  expect(currentDoc?.title).toEqual('Initial Release Title')
+
+  // Discard the version document
+  const {disappeared} = await applyDocumentActions(instance, {
+    actions: [discardDocument(doc)],
+  })
+  expect(disappeared).toContain(versionId)
+
+  currentDoc = documentState.getCurrent()
+  expect(currentDoc).toBeNull()
+
+  unsubscribe()
+})
+
+it('version edits are isolated from draft state', async () => {
+  const documentId = DocumentId('doc-version-isolation')
+  const releaseName = 'isolation-release'
+  const versionDoc = createDocumentHandle({
+    documentId,
+    documentType: 'article',
+    perspective: {releaseName},
+  })
+  const draftDoc = createDocumentHandle({documentId, documentType: 'article'})
+  const versionId = `versions.${releaseName}.${documentId}`
+
+  const versionState = getDocumentState<TestDocument>(instance, versionDoc)
+  const draftState = getDocumentState<TestDocument>(instance, draftDoc)
+
+  const unsubscribeVersion = versionState.subscribe()
+  const unsubscribeDraft = draftState.subscribe()
+
+  // Create draft and version documents
+  await applyDocumentActions(instance, {
+    actions: [createDocument(draftDoc)],
+  })
+  await applyDocumentActions(instance, {
+    actions: [editDocument(draftDoc, {set: {title: 'Draft Title'}})],
+  })
+  await applyDocumentActions(instance, {
+    actions: [createDocument(versionDoc, {title: 'Release Title'})],
+  })
+
+  // Version perspective shows the version doc
+  expect(versionState.getCurrent()?._id).toEqual(versionId)
+  expect(versionState.getCurrent()?.title).toEqual('Release Title')
+
+  // Draft state shows the draft doc
+  expect(draftState.getCurrent()?.title).toEqual('Draft Title')
+
+  // Editing the version doc should not affect the draft
+  await applyDocumentActions(instance, {
+    actions: [editDocument(versionDoc, {set: {title: 'Updated Release Title'}})],
+  })
+  expect(versionState.getCurrent()?.title).toEqual('Updated Release Title')
+  expect(draftState.getCurrent()?.title).toEqual('Draft Title')
+
+  unsubscribeVersion()
+  unsubscribeDraft()
 })
 
 vi.mock('../client/clientStore.ts', () => ({
@@ -932,8 +1063,8 @@ beforeEach(() => {
   )()
 
   let documents: DocumentSet = {
-    [getDraftId('existing-doc')]: {
-      _id: getDraftId('existing-doc'),
+    [getDraftId(DocumentId('existing-doc'))]: {
+      _id: getDraftId(DocumentId('existing-doc')),
       _createdAt: '2025-02-06T06:43:46.236Z',
       _updatedAt: '2025-02-06T06:43:46.236Z',
       _rev: 'initial-rev',
@@ -1174,7 +1305,7 @@ beforeEach(() => {
             continue
           }
           case 'sanity.action.document.edit': {
-            const documentSource = next[i.draftId] ?? next[i.publishedId]
+            const documentSource = (i.draftId && next[i.draftId]) ?? next[i.publishedId]
             if (!documentSource) {
               throw new Error(
                 `Could not find a document to edit from \`draftId\` \`${i.draftId}\` or \`publishedId\` ${i.publishedId}`,
@@ -1184,8 +1315,8 @@ beforeEach(() => {
             next = processMutations({
               documents: next,
               mutations: [
-                {createIfNotExists: {...documentSource, _id: i.draftId}},
-                {patch: {id: i.draftId, ...i.patch}},
+                {createIfNotExists: {...documentSource, _id: i.draftId!}},
+                {patch: {id: i.draftId!, ...i.patch}},
               ],
               transactionId,
               timestamp,

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -1,5 +1,5 @@
 import {type Action, type Mutation} from '@sanity/client'
-import {getPublishedId} from '@sanity/client/csm'
+import {DocumentId, getDraftId, getPublishedId, getVersionId} from '@sanity/id-utils'
 import {jsonMatch} from '@sanity/json-match'
 import {type SanityDocument} from 'groq'
 import {type ExprNode} from 'groq-js'
@@ -34,6 +34,7 @@ import {
   isDatasetSource,
   isMediaLibrarySource,
 } from '../config/sanityConfig'
+import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
 import {
   bindActionBySource,
   type BoundSourceKey,
@@ -42,7 +43,6 @@ import {
 import {type SanityInstance} from '../store/createSanityInstance'
 import {createStateSourceAction, type StateSource} from '../store/createStateSourceAction'
 import {defineStore, type StoreContext} from '../store/defineStore'
-import {getDraftId} from '../utils/ids'
 import {type DocumentAction} from './actions'
 import {API_VERSION, INITIAL_OUTGOING_THROTTLE_TIME} from './documentConstants'
 import {
@@ -65,7 +65,6 @@ import {
   applyFirstQueuedTransaction,
   applyRemoteDocument,
   cleanupOutgoingTransaction,
-  getDocumentIdsFromActions,
   manageSubscriberIds,
   type OutgoingTransaction,
   type QueuedTransaction,
@@ -203,29 +202,28 @@ const _getDocumentState = bindActionBySource(
   documentStore,
   createStateSourceAction({
     selector: ({state: {error, documentStates}}, options: DocumentOptions<string | undefined>) => {
-      const {documentId, path, liveEdit} = options
+      const {documentId: docId, path, liveEdit, perspective} = options
+      const documentId = DocumentId(docId)
       if (error) throw error
+      let document: SanityDocument | null | undefined
 
       if (liveEdit) {
-        // For liveEdit documents, only look at the single document
-        const document = documentStates[documentId]?.local
-        if (document === undefined) return undefined
-        if (!path) return document
-        const result = jsonMatch(document, path).next()
-        if (result.done) return undefined
-        const {value} = result.value
-        return value
+        document = documentStates[documentId]?.local
+      } else {
+        let version: SanityDocument | null | undefined
+        if (isReleasePerspective(perspective)) {
+          const versionId = getVersionId(documentId, perspective.releaseName)
+          version = documentStates[versionId]?.local
+          // early exit if we don't have the version document and we're in a release perspective
+          if (version === undefined) return undefined
+        }
+        const draft = documentStates[getDraftId(documentId)]?.local
+        const published = documentStates[getPublishedId(documentId)]?.local
+        // early exit if we don't have all the documents for draft/published logic
+        if (draft === undefined || published === undefined) return undefined
+        document = version ?? draft ?? published
       }
 
-      // Standard draft/published logic
-      const draftId = getDraftId(documentId)
-      const publishedId = getPublishedId(documentId)
-      const draft = documentStates[draftId]?.local
-      const published = documentStates[publishedId]?.local
-
-      // wait for draft and published to be loaded before returning a value
-      if (draft === undefined || published === undefined) return undefined
-      const document = draft ?? published
       if (!path) return document
       const result = jsonMatch(document, path).next()
       if (result.done) return undefined
@@ -233,7 +231,7 @@ const _getDocumentState = bindActionBySource(
       return value
     },
     onSubscribe: (context, options: DocumentOptions<string | undefined>) =>
-      manageSubscriberIds(context, options.documentId, {expandDraftPublished: !options.liveEdit}),
+      manageSubscriberIds(context, [options]),
   }),
 )
 
@@ -277,27 +275,27 @@ export const getDocumentSyncStatus = bindActionBySource(
       {state: {error, documentStates: documents, outgoing, applied, queued}},
       doc: DocumentHandle,
     ) => {
-      const documentId = typeof doc === 'string' ? doc : doc.documentId
+      const documentId = DocumentId(typeof doc === 'string' ? doc : doc.documentId)
       if (error) throw error
 
       if (doc.liveEdit) {
         // For liveEdit documents, only check the single document
-        const document = documents[documentId]
-        if (document === undefined) return undefined
-        return !queued.length && !applied.length && !outgoing
+        if (documents[documentId] === undefined) return undefined
+      } else {
+        const version = isReleasePerspective(doc.perspective)
+          ? documents[getVersionId(documentId, doc.perspective.releaseName)]
+          : undefined
+        if (isReleasePerspective(doc.perspective) && version === undefined) return undefined
+        // Standard draft/published logic
+        const draft = documents[getDraftId(documentId)]
+        const published = documents[getPublishedId(documentId)]
+        if (draft === undefined || published === undefined) return undefined
       }
-
-      // Standard draft/published logic
-      const draftId = getDraftId(documentId)
-      const publishedId = getPublishedId(documentId)
-
-      const draft = documents[draftId]
-      const published = documents[publishedId]
-
-      if (draft === undefined || published === undefined) return undefined
       return !queued.length && !applied.length && !outgoing
     },
-    onSubscribe: (context, doc: DocumentHandle) => manageSubscriberIds(context, doc.documentId),
+    onSubscribe: (context, doc: DocumentHandle) => {
+      return manageSubscriberIds(context, [doc])
+    },
   }),
 )
 
@@ -311,8 +309,9 @@ export const getPermissionsState = bindActionBySource(
   documentStore,
   createStateSourceAction({
     selector: calculatePermissions,
-    onSubscribe: (context, {actions}: PermissionsStateOptions) =>
-      manageSubscriberIds(context, getDocumentIdsFromActions(actions)),
+    onSubscribe: (context, {actions}: PermissionsStateOptions) => {
+      manageSubscriberIds(context, actions)
+    },
   }) as StoreAction<
     DocumentStoreState,
     [PermissionsStateOptions],
@@ -481,8 +480,8 @@ const subscribeToSubscriptionsAndListenToDocuments = (
           ...added.map((id) => ({id, add: true})),
           ...removed.map((id) => ({id, add: false})),
         ].sort((a, b) => {
-          const aIsDraft = a.id === getDraftId(a.id)
-          const bIsDraft = b.id === getDraftId(b.id)
+          const aIsDraft = a.id === getDraftId(DocumentId(a.id))
+          const bIsDraft = b.id === getDraftId(DocumentId(b.id))
 
           if (aIsDraft && bIsDraft) return a.id.localeCompare(b.id, 'en-US')
           if (aIsDraft) return -1

--- a/packages/core/src/document/permissions.test.ts
+++ b/packages/core/src/document/permissions.test.ts
@@ -1,9 +1,9 @@
+import {DocumentId, getDraftId, getPublishedId} from '@sanity/id-utils'
 import {type SanityDocument} from '@sanity/types'
 import {evaluateSync, type ExprNode, parse} from 'groq-js'
 import {describe, expect, it} from 'vitest'
 
 import {createSanityInstance} from '../store/createSanityInstance'
-import {getDraftId, getPublishedId} from '../utils/ids'
 import {type DocumentAction} from './actions'
 import {calculatePermissions, createGrantsLookup, type DatasetAcl, type Grant} from './permissions'
 import {type SyncTransactionState} from './reducers'
@@ -66,8 +66,10 @@ describe('calculatePermissions', () => {
     // For a document.create action, the selector expects both published and draft keys.
     const state = createState(
       {
-        [getPublishedId('doc1')]: {local: createDoc('doc1', 'Original Title')},
-        [getDraftId('doc1')]: {local: null},
+        [getPublishedId(DocumentId('doc1'))]: {
+          local: createDoc(DocumentId('doc1'), 'Original Title'),
+        },
+        [getDraftId(DocumentId('doc1'))]: {local: null},
       },
       defaultGrants,
     )
@@ -83,7 +85,7 @@ describe('calculatePermissions', () => {
     // Missing the draft key will cause documentsSelector to return undefined.
     const state = createState(
       {
-        [getPublishedId('doc1')]: {local: createDoc('doc1', 'Title')},
+        [getPublishedId(DocumentId('doc1'))]: {local: createDoc(DocumentId('doc1'), 'Title')},
         // Missing getDraftId('doc1')
       },
       defaultGrants,
@@ -99,8 +101,8 @@ describe('calculatePermissions', () => {
     const deniedGrants = {...defaultGrants, create: alwaysDeny}
     const state = createState(
       {
-        [getPublishedId('doc1')]: {local: createDoc('doc1', 'Title')},
-        [getDraftId('doc1')]: {local: null},
+        [getPublishedId(DocumentId('doc1'))]: {local: createDoc(DocumentId('doc1'), 'Title')},
+        [getDraftId(DocumentId('doc1'))]: {local: null},
       },
       deniedGrants,
     )
@@ -127,8 +129,8 @@ describe('calculatePermissions', () => {
     // Both published and draft documents are present as null.
     const state = createState(
       {
-        [getPublishedId('doc1')]: {local: null},
-        [getDraftId('doc1')]: {local: null},
+        [getPublishedId(DocumentId('doc1'))]: {local: null},
+        [getDraftId(DocumentId('doc1'))]: {local: null},
       },
       defaultGrants,
     )
@@ -153,8 +155,8 @@ describe('calculatePermissions', () => {
     const deniedGrants = {...defaultGrants, update: alwaysDeny}
     const state = createState(
       {
-        [getPublishedId('doc1')]: {local: createDoc('doc1', 'Title')},
-        [getDraftId('doc1')]: {local: createDoc(getDraftId('doc1'), 'Draft Title')},
+        [getPublishedId(DocumentId('doc1'))]: {local: createDoc(DocumentId('doc1'), 'Title')},
+        [getDraftId(DocumentId('doc1'))]: {local: createDoc(DocumentId('doc1'), 'Draft Title')},
       },
       deniedGrants,
     )
@@ -179,8 +181,8 @@ describe('calculatePermissions', () => {
 
   it('should return undefined if grants are not provided', () => {
     const state = createState({
-      [getPublishedId('doc1')]: {local: createDoc('doc1', 'Title')},
-      [getDraftId('doc1')]: {local: null},
+      [getPublishedId(DocumentId('doc1'))]: {local: createDoc(DocumentId('doc1'), 'Title')},
+      [getDraftId(DocumentId('doc1'))]: {local: null},
     })
     const actions: DocumentAction[] = [
       {documentId: 'doc1', type: 'document.create', documentType: 'article'},
@@ -192,8 +194,8 @@ describe('calculatePermissions', () => {
     // For document.delete, if the published document is missing, processActions throws an ActionError.
     const state = createState(
       {
-        [getPublishedId('doc1')]: {local: null},
-        [getDraftId('doc1')]: {local: null},
+        [getPublishedId(DocumentId('doc1'))]: {local: null},
+        [getDraftId(DocumentId('doc1'))]: {local: null},
       },
       defaultGrants,
     )
@@ -217,8 +219,8 @@ describe('calculatePermissions', () => {
   it('should memoize the result for identical state and actions inputs', () => {
     const state = createState(
       {
-        [getPublishedId('doc1')]: {local: createDoc('doc1', 'Title')},
-        [getDraftId('doc1')]: {local: null},
+        [getPublishedId(DocumentId('doc1'))]: {local: createDoc(DocumentId('doc1'), 'Title')},
+        [getDraftId(DocumentId('doc1'))]: {local: null},
       },
       defaultGrants,
     )

--- a/packages/core/src/document/permissions.ts
+++ b/packages/core/src/document/permissions.ts
@@ -1,9 +1,10 @@
+import {DocumentId, getDraftId, getPublishedId, getVersionId} from '@sanity/id-utils'
 import {type SanityDocument} from '@sanity/types'
 import {evaluateSync, type ExprNode, parse} from 'groq-js'
 import {createSelector} from 'reselect'
 
+import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
 import {type SelectorContext} from '../store/createStateSourceAction'
-import {getDraftId, getPublishedId} from '../utils/ids'
 import {MultiKeyWeakMap} from '../utils/MultiKeyWeakMap'
 import {type DocumentAction} from './actions'
 import {ActionError, PermissionActionError, processActions} from './processActions'
@@ -71,7 +72,14 @@ const documentsSelector = createSelector(
           // For liveEdit documents, only fetch the single document
           if (action.liveEdit) return [action.documentId]
           // For standard documents, fetch both draft and published
-          return [getPublishedId(action.documentId), getDraftId(action.documentId)]
+          const ids: string[] = [
+            getPublishedId(DocumentId(action.documentId)),
+            getDraftId(DocumentId(action.documentId)),
+          ]
+          if (isReleasePerspective(action.perspective)) {
+            ids.push(getVersionId(DocumentId(action.documentId), action.perspective.releaseName))
+          }
+          return ids
         })
         .flat(),
     )
@@ -210,16 +218,32 @@ const _calculatePermissions = createSelector(
       // Check edit actions with no patches
       if (action.type === 'document.edit' && !action.patches?.length) {
         const docId = action.documentId
-        // For liveEdit documents, only check the single document
-        const doc = action.liveEdit
-          ? documents[docId]
-          : (documents[getDraftId(docId)] ?? documents[getPublishedId(docId)])
+        let doc: SanityDocument | null | undefined
+        if (action.liveEdit) {
+          doc = documents[docId]
+        }
+        // don't allow users to edit version documents that don't exist
+        // they should be explicitly created first, as in studio
+        else if (isReleasePerspective(action.perspective)) {
+          doc = documents[getVersionId(DocumentId(docId), action.perspective.releaseName)]
+        } else {
+          doc =
+            documents[getDraftId(DocumentId(docId))] ?? documents[getPublishedId(DocumentId(docId))]
+        }
         if (!doc) {
-          reasons.push({
-            type: 'precondition',
-            message: `The document with ID "${docId}" could not be found. Please check that it exists before editing.`,
-            documentId: docId,
-          })
+          if (isReleasePerspective(action.perspective)) {
+            reasons.push({
+              type: 'precondition',
+              message: `The version document with ID "${docId}" could not be found. Please create it or add it to the release first.`,
+              documentId: docId,
+            })
+          } else {
+            reasons.push({
+              type: 'precondition',
+              message: `The document with ID "${docId}" could not be found. Please check that it exists before editing.`,
+              documentId: docId,
+            })
+          }
         } else if (!checkGrant(grants.update, doc)) {
           reasons.push({
             type: 'access',

--- a/packages/core/src/document/processActions.test.ts
+++ b/packages/core/src/document/processActions.test.ts
@@ -1066,10 +1066,7 @@ describe('processActions', () => {
 
         expect(() =>
           processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
-        ).toThrow('Cannot publish liveEdit document')
-        expect(() =>
-          processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
-        ).toThrow('LiveEdit documents do not support drafts or publishing')
+        ).toThrow(/Publishing is not supported for liveEdit or version/)
       })
     })
 
@@ -1089,10 +1086,7 @@ describe('processActions', () => {
 
         expect(() =>
           processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
-        ).toThrow('Cannot unpublish liveEdit document')
-        expect(() =>
-          processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
-        ).toThrow('LiveEdit documents do not support drafts or publishing')
+        ).toThrow(/Unpublishing is not supported for liveEdit or version/)
       })
     })
 
@@ -1112,10 +1106,317 @@ describe('processActions', () => {
 
         expect(() =>
           processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
-        ).toThrow('Cannot discard changes for liveEdit document')
+        ).toThrow('Cannot discard changes for liveEdit document "live1"')
+
         expect(() =>
           processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
         ).toThrow('LiveEdit documents do not support drafts')
+      })
+    })
+  })
+
+  describe('release perspective (version) documents', () => {
+    const releaseName = 'test-release'
+    const perspective = {releaseName}
+    const versionId = `versions.${releaseName}.doc1`
+
+    describe('document.create', () => {
+      it('should create a version document for a release perspective', () => {
+        const base: DocumentSet = {}
+        const working: DocumentSet = {}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.create',
+            documentType: 'article',
+            perspective,
+          },
+        ]
+        const result = processActions({
+          actions,
+          transactionId,
+          base,
+          working,
+          timestamp,
+          grants: defaultGrants,
+        })
+
+        const versionDoc = result.working[versionId]
+        expect(versionDoc).toBeDefined()
+        expect(versionDoc?._id).toBe(versionId)
+        expect(versionDoc?._type).toBe('article')
+        expect(versionDoc?._rev).toBe(transactionId)
+
+        expect(result.outgoingActions).toEqual([
+          {
+            actionType: 'sanity.action.document.version.create',
+            publishedId: 'doc1',
+            attributes: expect.objectContaining({_id: versionId, _type: 'article'}),
+          },
+        ])
+      })
+
+      it('should create a version document using the published document as a base', () => {
+        const published = createDoc('doc1', 'Published Title')
+        const base: DocumentSet = {doc1: published}
+        const working: DocumentSet = {doc1: published}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.create',
+            documentType: 'article',
+            perspective,
+          },
+        ]
+        const result = processActions({
+          actions,
+          transactionId,
+          base,
+          working,
+          timestamp,
+          grants: defaultGrants,
+        })
+
+        const versionDoc = result.working[versionId]
+        expect(versionDoc).toBeDefined()
+        expect(versionDoc?._id).toBe(versionId)
+        expect(versionDoc?.['title']).toBe('Published Title')
+      })
+
+      it('should throw if a version document already exists', () => {
+        const existingVersion = createDoc(versionId, 'Existing Version')
+        const base: DocumentSet = {[versionId]: existingVersion}
+        const working: DocumentSet = {[versionId]: existingVersion}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.create',
+            documentType: 'article',
+            perspective,
+          },
+        ]
+        expect(() =>
+          processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
+        ).toThrow(/release version.*already exists/i)
+      })
+
+      it('should create a version document with initial values', () => {
+        const base: DocumentSet = {}
+        const working: DocumentSet = {}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.create',
+            documentType: 'article',
+            perspective,
+            initialValue: {title: 'Release Version Title', count: 7},
+          },
+        ]
+        const result = processActions({
+          actions,
+          transactionId,
+          base,
+          working,
+          timestamp,
+          grants: defaultGrants,
+        })
+
+        const versionDoc = result.working[versionId]
+        expect(versionDoc?.['title']).toBe('Release Version Title')
+        expect(versionDoc?.['count']).toBe(7)
+      })
+
+      it('should throw PermissionActionError if create permission is denied', () => {
+        const base: DocumentSet = {}
+        const working: DocumentSet = {}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.create',
+            documentType: 'article',
+            perspective,
+          },
+        ]
+        const grants = {...defaultGrants, create: alwaysDeny}
+        expect(() =>
+          processActions({actions, transactionId, base, working, timestamp, grants}),
+        ).toThrow(/You do not have permission to create a release version/)
+      })
+    })
+
+    describe('document.edit', () => {
+      it('should edit a version document directly', () => {
+        const version = createDoc(versionId, 'Original Version Title')
+        const base: DocumentSet = {[versionId]: version}
+        const working: DocumentSet = {[versionId]: version}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.edit',
+            documentType: 'article',
+            perspective,
+            patches: [{set: {title: 'Updated Version Title'}}],
+          },
+        ]
+        const result = processActions({
+          actions,
+          transactionId,
+          base,
+          working,
+          timestamp,
+          grants: defaultGrants,
+        })
+
+        const editedDoc = result.working[versionId]
+        expect(editedDoc?.['title']).toBe('Updated Version Title')
+        expect(editedDoc?._id).toBe(versionId)
+
+        // outgoing action should use versionId as draftId and the base publishedId
+        expect(result.outgoingActions[0]).toMatchObject({
+          actionType: 'sanity.action.document.edit',
+          draftId: versionId,
+          publishedId: 'doc1',
+        })
+      })
+
+      it('should throw if the version document does not exist', () => {
+        const base: DocumentSet = {}
+        const working: DocumentSet = {}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.edit',
+            documentType: 'article',
+            perspective,
+            patches: [{set: {title: 'Should Fail'}}],
+          },
+        ]
+        expect(() =>
+          processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
+        ).toThrow(/does not exist in the release/)
+      })
+
+      it('should throw PermissionActionError if update permission is denied', () => {
+        const version = createDoc(versionId, 'Version Title')
+        const base: DocumentSet = {[versionId]: version}
+        const working: DocumentSet = {[versionId]: version}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.edit',
+            documentType: 'article',
+            perspective,
+            patches: [{set: {title: 'No Permission'}}],
+          },
+        ]
+        const grants = {...defaultGrants, update: alwaysDeny}
+        expect(() =>
+          processActions({actions, transactionId, base, working, timestamp, grants}),
+        ).toThrow(/You do not have permission to edit document/)
+      })
+    })
+
+    describe('document.discard', () => {
+      it('should discard a version document', () => {
+        const version = createDoc(versionId, 'Version Title')
+        const base: DocumentSet = {[versionId]: version}
+        const working: DocumentSet = {[versionId]: version}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.discard',
+            documentType: 'article',
+            perspective,
+          },
+        ]
+        const result = processActions({
+          actions,
+          transactionId,
+          base,
+          working,
+          timestamp,
+          grants: defaultGrants,
+        })
+
+        expect(result.working[versionId]).toBeNull()
+        expect(result.outgoingActions).toEqual([
+          {
+            actionType: 'sanity.action.document.version.discard',
+            versionId,
+          },
+        ])
+      })
+
+      it('should throw if there is no version document to discard', () => {
+        const base: DocumentSet = {}
+        const working: DocumentSet = {}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.discard',
+            documentType: 'article',
+            perspective,
+          },
+        ]
+        expect(() =>
+          processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
+        ).toThrow(/no draft or version available to discard/)
+      })
+
+      it('should throw PermissionActionError if update permission is denied', () => {
+        const version = createDoc(versionId, 'Version Title')
+        const base: DocumentSet = {[versionId]: version}
+        const working: DocumentSet = {[versionId]: version}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.discard',
+            documentType: 'article',
+            perspective,
+          },
+        ]
+        const grants = {...defaultGrants, update: alwaysDeny}
+        expect(() =>
+          processActions({actions, transactionId, base, working, timestamp, grants}),
+        ).toThrow(/You do not have permission to discard changes/)
+      })
+    })
+
+    describe('document.publish', () => {
+      it('should throw for release perspective documents', () => {
+        const version = createDoc(versionId, 'Version Title')
+        const base: DocumentSet = {[versionId]: version}
+        const working: DocumentSet = {[versionId]: version}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.publish',
+            documentType: 'article',
+            perspective,
+          },
+        ]
+        expect(() =>
+          processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
+        ).toThrow(/Publishing is not supported for liveEdit or version/)
+      })
+    })
+
+    describe('document.delete', () => {
+      it('should throw for release perspective documents', () => {
+        const version = createDoc(versionId, 'Version Title')
+        const base: DocumentSet = {[versionId]: version}
+        const working: DocumentSet = {[versionId]: version}
+        const actions: DocumentAction[] = [
+          {
+            documentId: versionId,
+            type: 'document.delete',
+            documentType: 'article',
+            perspective,
+          },
+        ]
+        expect(() =>
+          processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
+        ).toThrow(/Cannot delete a version document/)
       })
     })
   })

--- a/packages/core/src/document/processActions.ts
+++ b/packages/core/src/document/processActions.ts
@@ -1,4 +1,5 @@
 import {diffValue} from '@sanity/diff-patch'
+import {DocumentId, getDraftId, getPublishedId, getVersionId} from '@sanity/id-utils'
 import {
   type Mutation,
   type PatchOperations,
@@ -8,7 +9,7 @@ import {
 import {evaluateSync, type ExprNode} from 'groq-js'
 import {isEqual} from 'lodash-es'
 
-import {getDraftId, getPublishedId} from '../utils/ids'
+import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
 import {type DocumentAction} from './actions'
 import {type Grant} from './permissions'
 import {type DocumentSet, getId, processMutations} from './processMutations'
@@ -185,29 +186,36 @@ export function processActions({
           continue
         }
 
-        // Standard draft/published logic
-        const draftId = getDraftId(documentId)
-        const publishedId = getPublishedId(documentId)
+        // Standard draft/published/version logic
+        const versionId = isReleasePerspective(action.perspective)
+          ? getVersionId(DocumentId(documentId), action.perspective.releaseName)
+          : undefined
+        const draftId = getDraftId(DocumentId(documentId))
+        const publishedId = getPublishedId(DocumentId(documentId))
 
-        if (working[draftId]) {
+        const alreadyHasVersion = versionId ? working[versionId] : working[draftId]
+
+        if (alreadyHasVersion) {
+          const errorDocType = versionId ? 'release version' : 'draft'
           throw new ActionError({
             documentId,
             transactionId,
-            message: `A draft version of this document already exists. Please use or discard the existing draft before creating a new one.`,
+            message: `A ${errorDocType} of this document already exists. Please use or discard the existing ${errorDocType} before creating a new one.`,
           })
         }
 
-        // Spread the (possibly undefined) published version directly.
+        // Spread the (possibly undefined) draft or published version directly.
+        // (studio uses the draft version as a base if you are in a release perspective)
         const newDocBase = {
-          ...base[publishedId],
+          ...(base[draftId] ?? base[publishedId]),
           _type: action.documentType,
-          _id: draftId,
+          _id: versionId ?? draftId,
           ...action.initialValue,
         }
         const newDocWorking = {
-          ...working[publishedId],
+          ...(working[draftId] ?? working[publishedId]),
           _type: action.documentType,
-          _id: draftId,
+          _id: versionId ?? draftId,
           ...action.initialValue,
         }
         const mutations: Mutation[] = [{create: newDocWorking}]
@@ -225,7 +233,13 @@ export function processActions({
           timestamp,
         })
 
-        if (!checkGrant(grants.create, working[draftId] as SanityDocument)) {
+        if (versionId && !checkGrant(grants.create, working[versionId] as SanityDocument)) {
+          throw new PermissionActionError({
+            documentId,
+            transactionId,
+            message: `You do not have permission to create a release version for document "${documentId}".`,
+          })
+        } else if (!versionId && !checkGrant(grants.create, working[draftId] as SanityDocument)) {
           throw new PermissionActionError({
             documentId,
             transactionId,
@@ -245,8 +259,15 @@ export function processActions({
       case 'document.delete': {
         const documentId = action.documentId
 
+        if (isReleasePerspective(action.perspective)) {
+          throw new ActionError({
+            documentId,
+            transactionId,
+            message: `Cannot delete a version document. You may want to use the "unpublish" or "discard" actions instead.`,
+          })
+        }
+
         if (action.liveEdit) {
-          // For liveEdit documents, delete directly
           if (!working[documentId]) {
             throw new ActionError({
               documentId,
@@ -276,8 +297,8 @@ export function processActions({
         }
 
         // Standard draft/published logic
-        const draftId = getDraftId(documentId)
-        const publishedId = getPublishedId(documentId)
+        const draftId = getDraftId(DocumentId(documentId))
+        const publishedId = getPublishedId(DocumentId(documentId))
 
         if (!working[publishedId]) {
           throw new ActionError({
@@ -327,19 +348,21 @@ export function processActions({
           })
         }
 
-        // Standard draft/published logic
-        const draftId = getDraftId(documentId)
-        const mutations: Mutation[] = [{delete: {id: draftId}}]
+        // draft/published or version logic
+        const versionId = isReleasePerspective(action.perspective)
+          ? getVersionId(DocumentId(documentId), action.perspective.releaseName)
+          : getDraftId(DocumentId(documentId))
+        const mutations: Mutation[] = [{delete: {id: versionId}}]
 
-        if (!working[draftId]) {
+        if (!working[versionId]) {
           throw new ActionError({
             documentId,
             transactionId,
-            message: `There is no draft available to discard for document "${documentId}".`,
+            message: `There is no draft or version available to discard for document "${documentId}".`,
           })
         }
 
-        if (!checkGrant(grants.update, working[draftId])) {
+        if (!checkGrant(grants.update, working[versionId])) {
           throw new PermissionActionError({
             documentId,
             transactionId,
@@ -353,7 +376,7 @@ export function processActions({
         outgoingMutations.push(...mutations)
         outgoingActions.push({
           actionType: 'sanity.action.document.version.discard',
-          versionId: draftId,
+          versionId,
         })
         continue
       }
@@ -362,7 +385,7 @@ export function processActions({
         const documentId = getId(action.documentId)
 
         if (action.liveEdit) {
-          // For liveEdit documents, edit directly without draft logic
+          // Single-document mode (liveEdit or release perspective): edit directly without draft logic
           const userPatches = action.patches?.map((patch) => ({patch: {id: documentId, ...patch}}))
 
           // skip this action if there are no associated patches
@@ -412,15 +435,28 @@ export function processActions({
           continue
         }
 
-        // Standard draft/published logic
-        const draftId = getDraftId(documentId)
-        const publishedId = getPublishedId(documentId)
-        const userPatches = action.patches?.map((patch) => ({patch: {id: draftId, ...patch}}))
+        const versionId = isReleasePerspective(action.perspective)
+          ? getVersionId(DocumentId(documentId), action.perspective.releaseName)
+          : undefined
+        const draftId = getDraftId(DocumentId(documentId))
+        const publishedId = getPublishedId(DocumentId(documentId))
+        const patchDocumentId = isReleasePerspective(action.perspective) ? versionId! : draftId
+        const userPatches = action.patches?.map((patch) => ({
+          patch: {id: patchDocumentId, ...patch},
+        }))
 
         // skip this action if there are no associated patches
         if (!userPatches?.length) continue
 
-        if (
+        if (isReleasePerspective(action.perspective)) {
+          if (!working[versionId!] && !base[versionId!]) {
+            throw new ActionError({
+              documentId,
+              transactionId,
+              message: `This document does not exist in the release. Please create it or add it to the release first.`,
+            })
+          }
+        } else if (
           (!working[draftId] && !working[publishedId]) ||
           (!base[draftId] && !base[publishedId])
         ) {
@@ -432,12 +468,14 @@ export function processActions({
         }
 
         const baseMutations: Mutation[] = []
-        if (!base[draftId] && base[publishedId]) {
+        // don't create a draft from the published version in a release perspective
+        if (!isReleasePerspective(action.perspective) && !base[draftId] && base[publishedId]) {
+          // otherwise make a draft from the published version
           baseMutations.push({create: {...base[publishedId], _id: draftId}})
         }
 
-        // the first if statement should make this never be null or undefined
-        const baseBefore = (base[draftId] ?? base[publishedId]) as SanityDocument
+        // the above statement and guards should make this never be null or undefined
+        const baseBefore = base[patchDocumentId] ?? base[publishedId]
         if (userPatches) {
           baseMutations.push(...userPatches)
         }
@@ -450,11 +488,15 @@ export function processActions({
         })
         // this one will always be defined because a patch mutation will never
         // delete an input document
-        const baseAfter = base[draftId] as SanityDocument
+        const baseAfter = base[patchDocumentId] as SanityDocument
         const patches = diffValue(baseBefore, baseAfter)
 
         const workingMutations: Mutation[] = []
-        if (!working[draftId] && working[publishedId]) {
+        if (
+          !isReleasePerspective(action.perspective) &&
+          !working[draftId] &&
+          working[publishedId]
+        ) {
           const newDraftFromPublished = {...working[publishedId], _id: draftId}
 
           if (!checkGrant(grants.create, newDraftFromPublished)) {
@@ -469,15 +511,15 @@ export function processActions({
         }
 
         // the first if statement should make this never be null or undefined
-        const workingBefore = (working[draftId] ?? working[publishedId]) as SanityDocument
-        if (!checkGrant(grants.update, workingBefore)) {
+        const workingBefore = working[patchDocumentId] ?? working[publishedId]
+        if (!checkGrant(grants.update, workingBefore!)) {
           throw new PermissionActionError({
             documentId,
             transactionId,
             message: `You do not have permission to edit document "${documentId}".`,
           })
         }
-        workingMutations.push(...patches.map((patch) => ({patch: {id: draftId, ...patch}})))
+        workingMutations.push(...patches.map((patch) => ({patch: {id: patchDocumentId, ...patch}})))
 
         working = processMutations({
           documents: working,
@@ -488,14 +530,12 @@ export function processActions({
 
         outgoingMutations.push(...workingMutations)
         outgoingActions.push(
-          ...patches.map(
-            (patch): HttpAction => ({
-              actionType: 'sanity.action.document.edit',
-              draftId,
-              publishedId,
-              patch: patch as PatchOperations,
-            }),
-          ),
+          ...patches.map((patch) => ({
+            actionType: 'sanity.action.document.edit' as const,
+            draftId: patchDocumentId,
+            publishedId,
+            patch: patch as PatchOperations,
+          })),
         )
 
         continue
@@ -504,17 +544,17 @@ export function processActions({
       case 'document.publish': {
         const documentId = getId(action.documentId)
 
-        if (action.liveEdit) {
+        if (action.liveEdit || isReleasePerspective(action.perspective)) {
           throw new ActionError({
             documentId,
             transactionId,
-            message: `Cannot publish liveEdit document "${documentId}". LiveEdit documents do not support drafts or publishing.`,
+            message: `Cannot publish this document. Publishing is not supported for liveEdit or version (release) documents.`,
           })
         }
 
         // Standard draft/published logic
-        const draftId = getDraftId(documentId)
-        const publishedId = getPublishedId(documentId)
+        const draftId = getDraftId(DocumentId(documentId))
+        const publishedId = getPublishedId(DocumentId(documentId))
 
         const workingDraft = working[draftId]
         const baseDraft = base[draftId]
@@ -580,17 +620,17 @@ export function processActions({
       case 'document.unpublish': {
         const documentId = getId(action.documentId)
 
-        if (action.liveEdit) {
+        if (action.liveEdit || isReleasePerspective(action.perspective)) {
           throw new ActionError({
             documentId,
             transactionId,
-            message: `Cannot unpublish liveEdit document "${documentId}". LiveEdit documents do not support drafts or publishing.`,
+            message: `Cannot unpublish this document. Unpublishing is not supported for liveEdit or version (release) documents.`,
           })
         }
 
-        // Standard draft/published logic
-        const draftId = getDraftId(documentId)
-        const publishedId = getPublishedId(documentId)
+        // Standard draft/published or version logic
+        const draftId = getDraftId(DocumentId(documentId))
+        const publishedId = getPublishedId(DocumentId(documentId))
 
         if (!working[publishedId] && !base[publishedId]) {
           throw new ActionError({

--- a/packages/core/src/document/reducers.test.ts
+++ b/packages/core/src/document/reducers.test.ts
@@ -1,9 +1,9 @@
+import {DocumentId, getDraftId, getPublishedId} from '@sanity/id-utils'
 import {type SanityDocument} from '@sanity/types'
 import {parse} from 'groq-js'
 import {Subject} from 'rxjs'
 import {describe, expect, it} from 'vitest'
 
-import {getDraftId, getPublishedId} from '../utils/ids'
 import {type DocumentEvent} from './events'
 import {type RemoteDocument} from './listen'
 import {type DocumentSet} from './processMutations'
@@ -66,8 +66,8 @@ describe('queueTransaction', () => {
     expect(newState.queued[0]).toEqual(transaction)
 
     // Check that both the published and draft documentStates got a subscription id added.
-    const draftId = getDraftId('doc1')
-    const pubId = getPublishedId('doc1')
+    const draftId = getDraftId(DocumentId('doc1'))
+    const pubId = getPublishedId(DocumentId('doc1'))
     expect(newState.documentStates[draftId]).toBeDefined()
     expect(newState.documentStates[pubId]).toBeDefined()
     expect(newState.documentStates[draftId]?.subscriptions).toContain('txn1')
@@ -77,8 +77,8 @@ describe('queueTransaction', () => {
 
 describe('removeQueuedTransaction', () => {
   it('removes the transaction from queued and removes subscription ids from documents', () => {
-    const draftId = getDraftId('doc1')
-    const pubId = getPublishedId('doc1')
+    const draftId = getDraftId(DocumentId('doc1'))
+    const pubId = getPublishedId(DocumentId('doc1'))
 
     const initialState: SyncTransactionState = {
       queued: [
@@ -98,8 +98,8 @@ describe('removeQueuedTransaction', () => {
       outgoing: undefined,
       grants,
       documentStates: {
-        [draftId]: {id: draftId, subscriptions: ['txn1'], local: {}},
-        [pubId]: {id: pubId, subscriptions: ['txn1'], local: {}},
+        [draftId]: {id: draftId, subscriptions: ['txn1']},
+        [pubId]: {id: pubId, subscriptions: ['txn1']},
       } as SyncTransactionState['documentStates'],
     }
 
@@ -138,7 +138,7 @@ describe('applyFirstQueuedTransaction', () => {
 
   it('returns unchanged state if any required document is not yet loaded', () => {
     // If a document's local value is undefined, the reducer should do nothing.
-    const draftId = getDraftId('doc1')
+    const draftId = getDraftId(DocumentId('doc1'))
     const state: SyncTransactionState = {
       queued: [
         {
@@ -176,8 +176,8 @@ describe('applyFirstQueuedTransaction', () => {
 
   it('applies the first queued transaction (using a discard action)', () => {
     // For a discard action, processActions deletes the draft document.
-    const draftId = getDraftId('doc1')
-    const pubId = getPublishedId('doc1')
+    const draftId = getDraftId(DocumentId('doc1'))
+    const pubId = getPublishedId(DocumentId('doc1'))
     const initialDraft = {...exampleDoc, _id: draftId, foo: 'bar', _rev: 'rev1'}
     const initialPub = {...exampleDoc, _id: pubId, foo: 'bar', _rev: 'rev1'}
 
@@ -235,18 +235,26 @@ describe('batchAppliedTransactions', () => {
       disableBatching: false,
       outgoingActions: [],
       outgoingMutations: [],
-      base: {[getDraftId('doc1')]: {_id: getDraftId('doc1'), _rev: 'rev1'}} as DocumentSet,
+      base: {
+        [getDraftId(DocumentId('doc1'))]: {_id: getDraftId(DocumentId('doc1')), _rev: 'rev1'},
+      } as unknown as DocumentSet,
       working: {
-        [getDraftId('doc1')]: {
+        [getDraftId(DocumentId('doc1'))]: {
           ...exampleDoc,
-          _id: getDraftId('doc1'),
+          _id: getDraftId(DocumentId('doc1')),
           _rev: 'rev2',
           foo: 'a',
           bar: 'b',
         },
       },
-      previous: {[getDraftId('doc1')]: {...exampleDoc, _id: getDraftId('doc1'), _rev: 'rev1'}},
-      previousRevs: {[getDraftId('doc1')]: 'rev1'},
+      previous: {
+        [getDraftId(DocumentId('doc1'))]: {
+          ...exampleDoc,
+          _id: getDraftId(DocumentId('doc1')),
+          _rev: 'rev1',
+        },
+      },
+      previousRevs: {[getDraftId(DocumentId('doc1'))]: 'rev1'},
       timestamp: '2025-02-06T00:00:00.000Z',
     }
     const result = batchAppliedTransactions([appliedTx])
@@ -256,13 +264,14 @@ describe('batchAppliedTransactions', () => {
   })
 
   it('batches two edit transactions when possible', () => {
-    const draftId = getDraftId('doc1')
+    const documentId = DocumentId('doc1')
+    const draftId = getDraftId(documentId)
     const appliedTx1: AppliedTransaction = {
       transactionId: 'txn5',
       actions: [
         {
           type: 'document.edit',
-          documentId: 'doc1',
+          documentId,
           documentType: 'book',
           patches: [{set: {foo: 'a'}}],
         },
@@ -272,7 +281,7 @@ describe('batchAppliedTransactions', () => {
         {
           actionType: 'sanity.action.document.edit',
           draftId,
-          publishedId: getPublishedId('doc1'),
+          publishedId: getPublishedId(documentId),
           patch: {set: {foo: 'a'}},
         },
       ],
@@ -288,7 +297,7 @@ describe('batchAppliedTransactions', () => {
       actions: [
         {
           type: 'document.edit',
-          documentId: 'doc1',
+          documentId,
           documentType: 'book',
           patches: [{set: {bar: 'b'}}],
         },
@@ -298,7 +307,7 @@ describe('batchAppliedTransactions', () => {
         {
           actionType: 'sanity.action.document.edit',
           draftId,
-          publishedId: getPublishedId('doc1'),
+          publishedId: getPublishedId(documentId),
           patch: {set: {bar: 'b'}},
         },
       ],
@@ -322,7 +331,7 @@ describe('batchAppliedTransactions', () => {
   })
 
   it('returns a transaction with disableBatching true if a single edit action already has disableBatching set', () => {
-    const draftId = getDraftId('docA')
+    const draftId = getDraftId(DocumentId('docA'))
     const appliedTx: AppliedTransaction = {
       transactionId: 'txn-disable',
       actions: [
@@ -366,16 +375,34 @@ describe('batchAppliedTransactions', () => {
       outgoingActions: [
         {
           actionType: 'sanity.action.document.edit',
-          draftId: getDraftId('doc1'),
-          publishedId: getPublishedId('doc1'),
+          draftId: getDraftId(DocumentId('doc1')),
+          publishedId: getPublishedId(DocumentId('doc1')),
           patch: {set: {foo: 'a'}},
         },
       ],
       outgoingMutations: [],
-      base: {[getDraftId('doc1')]: {...exampleDoc, _id: getDraftId('doc1'), _rev: 'rev1'}},
-      working: {[getDraftId('doc1')]: {...exampleDoc, _id: getDraftId('doc1'), _rev: 'rev2'}},
-      previous: {[getDraftId('doc1')]: {...exampleDoc, _id: getDraftId('doc1'), _rev: 'rev1'}},
-      previousRevs: {[getDraftId('doc1')]: 'rev1'},
+      base: {
+        [getDraftId(DocumentId('doc1'))]: {
+          ...exampleDoc,
+          _id: getDraftId(DocumentId('doc1')),
+          _rev: 'rev1',
+        },
+      },
+      working: {
+        [getDraftId(DocumentId('doc1'))]: {
+          ...exampleDoc,
+          _id: getDraftId(DocumentId('doc1')),
+          _rev: 'rev2',
+        },
+      },
+      previous: {
+        [getDraftId(DocumentId('doc1'))]: {
+          ...exampleDoc,
+          _id: getDraftId(DocumentId('doc1')),
+          _rev: 'rev1',
+        },
+      },
+      previousRevs: {[getDraftId(DocumentId('doc1'))]: 'rev1'},
       timestamp: '2025-02-06T00:00:00.000Z',
     }
     const liveEditTx: AppliedTransaction = {
@@ -427,7 +454,7 @@ describe('transitionAppliedTransactionsToOutgoing', () => {
   })
 
   it('transitions applied transactions to an outgoing transaction', () => {
-    const draftId = getDraftId('doc1')
+    const draftId = getDraftId(DocumentId('doc1'))
     const initialDoc = {...exampleDoc, _id: draftId, foo: 'old', _rev: 'rev1'}
     const state: SyncTransactionState = {
       queued: [],
@@ -487,8 +514,8 @@ describe('cleanupOutgoingTransaction', () => {
   })
 
   it('removes subscription ids for all documents associated with the outgoing transaction and then clears outgoing', () => {
-    const draftId = getDraftId('doc1')
-    const pubId = getPublishedId('doc1')
+    const draftId = getDraftId(DocumentId('doc1'))
+    const pubId = getPublishedId(DocumentId('doc1'))
     const state: SyncTransactionState = {
       queued: [],
       applied: [],
@@ -528,8 +555,8 @@ describe('cleanupOutgoingTransaction', () => {
 
 describe('revertOutgoingTransaction', () => {
   it('reverts the outgoing transaction and updates documentStates by removing unverified revisions', () => {
-    const draftId = getDraftId('doc1')
-    const pubId = getPublishedId('doc1')
+    const draftId = getDraftId(DocumentId('doc1'))
+    const pubId = getPublishedId(DocumentId('doc1'))
     // In this test we simulate a state with one applied transaction and an outgoing transaction.
     const state: SyncTransactionState = {
       queued: [],
@@ -626,7 +653,7 @@ describe('applyRemoteDocument', () => {
   })
 
   it('verifies an unverified revision when the revision matches and previousRev is as expected', () => {
-    const docId = getDraftId('doc1')
+    const docId = getDraftId(DocumentId('doc1'))
     const initialState: SyncTransactionState = {
       queued: [],
       applied: [],
@@ -668,7 +695,7 @@ describe('applyRemoteDocument', () => {
 
   it('rebases local changes when no matching unverified revision is found', () => {
     // In this branch we simply let processActions rebase so that the local becomes the remote.
-    const docId = getDraftId('doc1')
+    const docId = getDraftId(DocumentId('doc1'))
     const initialState: SyncTransactionState = {
       queued: [],
       applied: [],
@@ -703,7 +730,7 @@ describe('applyRemoteDocument', () => {
 
   // Test that a sync event removes outdated unverified revisions.
   it('removes outdated unverified revisions when a sync event is received', () => {
-    const docId = getDraftId('doc1')
+    const docId = getDraftId(DocumentId('doc1'))
     // An unverified revision created at an earlier time.
     const outdatedTimestamp = new Date('2025-02-06T00:09:00.000Z').toISOString()
     // The incoming sync event timestamp is later.

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -1,9 +1,11 @@
-import {getPublishedId} from '@sanity/client/csm'
+import {DocumentId, getDraftId, getPublishedId, getVersionId} from '@sanity/id-utils'
 import {type Mutation, type PatchOperations, type SanityDocumentLike} from '@sanity/types'
 import {omit} from 'lodash-es'
 
+import {type DocumentHandle} from '../config/sanityConfig'
+import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
 import {type StoreContext} from '../store/defineStore'
-import {getDraftId, insecureRandomId} from '../utils/ids'
+import {insecureRandomId} from '../utils/ids'
 import {setCleanupTimeout} from '../utils/setCleanupTimeout'
 import {type DocumentAction} from './actions'
 import {DOCUMENT_STATE_CLEAR_DELAY} from './documentConstants'
@@ -18,6 +20,11 @@ export type SyncTransactionState = Pick<
   DocumentStoreState,
   'queued' | 'applied' | 'documentStates' | 'outgoing' | 'grants'
 >
+
+type DocumentHandleLike = Pick<DocumentHandle, 'perspective'> & {
+  documentId?: string
+  liveEdit?: boolean
+}
 
 type ActionMap = {
   create: 'sanity.action.document.version.create'
@@ -144,7 +151,7 @@ export function queueTransaction(
   transaction: QueuedTransaction,
 ): SyncTransactionState {
   const {transactionId, actions} = transaction
-  const prevWithSubscriptionIds = getDocumentIdsFromActions(actions).reduce(
+  const prevWithSubscriptionIds = getDocumentIdsFromHandleLikes(actions).reduce(
     (acc, id) => addSubscriptionIdToDocument(acc, id, transactionId),
     prev,
   )
@@ -162,7 +169,7 @@ export function removeQueuedTransaction(
   const transaction = prev.queued.find((t) => t.transactionId === transactionId)
   if (!transaction) return prev
 
-  const prevWithSubscriptionIds = getDocumentIdsFromActions(transaction.actions).reduce(
+  const prevWithSubscriptionIds = getDocumentIdsFromHandleLikes(transaction.actions).reduce(
     (acc, id) => removeSubscriptionIdFromDocument(acc, id, transactionId),
     prev,
   )
@@ -178,7 +185,7 @@ export function applyFirstQueuedTransaction(prev: SyncTransactionState): SyncTra
   if (!queued) return prev
   if (!prev.grants) return prev
 
-  const ids = getDocumentIdsFromActions(queued.actions)
+  const ids = getDocumentIdsFromHandleLikes(queued.actions)
   // the local value is only ever `undefined` if it has not been loaded yet
   // we can't get the next applied state unless all relevant documents are ready
   if (ids.some((id) => prev.documentStates[id]?.local === undefined)) return prev
@@ -339,7 +346,7 @@ export function cleanupOutgoingTransaction(prev: SyncTransactionState): SyncTran
   if (!outgoing) return prev
 
   let next = prev
-  const ids = getDocumentIdsFromActions(outgoing.actions)
+  const ids = getDocumentIdsFromHandleLikes(outgoing.actions)
   for (const transactionId of outgoing.batchedTransactionIds) {
     for (const documentId of ids) {
       next = removeSubscriptionIdFromDocument(next, documentId, transactionId)
@@ -553,22 +560,10 @@ export function removeSubscriptionIdFromDocument(
 
 export function manageSubscriberIds(
   {state}: StoreContext<SyncTransactionState>,
-  documentId: string | string[],
-  options?: {expandDraftPublished?: boolean},
+  handles: DocumentHandleLike[],
 ): () => void {
-  const expandDraftPublished = options?.expandDraftPublished ?? true
-  const documentIds = Array.from(
-    new Set(
-      expandDraftPublished
-        ? (Array.isArray(documentId) ? documentId : [documentId]).flatMap((id) => [
-            getPublishedId(id),
-            getDraftId(id),
-          ])
-        : Array.isArray(documentId)
-          ? documentId
-          : [documentId],
-    ),
-  )
+  const documentIds = getDocumentIdsFromHandleLikes(handles)
+
   const subscriptionId = insecureRandomId()
   state.set('addSubscribers', (prev) =>
     documentIds.reduce(
@@ -589,13 +584,23 @@ export function manageSubscriberIds(
   }
 }
 
-export function getDocumentIdsFromActions(actions: DocumentAction[]): string[] {
-  return Array.from(
-    new Set(
-      actions
-        .map((i) => i.documentId)
-        .filter((i) => typeof i === 'string')
-        .flatMap((documentId) => [getPublishedId(documentId), getDraftId(documentId)]),
-    ),
-  )
+// document handles are passed in via the public facing API, but we also need to
+// pull the correct document ids from action bodies, which have similar but not
+// identical shapes to the document handles.
+function getDocumentIdsFromHandleLikes(handles: DocumentHandleLike[]): string[] {
+  return handles.flatMap((handle) => {
+    const idsForDocument = []
+    if (!handle.documentId) return []
+    if (handle.liveEdit) {
+      return [handle.documentId]
+    }
+    if (isReleasePerspective(handle.perspective)) {
+      idsForDocument.push(
+        getVersionId(DocumentId(handle.documentId), handle.perspective.releaseName),
+      )
+    }
+    idsForDocument.push(getPublishedId(DocumentId(handle.documentId)))
+    idsForDocument.push(getDraftId(DocumentId(handle.documentId)))
+    return idsForDocument
+  })
 }

--- a/packages/core/src/document/sharedListener.ts
+++ b/packages/core/src/document/sharedListener.ts
@@ -76,9 +76,9 @@ export function createFetchDocument(instance: SanityInstance, source?: DocumentS
       source: source && !isDatasetSource(source) ? source : undefined,
     }).observable.pipe(
       switchMap((client) => {
-        // TODO: remove this once the client is updated to v7 the new type is available in @sanity/mutate/_unstable_store
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const loadDocument = createDocumentLoaderFromClient(client as any)
+        // creates a observable request to the /doc/{documentId} endpoint for a given document id
+        // should work across all kinds of document IDs (drafts.**, version.**., etc.)
+        const loadDocument = createDocumentLoaderFromClient(client)
         return loadDocument(documentId)
       }),
       map((result) => {

--- a/packages/core/src/document/util.ts
+++ b/packages/core/src/document/util.ts
@@ -1,0 +1,14 @@
+import {DocumentId, getPublishedId, getVersionId} from '@sanity/id-utils'
+
+import {type DocumentHandle} from '../config/sanityConfig'
+import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
+
+export function getEffectiveDocumentId(doc: DocumentHandle): string {
+  if (doc.liveEdit) {
+    return doc.documentId
+  } else if (isReleasePerspective(doc.perspective)) {
+    return getVersionId(DocumentId(doc.documentId), doc.perspective.releaseName)
+  } else {
+    return getPublishedId(DocumentId(doc.documentId))
+  }
+}

--- a/packages/core/src/projection/projectionQuery.ts
+++ b/packages/core/src/projection/projectionQuery.ts
@@ -1,8 +1,7 @@
 import {type ClientPerspective} from '@sanity/client'
-import {DocumentId} from '@sanity/id-utils'
+import {DocumentId, getPublishedId} from '@sanity/id-utils'
 
 import {type ReleasePerspective} from '../config/sanityConfig'
-import {getPublishedId} from '../utils/ids'
 import {
   type DocumentProjections,
   type DocumentProjectionValues,
@@ -85,7 +84,7 @@ export function processProjectionQuery({
   } = {}
 
   for (const result of results) {
-    const originalId = getPublishedId(result._id)
+    const originalId = getPublishedId(DocumentId(result._id))
     const hash = result.__projectionHash
 
     if (!ids.has(originalId)) continue

--- a/packages/core/src/utils/ids.test.ts
+++ b/packages/core/src/utils/ids.test.ts
@@ -1,34 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {getDraftId, getPublishedId, insecureRandomId} from './ids'
-
-describe('getDraftId', () => {
-  it('should add drafts prefix to non-draft ids', () => {
-    expect(getDraftId('abc123')).toBe('drafts.abc123')
-  })
-
-  it('should not modify ids that already have drafts prefix', () => {
-    expect(getDraftId('drafts.abc123')).toBe('drafts.abc123')
-  })
-
-  it('should handle empty string', () => {
-    expect(getDraftId('')).toBe('drafts.')
-  })
-})
-
-describe('getPublishedId', () => {
-  it('should remove drafts prefix from draft ids', () => {
-    expect(getPublishedId('drafts.abc123')).toBe('abc123')
-  })
-
-  it('should not modify ids that dont have drafts prefix', () => {
-    expect(getPublishedId('abc123')).toBe('abc123')
-  })
-
-  it('should handle empty string', () => {
-    expect(getPublishedId('')).toBe('')
-  })
-})
+import {insecureRandomId} from './ids'
 
 describe('insecureRandomId', () => {
   it('should generate 16-character string', () => {

--- a/packages/core/src/utils/ids.ts
+++ b/packages/core/src/utils/ids.ts
@@ -1,13 +1,3 @@
-export function getPublishedId(id: string): string {
-  const draftsPrefix = 'drafts.'
-  return id.startsWith(draftsPrefix) ? id.slice(draftsPrefix.length) : id
-}
-
-export function getDraftId(id: string): string {
-  const draftsPrefix = 'drafts.'
-  return id.startsWith(draftsPrefix) ? id : `${draftsPrefix}${id}`
-}
-
 export function insecureRandomId(): string {
   return Array.from({length: 16}, () => Math.floor(Math.random() * 16).toString(16)).join('')
 }

--- a/packages/react/src/hooks/document/useApplyDocumentActions.ts
+++ b/packages/react/src/hooks/document/useApplyDocumentActions.ts
@@ -155,6 +155,66 @@ interface UseApplyDocumentActions {
  *   return <button onClick={handleCreateArticle}>Create Article</button>
  * }
  * ```
+ *
+ * @example Create a new document in a release
+ * ```tsx
+ * import {
+ *   createDocument,
+ *   createDocumentHandle,
+ *   useApplyDocumentActions
+ * } from '@sanity/sdk-react'
+ *
+ * function CreateArticleButton() {
+ *   const apply = useApplyDocumentActions()
+ *
+ *   const handleCreateArticle = () => {
+ *     // Use any valid document ID — not the internal `versions.<releaseName>.<id>` format or "drafts.<id>" format.
+ *     // New documents must be explicitly created with `createDocument` to become part of a release.
+ *     const newDocHandle = createDocumentHandle({
+ *       documentId: crypto.randomUUID(), // or the existing document ID you want to make a release version of
+ *       documentType: 'article',
+ *       perspective: {releaseName: 'summer-drop'},
+ *     })
+ *
+ *     apply(
+ *       createDocument(newDocHandle, {
+ *         title: 'New Article',
+ *         author: 'John Doe',
+ *         publishedAt: new Date().toISOString(),
+ *       })
+ *     )
+ *   }
+ *
+ *   return <button onClick={handleCreateArticle}>Create Article</button>
+ * }
+ * ```
+ *
+ * @example Edit an existing document in a release
+ * ```tsx
+ * import {
+ *   editDocument,
+ *   createDocumentHandle,
+ *   useApplyDocumentActions
+ * } from '@sanity/sdk-react'
+ *
+ * function EditArticleInReleaseButton({documentId}: {documentId: string}) {
+ *   const apply = useApplyDocumentActions()
+ *
+ *   const handleEdit = () => {
+ *     // Pass the document's regular ID — not `versions.<releaseName>.<id>`.
+ *     // Documents that already have a version in the release can be edited directly with `editDocument`.
+ *     const docHandle = createDocumentHandle({
+ *       documentId,
+ *       documentType: 'article',
+ *       perspective: {releaseName: 'summer-drop'},
+ *     })
+ *
+ *     apply(editDocument(docHandle, {title: 'Updated for release'}))
+ *   }
+ *
+ *   return <button onClick={handleEdit}>Edit in Release</button>
+ * }
+ * ```
  */
 export const useApplyDocumentActions: UseApplyDocumentActions = () => {
   const instance = useSanityInstance()

--- a/packages/react/src/hooks/document/useEditDocument.ts
+++ b/packages/react/src/hooks/document/useEditDocument.ts
@@ -260,6 +260,27 @@ export function useEditDocument<TData>(
  * }
  *
  * ```
+ *
+ * @example Edit a document in a release
+ * ```tsx
+ * import {useEditDocument} from '@sanity/sdk-react'
+ *
+ * function EditArticleInRelease({documentId}: {documentId: string}) {
+ *   // Use the document's plain ID — not `versions.<releaseName>.<id>`.
+ *   // The document must already exist in the release (added via `createDocument` first).
+ *   const editArticle = useEditDocument({
+ *     documentId,
+ *     documentType: 'article',
+ *     perspective: {releaseName: 'summer-drop'},
+ *   })
+ *
+ *   return (
+ *     <button onClick={() => editArticle(prev => ({...prev, title: 'Updated for release'}))}>
+ *       Edit in Release
+ *     </button>
+ *   )
+ * }
+ * ```
  */
 export function useEditDocument({
   path,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,8 +372,8 @@ importers:
         specifier: ^0.18.0
         version: 0.18.0
       '@sanity/mutate':
-        specifier: ^0.12.4
-        version: 0.12.4(debug@4.4.3)
+        specifier: ^0.16.1
+        version: 0.16.1(xstate@5.25.1)
       '@sanity/telemetry':
         specifier: ^1.0.0
         version: 1.0.0(react@19.2.1)
@@ -3386,6 +3386,15 @@ packages:
   '@sanity/mutate@0.15.0':
     resolution: {integrity: sha512-q91tzqOoGguLm0BSoCCKAbVSQNtQE/agGHWD31v1e2uh3E2fEZ1cPcAUsQVlTXc1nvuP86QX5A8/P6QR9Gpt6g==}
     engines: {node: '>=18'}
+
+  '@sanity/mutate@0.16.1':
+    resolution: {integrity: sha512-400OooNtiafgJEOCzj0E5atuWlaKp1z6LU/LB/xZUVVywNj3WuT52U6qeVOfGlZeWKhYMCdGFX2ZnMbIrME95w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      xstate: ^5.19.0
+    peerDependenciesMeta:
+      xstate:
+        optional: true
 
   '@sanity/mutator@5.5.0':
     resolution: {integrity: sha512-BoxT9O6rh3W7IyLwkksdASJQlMV8BrpGt57fJIZqDpTYzJFMu7VEyJFwJefkTfkcOEvx4wXBye/4/gZ78Kxd7w==}
@@ -11308,7 +11317,7 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@sanity/cli-test@0.0.2-alpha.6(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.7(@noble/hashes@2.0.1)(@types/node@22.19.1)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.36.0)(yaml@2.8.2))(@sanity/client@7.14.1)(vitest@3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@sanity/cli-test@0.0.2-alpha.6(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.7(@noble/hashes@2.0.1)(@types/node@22.19.1)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.36.0)(yaml@2.8.2))(@sanity/client@7.14.1(debug@4.4.3))(vitest@3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@oclif/core': 4.8.0
       '@sanity/cli-core': 0.1.0-alpha.7(@noble/hashes@2.0.1)(@types/node@22.19.1)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.36.0)(yaml@2.8.2)
@@ -11565,7 +11574,7 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@sanity/insert-menu@3.0.3(@emotion/is-prop-valid@1.2.2)(@sanity/types@5.5.0(@types/react@19.2.7))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.18(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@sanity/insert-menu@3.0.3(@emotion/is-prop-valid@1.2.2)(@sanity/types@5.5.0(@types/react@19.2.7)(debug@4.4.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.18(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.1)
       '@sanity/types': 5.5.0(@types/react@19.2.7)(debug@4.4.3)
@@ -11604,7 +11613,7 @@ snapshots:
       '@oclif/core': 4.8.0
       '@oclif/plugin-help': 6.2.37
       '@sanity/cli-core': 0.1.0-alpha.7(@noble/hashes@2.0.1)(@types/node@22.19.1)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.36.0)(yaml@2.8.2)
-      '@sanity/cli-test': 0.0.2-alpha.6(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.7(@noble/hashes@2.0.1)(@types/node@22.19.1)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.36.0)(yaml@2.8.2))(@sanity/client@7.14.1)(vitest@3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@sanity/cli-test': 0.0.2-alpha.6(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.7(@noble/hashes@2.0.1)(@types/node@22.19.1)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.36.0)(yaml@2.8.2))(@sanity/client@7.14.1(debug@4.4.3))(vitest@3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.2))
       '@sanity/client': 7.14.1(debug@4.4.3)
       '@sanity/mutate': 0.15.0(debug@4.4.3)
       '@sanity/types': 5.5.0(@types/react@19.2.7)(debug@4.4.3)
@@ -11661,6 +11670,21 @@ snapshots:
       mendoza: 3.0.8
       nanoid: 5.1.9
       rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
+
+  '@sanity/mutate@0.16.1(xstate@5.25.1)':
+    dependencies:
+      '@sanity/client': 7.14.1(debug@4.4.3)
+      '@sanity/diff-match-patch': 3.2.0
+      '@sanity/uuid': 3.0.2
+      hotscript: 1.0.13
+      lodash: 4.17.21
+      mendoza: 3.0.8
+      nanoid: 5.1.5
+      rxjs: 7.8.2
+    optionalDependencies:
+      xstate: 5.25.1
     transitivePeerDependencies:
       - debug
 
@@ -11797,10 +11821,10 @@ snapshots:
       - supports-color
       - vue-tsc
 
-  '@sanity/presentation-comlink@2.0.1(@sanity/client@7.14.1)(@sanity/types@5.5.0(@types/react@19.2.7))':
+  '@sanity/presentation-comlink@2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.5.0(@types/react@19.2.7)(debug@4.4.3))':
     dependencies:
       '@sanity/comlink': 4.0.1
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.14.1)(@sanity/types@5.5.0(@types/react@19.2.7))
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.5.0(@types/react@19.2.7)(debug@4.4.3))
     transitivePeerDependencies:
       - '@sanity/client'
       - '@sanity/types'
@@ -11810,7 +11834,7 @@ snapshots:
       prettier: 3.7.4
       prettier-plugin-packagejson: 2.5.20(prettier@3.7.4)
 
-  '@sanity/preview-url-secret@4.0.2(@sanity/client@7.14.1)':
+  '@sanity/preview-url-secret@4.0.2(@sanity/client@7.14.1(debug@4.4.3))':
     dependencies:
       '@sanity/client': 7.14.1(debug@4.4.3)
       '@sanity/uuid': 3.0.2
@@ -12040,7 +12064,7 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.14.1)(@sanity/types@5.5.0(@types/react@19.2.7))':
+  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.5.0(@types/react@19.2.7)(debug@4.4.3))':
     dependencies:
       '@sanity/client': 7.14.1(debug@4.4.3)
     optionalDependencies:
@@ -16555,14 +16579,14 @@ snapshots:
       '@sanity/id-utils': 1.0.0
       '@sanity/image-url': 2.0.3
       '@sanity/import': 4.1.0(@types/node@22.19.1)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.36.0)(yaml@2.8.2)
-      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.2.2)(@sanity/types@5.5.0(@types/react@19.2.7))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.18(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.2.2)(@sanity/types@5.5.0(@types/react@19.2.7)(debug@4.4.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(styled-components@6.1.18(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@sanity/logos': 2.2.2(react@19.2.1)
       '@sanity/media-library-types': 1.2.0
       '@sanity/message-protocol': 0.19.0
       '@sanity/migrate': 5.2.2(@noble/hashes@2.0.1)(@types/node@22.19.1)(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.36.0)(vitest@3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
       '@sanity/mutator': 5.5.0(@types/react@19.2.7)
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1)(@sanity/types@5.5.0(@types/react@19.2.7))
-      '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.1)
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.5.0(@types/react@19.2.7)(debug@4.4.3))
+      '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.1(debug@4.4.3))
       '@sanity/schema': 5.5.0(@types/react@19.2.7)(debug@4.4.3)
       '@sanity/sdk': 2.1.2(@types/react@19.2.7)(debug@4.4.3)(immer@10.1.1)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))
       '@sanity/telemetry': 0.8.1(react@19.2.1)


### PR DESCRIPTION
### Description
This is a cherry-pick from #754, but applied to `main`. There had to be some minor changes now that `liveEdit` documents work a bit differently, but shouldn't be too off. Some additional help text was added for users new to the concepts.

### What to review
Does everything make sense?

### Testing
e2e and unit tests were added.

### Fun gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWt1dHc2anRiOWhnYzIxcXFzbzZzMGcwbTYyNWp5NWFycTllczNxOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/6pUjuQQX9kEfSe604w/giphy.gif)