### PR TITLE
fix(e2e): search params for multi-resource test

### DIFF
--- a/apps/kitchensink-react/e2e/multi-resource.spec.ts
+++ b/apps/kitchensink-react/e2e/multi-resource.spec.ts
@@ -40,7 +40,7 @@ test.describe('Multi Resource Route', () => {
       process.env['SDK_E2E_DATASET_1'], // Second dataset
     )
 
-    await page.goto('./multi-resource')
+    await page.goto(`./multi-resource?authorId=${authorId}&movieId=${movieId}`)
 
     // get the page context for iframe/page detection
     const pageContext = await getPageContext(page)
@@ -59,6 +59,11 @@ test.describe('Multi Resource Route', () => {
       'Test Movie Multi Resource',
     )
 
+    // Scroll projection cards into view so their visibility-gated subscriptions are active
+    // before we trigger external changes — useDocumentProjection uses a ref-based observer
+    // and won't receive updates for off-screen elements.
+    // (Specifically, do this between editing and verifying the projection -- they're a bit far from each other)
+    await pageContext.getByTestId('author-projection-name').scrollIntoViewIfNeeded()
     // Test author projection data
     await expect(pageContext.getByTestId('author-projection-name')).toContainText(
       'Test Author Multi Resource',
@@ -90,6 +95,7 @@ test.describe('Multi Resource Route', () => {
 
     // Then verify the projection also updated (propagation can lag behind display updates)
     await expect(async () => {
+      await pageContext.getByTestId('author-projection-name').scrollIntoViewIfNeeded()
       const authorProjection = await pageContext.getByTestId('author-projection-name').textContent()
       expect(authorProjection).toContain('Updated Author Name')
     }).toPass({timeout: 25000, intervals: [1000, 2000, 5000]})
@@ -106,6 +112,7 @@ test.describe('Multi Resource Route', () => {
 
     // Then verify the projection also updated (propagation can lag behind display updates)
     await expect(async () => {
+      await pageContext.getByTestId('movie-projection-name').scrollIntoViewIfNeeded()
       const movieProjection = await pageContext.getByTestId('movie-projection-name').textContent()
       expect(movieProjection).toContain('Updated Movie Name')
     }).toPass({timeout: 25000, intervals: [1000, 2000, 5000]})

--- a/apps/kitchensink-react/e2e/multi-resource.spec.ts
+++ b/apps/kitchensink-react/e2e/multi-resource.spec.ts
@@ -40,7 +40,7 @@ test.describe('Multi Resource Route', () => {
       process.env['SDK_E2E_DATASET_1'], // Second dataset
     )
 
-    await page.goto('./multi-resource')
+    await page.goto(`./multi-resource?authorId=${authorId}&movieId=${movieId}`)
 
     // get the page context for iframe/page detection
     const pageContext = await getPageContext(page)
@@ -89,10 +89,10 @@ test.describe('Multi Resource Route', () => {
     })
 
     // Then verify the projection also updated (propagation can lag behind display updates)
-    await expect(async () => {
-      const authorProjection = await pageContext.getByTestId('author-projection-name').textContent()
-      expect(authorProjection).toContain('Updated Author Name')
-    }).toPass({timeout: 25000, intervals: [1000, 2000, 5000]})
+    await expect(pageContext.getByTestId('author-projection-name')).toContainText(
+      'Updated Author Name',
+      {timeout: 25000},
+    )
 
     // Test editing the movie document
     const movieNameInput = pageContext.getByTestId('movie-name-input')
@@ -105,10 +105,10 @@ test.describe('Multi Resource Route', () => {
     })
 
     // Then verify the projection also updated (propagation can lag behind display updates)
-    await expect(async () => {
-      const movieProjection = await pageContext.getByTestId('movie-projection-name').textContent()
-      expect(movieProjection).toContain('Updated Movie Name')
-    }).toPass({timeout: 25000, intervals: [1000, 2000, 5000]})
+    await expect(pageContext.getByTestId('movie-projection-name')).toContainText(
+      'Updated Movie Name',
+      {timeout: 25000},
+    )
 
     // Skip external changes test for standalone mode (WebKit on localhost)
     // Real-time subscriptions are unreliable in this mode

--- a/apps/kitchensink-react/src/DocumentCollection/MultiResourceRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/MultiResourceRoute.tsx
@@ -9,6 +9,7 @@ import {
 import {Box, TextInput} from '@sanity/ui'
 import {defineProjection} from 'groq'
 import {JSX, Suspense, useRef} from 'react'
+import {useSearchParams} from 'react-router'
 
 import {
   type MultiResourceAuthorProjectionProjectionResult,
@@ -338,11 +339,16 @@ function MoviePreview({docHandle}: {docHandle: DocumentHandle<'movie'>}) {
 
 export function MultiResourceRoute(): JSX.Element {
   const configs = import.meta.env['VITE_IS_E2E'] ? e2eConfigs : devConfigs
+  const [searchParams] = useSearchParams()
+  const authorIdParam = searchParams.get('authorId')
+  const movieIdParam = searchParams.get('movieId')
+
   const {data: authorDocuments} = useDocuments({
     documentType: 'author',
     batchSize: 1,
     projectId: configs[0].projectId,
     dataset: configs[0].dataset,
+    ...(authorIdParam ? {filter: '_id == $authorId', params: {authorId: authorIdParam}} : {}),
   })
 
   const {data: movieDocuments} = useDocuments({
@@ -350,6 +356,7 @@ export function MultiResourceRoute(): JSX.Element {
     batchSize: 1,
     projectId: configs[1].projectId,
     dataset: configs[1].dataset,
+    ...(movieIdParam ? {filter: '_id == $movieId', params: {movieId: movieIdParam}} : {}),
   })
 
   const authorHandle = authorDocuments[0] ?? null


### PR DESCRIPTION
### Description
There was in issue with staleness in projections that were offscreen -- that's covered by #942. 

<img width="1280" height="720" alt="b8413a099f5a9411a28a7f4b07ad9c6d15aedac4" src="https://github.com/user-attachments/assets/e3365a32-9b8d-421a-847d-84f7883e1105" />

I also noticed that the tests were just grabbing whatever document and hoping for the best, which is very silly. This PR updates the search params to take care of that.

### What to review
Everything make sense?

### Testing
Hopefully less flake!

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3h6NHU1c3ZpbGxxOGlwdm5xOWw3MTM1N3A0MGkxNDlwb2Z4dG5pMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/XD4qHZpkyUFfq/giphy.gif)

FIXES SDK-1288