### PR TITLE
fix(ci): unblock Renovate auto-approve on skipped checks

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,7 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'skip-review') &&
       github.actor != 'squiggler[bot]' &&
       github.actor != 'squiggler-app[bot]' &&
-      (github.actor != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, '⚠️ major'))
+      (github.actor != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'major-update'))
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -49,7 +49,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
           running-workflow-name: "auto-approve"
-          allowed-conclusions: success
+          # Include "skipped" so conditionally-run jobs (e.g. claude-review,
+          # publish-preview) don't block auto-approval when they don't execute
+          # on Renovate PRs.
+          allowed-conclusions: success,skipped
 
       - name: Auto-approve Renovate PR
         if: steps.check-labels.outputs.skip != 'true'


### PR DESCRIPTION
### Description

Two small CI fixes for the Renovate PR pipeline, both surfaced while debugging a recent failed `auto-approve` run on a Renovate PR.

**1. Allow `skipped` checks in the Renovate auto-approve workflow.**

`renovate-auto-approve.yml` waits for required CI checks via `lewagon/wait-on-check-action` configured with `allowed-conclusions: success`. Several jobs in this repo legitimately complete as `skipped` rather than `success` because their `if:` guards don't apply to Renovate PRs (notably `claude-review` and `publish-preview`). The wait step rejects every non-success conclusion, so the auto-approver fails on every Renovate PR and never reaches the approval step.

Switching to `allowed-conclusions: success,skipped` matches the action's own default and unblocks the rubber-stamp signal CODEOWNERS rely on when triaging the Renovate queue. `failure` and `cancelled` are still treated as blocking.

**2. Fix the Claude review label gate for Renovate PRs.**

`claude-code-review.yml` had a job-level `if:` that ran the renovate-tailored Claude review only when the PR carried a `⚠️ major` label. No rule in `renovate.json` ever applies that label, so the dedicated changelog/usage-search prompt for major Renovate upgrades never executed. Switching to `major-update`, which Renovate actually applies to dev-deps and production-deps major bumps, restores the intended behavior.

### What to review

- `.github/workflows/renovate-auto-approve.yml`: confirm `success,skipped` is the right policy. `failure`, `cancelled`, `timed_out`, and `action_required` remain blocking, so the only behavioral change is that legitimately skipped jobs no longer fail the wait step.
- `.github/workflows/claude-code-review.yml`: confirm `major-update` is the right label to gate on. Today this label is set by both the dev-deps majors rule and the production-deps majors rule in `renovate.json`. If we want to narrow Claude review to changes that affect SDK consumers only, `breaking-change` or `needs-review` would scope it to production-deps majors / peer deps. Happy to narrow as a follow-up if cost or noise becomes an issue.

### Testing

CI on this PR exercises both workflows end-to-end:

- The `auto-approve` workflow on this PR will not run (it gates on `github.actor == 'renovate[bot]'`), so verifying the fix in production requires watching the next Renovate PR's `auto-approve` check go green instead of failing on the wait step.
- The Claude review gate change is config-only; the next Renovate PR with the `major-update` label will be the real validation. Until then, the existing non-Renovate path (this PR included) continues to behave as before.

No code paths are exercised by automated tests.

### Fun gif
![skip](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMXV1Nnd1ZHZ5d2RyMDVybXJlcmVlemJ4cXM5aHlsdWcyeTg3MWxubCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/H4EaXhSucnqhylZyvd/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
FIXES SDK-1352