### PR TITLE
feat(core): use global endpoints in v2

### DIFF
--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -24,7 +24,7 @@ import {
 } from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
-import {type DatasetHandle, isDatasetResource} from '../config/sanityConfig'
+import {type DatasetHandle} from '../config/sanityConfig'
 /*
  * Although this is an import dependency cycle, it is not a logical cycle:
  * 1. queryStore uses getPerspectiveState when resolving release perspectives
@@ -230,8 +230,7 @@ const listenToLiveClientAndSetLastLiveEventIds = ({
 }: StoreContext<QueryStoreState, BoundResourceKey>) => {
   const liveMessages$ = getClientState(instance, {
     apiVersion: QUERY_STORE_API_VERSION,
-    // temporary guard here until we're ready for everything to be queried via global api
-    ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+    resource,
   }).observable.pipe(
     switchMap((client) =>
       defer(() =>


### PR DESCRIPTION
### Description
(redo of #817 which was incorrectly merged)
This PR replicates one made in the v3 branch to normalize all calls, when possible, to a `/projects/{projectId}/datasets/{dataset}` endpoint. This helps keep everything somewhat predictable and aligned.

The `scope` parameter is deprecated as a result (but should still be functional).

The users store was also slightly changed because a project hostname is not needed for `p-{user}` anymore.

### What to review
Most relevant changes are in the client store. Any odd edge cases? Anything I'm missing?

### Testing
A few tests were added or updated.

### Fun gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExOXVwYXY1cTl3bnhicGdhODdhM28xengzZTE0eG50NThwZGk2dWZlZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZaTByM7nq0ss1woo8y/giphy.gif)