### PR TITLE
feat(core): send _origin, _sdkVersion, _appId on SDK API requests

### DIFF
--- a/apps/kitchensink-react/src/sanityConfigs.ts
+++ b/apps/kitchensink-react/src/sanityConfigs.ts
@@ -1,13 +1,20 @@
 import {type DocumentSource, type SanityConfig} from '@sanity/sdk'
 
+// Mirrors `app.id` in sanity.cli.ts. A future CLI release is expected to emit a
+// generated module (alongside `.sanity/resources.ts`) that we can import here
+// instead of hardcoding.
+const APPLICATION_ID = 'wkyoigmzawwnnwx458zgoh46'
+
 export const devConfigs: SanityConfig[] = [
   {
     projectId: 'ppsg7ml5',
     dataset: 'test',
+    applicationId: APPLICATION_ID,
   },
   {
     projectId: 'vo1ysemo',
     dataset: 'production',
+    applicationId: APPLICATION_ID,
   },
 ]
 

--- a/packages/core/src/client/clientStore.test.ts
+++ b/packages/core/src/client/clientStore.test.ts
@@ -7,7 +7,13 @@ import {createSanityInstance, type SanityInstance} from '../store/createSanityIn
 import {getClient, getClientState} from './clientStore'
 
 // Mock dependencies
-vi.mock('@sanity/client')
+vi.mock('@sanity/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/client')>()
+  return {
+    ...actual,
+    createClient: vi.fn(),
+  }
+})
 
 vi.mock('../auth/authStore')
 
@@ -61,10 +67,12 @@ describe('clientStore', () => {
       expect(vi.mocked(createClient)).toHaveBeenCalledWith({
         ...defaultConfiguration,
         apiVersion: '2024-11-12',
+        requester: expect.any(Function),
       })
       expect(client.config()).toEqual({
         ...defaultConfiguration,
         apiVersion: '2024-11-12',
+        requester: expect.any(Function),
       })
     })
 
@@ -80,6 +88,60 @@ describe('clientStore', () => {
       )
 
       vi.unstubAllGlobals()
+    })
+
+    describe('attribution via custom requester', () => {
+      it('passes a custom requester to createClient', () => {
+        getClient(instance, {apiVersion: '2024-11-12'})
+
+        expect(vi.mocked(createClient)).toHaveBeenCalledWith(
+          expect.objectContaining({requester: expect.any(Function)}),
+        )
+      })
+
+      it('does not leak applicationId into the @sanity/client config', () => {
+        getClient(instance, {apiVersion: '2024-11-12', applicationId: 'opt-app'})
+
+        const call = vi.mocked(createClient).mock.calls[0][0]
+        expect(call).not.toHaveProperty('applicationId')
+      })
+
+      it('creates separate client instances for different applicationIds', () => {
+        const client1 = getClient(instance, {apiVersion: '2024-11-12', applicationId: 'app-a'})
+        const client2 = getClient(instance, {apiVersion: '2024-11-12', applicationId: 'app-b'})
+
+        expect(client1).not.toBe(client2)
+        expect(vi.mocked(createClient)).toHaveBeenCalledTimes(2)
+      })
+
+      it('reuses the same client instance when applicationId is identical', () => {
+        const client1 = getClient(instance, {apiVersion: '2024-11-12', applicationId: 'app-a'})
+        const client2 = getClient(instance, {apiVersion: '2024-11-12', applicationId: 'app-a'})
+
+        expect(client1).toBe(client2)
+        expect(vi.mocked(createClient)).toHaveBeenCalledTimes(1)
+      })
+
+      it('resolves applicationId from options over instance config', () => {
+        const instanceWithAppId = createSanityInstance({
+          projectId: 'test-project',
+          dataset: 'test-dataset',
+          applicationId: 'cfg-app',
+        })
+
+        const c1 = getClient(instanceWithAppId, {
+          apiVersion: '2024-11-12',
+          applicationId: 'opt-app',
+        })
+        const c2 = getClient(instanceWithAppId, {apiVersion: '2024-11-12'})
+        const c3 = getClient(instance, {apiVersion: '2024-11-12'})
+
+        expect(c1).not.toBe(c2)
+        expect(c2).not.toBe(c3)
+        expect(vi.mocked(createClient)).toHaveBeenCalledTimes(3)
+
+        instanceWithAppId.dispose()
+      })
     })
 
     it('should throw when using disallowed configuration keys', () => {

--- a/packages/core/src/client/clientStore.ts
+++ b/packages/core/src/client/clientStore.ts
@@ -12,6 +12,7 @@ import {bindActionGlobally} from '../store/createActionBinder'
 import {createStateSourceAction} from '../store/createStateSourceAction'
 import {defineStore, type StoreContext} from '../store/defineStore'
 import {getStagingApiHost} from '../utils/getStagingApiHost'
+import {createSdkRequester} from './sdkRequester'
 
 const DEFAULT_API_VERSION = '2024-11-12'
 const DEFAULT_REQUEST_TAG_PREFIX = 'sanity.sdk'
@@ -47,6 +48,7 @@ const allowedKeys = Object.keys({
   'useProjectHostname': null,
   '~experimental_resource': null,
   'source': null,
+  'applicationId': null,
 } satisfies Record<keyof ClientOptions, null>) as (keyof ClientOptions)[]
 
 const DEFAULT_CLIENT_CONFIG: ClientConfig = {
@@ -108,6 +110,15 @@ export interface ClientOptions extends Pick<ClientConfig, AllowedClientConfigKey
    * @internal
    */
   'source'?: DocumentSource
+
+  /**
+   * Identifies the application making API requests for attribution and metrics.
+   *
+   * Falls back to the `applicationId` on the instance config when omitted.
+   *
+   * @public
+   */
+  'applicationId'?: string
 }
 
 const clientStore = defineStore<ClientStoreState>({
@@ -197,6 +208,7 @@ export const getClient = bindActionGlobally(
     const projectId = options.projectId ?? instance.config.projectId
     const dataset = options.dataset ?? instance.config.dataset
     const apiHost = options.apiHost ?? instance.config.auth?.apiHost ?? getStagingApiHost()
+    const applicationId = options.applicationId ?? instance.config.applicationId
 
     const effectiveOptions: ClientOptions = {
       ...DEFAULT_CLIENT_CONFIG,
@@ -206,6 +218,7 @@ export const getClient = bindActionGlobally(
       ...(projectId && {projectId}),
       ...(dataset && {dataset}),
       ...(apiHost && {apiHost}),
+      ...(applicationId && {applicationId}),
       ...(resource && {'~experimental_resource': resource}),
     }
 
@@ -236,7 +249,14 @@ export const getClient = bindActionGlobally(
 
     if (clients[key]) return clients[key]
 
-    const client = createClient(effectiveOptions)
+    // `applicationId` is SDK-owned config surfaced through the custom requester.
+    // Keep it in the cache key (above) but strip it from what reaches
+    // `@sanity/client` so we don't leak an unknown config field.
+    const {applicationId: _resolvedAppId, ...clientOptions} = effectiveOptions
+    const client = createClient({
+      ...clientOptions,
+      requester: createSdkRequester({applicationId: _resolvedAppId}),
+    })
     state.set('addClient', (prev) => ({clients: {...prev.clients, [key]: client}}))
 
     return client

--- a/packages/core/src/client/sdkRequester.test.ts
+++ b/packages/core/src/client/sdkRequester.test.ts
@@ -1,0 +1,111 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {CORE_SDK_VERSION} from '../version'
+import {
+  createSdkAttributionMiddleware,
+  createSdkRequester,
+  SDK_ATTRIBUTION_PARAMS,
+} from './sdkRequester'
+
+const EXPECTED_SDK_VERSION = String(CORE_SDK_VERSION)
+
+interface TestRequestOptions {
+  url?: string
+  uri?: string
+  method?: string
+}
+
+const ORIGIN = 'https://example.test'
+
+function runMiddleware(
+  applicationId: string | undefined,
+  opts: TestRequestOptions,
+): TestRequestOptions {
+  const middleware = createSdkAttributionMiddleware({applicationId})
+  const result = middleware.processOptions!({...opts} as never)
+  return result as TestRequestOptions
+}
+
+describe('createSdkAttributionMiddleware', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('appends _origin and _sdkVersion to request URLs', () => {
+    vi.stubGlobal('window', {location: {origin: ORIGIN}})
+
+    const result = runMiddleware(undefined, {url: 'https://api.sanity.io/v1/data/query/ds'})
+
+    const parsed = new URL(result.url!)
+    expect(parsed.searchParams.get(SDK_ATTRIBUTION_PARAMS.origin)).toBe(ORIGIN)
+    expect(parsed.searchParams.get(SDK_ATTRIBUTION_PARAMS.sdkVersion)).toBe(EXPECTED_SDK_VERSION)
+    expect(parsed.searchParams.get(SDK_ATTRIBUTION_PARAMS.appId)).toBeNull()
+  })
+
+  it('includes _appId when applicationId is provided', () => {
+    vi.stubGlobal('window', {location: {origin: ORIGIN}})
+
+    const result = runMiddleware('app-123', {url: 'https://api.sanity.io/v1/data/query/ds'})
+
+    const parsed = new URL(result.url!)
+    expect(parsed.searchParams.get(SDK_ATTRIBUTION_PARAMS.appId)).toBe('app-123')
+  })
+
+  it('omits _appId when applicationId is an empty string', () => {
+    vi.stubGlobal('window', {location: {origin: ORIGIN}})
+
+    const result = runMiddleware('', {url: 'https://api.sanity.io/v1/data/query/ds'})
+
+    const parsed = new URL(result.url!)
+    expect(parsed.searchParams.has(SDK_ATTRIBUTION_PARAMS.appId)).toBe(false)
+  })
+
+  it('uses "server" as the origin when window is unavailable', () => {
+    vi.stubGlobal('window', undefined)
+
+    const result = runMiddleware(undefined, {url: 'https://api.sanity.io/v1/data/query/ds'})
+
+    const parsed = new URL(result.url!)
+    expect(parsed.searchParams.get(SDK_ATTRIBUTION_PARAMS.origin)).toBe('server')
+  })
+
+  it('appends to an existing query string rather than overwriting it', () => {
+    vi.stubGlobal('window', {location: {origin: ORIGIN}})
+
+    const result = runMiddleware('app-123', {
+      url: 'https://api.sanity.io/v1/data/query/ds?query=*&tag=sanity.sdk.test',
+    })
+
+    const parsed = new URL(result.url!)
+    expect(parsed.searchParams.get('query')).toBe('*')
+    expect(parsed.searchParams.get('tag')).toBe('sanity.sdk.test')
+    expect(parsed.searchParams.get(SDK_ATTRIBUTION_PARAMS.origin)).toBe(ORIGIN)
+    expect(parsed.searchParams.get(SDK_ATTRIBUTION_PARAMS.sdkVersion)).toBe(EXPECTED_SDK_VERSION)
+    expect(parsed.searchParams.get(SDK_ATTRIBUTION_PARAMS.appId)).toBe('app-123')
+  })
+
+  it('falls back to opts.uri when opts.url is not set', () => {
+    vi.stubGlobal('window', {location: {origin: ORIGIN}})
+
+    const result = runMiddleware(undefined, {uri: 'https://api.sanity.io/v1/data/query/ds'})
+
+    expect(result.url).toMatch(/^https:\/\/api\.sanity\.io\/v1\/data\/query\/ds\?/)
+  })
+
+  it('leaves opts.url untouched when neither url nor uri is set', () => {
+    vi.stubGlobal('window', {location: {origin: ORIGIN}})
+
+    const result = runMiddleware(undefined, {})
+
+    expect(result.url).toBeUndefined()
+  })
+})
+
+describe('createSdkRequester', () => {
+  it('returns a requester with use/clone methods (get-it Requester API)', () => {
+    const requester = createSdkRequester()
+    expect(typeof requester).toBe('function')
+    expect(typeof requester.use).toBe('function')
+    expect(typeof requester.clone).toBe('function')
+  })
+})

--- a/packages/core/src/client/sdkRequester.ts
+++ b/packages/core/src/client/sdkRequester.ts
@@ -1,0 +1,75 @@
+import {requester as defaultRequester} from '@sanity/client'
+
+import {getOrigin} from '../utils/getOrigin'
+import {CORE_SDK_VERSION} from '../version'
+
+/**
+ * Query param keys appended by the SDK for request attribution. Kept in a
+ * single place so tests and Kong's `request-transformer` strip list can be
+ * kept in sync.
+ *
+ * @internal
+ */
+export const SDK_ATTRIBUTION_PARAMS = {
+  appId: '_appId',
+  origin: '_origin',
+  sdkVersion: '_sdkVersion',
+} as const
+
+type SdkRequester = typeof defaultRequester
+type SdkMiddleware = NonNullable<Parameters<SdkRequester['use']>[0]>
+type ProcessOptionsFn = NonNullable<SdkMiddleware['processOptions']>
+type GetItRequestOptions = Parameters<ProcessOptionsFn>[0]
+
+interface SdkAttributionOptions {
+  /** Resolved application ID, if available. Omitted from the URL when falsy. */
+  applicationId?: string
+}
+
+/**
+ * A `get-it` middleware that appends SDK attribution query params (`_origin`,
+ * `_sdkVersion`, and `_appId` when set) to every outgoing request URL.
+ *
+ * The middleware runs after `get-it`'s default `processOptions` (which encodes
+ * `options.query` into `options.url`), so it appends directly to `options.url`
+ * rather than mutating `options.query` (which has already been consumed).
+ *
+ * Kong's `request-transformer` plugin strips these params before they reach
+ * upstream services (see SDK-1165).
+ *
+ * @internal
+ */
+export function createSdkAttributionMiddleware(options: SdkAttributionOptions = {}): SdkMiddleware {
+  const {applicationId} = options
+  const origin = getOrigin()
+  const sdkVersion = String(CORE_SDK_VERSION)
+
+  return {
+    processOptions(opts: GetItRequestOptions) {
+      const inputUrl = (opts as {url?: string}).url ?? (opts as {uri?: string}).uri
+      if (typeof inputUrl !== 'string' || inputUrl.length === 0) return opts
+
+      const params = new URLSearchParams()
+      params.set(SDK_ATTRIBUTION_PARAMS.origin, origin)
+      params.set(SDK_ATTRIBUTION_PARAMS.sdkVersion, sdkVersion)
+      if (applicationId) {
+        params.set(SDK_ATTRIBUTION_PARAMS.appId, applicationId)
+      }
+
+      const separator = inputUrl.includes('?') ? '&' : '?'
+      ;(opts as {url?: string}).url = `${inputUrl}${separator}${params.toString()}`
+      return opts
+    },
+  }
+}
+
+/**
+ * Clones the default `@sanity/client` requester and adds the SDK attribution
+ * middleware. The returned requester can be passed to `createClient` via the
+ * `requester` config field.
+ *
+ * @internal
+ */
+export function createSdkRequester(options: SdkAttributionOptions = {}): SdkRequester {
+  return defaultRequester.clone().use(createSdkAttributionMiddleware(options))
+}

--- a/packages/core/src/config/sanityConfig.ts
+++ b/packages/core/src/config/sanityConfig.ts
@@ -148,6 +148,21 @@ export interface SanityConfig extends DatasetHandle, PerspectiveHandle {
    * A list of named sources to use for this instance.
    */
   sources?: Record<string, DocumentSource>
+
+  /**
+   * Identifies the application making API requests for attribution and metrics.
+   *
+   * When set, it's appended to outgoing API requests as the `_appId` query
+   * param. The value matches `deployment.appId` (or the legacy `app.id`) from
+   * `sanity.cli.ts`. A future Sanity CLI release is expected to generate a
+   * module (alongside `.sanity/resources.ts`) that apps can import and pass
+   * through here, so the value stays in lockstep with the deployed app.
+   *
+   * If unset, no `_appId` param is sent.
+   *
+   * @public
+   */
+  applicationId?: string
 }
 
 /**

--- a/packages/core/src/utils/getOrigin.test.ts
+++ b/packages/core/src/utils/getOrigin.test.ts
@@ -1,0 +1,24 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {getOrigin} from './getOrigin'
+
+describe('getOrigin', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns window.location.origin when window is available', () => {
+    vi.stubGlobal('window', {location: {origin: 'https://example.com'}})
+    expect(getOrigin()).toBe('https://example.com')
+  })
+
+  it('returns "server" when window is undefined', () => {
+    vi.stubGlobal('window', undefined)
+    expect(getOrigin()).toBe('server')
+  })
+
+  it('returns "server" when window.location.origin is not a string', () => {
+    vi.stubGlobal('window', {location: {}})
+    expect(getOrigin()).toBe('server')
+  })
+})

--- a/packages/core/src/utils/getOrigin.ts
+++ b/packages/core/src/utils/getOrigin.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns the origin string used for the `_origin` request attribution param.
+ * In the browser, this is `window.location.origin`. On the server (Node, etc.)
+ * where `window.location` isn't available, it returns the literal `"server"`.
+ *
+ * @internal
+ */
+export function getOrigin(): string {
+  if (
+    typeof window !== 'undefined' &&
+    window.location &&
+    typeof window.location.origin === 'string'
+  ) {
+    return window.location.origin
+  }
+  return 'server'
+}


### PR DESCRIPTION
### Description

Implements SDK-1165: the SDK now attaches three query params to every API request it makes through `@sanity/client`:

- `_origin` — `window.location.origin` in the browser, `"server"` otherwise
- `_sdkVersion` — current `@sanity/sdk` version
- `_appId` — the Sanity app ID (when set)

Injection happens inside `@sanity/sdk` via a `get-it` middleware that clones the default `@sanity/client` requester. No changes to `@sanity/client`. Kong's `request-transformer` will strip these before they reach upstream services; a companion Kong change is required for this SDK change to be safe to roll out, since unknown query params cause 400s on services like Mercury.

On `applicationId` specifically: [cli#878](https://github.com/sanity-io/cli/pull/878) and its dependent [cli#961](https://github.com/sanity-io/cli/pull/961) show the CLI using this pattern for `app.resources` ("simpler, with less magic") in favor of a generated `.sanity/resources.ts` module that apps import and pass through. We align with that shape: `SanityConfig.applicationId` is the one wire, and a future CLI release can generate a module that reads `deployment.appId` (or the legacy `app.id`) from `sanity.cli.ts` for apps to import.

Kong PR change: https://github.com/sanity-io/kong/pull/1248

Linear: [SDK-1165](https://linear.app/sanity/issue/SDK-1165)

### What to review

Files of interest:

- `packages/core/src/client/sdkRequester.ts` — new. `createSdkAttributionMiddleware` is the unit of interest; `createSdkRequester` wraps the default requester with it. Types are inferred from `@sanity/client`'s exported `requester` so we don't take a direct dep on `get-it`.
- `packages/core/src/client/clientStore.ts` — resolves `applicationId` from `options ?? instance.config`, includes it in the cache key, strips it from the options handed to `createClient`, and passes the custom requester.
- `packages/core/src/utils/getOrigin.ts` — browser/server origin helper.
- `packages/core/src/config/sanityConfig.ts` — new `applicationId?: string` field on `SanityConfig`. Docstring points at `sanity.cli.ts` as source of truth.
- `apps/kitchensink-react/src/sanityConfigs.ts` — wires `applicationId` through so the network tab shows `_appId`.

A few things worth sanity-checking:

- Middleware ordering: we append after `get-it`'s default `processOptions` so `options.query` has already been encoded into `options.url`. We mutate `options.url` directly.
- Client caching: `applicationId` is in the cache key, so two calls with different app IDs get different `SanityClient` instances (confirmed by test).
- No leak into `@sanity/client` config: `applicationId` is stripped from `createClient` options before being passed. Confirmed by test.

### Testing

- `packages/core/src/client/sdkRequester.test.ts` — covers middleware behavior: appends params, preserves existing query strings, omits `_appId` when unset, handles both browser and server origins.
- `packages/core/src/utils/getOrigin.test.ts` — browser/server branches.
- `packages/core/src/client/clientStore.test.ts` — updates cover the `applicationId` cache-key behavior, distinct client instances per app ID, and that `applicationId` does not leak into `createClient`'s config.

Local verification:

- Manual: ran the kitchensink dev server and confirmed requests carry `_origin`, `_sdkVersion`, and `_appId=wkyoigmzawwnnwx458zgoh46` in the query string.

### Notes for release

**Blocked on a Kong change.** The SDK now sends these params on every request, including to endpoints that don't currently tolerate unknown query params (e.g. `GET /v*/projects/*` on Mercury returns 400). The Kong `request-transformer` plugin must be updated to strip `_origin`, `_sdkVersion`, and `_appId` from the query string before proxying upstream. That change should land (and be verified in staging) before this SDK release is cut.

### Fun gif
![be prepared](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExd3gycXVzeXh3ZDRtbmdqMzNhM3V1em44b3Z2dG84M2IydGVjNW5qZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xUOwG4ZJBYTfPrpnbO/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
