### PR TITLE
refactor(core): use global API endpoint wherever possible

### DIFF
--- a/apps/kitchensink-react/src/AppRoutes.tsx
+++ b/apps/kitchensink-react/src/AppRoutes.tsx
@@ -111,6 +111,10 @@ export function AppRoutes(): JSX.Element {
                   ...documentCollectionRoutes,
                   ...dashboardInteractionRoutes,
                   {
+                    path: 'agent-actions',
+                    element: <AgentActionsRoute />,
+                  },
+                  {
                     path: 'comlink-demo',
                     element: <ParentApp />,
                   },

--- a/packages/core/guides/AuthenticationGuide.md
+++ b/packages/core/guides/AuthenticationGuide.md
@@ -121,7 +121,7 @@ The primary interactive authentication flow involves redirecting the user to `sa
 
 - **Tokens:**
   - **Types:**
-    - **Global Tokens:** Tokens not tied to a specific project, but instead to a Sanity User. It includes access to all of the user's orgs and projects. Required for accessing global Sanity APIs (e.g., project management). Used when `clientStore` configures a client with `scope: 'global'` or without a `projectId`.
+    - **Global Tokens:** Tokens not tied to a specific project, but instead to a Sanity User. It includes access to all of the user's orgs and projects. Required for accessing global Sanity APIs (e.g., project management). Used when `clientStore` configures a client with `useProjectHostname: false` or without a `projectId`.
 
     - **Project Tokens:** Scoped to a single project (any of that project's datasets). Used by Studio integration or can be provided manually. Can only be used for project-specific endpoints (`<projectId>.api.sanity.io`).
 
@@ -148,9 +148,8 @@ The primary interactive authentication flow involves redirecting the user to `sa
   - Listens to `getTokenState` changes (`listenToToken`). When the token updates, it clears the client cache (`clients: {}`), forcing regeneration of clients with the new token upon next request.
 
   - **Client Scope:**
-    - `scope: 'global'` or missing `projectId` results in a client configured with `useProjectHostname: false`, targeting global APIs (e.g., `api.sanity.io`). Requires a global token.
-
-    - Default behavior (with `projectId` and `dataset`) uses project-specific hostnames (e.g., `<projectId>.api.sanity.io`).
+    - Default behavior uses resource-based hostnames, like `api.sanity.io/projects/<projectId>/datasets/<datasetId>`.
+    - To use a project-based hostname like `<projectId>.api.sanity.io`, pass `useProjectHostname: true` via the client options.
 
 - **CORS & Endpoints:**
   - **Global Endpoints (e.g., `api.sanity.io`):** Generally have stricter Cross-Origin Resource Sharing (CORS) policies. They primarily allow requests from Sanity's own domains (`*.sanity.io`, `*.sanity.work`), associated development domains (`*.sanity.dev`), and `localhost`. Accessing these from arbitrary external domains is usually blocked by browser CORS rules. They also require global tokens.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "@sanity/diff-match-patch": "^3.2.0",
     "@sanity/diff-patch": "^6.0.0",
     "@sanity/id-utils": "^1.0.0",
-    "@sanity/image-url": "^2.0.3",
+    "@sanity/image-url": "^2.1.1",
     "@sanity/json-match": "^1.0.5",
     "@sanity/message-protocol": "^0.18.0",
     "@sanity/mutate": "^0.16.1",

--- a/packages/core/src/agent/agentActions.test.ts
+++ b/packages/core/src/agent/agentActions.test.ts
@@ -11,12 +11,15 @@ import {
 } from './agentActions'
 
 let mockClient: any
+const mockGetClientState = vi.fn()
 
 vi.mock('../client/clientStore', () => {
   return {
-    getClientState: () => ({observable: of(mockClient)}),
+    getClientState: (...args: unknown[]) => mockGetClientState(...args),
   }
 })
+
+const testResource = {projectId: 'p', dataset: 'd'}
 
 describe('agent actions', () => {
   beforeEach(() => {
@@ -37,45 +40,88 @@ describe('agent actions', () => {
         },
       },
     }
+    mockGetClientState.mockReturnValue({observable: of(mockClient)})
   })
 
-  it('agentGenerate returns observable from client', async () => {
+  it('agentGenerate passes projectId and dataset to getClientState and strips resource from agent options', async () => {
     mockClient.observable.agent.action.generate.mockReturnValue(of('gen'))
-    const instance = {config: {projectId: 'p', dataset: 'd'}} as any
-    const value = await firstValueFrom(agentGenerate(instance, {foo: 'bar'} as any))
+    const instance = {config: {}} as any
+    const value = await firstValueFrom(
+      agentGenerate(instance, {foo: 'bar', resource: testResource} as any),
+    )
     expect(value).toBe('gen')
+    expect(mockGetClientState).toHaveBeenCalledWith(instance, {
+      apiVersion: 'vX',
+      projectId: 'p',
+      dataset: 'd',
+    })
     expect(mockClient.observable.agent.action.generate).toHaveBeenCalledWith({foo: 'bar'})
   })
 
-  it('agentTransform returns observable from client', async () => {
+  it('agentTransform passes projectId and dataset to getClientState and strips resource from agent options', async () => {
     mockClient.observable.agent.action.transform.mockReturnValue(of('xform'))
-    const instance = {config: {projectId: 'p', dataset: 'd'}} as any
-    const value = await firstValueFrom(agentTransform(instance, {a: 1} as any))
+    const instance = {config: {}} as any
+    const value = await firstValueFrom(
+      agentTransform(instance, {a: 1, resource: testResource} as any),
+    )
     expect(value).toBe('xform')
+    expect(mockGetClientState).toHaveBeenCalledWith(instance, {
+      apiVersion: 'vX',
+      projectId: 'p',
+      dataset: 'd',
+    })
     expect(mockClient.observable.agent.action.transform).toHaveBeenCalledWith({a: 1})
   })
 
-  it('agentTranslate returns observable from client', async () => {
+  it('agentTranslate passes projectId and dataset to getClientState and strips resource from agent options', async () => {
     mockClient.observable.agent.action.translate.mockReturnValue(of('xlate'))
-    const instance = {config: {projectId: 'p', dataset: 'd'}} as any
-    const value = await firstValueFrom(agentTranslate(instance, {b: 2} as any))
+    const instance = {config: {}} as any
+    const value = await firstValueFrom(
+      agentTranslate(instance, {b: 2, resource: testResource} as any),
+    )
     expect(value).toBe('xlate')
+    expect(mockGetClientState).toHaveBeenCalledWith(instance, {
+      apiVersion: 'vX',
+      projectId: 'p',
+      dataset: 'd',
+    })
     expect(mockClient.observable.agent.action.translate).toHaveBeenCalledWith({b: 2})
   })
 
-  it('agentPrompt wraps promise into observable', async () => {
+  it('agentPrompt passes projectId and dataset to getClientState and strips resource from agent options', async () => {
     mockClient.agent.action.prompt.mockResolvedValue('prompted')
-    const instance = {config: {projectId: 'p', dataset: 'd'}} as any
-    const value = await firstValueFrom(agentPrompt(instance, {p: true} as any))
+    const instance = {config: {}} as any
+    const value = await firstValueFrom(
+      agentPrompt(instance, {p: true, resource: testResource} as any),
+    )
     expect(value).toBe('prompted')
+    expect(mockGetClientState).toHaveBeenCalledWith(instance, {
+      apiVersion: 'vX',
+      projectId: 'p',
+      dataset: 'd',
+    })
     expect(mockClient.agent.action.prompt).toHaveBeenCalledWith({p: true})
   })
 
-  it('agentPatch wraps promise into observable', async () => {
+  it('agentPatch passes projectId and dataset to getClientState and strips resource from agent options', async () => {
     mockClient.agent.action.patch.mockResolvedValue('patched')
-    const instance = {config: {projectId: 'p', dataset: 'd'}} as any
-    const value = await firstValueFrom(agentPatch(instance, {q: false} as any))
+    const instance = {config: {}} as any
+    const value = await firstValueFrom(
+      agentPatch(instance, {q: false, resource: testResource} as any),
+    )
     expect(value).toBe('patched')
+    expect(mockGetClientState).toHaveBeenCalledWith(instance, {
+      apiVersion: 'vX',
+      projectId: 'p',
+      dataset: 'd',
+    })
     expect(mockClient.agent.action.patch).toHaveBeenCalledWith({q: false})
+  })
+
+  it('throws when resource is not a dataset resource', () => {
+    const instance = {config: {}} as any
+    expect(() =>
+      agentGenerate(instance, {foo: 'bar', resource: {mediaLibraryId: 'ml'} as any} as any),
+    ).toThrow('Resource is not a dataset resource. This is required for agent actions.')
   })
 })

--- a/packages/core/src/agent/agentActions.ts
+++ b/packages/core/src/agent/agentActions.ts
@@ -2,9 +2,19 @@ import {type SanityClient} from '@sanity/client'
 import {from, Observable, switchMap} from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
+import {type DocumentResource, isDatasetResource} from '../config/sanityConfig'
 import {type SanityInstance} from '../store/createSanityInstance'
 
 const API_VERSION = 'vX'
+
+/**
+ * Options that all agent actions accept for targeting a specific resource.
+ * Agent actions fail when targeting the global endpoint so this is destructured from the resource;
+ * this is more for forward compatibility with the "resource everything" future.
+ */
+interface AgentResourceOptions {
+  resource?: DocumentResource
+}
 
 /** @alpha */
 export type AgentGenerateOptions = Parameters<
@@ -48,6 +58,17 @@ export type AgentPromptResult = Awaited<ReturnType<SanityClient['agent']['action
 /** @alpha */
 export type AgentPatchResult = Awaited<ReturnType<SanityClient['agent']['action']['patch']>>
 
+const projectAndDatasetFromResource = (instance: SanityInstance, resource?: DocumentResource) => {
+  if (resource && !isDatasetResource(resource)) {
+    throw new Error('Resource is not a dataset resource. This is required for agent actions.')
+  }
+  const utilizedResource = resource ?? {
+    projectId: instance.config.projectId,
+    dataset: instance.config.dataset,
+  }
+  return utilizedResource
+}
+
 /**
  * Generates a new document using the agent.
  * @param instance - The Sanity instance.
@@ -57,13 +78,15 @@ export type AgentPatchResult = Awaited<ReturnType<SanityClient['agent']['action'
  */
 export function agentGenerate(
   instance: SanityInstance,
-  options: AgentGenerateOptions,
+  options: AgentGenerateOptions & AgentResourceOptions,
 ): AgentGenerateResult {
+  const {resource, ...agentOptions} = options
+  const {projectId, dataset} = projectAndDatasetFromResource(instance, resource)
   return getClientState(instance, {
     apiVersion: API_VERSION,
-    projectId: instance.config.projectId,
-    dataset: instance.config.dataset,
-  }).observable.pipe(switchMap((client) => client.observable.agent.action.generate(options)))
+    projectId,
+    dataset,
+  }).observable.pipe(switchMap((client) => client.observable.agent.action.generate(agentOptions)))
 }
 
 /**
@@ -75,13 +98,15 @@ export function agentGenerate(
  */
 export function agentTransform(
   instance: SanityInstance,
-  options: AgentTransformOptions,
+  options: AgentTransformOptions & AgentResourceOptions,
 ): AgentTransformResult {
+  const {resource, ...agentOptions} = options
+  const {projectId, dataset} = projectAndDatasetFromResource(instance, resource)
   return getClientState(instance, {
     apiVersion: API_VERSION,
-    projectId: instance.config.projectId,
-    dataset: instance.config.dataset,
-  }).observable.pipe(switchMap((client) => client.observable.agent.action.transform(options)))
+    projectId,
+    dataset,
+  }).observable.pipe(switchMap((client) => client.observable.agent.action.transform(agentOptions)))
 }
 
 /**
@@ -93,13 +118,15 @@ export function agentTransform(
  */
 export function agentTranslate(
   instance: SanityInstance,
-  options: AgentTranslateOptions,
+  options: AgentTranslateOptions & AgentResourceOptions,
 ): AgentTranslateResult {
+  const {resource, ...agentOptions} = options
+  const {projectId, dataset} = projectAndDatasetFromResource(instance, resource)
   return getClientState(instance, {
     apiVersion: API_VERSION,
-    projectId: instance.config.projectId,
-    dataset: instance.config.dataset,
-  }).observable.pipe(switchMap((client) => client.observable.agent.action.translate(options)))
+    projectId,
+    dataset,
+  }).observable.pipe(switchMap((client) => client.observable.agent.action.translate(agentOptions)))
 }
 
 /**
@@ -111,13 +138,15 @@ export function agentTranslate(
  */
 export function agentPrompt(
   instance: SanityInstance,
-  options: AgentPromptOptions,
+  options: AgentPromptOptions & AgentResourceOptions,
 ): Observable<AgentPromptResult> {
+  const {resource, ...agentOptions} = options
+  const {projectId, dataset} = projectAndDatasetFromResource(instance, resource)
   return getClientState(instance, {
     apiVersion: API_VERSION,
-    projectId: instance.config.projectId,
-    dataset: instance.config.dataset,
-  }).observable.pipe(switchMap((client) => from(client.agent.action.prompt(options))))
+    projectId,
+    dataset,
+  }).observable.pipe(switchMap((client) => from(client.agent.action.prompt(agentOptions))))
 }
 
 /**
@@ -129,11 +158,13 @@ export function agentPrompt(
  */
 export function agentPatch(
   instance: SanityInstance,
-  options: AgentPatchOptions,
+  options: AgentPatchOptions & AgentResourceOptions,
 ): Observable<AgentPatchResult> {
+  const {resource, ...agentOptions} = options
+  const {projectId, dataset} = projectAndDatasetFromResource(instance, resource)
   return getClientState(instance, {
     apiVersion: API_VERSION,
-    projectId: instance.config.projectId,
-    dataset: instance.config.dataset,
-  }).observable.pipe(switchMap((client) => from(client.agent.action.patch(options))))
+    projectId,
+    dataset,
+  }).observable.pipe(switchMap((client) => from(client.agent.action.patch(agentOptions))))
 }

--- a/packages/core/src/auth/logout.test.ts
+++ b/packages/core/src/auth/logout.test.ts
@@ -56,7 +56,6 @@ describe('logout', () => {
       apiVersion: '2021-06-07',
       requestTagPrefix: 'sanity.sdk.auth',
       token: 'token',
-      useProjectHostname: false,
       useCdn: false,
     })
     expect(mockRequest).toHaveBeenCalledWith({method: 'POST', uri: '/auth/logout', tag: 'logout'})

--- a/packages/core/src/auth/logout.ts
+++ b/packages/core/src/auth/logout.ts
@@ -29,7 +29,6 @@ export const logout = bindActionGlobally(authStore, async ({state}) => {
         requestTagPrefix: REQUEST_TAG_PREFIX,
         apiVersion: DEFAULT_API_VERSION,
         ...(apiHost && {apiHost}),
-        useProjectHostname: false,
         useCdn: false,
       })
 

--- a/packages/core/src/auth/refreshStampedToken.ts
+++ b/packages/core/src/auth/refreshStampedToken.ts
@@ -59,8 +59,6 @@ function createTokenRefreshStream(
     const client = clientFactory({
       apiVersion: DEFAULT_API_VERSION,
       requestTagPrefix: REQUEST_TAG_PREFIX,
-      useProjectHostname: false,
-      useCdn: false,
       token,
       ignoreBrowserTokenWarning: true,
       ...(apiHost && {apiHost}),

--- a/packages/core/src/auth/standaloneAuth.ts
+++ b/packages/core/src/auth/standaloneAuth.ts
@@ -92,7 +92,7 @@ export function initializeStandaloneAuth(
   const subscriptions: Subscription[] = []
   let startedRefresher = false
 
-  subscriptions.push(subscribeToStateAndFetchCurrentUser(context, {useProjectHostname: false}))
+  subscriptions.push(subscribeToStateAndFetchCurrentUser(context))
 
   const storageArea = context.state.get().options?.storageArea
   if (storageArea) {

--- a/packages/core/src/client/clientStore.test.ts
+++ b/packages/core/src/client/clientStore.test.ts
@@ -1,6 +1,6 @@
 import {createClient, type SanityClient} from '@sanity/client'
 import {Subject} from 'rxjs'
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {getAuthMethodState, getTokenState} from '../auth/authStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
@@ -53,9 +53,9 @@ describe('clientStore', () => {
         ignoreBrowserTokenWarning: true,
         allowReconfigure: false,
         requestTagPrefix: 'sanity.sdk',
-        projectId: 'test-project',
-        dataset: 'test-dataset',
         token: 'initial-token',
+        useProjectHostname: false,
+        resource: {type: 'dataset', id: 'test-project.test-dataset'},
       }
 
       expect(vi.mocked(createClient)).toHaveBeenCalledWith({
@@ -67,7 +67,6 @@ describe('clientStore', () => {
         apiVersion: '2024-11-12',
       })
     })
-
     it('should pass staging apiHost when __SANITY_STAGING__ is true and no explicit apiHost', () => {
       vi.stubGlobal('__SANITY_STAGING__', true)
 
@@ -121,6 +120,49 @@ describe('clientStore', () => {
 
       expect(client1).not.toBe(client2)
       expect(vi.mocked(createClient)).toHaveBeenCalledTimes(2)
+    })
+
+    it('should set useProjectHostname when both projectId and dataset are provided', () => {
+      getClient(instance, {
+        apiVersion: '2024-11-12',
+        projectId: 'abc123',
+        dataset: 'production',
+      })
+
+      expect(vi.mocked(createClient)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: 'abc123',
+          dataset: 'production',
+          useProjectHostname: true,
+        }),
+      )
+    })
+
+    it('should respect the deprecated scope option', () => {
+      getClient(instance, {
+        apiVersion: '2024-11-12',
+        scope: 'default',
+      })
+      expect(vi.mocked(createClient)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          useProjectHostname: true,
+        }),
+      )
+    })
+
+    it('should allow explicit useProjectHostname: false to override when project and dataset are set', () => {
+      getClient(instance, {
+        apiVersion: '2024-11-12',
+        projectId: 'abc123',
+        dataset: 'production',
+        useProjectHostname: false,
+      })
+
+      expect(vi.mocked(createClient)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          useProjectHostname: false,
+        }),
+      )
     })
   })
 
@@ -191,29 +233,7 @@ describe('clientStore', () => {
   })
 
   describe('resource handling', () => {
-    it('should create client when resource is provided', () => {
-      const client = getClient(instance, {
-        apiVersion: '2024-11-12',
-        resource: {projectId: 'source-project', dataset: 'source-dataset'},
-      })
-
-      expect(vi.mocked(createClient)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          apiVersion: '2024-11-12',
-          resource: {type: 'dataset', id: 'source-project.source-dataset'},
-        }),
-      )
-      // Client should be projectless - no projectId/dataset in config
-      expect(client.config()).not.toHaveProperty('projectId')
-      expect(client.config()).not.toHaveProperty('dataset')
-      expect(client.config()).toEqual(
-        expect.objectContaining({
-          resource: {type: 'dataset', id: 'source-project.source-dataset'},
-        }),
-      )
-    })
-
-    it('should create resource when resource has array resourceId and be projectless', () => {
+    it('should create client when media library resource is provided', () => {
       const client = getClient(instance, {
         apiVersion: '2024-11-12',
         resource: {mediaLibraryId: 'media-lib-123'},
@@ -221,8 +241,8 @@ describe('clientStore', () => {
 
       expect(vi.mocked(createClient)).toHaveBeenCalledWith(
         expect.objectContaining({
-          resource: {type: 'media-library', id: 'media-lib-123'},
           apiVersion: '2024-11-12',
+          resource: {type: 'media-library', id: 'media-lib-123'},
         }),
       )
       // Client should be projectless - no projectId/dataset in config
@@ -235,7 +255,7 @@ describe('clientStore', () => {
       )
     })
 
-    it('should create resource when canvas resource is provided and be projectless', () => {
+    it('should create client when canvas resource is provided', () => {
       const client = getClient(instance, {
         apiVersion: '2024-11-12',
         resource: {canvasId: 'canvas-123'},
@@ -257,13 +277,13 @@ describe('clientStore', () => {
       )
     })
 
-    it('should create projectless client when resource is provided, ignoring instance config', () => {
+    it('should create client when dataset resource is provided', () => {
       const client = getClient(instance, {
         apiVersion: '2024-11-12',
         resource: {projectId: 'source-project', dataset: 'source-dataset'},
       })
 
-      // Client should be projectless - resource takes precedence, instance config is ignored
+      // Client should be projectless - source takes precedence, instance config is ignored
       expect(client.config()).not.toHaveProperty('projectId')
       expect(client.config()).not.toHaveProperty('dataset')
       expect(client.config()).toEqual(
@@ -273,11 +293,11 @@ describe('clientStore', () => {
       )
     })
 
-    it('should warn when both resource and explicit projectId/dataset are provided', () => {
+    it('should warn when both source and explicit projectId/dataset are provided', () => {
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const client = getClient(instance, {
         apiVersion: '2024-11-12',
-        resource: {projectId: 'source-project', dataset: 'source-dataset'},
+        resource: {mediaLibraryId: 'media-lib-123'},
         projectId: 'explicit-project',
         dataset: 'explicit-dataset',
       })

--- a/packages/core/src/client/clientStore.ts
+++ b/packages/core/src/client/clientStore.ts
@@ -192,6 +192,9 @@ export const getClient = bindActionGlobally(
       } else if (isCanvasResource(options.resource)) {
         resource = {type: 'canvas', id: options.resource.canvasId}
       }
+      // temporary excluding dataset source as a resource for now. Many of the global API endpoints require vX api version.
+      // } else if (isDatasetSource(options.source)) {
+      //   resource = {type: 'dataset', id: `${options.source.projectId}.${options.source.dataset}`}
     }
 
     const projectId = options.projectId ?? instance.config.projectId
@@ -212,15 +215,18 @@ export const getClient = bindActionGlobally(
     // When a resource is provided, don't use projectId/dataset - the client should be "projectless"
     // The client code itself will ignore the non-resource config, so we do this to prevent confusing the user.
     // (ref: https://github.com/sanity-io/client/blob/5c23f81f5ab93a53f5b22b39845c867988508d84/src/data/dataMethods.ts#L691)
-    if (resource) {
+    // Note: DatasetSource is handled differently - it extracts projectId/dataset from the source and uses those
+    if (options.resource) {
       if (options.projectId || options.dataset) {
         // eslint-disable-next-line no-console
         console.warn(
           'Both resource and explicit projectId/dataset are provided. The resource will be used and projectId/dataset will be ignored.',
         )
       }
-      delete effectiveOptions.projectId
-      delete effectiveOptions.dataset
+      if (resource) {
+        delete effectiveOptions.projectId
+        delete effectiveOptions.dataset
+      }
     }
 
     if (effectiveOptions.token === null || typeof effectiveOptions.token === 'undefined') {

--- a/packages/core/src/client/clientStore.ts
+++ b/packages/core/src/client/clientStore.ts
@@ -1,4 +1,9 @@
-import {type ClientConfig, createClient, type SanityClient} from '@sanity/client'
+import {
+  type ClientConfig,
+  type ClientPerspective,
+  createClient,
+  type SanityClient,
+} from '@sanity/client'
 import {pick} from 'lodash-es'
 
 import {getAuthMethodState, getTokenState} from '../auth/authStore'
@@ -41,11 +46,11 @@ const allowedKeys = Object.keys({
   maxRetries: null,
   dataset: null,
   projectId: null,
-  scope: null,
   apiVersion: null,
   requestTagPrefix: null,
   useProjectHostname: null,
   resource: null,
+  scope: null,
 } satisfies Record<keyof ClientOptions, null>) as (keyof ClientOptions)[]
 
 const DEFAULT_CLIENT_CONFIG: ClientConfig = {
@@ -54,7 +59,8 @@ const DEFAULT_CLIENT_CONFIG: ClientConfig = {
   ignoreBrowserTokenWarning: true,
   allowReconfigure: false,
   requestTagPrefix: DEFAULT_REQUEST_TAG_PREFIX,
-}
+  useProjectHostname: false,
+} satisfies ClientConfig
 
 /**
  * States tracked by the client store
@@ -72,9 +78,11 @@ export interface ClientStoreState {
  * This interface extends the base {@link ClientConfig} and adds:
  *
  * - **apiVersion:** A required string indicating the API version for the client.
+ *
  * - **scope:** An optional flag to choose between the project-specific client
- *   ('project') and the global client ('global'). When set to `'global'`, the
- *   global client is used.
+ *   ('project') and the global client ('global'). Most client calls are global by default.
+ *   This flag is deprecated and will be removed in a future version;
+ *   prefer using the native Sanity client `useProjectHostname` option instead.
  *
  * These options are utilized by `getClient` and `getClientState` to configure and
  * return appropriate client instances that automatically handle authentication
@@ -84,21 +92,25 @@ export interface ClientStoreState {
  */
 export interface ClientOptions extends Pick<ClientConfig, AllowedClientConfigKey> {
   /**
-   * An optional flag to choose between the default client (typically project-level)
-   * and the global client ('global'). When set to `'global'`, the global client
-   * is used.
+   * The perspective to use for the client. Note that array-based perpsectives may not behave as expected.
    */
-  scope?: 'default' | 'global'
+  perspective?: ClientPerspective
   /**
    * A required string indicating the API version for the client.
    */
   apiVersion: string
-
   /**
    * @internal
    * The SDK resource to use for the client -- this will get transformed into a ClientConfig resource.
    */
   resource?: DocumentResource
+  /**
+   * An optional flag to choose between the default client (typically project-level)
+   * and the global client ('global'). Most client calls are global by default.
+   * This flag is deprecated and will be removed in a future version.
+   * @deprecated Use `useProjectHostname` instead.
+   */
+  scope?: 'default' | 'global'
 }
 
 const clientStore = defineStore<ClientStoreState>({
@@ -136,7 +148,7 @@ const listenToAuthMethod = ({instance, state}: StoreContext<ClientStoreState>) =
 }
 
 type ClientInstanceCacheKeyInput = ClientConfig &
-  Partial<Pick<ClientOptions, 'scope'>> & {
+  Partial<Pick<ClientOptions, 'perspective'>> & {
     apiVersion: string
   }
 
@@ -179,43 +191,46 @@ export const getClient = bindActionGlobally(
     const tokenFromState = state.get().token
     const {clients, authMethod} = state.get()
 
+    const {resource: sdkResource, scope, ...restOptions} = options
+
     let resource: ClientConfig['resource'] | undefined
 
-    if (options.resource) {
-      if (isDatasetResource(options.resource)) {
+    if (sdkResource) {
+      if (isDatasetResource(sdkResource)) {
         resource = {
           type: 'dataset',
-          id: `${options.resource.projectId}.${options.resource.dataset}`,
+          id: `${sdkResource.projectId}.${sdkResource.dataset}`,
         }
-      } else if (isMediaLibraryResource(options.resource)) {
-        resource = {type: 'media-library', id: options.resource.mediaLibraryId}
-      } else if (isCanvasResource(options.resource)) {
-        resource = {type: 'canvas', id: options.resource.canvasId}
+      } else if (isMediaLibraryResource(sdkResource)) {
+        resource = {type: 'media-library', id: sdkResource.mediaLibraryId}
+      } else if (isCanvasResource(sdkResource)) {
+        resource = {type: 'canvas', id: sdkResource.canvasId}
       }
-      // temporary excluding dataset source as a resource for now. Many of the global API endpoints require vX api version.
-      // } else if (isDatasetSource(options.source)) {
-      //   resource = {type: 'dataset', id: `${options.source.projectId}.${options.source.dataset}`}
+    } else if (!options.projectId || !options.dataset) {
+      const {projectId, dataset} = instance.config
+      if (projectId && dataset) {
+        resource = {type: 'dataset', id: `${projectId}.${dataset}`}
+      }
     }
 
-    const projectId = options.projectId ?? instance.config.projectId
-    const dataset = options.dataset ?? instance.config.dataset
     const apiHost = options.apiHost ?? instance.config.auth?.apiHost ?? getStagingApiHost()
 
-    const effectiveOptions: ClientConfig & {apiVersion: string} = {
+    const effectiveOptions = {
       ...DEFAULT_CLIENT_CONFIG,
-      ...((options.scope === 'global' || !projectId || resource) && {useProjectHostname: false}),
+      // assume explicit projectId / dataset rather than resource means project-specific client
+      // useProjectHostname will also navigate to the correct endpoint with just a resource
+      ...((options.projectId && options.dataset) || scope === 'default'
+        ? {useProjectHostname: true}
+        : {}),
       token: authMethod === 'cookie' ? undefined : (tokenFromState ?? undefined),
-      ...options,
-      ...(projectId && {projectId}),
-      ...(dataset && {dataset}),
-      ...(resource ? {resource} : {resource: undefined}),
+      ...restOptions,
       ...(apiHost && {apiHost}),
+      ...(resource && {resource}),
     }
 
     // When a resource is provided, don't use projectId/dataset - the client should be "projectless"
     // The client code itself will ignore the non-resource config, so we do this to prevent confusing the user.
     // (ref: https://github.com/sanity-io/client/blob/5c23f81f5ab93a53f5b22b39845c867988508d84/src/data/dataMethods.ts#L691)
-    // Note: DatasetSource is handled differently - it extracts projectId/dataset from the source and uses those
     if (options.resource) {
       if (options.projectId || options.dataset) {
         // eslint-disable-next-line no-console
@@ -223,10 +238,9 @@ export const getClient = bindActionGlobally(
           'Both resource and explicit projectId/dataset are provided. The resource will be used and projectId/dataset will be ignored.',
         )
       }
-      if (resource) {
-        delete effectiveOptions.projectId
-        delete effectiveOptions.dataset
-      }
+      delete effectiveOptions.projectId
+      delete effectiveOptions.dataset
+      effectiveOptions.useProjectHostname = false
     }
 
     if (effectiveOptions.token === null || typeof effectiveOptions.token === 'undefined') {

--- a/packages/core/src/datasets/datasets.ts
+++ b/packages/core/src/datasets/datasets.ts
@@ -19,9 +19,7 @@ export const datasets = createFetcherStore({
   fetcher: (instance) => (options?: ProjectHandle) => {
     return getClientState(instance, {
       apiVersion: API_VERSION,
-      // non-null assertion is fine because we check above
-      projectId: (options?.projectId ?? instance.config.projectId)!,
-      useProjectHostname: true,
+      projectId: options?.projectId ?? instance.config.projectId,
     }).observable.pipe(switchMap((client) => client.observable.datasets.list()))
   },
 })

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -396,8 +396,8 @@ const subscribeToAppliedAndSubmitNextTransaction = ({
       withLatestFrom(
         getClientState(instance, {
           apiVersion: API_VERSION,
-          // TODO: remove in v3 when we're ready for everything to be queried via resource
-          resource: resource && !isDatasetResource(resource) ? resource : undefined,
+          resource,
+          perspective: 'raw',
         }).observable,
       ),
       concatMap(([outgoing, client]) => {
@@ -520,11 +520,7 @@ const subscribeToClientAndFetchDatasetAcl = ({
   state,
   key: {resource},
 }: StoreContext<DocumentStoreState, BoundResourceKey>) => {
-  const clientOptions: ClientOptions = {apiVersion: API_VERSION}
-  // TODO: remove in v3 when we're ready for everything to be queried via resource
-  if (resource && !isDatasetResource(resource)) {
-    clientOptions.resource = resource
-  }
+  const clientOptions: ClientOptions = {apiVersion: API_VERSION, resource}
 
   let uri: string
   if (resource && isDatasetResource(resource)) {

--- a/packages/core/src/document/processActions.ts
+++ b/packages/core/src/document/processActions.ts
@@ -385,7 +385,7 @@ export function processActions({
         const documentId = getId(action.documentId)
 
         if (action.liveEdit) {
-          // Single-document mode (liveEdit or release perspective): edit directly without draft logic
+          // Single-document mode (liveEdit): edit directly without draft logic
           const userPatches = action.patches?.map((patch) => ({patch: {id: documentId, ...patch}}))
 
           // skip this action if there are no associated patches

--- a/packages/core/src/document/sharedListener.ts
+++ b/packages/core/src/document/sharedListener.ts
@@ -14,7 +14,7 @@ import {
 } from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
-import {type DocumentResource, isDatasetResource} from '../config/sanityConfig'
+import {type DocumentResource} from '../config/sanityConfig'
 import {type SanityInstance} from '../store/createSanityInstance'
 
 const API_VERSION = 'v2025-05-06'
@@ -31,8 +31,8 @@ export function createSharedListener(
   const dispose$ = new Subject<void>()
   const events$ = getClientState(instance, {
     apiVersion: API_VERSION,
-    // TODO: remove in v3 when we're ready for everything to be queried via resource
-    resource: resource && !isDatasetResource(resource) ? resource : undefined,
+    resource,
+    perspective: 'raw',
   }).observable.pipe(
     switchMap((client) =>
       // TODO: it seems like the client.listen method is not emitting disconnected
@@ -72,8 +72,8 @@ export function createFetchDocument(instance: SanityInstance, resource?: Documen
   return function (documentId: string): Observable<SanityDocument | null> {
     return getClientState(instance, {
       apiVersion: API_VERSION,
-      // TODO: remove in v3 when we're ready for everything to be queried via resource
-      resource: resource && !isDatasetResource(resource) ? resource : undefined,
+      resource,
+      perspective: 'raw',
     }).observable.pipe(
       switchMap((client) => {
         // creates a observable request to the /doc/{documentId} endpoint for a given document id

--- a/packages/core/src/preview/previewConstants.ts
+++ b/packages/core/src/preview/previewConstants.ts
@@ -34,6 +34,7 @@ export const PREVIEW_PROJECTION = `{
       defined(asset) => {"type": "image-asset", "_ref": asset._ref},
       defined(image.asset) => {"type": "image-asset", "_ref": image.asset._ref},
       defined(mainImage.asset) => {"type": "image-asset", "_ref": mainImage.asset._ref},
+      defined(currentVersion) => {"type": "image-asset", "_ref": currentVersion._ref},
       null
     )
   ),

--- a/packages/core/src/preview/previewProjectionUtils.ts
+++ b/packages/core/src/preview/previewProjectionUtils.ts
@@ -3,7 +3,7 @@ import {createImageUrlBuilder} from '@sanity/image-url'
 import {isObject} from 'lodash-es'
 
 import {getClient} from '../client/clientStore'
-import {type DocumentResource, isDatasetResource} from '../config/sanityConfig'
+import {type DocumentResource} from '../config/sanityConfig'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {SUBTITLE_CANDIDATES, TITLE_CANDIDATES} from './previewConstants'
 import {type PreviewQueryResult, type PreviewValue} from './types'
@@ -80,8 +80,7 @@ export function transformProjectionToPreview(
   // Get a client for the resource (if provided) or use the instance config
   const client = getClient(instance, {
     apiVersion: API_VERSION,
-    // TODO: remove in v3 when we're ready for everything to be queried via resource
-    resource: resource && !isDatasetResource(resource) ? resource : undefined,
+    resource,
   })
 
   return {

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -22,7 +22,6 @@ const project = createFetcherStore({
 
       return getClientState(instance, {
         apiVersion: API_VERSION,
-        scope: 'global',
         projectId,
       }).observable.pipe(
         switchMap((client) =>

--- a/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
+++ b/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
@@ -16,7 +16,6 @@ import {
   tap,
 } from 'rxjs'
 
-import {isDatasetResource} from '../config/sanityConfig'
 import {getQueryState, resolveQuery} from '../query/queryStore'
 import {type BoundPerspectiveKey} from '../store/createActionBinder'
 import {type StoreContext} from '../store/defineStore'
@@ -112,8 +111,7 @@ export const subscribeToStateAndFetchBatches = ({
               tag: PROJECTION_TAG,
               perspective,
             },
-            // temporary guard here until we're ready for everything to be queried via global API
-            ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+            resource,
           })
 
           const querySource$ = defer(() => {
@@ -127,8 +125,7 @@ export const subscribeToStateAndFetchBatches = ({
                     signal: controller.signal,
                     perspective,
                   },
-                  // temporary guard here until we're ready for everything to be queried via global API in v3
-                  ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+                  resource,
                 }),
               ).pipe(switchMap(() => observable))
             }
@@ -153,8 +150,7 @@ export const subscribeToStateAndFetchBatches = ({
               tag: PROJECTION_TAG,
               perspective: 'raw',
             },
-            // temporary guard here until we're ready for everything to be queried via global API
-            ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+            resource,
           })
 
           const statusQuerySource$ = defer(() => {
@@ -168,8 +164,7 @@ export const subscribeToStateAndFetchBatches = ({
                     signal: controller.signal,
                     perspective: 'raw',
                   },
-                  // temporary guard here until we're ready for everything to be queried via global API
-                  ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+                  resource,
                 }),
               ).pipe(switchMap(() => observable))
             }

--- a/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
+++ b/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
@@ -105,12 +105,10 @@ export const subscribeToStateAndFetchBatches = ({
 
         const projectionQuery$ = new Observable<ProjectionQueryResult[]>((observer) => {
           const {getCurrent, observable} = getQueryState<ProjectionQueryResult[]>(instance, {
-            ...{
-              query,
-              params,
-              tag: PROJECTION_TAG,
-              perspective,
-            },
+            query,
+            params,
+            tag: PROJECTION_TAG,
+            perspective,
             resource,
           })
 
@@ -118,13 +116,11 @@ export const subscribeToStateAndFetchBatches = ({
             if (getCurrent() === undefined) {
               return from(
                 resolveQuery<ProjectionQueryResult[]>(instance, {
-                  ...{
-                    query,
-                    params,
-                    tag: PROJECTION_TAG,
-                    signal: controller.signal,
-                    perspective,
-                  },
+                  query,
+                  params,
+                  tag: PROJECTION_TAG,
+                  signal: controller.signal,
+                  perspective,
                   resource,
                 }),
               ).pipe(switchMap(() => observable))
@@ -144,12 +140,10 @@ export const subscribeToStateAndFetchBatches = ({
 
         const statusQuery$ = new Observable<StatusQueryResult[]>((observer) => {
           const {getCurrent, observable} = getQueryState<StatusQueryResult[]>(instance, {
-            ...{
-              query: statusQuery,
-              params: statusParams,
-              tag: PROJECTION_TAG,
-              perspective: 'raw',
-            },
+            query: statusQuery,
+            params: statusParams,
+            tag: PROJECTION_TAG,
+            perspective: 'raw',
             resource,
           })
 
@@ -157,13 +151,11 @@ export const subscribeToStateAndFetchBatches = ({
             if (getCurrent() === undefined) {
               return from(
                 resolveQuery<StatusQueryResult[]>(instance, {
-                  ...{
-                    query: statusQuery,
-                    params: statusParams,
-                    tag: PROJECTION_TAG,
-                    signal: controller.signal,
-                    perspective: 'raw',
-                  },
+                  query: statusQuery,
+                  params: statusParams,
+                  tag: PROJECTION_TAG,
+                  signal: controller.signal,
+                  perspective: 'raw',
                   resource,
                 }),
               ).pipe(switchMap(() => observable))

--- a/packages/core/src/projects/projects.ts
+++ b/packages/core/src/projects/projects.ts
@@ -15,7 +15,6 @@ const projects = createFetcherStore({
   fetcher: (instance) => (options?: {organizationId?: string; includeMembers?: boolean}) =>
     getClientState(instance, {
       apiVersion: API_VERSION,
-      scope: 'global',
       requestTagPrefix: 'sanity.sdk.projects',
     }).observable.pipe(
       switchMap((client) => {

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -138,7 +138,11 @@ const errorHandler = (state: StoreState<{error?: unknown}>) => {
   return (error: unknown): void => state.set('setError', {error})
 }
 
-const listenForNewSubscribersAndFetch = ({state, instance}: StoreContext<QueryStoreState>) => {
+const listenForNewSubscribersAndFetch = ({
+  state,
+  instance,
+  key: {resource},
+}: StoreContext<QueryStoreState, BoundResourceKey>) => {
   return state.observable
     .pipe(
       map((s) => new Set(Object.keys(s.queries))),
@@ -170,11 +174,9 @@ const listenForNewSubscribersAndFetch = ({state, instance}: StoreContext<QuerySt
             const {
               query,
               params,
-              projectId,
-              dataset,
               tag,
-              resource,
               perspective: perspectiveFromOptions,
+              resource: resourceFromOptions,
               ...restOptions
             } = parseQueryKey(group$.key)
 
@@ -183,14 +185,13 @@ const listenForNewSubscribersAndFetch = ({state, instance}: StoreContext<QuerySt
             const perspective$ = isReleasePerspective(perspectiveFromOptions)
               ? getPerspectiveState(instance, {
                   perspective: perspectiveFromOptions,
+                  resource: resourceFromOptions ?? resource,
                 }).observable.pipe(filter(Boolean))
               : of(perspectiveFromOptions ?? QUERY_STORE_DEFAULT_PERSPECTIVE)
 
             const client$ = getClientState(instance, {
               apiVersion: QUERY_STORE_API_VERSION,
-              projectId,
-              dataset,
-              resource,
+              resource: resourceFromOptions ?? resource,
             }).observable
 
             return combineLatest({

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -24,7 +24,7 @@ import {
 } from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
-import {type DatasetHandle, isDatasetResource} from '../config/sanityConfig'
+import {type DatasetHandle} from '../config/sanityConfig'
 /*
  * Although this is an import dependency cycle, it is not a logical cycle:
  * 1. queryStore uses getPerspectiveState when resolving release perspectives
@@ -230,8 +230,7 @@ const listenToLiveClientAndSetLastLiveEventIds = ({
 }: StoreContext<QueryStoreState, BoundResourceKey>) => {
   const liveMessages$ = getClientState(instance, {
     apiVersion: QUERY_STORE_API_VERSION,
-    // temporary guard here until we're ready for everything to be queried via global api
-    ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+    resource,
   }).observable.pipe(
     switchMap((client) =>
       defer(() =>

--- a/packages/core/src/releases/releasesStore.test.ts
+++ b/packages/core/src/releases/releasesStore.test.ts
@@ -39,7 +39,10 @@ describe('releasesStore', () => {
       expect.objectContaining({
         query: 'releases::all()',
         perspective: 'raw',
-        resource: undefined,
+        resource: {
+          dataset: 'test',
+          projectId: 'test',
+        },
         tag: 'releases',
       }),
     )

--- a/packages/core/src/releases/releasesStore.ts
+++ b/packages/core/src/releases/releasesStore.ts
@@ -1,7 +1,7 @@
 import {type SanityDocument} from '@sanity/types'
 import {map} from 'rxjs'
 
-import {type DocumentResource, isDatasetResource} from '../config/sanityConfig'
+import {type DocumentResource} from '../config/sanityConfig'
 /*
  * Although this is an import dependency cycle, it is not a logical cycle:
  * 1. releasesStore uses queryStore as a data source
@@ -84,7 +84,7 @@ const subscribeToReleases = ({
   const {observable: releases$} = getQueryState<ReleaseDocument[]>(instance, {
     query: RELEASES_QUERY,
     perspective: 'raw',
-    resource: resource && !isDatasetResource(resource) ? resource : undefined,
+    resource,
     tag: 'releases',
   })
   return releases$

--- a/packages/core/src/users/usersStore.test.ts
+++ b/packages/core/src/users/usersStore.test.ts
@@ -444,8 +444,7 @@ describe('usersStore', () => {
       expect(getClient).toHaveBeenCalledWith(
         instance,
         expect.objectContaining({
-          projectId: 'project1',
-          useProjectHostname: true,
+          apiVersion: expect.any(String),
         }),
       )
       expect(specificRequest).toHaveBeenCalledWith({

--- a/packages/core/src/users/usersStore.ts
+++ b/packages/core/src/users/usersStore.ts
@@ -116,15 +116,9 @@ const listenForLoadMoreAndFetch = ({state, instance}: StoreContext<UsersStoreSta
             const {userId, batchSize, ...options} = parseUsersKey(group$.key)
 
             if (userId) {
-              // In the future we will be able to fetch a user from the global API using the resourceUserId,
-              // but for now we need to use the project subdomain to fetch a user if the userId is a project user (starts with "p")
               if (userId.startsWith('p')) {
                 const client = getClient(instance, {
                   apiVersion: PROJECT_API_VERSION,
-                  // this is a global store, so we need to use the projectId from the options when we're fetching
-                  // users from a project subdomain
-                  projectId: options.projectId,
-                  useProjectHostname: true,
                 })
 
                 return client.observable
@@ -169,10 +163,7 @@ const listenForLoadMoreAndFetch = ({state, instance}: StoreContext<UsersStoreSta
                   )
               }
 
-              // Fetch the user from the global API
-              const scope = userId.startsWith('g') ? 'global' : undefined
               const client = getClient(instance, {
-                scope,
                 apiVersion: API_VERSION,
               })
               const resourceType = options.resourceType || 'project'
@@ -233,7 +224,6 @@ const listenForLoadMoreAndFetch = ({state, instance}: StoreContext<UsersStoreSta
                 : organizationId$.pipe(map((id) => ({type: 'organization', id})))
 
             const client$ = getClientState(instance, {
-              scope: 'global',
               apiVersion: API_VERSION,
             }).observable
 

--- a/packages/core/src/utils/createFetcherStore.ts
+++ b/packages/core/src/utils/createFetcherStore.ts
@@ -176,7 +176,6 @@ export function createFetcherStore<TParams extends unknown[], TData>({
               const factoryFn = getObservable(entry.instance)
               return factoryFn(...entry.params).pipe(
                 // the `createStateSourceAction` util requires the update
-                // to
                 delay(0, asapScheduler),
                 tap((data: TData) =>
                   state.set('setData', (prev: FetcherStoreState<TParams, TData>) => ({

--- a/packages/react/src/hooks/client/useClient.test.tsx
+++ b/packages/react/src/hooks/client/useClient.test.tsx
@@ -39,4 +39,24 @@ describe('useClient', () => {
     expect(result.current).toBeDefined()
     expect(result.current.fetch).toBeDefined()
   })
+
+  it('should use explicit projectId and dataset instead of conforming to the context resource', () => {
+    const {result} = renderHook(
+      () =>
+        useClient({
+          apiVersion: '2024-11-12',
+          projectId: 'explicit-project',
+          dataset: 'explicit-dataset',
+        }),
+      {wrapper},
+    )
+    expect(result.current.config()).toEqual(
+      expect.objectContaining({
+        apiVersion: '2024-11-12',
+        projectId: 'explicit-project',
+        dataset: 'explicit-dataset',
+        useProjectHostname: true,
+      }),
+    )
+  })
 })

--- a/packages/react/src/hooks/client/useClient.ts
+++ b/packages/react/src/hooks/client/useClient.ts
@@ -1,6 +1,20 @@
+import {type SanityClient} from '@sanity/client'
 import {type ClientOptions, getClientState, type SanityInstance} from '@sanity/sdk'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
+
+const useClientValue = createStateSourceHook({
+  getState: (instance: SanityInstance, options: ClientOptions) => {
+    if (!options || typeof options !== 'object') {
+      throw new Error(
+        'useClient() requires a configuration object with at least an "apiVersion" property. ' +
+          'Example: useClient({ apiVersion: "2024-11-12" })',
+      )
+    }
+    return getClientState(instance, options)
+  },
+})
 
 /**
  * A React hook that provides a client that subscribes to changes in your application,
@@ -29,15 +43,15 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
  * @public
  * @function
  */
-export const useClient = createStateSourceHook({
-  getState: (instance: SanityInstance, options: ClientOptions) => {
-    if (!options || typeof options !== 'object') {
-      throw new Error(
-        'useClient() requires a configuration object with at least an "apiVersion" property. ' +
-          'Example: useClient({ apiVersion: "2024-11-12" })',
-      )
-    }
-    return getClientState(instance, options)
-  },
-  getConfig: (options: ClientOptions) => options,
-})
+export const useClient = (options: ClientOptions): SanityClient => {
+  const normalizedOptions = useNormalizedResourceOptions((options ?? {}) as ClientOptions)
+  // don't conform to a resource if the user has explicitly provided a projectId and dataset
+  const clientOptions = options?.projectId && options?.dataset ? options : normalizedOptions
+  if (!clientOptions.apiVersion) {
+    throw new Error(
+      'useClient() requires a configuration object with at least an "apiVersion" property. ' +
+        'Example: useClient({ apiVersion: "2024-11-12" })',
+    )
+  }
+  return useClientValue(clientOptions)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,8 +412,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       '@sanity/image-url':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.1.1
+        version: 2.1.1
       '@sanity/json-match':
         specifier: ^1.0.5
         version: 1.0.5
@@ -3266,6 +3266,10 @@ packages:
 
   '@sanity/image-url@2.0.3':
     resolution: {integrity: sha512-A/vOugFw/ROGgSeSGB6nimO0c35x9KztatOPIIVlhkL+zsOfP7khigCbdJup2FSv6C03FX2XaUAhXojCxANl2Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@sanity/image-url@2.1.1':
+    resolution: {integrity: sha512-qVXsF1teWR6FO3ZFAz46HDcRU+E6EQkpyncPnkGOzeJ1PgnaOiWMVbiSrZtX10s3txzzu/tAjKwbxbGHfDWgGw==}
     engines: {node: '>=20.19.0'}
 
   '@sanity/import@4.1.0':
@@ -11351,6 +11355,10 @@ snapshots:
       ts-brand: 0.2.0
 
   '@sanity/image-url@2.0.3':
+    dependencies:
+      '@sanity/signed-urls': 2.0.2
+
+  '@sanity/image-url@2.1.1':
     dependencies:
       '@sanity/signed-urls': 2.0.2
 


### PR DESCRIPTION
### Description
This PR replicates one made in the v3 branch to normalize all calls, when possible, to a `/projects/{projectId}/datasets/{dataset}` endpoint. This helps keep everything somewhat predictable and aligned.

The `scope` parameter is deprecated as a result (but should still be functional).

The users store was also slightly changed because a project hostname is not needed for `p-{user}` anymore.

### What to review
Most relevant changes are in the client store. Any odd edge cases? Anything I'm missing?

### Testing
A few tests were added or updated.

### Fun gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExOXVwYXY1cTl3bnhicGdhODdhM28xengzZTE0eG50NThwZGk2dWZlZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZaTByM7nq0ss1woo8y/giphy.gif)