### PR TITLE
fix(e2e): dismiss osano cookie consent in tests

### DIFF
--- a/packages/@repo/e2e/src/helpers/pageContext.ts
+++ b/packages/@repo/e2e/src/helpers/pageContext.ts
@@ -1,5 +1,16 @@
 import {type FrameLocator, type Page} from '@playwright/test'
 
+export async function dismissCookieConsent(page: Page): Promise<void> {
+  try {
+    const acceptButton = page
+      .getByRole('dialog', {name: 'Cookie Consent Banner'})
+      .getByRole('button', {name: 'Accept', exact: true})
+    await acceptButton.click({timeout: 3000})
+  } catch {
+    // Dialog not present — nothing to dismiss
+  }
+}
+
 /**
  * Unified interface for detecting elements in pages whether in iframe or not.
  * Methods delegate to either Page or FrameLocator depending on context,
@@ -43,6 +54,10 @@ export async function createPageContext(page: Page, projectName: string): Promis
     // Dashboard context - needs to be up-to-date with how this is implemented in the dashboard
     const iframe = page.getByTestId('app-frame')
     await iframe.waitFor({state: 'visible'})
+
+    // Osano cookie consent lives on the outer page and overlays the iframe —
+    // dismiss it before returning so clicks in the frame aren't intercepted.
+    await dismissCookieConsent(page)
 
     const frame = iframe.contentFrame()
     if (!frame) {

--- a/packages/@repo/e2e/src/helpers/pageContext.ts
+++ b/packages/@repo/e2e/src/helpers/pageContext.ts
@@ -1,16 +1,5 @@
 import {type FrameLocator, type Page} from '@playwright/test'
 
-export async function dismissCookieConsent(page: Page): Promise<void> {
-  try {
-    const acceptButton = page
-      .getByRole('dialog', {name: 'Cookie Consent Banner'})
-      .getByRole('button', {name: 'Accept', exact: true})
-    await acceptButton.click({timeout: 3000})
-  } catch {
-    // Dialog not present — nothing to dismiss
-  }
-}
-
 /**
  * Unified interface for detecting elements in pages whether in iframe or not.
  * Methods delegate to either Page or FrameLocator depending on context,
@@ -54,10 +43,6 @@ export async function createPageContext(page: Page, projectName: string): Promis
     // Dashboard context - needs to be up-to-date with how this is implemented in the dashboard
     const iframe = page.getByTestId('app-frame')
     await iframe.waitFor({state: 'visible'})
-
-    // Osano cookie consent lives on the outer page and overlays the iframe —
-    // dismiss it before returning so clicks in the frame aren't intercepted.
-    await dismissCookieConsent(page)
 
     const frame = iframe.contentFrame()
     if (!frame) {

--- a/packages/@repo/e2e/src/setup/auth.setup.ts
+++ b/packages/@repo/e2e/src/setup/auth.setup.ts
@@ -4,7 +4,6 @@ import {fileURLToPath} from 'node:url'
 import {type BrowserContext, test as setup} from '@playwright/test'
 
 import {getE2EEnv} from '../helpers/getE2EEnv'
-import {dismissCookieConsent} from '../helpers/pageContext'
 
 const __filename = fileURLToPath(import.meta.url)
 const AUTH_FILE = path.join(path.dirname(__filename), '..', '..', '.auth', 'user.json')
@@ -60,8 +59,17 @@ const setDashboardRedirectCookie = async (context: BrowserContext) => {
   // wait until the url is /application/__dev (indicating the redirect cookie was set)
   await page.waitForURL(`https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}/application/__dev`)
 
-  // Accept cookie consent so it's saved in the auth state and never blocks tests
-  await dismissCookieConsent(page)
+  // Accept cookie consent so it's saved in the auth state and never blocks tests.
+  // The Osano dialog appears on the dashboard page — dismissing it here ensures
+  // the consent cookie is included in the saved storageState.
+  try {
+    await page
+      .getByRole('dialog', {name: 'Cookie Consent Banner'})
+      .getByRole('button', {name: 'Accept', exact: true})
+      .click({timeout: 5000})
+  } catch {
+    // Dialog not present — nothing to dismiss
+  }
 
   await page.close()
 }

--- a/packages/@repo/e2e/src/setup/auth.setup.ts
+++ b/packages/@repo/e2e/src/setup/auth.setup.ts
@@ -4,6 +4,7 @@ import {fileURLToPath} from 'node:url'
 import {type BrowserContext, test as setup} from '@playwright/test'
 
 import {getE2EEnv} from '../helpers/getE2EEnv'
+import {dismissCookieConsent} from '../helpers/pageContext'
 
 const __filename = fileURLToPath(import.meta.url)
 const AUTH_FILE = path.join(path.dirname(__filename), '..', '..', '.auth', 'user.json')
@@ -58,6 +59,9 @@ const setDashboardRedirectCookie = async (context: BrowserContext) => {
 
   // wait until the url is /application/__dev (indicating the redirect cookie was set)
   await page.waitForURL(`https://www.sanity.work/@${env.SDK_E2E_ORGANIZATION_ID}/application/__dev`)
+
+  // Accept cookie consent so it's saved in the auth state and never blocks tests
+  await dismissCookieConsent(page)
 
   await page.close()
 }


### PR DESCRIPTION
### Description
One of the tests was consistently failing because its button was hiding behind a cookie consent pop-up.
<img width="476" height="355" alt="Screenshot 2026-04-20 at 3 36 39 PM" src="https://github.com/user-attachments/assets/600fbe22-ee5e-408c-81c1-1f36b1dca1bf" />


### What to review
Does this help? Introduce more flake?

### Testing
Let's see if we can avoid re-runs of tests now.

### Fun gif
I'm sorry I don't have it in me for a fun gif about cookie consent right now