### PR TITLE
chore(standalone-react): add minimal standalone SDK example app

### DIFF
--- a/apps/standalone-react/README.md
+++ b/apps/standalone-react/README.md
@@ -1,0 +1,43 @@
+# @sanity/standalone-react
+
+A minimal example of using `@sanity/sdk-react` in a plain React app, outside
+the Sanity Dashboard and without a Sanity Studio. Pairs with
+`apps/kitchensink-react`, which covers the Studio/Dashboard-embedded story.
+
+This app:
+
+- Uses `SDKProvider` directly (not `SanityApp`).
+- Has no Sanity Studio, no Dashboard iframe, no extra UI libraries.
+- Exercises the `standalone` branch of `resolveAuthMode` (no `_context` query
+  param, not inside an iframe).
+- Ships a small set of auth dev tools (expire token, clear token, live auth
+  state readout) for exercising login, logout, and error flows without having
+  to wait for a real token to expire.
+
+The configs in `src/sanityConfigs.ts` mirror
+`apps/kitchensink-react/src/sanityConfigs.ts` `devConfigs` so both apps point
+at the same projects.
+
+## Run it
+
+```bash
+pnpm --filter @sanity/standalone-react dev
+```
+
+Then open http://localhost:3334.
+
+On first load the SDK will send you to `www.sanity.io/login` and bring you
+back with a stored token in `localStorage.__sanity_auth_token`. After that,
+`CurrentUserCard` shows your authenticated user and the current auth state.
+
+## Auth dev tools
+
+- **Expire token**: overwrites `localStorage.__sanity_auth_token` with a
+  stamped-looking but unauthorized value and reloads. The SDK treats it as a
+  stored session, so the next authenticated request 401s. Handy for poking at
+  the auth error / re-login paths.
+- **Clear token and reload**: removes the stored token and reloads, which
+  takes you through the standalone login redirect.
+- **`/?expire`**: same as clicking "Expire token", but seeds the bad token
+  before the SDK mounts. Useful for repros where the app must boot into a
+  pre-expired state.

--- a/apps/standalone-react/eslint.config.mjs
+++ b/apps/standalone-react/eslint.config.mjs
@@ -1,0 +1,22 @@
+// @ts-check
+import baseESLintConfig from '@repo/config-eslint'
+import reactConfig from '@repo/config-eslint/react'
+
+export default [
+  {
+    ignores: [
+      '.DS_Store',
+      '**/node_modules',
+      '**/build',
+      '**/dist',
+      '.env',
+      '.env.*',
+      '!.env.example',
+      'pnpm-lock.yaml',
+      'package-lock.json',
+      'yarn.lock',
+    ],
+  },
+  ...baseESLintConfig,
+  ...reactConfig,
+]

--- a/apps/standalone-react/index.html
+++ b/apps/standalone-react/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>SDK Standalone (React)</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 24px;
+        max-width: 760px;
+      }
+      button {
+        font: inherit;
+        padding: 6px 12px;
+        margin-right: 8px;
+      }
+      pre {
+        background: rgba(128, 128, 128, 0.12);
+        padding: 12px;
+        border-radius: 6px;
+        overflow-x: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/standalone-react/package.json
+++ b/apps/standalone-react/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@sanity/standalone-react",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "pnpm tsc && vite build",
+    "clean": "rimraf dist",
+    "dev": "vite",
+    "lint": "eslint .",
+    "preview": "vite preview",
+    "tsc": "tsc --noEmit"
+  },
+  "prettier": "@sanity/prettier-config",
+  "dependencies": {
+    "@sanity/sdk-react": "workspace:*",
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "devDependencies": {
+    "@repo/config-eslint": "workspace:*",
+    "@repo/tsconfig": "workspace:*",
+    "@sanity/prettier-config": "^1.0.3",
+    "@sanity/sdk": "workspace:*",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^5.1.2",
+    "eslint": "^9.25.1",
+    "prettier": "^3.5.3",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.8.3",
+    "vite": "^7.0.0"
+  }
+}

--- a/apps/standalone-react/src/App.tsx
+++ b/apps/standalone-react/src/App.tsx
@@ -1,0 +1,30 @@
+import {SDKProvider} from '@sanity/sdk-react'
+import {type JSX, Suspense} from 'react'
+
+import {AuthDevControls} from './AuthDevControls'
+import {CurrentUserCard} from './CurrentUserCard'
+import {Fallback} from './Fallback'
+import {devConfigs} from './sanityConfigs'
+
+export default function App(): JSX.Element {
+  return (
+    <>
+      <header>
+        <h1>SDK Standalone (React)</h1>
+        <p>
+          Minimal <code>SDKProvider</code> example running outside the Sanity Dashboard and without
+          a Sanity Studio. The auth dev tools below let you poke at the stored token to exercise
+          login, logout, and error flows.
+        </p>
+      </header>
+
+      <AuthDevControls />
+
+      <SDKProvider fallback={<Fallback />} config={devConfigs}>
+        <Suspense fallback={<Fallback />}>
+          <CurrentUserCard />
+        </Suspense>
+      </SDKProvider>
+    </>
+  )
+}

--- a/apps/standalone-react/src/AuthDevControls.tsx
+++ b/apps/standalone-react/src/AuthDevControls.tsx
@@ -1,0 +1,45 @@
+import {type JSX} from 'react'
+
+import {clearToken, seedExpiredToken} from './seedToken'
+
+function expireAndReload() {
+  seedExpiredToken()
+  window.location.reload()
+}
+
+function clearAndReload() {
+  clearToken()
+  window.location.reload()
+}
+
+export function AuthDevControls(): JSX.Element {
+  return (
+    <section>
+      <h2>Auth dev tools</h2>
+      <p>
+        <strong>Expire token</strong> writes a stamped-looking but unauthorized value into{' '}
+        <code>localStorage.__sanity_auth_token</code> and reloads. The SDK treats it as a stored
+        session, so the next authenticated request 401s, which is a quick way to exercise the auth
+        error / re-login paths without waiting for a real token to expire.
+      </p>
+      <p>
+        <strong>Clear token</strong> removes the stored token and reloads, which should take you
+        through the standalone login redirect to <code>www.sanity.io/login</code>.
+      </p>
+      <p>
+        <button type="button" onClick={expireAndReload}>
+          Expire token
+        </button>
+        <button type="button" onClick={clearAndReload}>
+          Clear token and reload
+        </button>
+      </p>
+      <p>
+        <small>
+          Tip: visit <code>/?expire</code> to seed an expired token on first load (before the SDK
+          mounts).
+        </small>
+      </p>
+    </section>
+  )
+}

--- a/apps/standalone-react/src/CurrentUserCard.tsx
+++ b/apps/standalone-react/src/CurrentUserCard.tsx
@@ -1,0 +1,27 @@
+import {useAuthState, useCurrentUser} from '@sanity/sdk-react'
+import {type JSX} from 'react'
+
+export function CurrentUserCard(): JSX.Element {
+  const authState = useAuthState()
+  const user = useCurrentUser()
+
+  return (
+    <section
+      style={{
+        background: 'rgba(0, 128, 255, 0.08)',
+        border: '1px solid rgba(0, 128, 255, 0.4)',
+        padding: 12,
+        margin: '12px 0',
+        borderRadius: 6,
+      }}
+    >
+      <p>
+        <strong>Auth state:</strong> <code>{authState.type}</code>
+      </p>
+      <p>
+        <strong>Current user:</strong> {user ? user.name : '(none)'}
+      </p>
+      <pre style={{margin: 0}}>{JSON.stringify(user, null, 2)}</pre>
+    </section>
+  )
+}

--- a/apps/standalone-react/src/Fallback.tsx
+++ b/apps/standalone-react/src/Fallback.tsx
@@ -1,0 +1,19 @@
+import {type JSX} from 'react'
+
+export function Fallback(): JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        background: 'rgba(128, 128, 128, 0.1)',
+        border: '1px dashed rgba(128, 128, 128, 0.6)',
+        padding: 12,
+        margin: '12px 0',
+        borderRadius: 6,
+      }}
+    >
+      Loading…
+    </div>
+  )
+}

--- a/apps/standalone-react/src/main.tsx
+++ b/apps/standalone-react/src/main.tsx
@@ -1,0 +1,14 @@
+import {StrictMode} from 'react'
+import {createRoot} from 'react-dom/client'
+
+import App from './App'
+import {maybeSeedExpiredTokenFromUrl} from './seedToken'
+
+// Must run before React renders so the SDK picks up any seeded token on init.
+maybeSeedExpiredTokenFromUrl()
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/apps/standalone-react/src/sanityConfigs.ts
+++ b/apps/standalone-react/src/sanityConfigs.ts
@@ -1,0 +1,14 @@
+import {type SanityConfig} from '@sanity/sdk'
+
+// Mirrors apps/kitchensink-react/src/sanityConfigs.ts `devConfigs` so both
+// example apps point at the same projects and datasets.
+export const devConfigs: SanityConfig[] = [
+  {
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+  },
+  {
+    projectId: 'vo1ysemo',
+    dataset: 'production',
+  },
+]

--- a/apps/standalone-react/src/seedToken.ts
+++ b/apps/standalone-react/src/seedToken.ts
@@ -1,0 +1,29 @@
+// Small helpers for poking at the token the SDK reads out of localStorage.
+// Useful for manually exercising auth flows (expired tokens, logged-out
+// redirects, etc.) without having to actually let a real token expire.
+
+const STORAGE_KEY = '__sanity_auth_token'
+
+function writeToken(token: string) {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify({token}))
+}
+
+export function clearToken(): void {
+  window.localStorage.removeItem(STORAGE_KEY)
+}
+
+// Writes a syntactically valid but unauthorized stamped-looking token. The
+// `-st` substring is how the SDK identifies stamped tokens (see
+// `packages/core/src/auth/utils.ts`). Standalone logins always produce
+// stamped tokens, so this matches the real expiration shape.
+export function seedExpiredToken(): void {
+  writeToken('sk-bogus-expired-st-0000000000000000000000000000000000000000')
+}
+
+// Run at startup, before SDKProvider mounts, so `getStandaloneInitialState`
+// picks up whatever we put in localStorage.
+export function maybeSeedExpiredTokenFromUrl(): void {
+  const params = new URLSearchParams(window.location.search)
+  if (!params.has('expire')) return
+  seedExpiredToken()
+}

--- a/apps/standalone-react/tsconfig.json
+++ b/apps/standalone-react/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@repo/tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "../../",
+    "baseUrl": "../../",
+    "verbatimModuleSyntax": false,
+    "noEmit": true,
+    "module": "ESNext",
+    "types": ["vite/client"],
+    "paths": {
+      "@sanity/sdk": ["./packages/core/src/_exports/index.ts"],
+      "@sanity/sdk/*": ["./packages/core/src/_exports/*"],
+      "@sanity/sdk-react": ["./packages/react/src/_exports/index.ts"],
+      "@sanity/sdk-react/*": ["./packages/react/src/_exports/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx", "vite.config.mjs"]
+}

--- a/apps/standalone-react/vite.config.mjs
+++ b/apps/standalone-react/vite.config.mjs
@@ -1,0 +1,22 @@
+import {resolve} from 'node:path'
+
+import react from '@vitejs/plugin-react'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {defineConfig} from 'vite'
+
+export default defineConfig({
+  server: {
+    port: 3334,
+    fs: {
+      strict: false,
+    },
+  },
+  plugins: [react()],
+  clearScreen: false,
+  resolve: {
+    alias: {
+      '@sanity/sdk': resolve(import.meta.dirname, '../../packages/core/src/_exports'),
+      '@sanity/sdk-react': resolve(import.meta.dirname, '../../packages/react/src/_exports'),
+    },
+  },
+})

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -37,6 +37,14 @@ const baseConfig = {
       ],
       project,
     },
+    'apps/standalone-react': {
+      entry: ['src/main.tsx'],
+      typescript: {
+        config: 'tsconfig.json',
+      },
+      ignoreDependencies: ['@repo/tsconfig'],
+      project,
+    },
     'apps/*': {
       typescript: {
         config: 'tsconfig.json',

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "pnpm dev:kitchensink",
     "dev:e2e": "SANITY_INTERNAL_ENV=staging SDK_E2E_ORGANIZATION_ID=oFvj4MZWQ turbo run dev --filter=@sanity/kitchensink-react",
     "dev:kitchensink": "turbo run dev --filter=@sanity/kitchensink-react",
+    "dev:standalone": "turbo run dev --filter=@sanity/standalone-react",
     "format": "prettier --write --cache --ignore-unknown .",
     "lint": "turbo run lint -- --fix && eslint . --fix",
     "prepare": "husky",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,55 @@ importers:
         specifier: ^3.1.2
         version: 3.2.4(@types/node@22.19.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  apps/standalone-react:
+    dependencies:
+      '@sanity/sdk-react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      react:
+        specifier: ^19
+        version: 19.2.1
+      react-dom:
+        specifier: ^19
+        version: 19.2.1(react@19.2.1)
+    devDependencies:
+      '@repo/config-eslint':
+        specifier: workspace:*
+        version: link:../../packages/@repo/config-eslint
+      '@repo/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/@repo/tsconfig
+      '@sanity/prettier-config':
+        specifier: ^1.0.3
+        version: 1.0.6(prettier@3.7.4)
+      '@sanity/sdk':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/react':
+        specifier: ^19.1.2
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.1.2
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.2
+        version: 5.1.2(vite@7.3.2(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.2))
+      eslint:
+        specifier: ^9.25.1
+        version: 9.25.1(jiti@2.6.1)
+      prettier:
+        specifier: ^3.5.3
+        version: 3.7.4
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.2
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^7.0.0
+        version: 7.3.2(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/@repo/config-eslint:
     devDependencies:
       '@eslint/js':


### PR DESCRIPTION
### Description

Adds a new `apps/standalone-react` example to the monorepo, alongside the existing `apps/kitchensink-react`. This is an internal testing app only; it's `private: true`, excluded from the release-please publish flow, and marked as `chore` in conventional commits so it stays out of the user-facing changelog.

The app is a minimal `SDKProvider` setup outside the Sanity Dashboard and without a Sanity Studio. It's useful for:

- Smoke-testing the non-dashboard-embedded auth flow (`standalone` branch of `resolveAuthMode`).
- Exercising login, logout, and auth error paths without waiting for a real token to expire.
- Manually verifying fixes like [#810](https://github.com/sanity-io/sdk/pull/810) ("fix: keep `LoginError` synchronous in standalone apps"), which was originally reproduced with an early version of this app. The **Expire token** button + `/?expire` flow is the same repro path used on that PR: before #810, the app got stuck on the `SDKProvider` Suspense fallback; after #810, it surfaces the auth error / redirect as expected.

Pairs with `kitchensink-react` which already covers the Studio/Dashboard-embedded story.

Included auth dev tools:

- **Expire token**: writes a stamped-looking but unauthorized value into `localStorage.__sanity_auth_token` and reloads, so the next authenticated request 401s.
- **Clear token and reload**: removes the stored token, which takes you through the standalone login redirect.
- **`/?expire`**: same as "Expire token" but seeds the bad token before `SDKProvider` mounts (useful for boot-into-expired-state repros).

### What to review

- `apps/standalone-react/`: new app. Small surface, mostly follows the `kitchensink-react` layout conventions (same `tsconfig`, `eslint.config.mjs`, Vite setup with workspace aliases) but trimmed down (no Studio, no `@sanity/ui`, no Playwright). Configs in `src/sanityConfigs.ts` mirror the `devConfigs` from `kitchensink-react` so both apps point at the same projects.
- `apps/standalone-react/src/seedToken.ts` + `AuthDevControls.tsx`: the localStorage-poking helpers and their UI. These deliberately don't render the token anywhere in the DOM, to avoid leaking it.
- `package.json` (root): adds `"dev:standalone": "turbo run dev --filter=@sanity/standalone-react"`. Runs on port 3334 so it doesn't clash with kitchensink (3333).
- `knip.config.ts`: adds an explicit workspace entry for `apps/standalone-react` declaring `src/main.tsx` as the entry. Without this, `pnpm depcheck` flags every source file and every dependency as unused because the generic `apps/*` glob in the knip config doesn't declare an entry. Mirrors how `kitchensink-react` is configured.
- `pnpm-lock.yaml`: new workspace entry for `@sanity/standalone-react`.

Monorepo/release-process audit done separately; nothing else needs to change:

- Release-please config explicitly lists only `packages/core` and `packages/react`; the new app won't get version bumps or changelog entries.
- Release workflow publishes with `pnpm publish -r --filter=!./apps/*`, and the app is `private: true` as a second line of defense.
- Root `pnpm test` is `vitest run` scoped to `packages/core` and `packages/react`; the new app has no tests and is not scanned.
- Root `pnpm ts:check` is `turbo run ts:check`, which the new app doesn't define (same pattern as `kitchensink-react`); its TS check runs inside `build` via `pnpm tsc`.
- Deploy, e2e, bundle-stats, and pkg-pr-new workflows are all filter-scoped and untouched by the new app.

### Testing

Manual smoke:

```bash
pnpm --filter @sanity/standalone-react dev
# open http://localhost:3334
```

Verified:

Fresh load redirects to www.sanity.io/login and comes back with a valid token, CurrentUserCard shows the authenticated user.
"Clear token and reload" wipes the stored token and sends you back through the login redirect.
"Expire token" writes the stamped-looking bogus token and the app enters the auth error path. Exercised against [#810](https://github.com/sanity-io/sdk/pull/810) on both sides of the fix: stuck-on-Suspense before, redirect-to-login after.
/?expire seeds the expired token before SDKProvider mounts.
Monorepo checks run locally with the new app in place (all green):

pnpm build (turbo build across all packages and apps)
pnpm lint
pnpm ts:check
pnpm test
pnpm depcheck
No automated tests added; this is an internal dev/testing app with no exported surface to test.

### Fun gif
![alone](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExazA4Y3cxbXlrdzl0MHluemp0c3o2c3g0eTh4YTRsaHE4b3hqOXZjMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/H6cmWzp6LGFvqjidB7/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
