### PR TITLE
feat(react): add SanityInstanceProvider for externally-created instances

### DIFF
--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -7,6 +7,10 @@ export {SDKProvider, type SDKProviderProps} from '../components/SDKProvider'
 export {ComlinkTokenRefreshProvider} from '../context/ComlinkTokenRefresh'
 export {renderSanityApp} from '../context/renderSanityApp'
 export {ResourceProvider, type ResourceProviderProps} from '../context/ResourceProvider'
+export {
+  SanityInstanceProvider,
+  type SanityInstanceProviderProps,
+} from '../context/SanityInstanceProvider'
 export {SDKStudioContext, type StudioWorkspaceHandle} from '../context/SDKStudioContext'
 export {
   useAgentGenerate,

--- a/packages/react/src/context/ResourceProvider.tsx
+++ b/packages/react/src/context/ResourceProvider.tsx
@@ -1,8 +1,9 @@
 import {createSanityInstance, type SanityConfig, type SanityInstance} from '@sanity/sdk'
 import {initTelemetry} from '@sanity/sdk/_internal'
-import {Suspense, useContext, useEffect, useMemo, useRef} from 'react'
+import {useContext, useEffect, useMemo, useRef} from 'react'
 
 import {SanityInstanceContext} from './SanityInstanceContext'
+import {SanityInstanceProvider} from './SanityInstanceProvider'
 
 const DEFAULT_FALLBACK = (
   <>
@@ -110,8 +111,8 @@ export function ResourceProvider({
   }, [instance])
 
   return (
-    <SanityInstanceContext.Provider value={instance}>
-      <Suspense fallback={fallback ?? DEFAULT_FALLBACK}>{children}</Suspense>
-    </SanityInstanceContext.Provider>
+    <SanityInstanceProvider instance={instance} fallback={fallback ?? DEFAULT_FALLBACK}>
+      {children}
+    </SanityInstanceProvider>
   )
 }

--- a/packages/react/src/context/SanityInstanceProvider.test.tsx
+++ b/packages/react/src/context/SanityInstanceProvider.test.tsx
@@ -1,0 +1,100 @@
+import {createSanityInstance, type SanityInstance} from '@sanity/sdk'
+import {act, render, screen} from '@testing-library/react'
+import {use, useEffect} from 'react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {SanityInstanceContext} from './SanityInstanceContext'
+import {SanityInstanceProvider} from './SanityInstanceProvider'
+
+function promiseWithResolvers<T = void>(): {
+  promise: Promise<T>
+  resolve: (t: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (t: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return {resolve, reject, promise}
+}
+
+describe('SanityInstanceProvider', () => {
+  it('renders children', () => {
+    const instance = createSanityInstance({projectId: 'test', dataset: 'test'})
+
+    render(
+      <SanityInstanceProvider instance={instance} fallback={<div>Loading...</div>}>
+        <div data-testid="test-child">Child Component</div>
+      </SanityInstanceProvider>,
+    )
+
+    expect(screen.getByTestId('test-child')).toBeInTheDocument()
+    instance.dispose()
+  })
+
+  it('provides the given instance via context', async () => {
+    const instance = createSanityInstance({projectId: 'test', dataset: 'test'})
+    const {promise, resolve} = promiseWithResolvers<SanityInstance | null>()
+
+    const CaptureInstance = () => {
+      const ctx = use(SanityInstanceContext)
+      useEffect(() => resolve(ctx), [ctx])
+      return null
+    }
+
+    render(
+      <SanityInstanceProvider instance={instance} fallback={null}>
+        <CaptureInstance />
+      </SanityInstanceProvider>,
+    )
+
+    const provided = await promise
+    expect(provided).toBe(instance)
+    instance.dispose()
+  })
+
+  it('shows fallback during suspense', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const instance = createSanityInstance({projectId: 'test', dataset: 'test'})
+    const {promise, resolve} = promiseWithResolvers()
+
+    function SuspendingChild(): React.ReactNode {
+      throw promise
+    }
+
+    render(
+      <SanityInstanceProvider
+        instance={instance}
+        fallback={<div data-testid="fallback">Loading...</div>}
+      >
+        <SuspendingChild />
+      </SanityInstanceProvider>,
+    )
+
+    expect(screen.getByTestId('fallback')).toBeInTheDocument()
+    act(() => {
+      resolve()
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    instance.dispose()
+    consoleSpy.mockRestore()
+  })
+
+  it('does not dispose the instance on unmount', async () => {
+    const instance = createSanityInstance({projectId: 'test', dataset: 'test'})
+
+    const {unmount} = render(
+      <SanityInstanceProvider instance={instance} fallback={null}>
+        <div />
+      </SanityInstanceProvider>,
+    )
+
+    unmount()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(instance.isDisposed()).toBe(false)
+    instance.dispose()
+  })
+})

--- a/packages/react/src/context/SanityInstanceProvider.tsx
+++ b/packages/react/src/context/SanityInstanceProvider.tsx
@@ -25,7 +25,7 @@ export interface SanityInstanceProviderProps {
 /**
  * Provides an externally-created Sanity instance to child components through React Context.
  *
- * @public
+ * @internal
  *
  * @remarks
  * Unlike {@link ResourceProvider}, this component does not create or dispose a SanityInstance.

--- a/packages/react/src/context/SanityInstanceProvider.tsx
+++ b/packages/react/src/context/SanityInstanceProvider.tsx
@@ -1,0 +1,71 @@
+import {type SanityInstance} from '@sanity/sdk'
+import {Suspense} from 'react'
+
+import {SanityInstanceContext} from './SanityInstanceContext'
+
+/**
+ * Props for the SanityInstanceProvider component
+ * @public
+ */
+export interface SanityInstanceProviderProps {
+  /**
+   * A pre-created SanityInstance to provide to child components.
+   * The caller owns the instance lifecycle — SanityInstanceProvider
+   * will not dispose it on unmount.
+   */
+  instance: SanityInstance
+  /**
+   * React node to show while content is loading.
+   * Used as the fallback for the internal Suspense boundary.
+   */
+  fallback: React.ReactNode
+  children: React.ReactNode
+}
+
+/**
+ * Provides an externally-created Sanity instance to child components through React Context.
+ *
+ * @public
+ *
+ * @remarks
+ * Unlike {@link ResourceProvider}, this component does not create or dispose a SanityInstance.
+ * The caller is responsible for creating the instance via `createSanityInstance` and disposing
+ * it when appropriate. This is useful when a non-React system layer (e.g. a state machine)
+ * owns the instance and the React tree should consume it without managing its lifecycle.
+ *
+ * All SDK hooks (`useSanityInstance`, `useDocuments`, etc.) will read from the provided instance.
+ *
+ * @example Providing a pre-created instance
+ * ```tsx
+ * import { createSanityInstance, type SanityConfig } from '@sanity/sdk'
+ * import { SanityInstanceProvider } from '@sanity/sdk-react'
+ *
+ * const config: SanityConfig = {
+ *   projectId: 'my-project-id',
+ *   dataset: 'production',
+ * }
+ *
+ * const instance = createSanityInstance(config)
+ *
+ * function App() {
+ *   return (
+ *     <SanityInstanceProvider instance={instance} fallback={<div>Loading...</div>}>
+ *       <MyApp />
+ *     </SanityInstanceProvider>
+ *   )
+ * }
+ * ```
+ *
+ * @category Components
+ */
+export function SanityInstanceProvider({
+  instance,
+  fallback,
+  children,
+}: SanityInstanceProviderProps): React.ReactNode {
+  return (
+    <SanityInstanceContext.Provider value={instance}>
+      <Suspense fallback={fallback}>{children}</Suspense>
+    </SanityInstanceContext.Provider>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `SanityInstanceProvider` — a new public component that accepts a pre-created `SanityInstance` and provides it to the React tree via context + Suspense
- Refactors `ResourceProvider` to use `SanityInstanceProvider` internally (no behavior change)

## Use case

`SanityApp` and `ResourceProvider` always create their own `SanityInstance` internally. There's no way to provide an instance created outside the React tree.

This forces an architectural inversion for apps where a non-React system layer owns the SDK instance — you end up with duplicated state, duplicated auth, and no single source of truth.

`SanityInstanceProvider` sits at the bottom of the provider ladder (`SanityApp → SDKProvider → ResourceProvider → SanityInstanceProvider`) and gives full control to the caller:

```tsx
const instance = createSanityInstance({ projectId: 'abc', dataset: 'production' })

<SanityInstanceProvider instance={instance} fallback={<Loading />}>
  <App /> {/* useSanityInstance(), useDocuments(), etc. all work */}
</SanityInstanceProvider>
```

The caller owns the instance lifecycle — `SanityInstanceProvider` will not dispose it on unmount.

## Open questions

- Should `initTelemetry` live in `SanityInstanceProvider` rather than `ResourceProvider`? Currently telemetry is only initialised when `ResourceProvider` creates a root instance. If someone uses `SanityInstanceProvider` directly, telemetry won't be initialised automatically. This might be the right default (caller controls everything), but worth discussing. The current implementation also specifically won't happen if theres a parent sanity instance – so we probably do want to keep it in ResourceProvider?