### PR TITLE
fix: keep LoginError synchronous in standalone apps

### DIFF
--- a/packages/react/src/components/auth/DashboardAccessRequest.tsx
+++ b/packages/react/src/components/auth/DashboardAccessRequest.tsx
@@ -1,0 +1,37 @@
+import {SDK_CHANNEL_NAME, SDK_NODE_NAME} from '@sanity/message-protocol'
+import {useEffect} from 'react'
+
+import {useWindowConnection} from '../../hooks/comlink/useWindowConnection'
+
+interface DashboardAccessRequestProps {
+  projectId: string
+}
+
+/**
+ * Sends a `dashboard/v1/auth/access/request` message to the dashboard via
+ * comlink so the user can request access to a project they don't belong to.
+ *
+ * This is intentionally isolated in its own component because
+ * `useWindowConnection` suspends until a comlink node is available, which
+ * never happens outside the dashboard. Callers must gate rendering on
+ * `getIsInDashboardState(...).getCurrent()` and wrap this in a
+ * {@link https://react.dev/reference/react/Suspense | Suspense} boundary
+ * so the suspension stays local instead of bubbling up to the app shell.
+ *
+ * @internal
+ */
+export function DashboardAccessRequest({projectId}: DashboardAccessRequestProps): null {
+  const {fetch} = useWindowConnection({
+    name: SDK_NODE_NAME,
+    connectTo: SDK_CHANNEL_NAME,
+  })
+
+  useEffect(() => {
+    fetch('dashboard/v1/auth/access/request', {
+      resourceType: 'project',
+      resourceId: projectId,
+    })
+  }, [fetch, projectId])
+
+  return null
+}

--- a/packages/react/src/components/auth/LoginError.test.tsx
+++ b/packages/react/src/components/auth/LoginError.test.tsx
@@ -1,19 +1,50 @@
+import {ClientError} from '@sanity/client'
+import {getIsInDashboardState} from '@sanity/sdk'
 import {fireEvent, render, screen, waitFor} from '@testing-library/react'
-import {describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {ResourceProvider} from '../../context/ResourceProvider'
 import {AuthError} from './AuthError'
 import {LoginError} from './LoginError'
 
+vi.mock('@sanity/sdk', async () => {
+  const actual = await vi.importActual('@sanity/sdk')
+  return {
+    ...actual,
+    getIsInDashboardState: vi.fn(() => ({getCurrent: vi.fn(() => false)})),
+  }
+})
+
 vi.mock('../../hooks/auth/useLogOut', () => ({
   useLogOut: vi.fn(() => async () => {}),
 }))
 
+const mockWindowConnectionFetch = vi.fn()
 vi.mock('../../hooks/comlink/useWindowConnection', () => ({
-  useWindowConnection: vi.fn(() => ({fetch: vi.fn()})),
+  useWindowConnection: vi.fn(() => ({fetch: mockWindowConnectionFetch})),
 }))
 
+const mockGetIsInDashboardState = getIsInDashboardState as Mock
+
+function makeClientError(statusCode: number, body: unknown): ClientError {
+  return new ClientError({
+    statusCode,
+    headers: {},
+    body,
+    url: 'https://example.test',
+    method: 'GET',
+  } as ConstructorParameters<typeof ClientError>[0])
+}
+
 describe('LoginError', () => {
+  beforeEach(() => {
+    mockGetIsInDashboardState.mockReturnValue({getCurrent: vi.fn(() => false)})
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('shows authentication error and retry button', async () => {
     const mockReset = vi.fn()
     const error = new AuthError(new Error('Test error'))
@@ -38,7 +69,6 @@ describe('LoginError', () => {
     const mockReset = vi.fn()
     const nonAuthError = new Error('Non-auth error')
 
-    // Suppress console.error during this test
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     expect(() => {
@@ -49,6 +79,56 @@ describe('LoginError', () => {
       )
     }).toThrow('Non-auth error')
 
-    consoleErrorSpy.mockRestore() // Restore original console.error behavior
+    consoleErrorSpy.mockRestore()
+  })
+
+  // SDK-1318: in a standalone app (not embedded in the dashboard) the
+  // dashboard access request path must not render, because useWindowConnection
+  // would suspend waiting for a comlink node that never arrives.
+  it('renders synchronously on a 401 projectUserNotFound error outside the dashboard', async () => {
+    mockGetIsInDashboardState.mockReturnValue({getCurrent: vi.fn(() => false)})
+
+    const error = makeClientError(401, {
+      error: {
+        type: 'projectUserNotFoundError',
+        description: 'User is not a member of this project.',
+      },
+    })
+
+    render(
+      <ResourceProvider fallback={<div>SUSPENDED</div>}>
+        <LoginError error={error} resetErrorBoundary={vi.fn()} />
+      </ResourceProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('User is not a member of this project.')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('SUSPENDED')).not.toBeInTheDocument()
+    expect(mockWindowConnectionFetch).not.toHaveBeenCalled()
+  })
+
+  it('fires the dashboard access request on a 401 projectUserNotFound error inside the dashboard', async () => {
+    mockGetIsInDashboardState.mockReturnValue({getCurrent: vi.fn(() => true)})
+
+    const error = makeClientError(401, {
+      error: {
+        type: 'projectUserNotFoundError',
+        description: 'User is not a member of this project.',
+      },
+    })
+
+    render(
+      <ResourceProvider projectId="abc123" dataset="production" fallback={<div>SUSPENDED</div>}>
+        <LoginError error={error} resetErrorBoundary={vi.fn()} />
+      </ResourceProvider>,
+    )
+
+    await waitFor(() => {
+      expect(mockWindowConnectionFetch).toHaveBeenCalledWith('dashboard/v1/auth/access/request', {
+        resourceType: 'project',
+        resourceId: 'abc123',
+      })
+    })
   })
 })

--- a/packages/react/src/components/auth/LoginError.test.tsx
+++ b/packages/react/src/components/auth/LoginError.test.tsx
@@ -104,6 +104,10 @@ describe('LoginError', () => {
     await waitFor(() => {
       expect(screen.getByText('User is not a member of this project.')).toBeInTheDocument()
     })
+    // ClientError must render under the "Authentication Error" heading; it is
+    // not a ConfigurationError.
+    expect(screen.getByText('Authentication Error')).toBeInTheDocument()
+    expect(screen.queryByText('Configuration Error')).not.toBeInTheDocument()
     expect(screen.queryByText('SUSPENDED')).not.toBeInTheDocument()
     expect(mockWindowConnectionFetch).not.toHaveBeenCalled()
   })

--- a/packages/react/src/components/auth/LoginError.tsx
+++ b/packages/react/src/components/auth/LoginError.tsx
@@ -57,9 +57,12 @@ export function LoginError({error, resetErrorBoundary}: LoginErrorProps): React.
   // The dashboard access request flow relies on a comlink connection to the
   // parent window. In standalone apps that connection never materializes, so
   // we must skip it entirely to avoid suspending forever on the parent's
-  // Suspense boundary (see SDK-1318).
-  const shouldRequestDashboardAccess =
-    isProjectUserNotFound && !!projectId && getIsInDashboardState(instance).getCurrent()
+  // Suspense boundary (see SDK-1318). Resolving to the projectId (or null)
+  // here lets the JSX render the child with a single non-null guard.
+  const dashboardAccessProjectId =
+    isProjectUserNotFound && projectId && getIsInDashboardState(instance).getCurrent()
+      ? projectId
+      : null
 
   const handleRetry = useCallback(async () => {
     await logout()
@@ -95,13 +98,15 @@ export function LoginError({error, resetErrorBoundary}: LoginErrorProps): React.
 
   return (
     <>
-      {shouldRequestDashboardAccess && projectId && (
+      {dashboardAccessProjectId && (
         <Suspense fallback={null}>
-          <DashboardAccessRequest projectId={projectId} />
+          <DashboardAccessRequest projectId={dashboardAccessProjectId} />
         </Suspense>
       )}
       <Error
-        heading={error instanceof AuthError ? 'Authentication Error' : 'Configuration Error'}
+        heading={
+          error instanceof ConfigurationError ? 'Configuration Error' : 'Authentication Error'
+        }
         description={authErrorMessage}
         cta={
           showRetryCta

--- a/packages/react/src/components/auth/LoginError.tsx
+++ b/packages/react/src/components/auth/LoginError.tsx
@@ -1,21 +1,21 @@
 import {ClientError} from '@sanity/client'
-import {SDK_CHANNEL_NAME, SDK_NODE_NAME} from '@sanity/message-protocol'
 import {
   AuthStateType,
   getClientErrorApiBody,
   getClientErrorApiDescription,
+  getIsInDashboardState,
   isProjectUserNotFoundClientError,
 } from '@sanity/sdk'
-import {useCallback, useEffect, useState} from 'react'
+import {Suspense, useCallback, useEffect, useState} from 'react'
 import {type FallbackProps} from 'react-error-boundary'
 
 import {useAuthState} from '../../hooks/auth/useAuthState'
 import {useLogOut} from '../../hooks/auth/useLogOut'
-import {useWindowConnection} from '../../hooks/comlink/useWindowConnection'
 import {useSanityInstance} from '../../hooks/context/useSanityInstance'
 import {Error} from '../errors/Error'
 import {AuthError} from './AuthError'
 import {ConfigurationError} from './ConfigurationError'
+import {DashboardAccessRequest} from './DashboardAccessRequest'
 /**
  * @alpha
  */
@@ -39,22 +39,27 @@ export function LoginError({error, resetErrorBoundary}: LoginErrorProps): React.
 
   const logout = useLogOut()
   const authState = useAuthState()
+  const instance = useSanityInstance()
   const {
     config: {projectId},
-  } = useSanityInstance()
+  } = instance
 
   const [authErrorMessage, setAuthErrorMessage] = useState(
     'Please try again or contact support if the problem persists.',
   )
   const [showRetryCta, setShowRetryCta] = useState(true)
 
-  /**
-   * TODO: before merge update message-protocol package to include the new message type
-   */
-  const {fetch} = useWindowConnection({
-    name: SDK_NODE_NAME,
-    connectTo: SDK_CHANNEL_NAME,
-  })
+  const isProjectUserNotFound =
+    error instanceof ClientError &&
+    error.statusCode === 401 &&
+    isProjectUserNotFoundClientError(error)
+
+  // The dashboard access request flow relies on a comlink connection to the
+  // parent window. In standalone apps that connection never materializes, so
+  // we must skip it entirely to avoid suspending forever on the parent's
+  // Suspense boundary (see SDK-1318).
+  const shouldRequestDashboardAccess =
+    isProjectUserNotFound && !!projectId && getIsInDashboardState(instance).getCurrent()
 
   const handleRetry = useCallback(async () => {
     await logout()
@@ -64,18 +69,10 @@ export function LoginError({error, resetErrorBoundary}: LoginErrorProps): React.
   useEffect(() => {
     if (error instanceof ClientError) {
       if (error.statusCode === 401) {
-        // Surface a friendly message for projectUserNotFoundError (do not logout/refresh)
-        if (isProjectUserNotFoundClientError(error)) {
+        if (isProjectUserNotFound) {
           const description = getClientErrorApiDescription(error)
           if (description) setAuthErrorMessage(description)
           setShowRetryCta(false)
-          /**
-           * Handoff to dashboard to enable the request access flow for the project.
-           */
-          fetch('dashboard/v1/auth/access/request', {
-            resourceType: 'project',
-            resourceId: projectId,
-          })
         } else {
           setShowRetryCta(true)
           handleRetry()
@@ -94,20 +91,27 @@ export function LoginError({error, resetErrorBoundary}: LoginErrorProps): React.
       setAuthErrorMessage(error.message)
       setShowRetryCta(true)
     }
-  }, [authState, handleRetry, error, fetch, projectId])
+  }, [authState, handleRetry, error, isProjectUserNotFound])
 
   return (
-    <Error
-      heading={error instanceof AuthError ? 'Authentication Error' : 'Configuration Error'}
-      description={authErrorMessage}
-      cta={
-        showRetryCta
-          ? {
-              text: 'Retry',
-              onClick: handleRetry,
-            }
-          : undefined
-      }
-    />
+    <>
+      {shouldRequestDashboardAccess && projectId && (
+        <Suspense fallback={null}>
+          <DashboardAccessRequest projectId={projectId} />
+        </Suspense>
+      )}
+      <Error
+        heading={error instanceof AuthError ? 'Authentication Error' : 'Configuration Error'}
+        description={authErrorMessage}
+        cta={
+          showRetryCta
+            ? {
+                text: 'Retry',
+                onClick: handleRetry,
+              }
+            : undefined
+        }
+      />
+    </>
   )
 }


### PR DESCRIPTION
### Description

Fixes [SDK-1318](https://linear.app/sanity/issue/SDK-1318). In standalone SDK apps (using `SDKProvider` outside the Sanity Dashboard), the app got stuck on `SDKProvider`'s Suspense fallback whenever an auth error occurred, instead of surfacing the error or redirecting to `www.sanity.io/login`.

Root cause: `LoginError` unconditionally called `useWindowConnection` at the top level. That hook suspends until a Comlink node to the parent window is established. In standalone mode there is no parent window, so the suspension never resolved and bubbled up to `SDKProvider`'s outer `<Suspense>` boundary. The underlying auth store was transitioning to `ERROR` correctly (visible in Redux DevTools), but the UI never re-rendered to react to it.

Changes:

- New `DashboardAccessRequest` component that owns the only caller of `useWindowConnection` inside `LoginError` (the `dashboard/v1/auth/access/request` post to the parent window for projectUserNotFound errors).
- `LoginError` now renders synchronously in all environments. It checks `getIsInDashboardState(instance).getCurrent()` and only mounts `DashboardAccessRequest` (inside a local `<Suspense fallback={null}>`) when actually running in the dashboard. In standalone apps nothing suspends, so `AuthBoundary`'s redirect and error UI can do their job.

### What to review

- `packages/react/src/components/auth/LoginError.tsx`: verify the gating logic (`isProjectUserNotFound && projectId && getIsInDashboardState(instance).getCurrent()`) covers the intended dashboard flow, and that the local `<Suspense fallback={null}>` is the right boundary.
- `packages/react/src/components/auth/DashboardAccessRequest.tsx`: new internal component. The doc comment explains why it must be rendered under its own Suspense boundary.
- Affected flows: the auth error surface in the Dashboard (project-access-request handoff) and the equivalent surface in standalone apps (should render the error + retry CTA or let `AuthBoundary` redirect to login).

### Testing

Unit tests added in `LoginError.test.tsx`:

- `renders synchronously on a 401 projectUserNotFound error outside the dashboard`: asserts that the Suspense fallback is never shown and `useWindowConnection` is not called.
- `fires the dashboard access request on a 401 projectUserNotFound error inside the dashboard`: asserts that `fetch('dashboard/v1/auth/access/request', ...)` still runs with the expected payload when in-dashboard.
- Existing `AuthError`/rethrow tests still pass.

Manual repro used a minimal standalone app (`SDKProvider` + `useCurrentUser`) with a stamped-looking but unauthorized token seeded into `localStorage.__sanity_auth_token`. Before the fix: app stayed on the `SDKProvider` Suspense fallback. After the fix: `LoginError` renders, the 401 triggers `handleRetry` → `logout()` → `LOGGED_OUT`, and `AuthBoundary` redirects to `www.sanity.io/login` as expected.

### Fun gif
![suspenders](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2w1cGUxMXFvZjhwM3I3NXg1amtuYXZqazhlOGNqYjdvdXRpcW04biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/DQv0TCvjLklB6/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
