### PR TITLE
refactor: turn project / dataset pairs into resources internally

### DIFF
--- a/packages/core/src/_exports/_internal.ts
+++ b/packages/core/src/_exports/_internal.ts
@@ -12,3 +12,4 @@ export {getQueryKey, parseQueryKey} from '../query/queryStore' // only used for 
 export {getTelemetryManager, initTelemetry, trackHookMounted} from '../telemetry/initTelemetry'
 export {getUsersKey, parseUsersKey} from '../users/reducers' // only used for memoizing in React, not needed for actual functionality
 export {createGroqSearchFilter} from '../utils/createGroqSearchFilter'
+export {isDeepEqual, pickProperties} from '../utils/object'

--- a/packages/core/src/agent/agentActions.ts
+++ b/packages/core/src/agent/agentActions.ts
@@ -2,6 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {from, Observable, switchMap} from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
+import {type DocumentResource} from '../config/sanityConfig'
 import {type SanityInstance} from '../store/createSanityInstance'
 
 const API_VERSION = 'vX'
@@ -58,12 +59,11 @@ export type AgentPatchResult = Awaited<ReturnType<SanityClient['agent']['action'
 export function agentGenerate(
   instance: SanityInstance,
   options: AgentGenerateOptions,
+  resource?: DocumentResource,
 ): AgentGenerateResult {
-  return getClientState(instance, {
-    apiVersion: API_VERSION,
-    projectId: instance.config.projectId,
-    dataset: instance.config.dataset,
-  }).observable.pipe(switchMap((client) => client.observable.agent.action.generate(options)))
+  return getClientState(instance, {apiVersion: API_VERSION, resource}).observable.pipe(
+    switchMap((client) => client.observable.agent.action.generate(options)),
+  )
 }
 
 /**
@@ -76,12 +76,11 @@ export function agentGenerate(
 export function agentTransform(
   instance: SanityInstance,
   options: AgentTransformOptions,
+  resource?: DocumentResource,
 ): AgentTransformResult {
-  return getClientState(instance, {
-    apiVersion: API_VERSION,
-    projectId: instance.config.projectId,
-    dataset: instance.config.dataset,
-  }).observable.pipe(switchMap((client) => client.observable.agent.action.transform(options)))
+  return getClientState(instance, {apiVersion: API_VERSION, resource}).observable.pipe(
+    switchMap((client) => client.observable.agent.action.transform(options)),
+  )
 }
 
 /**
@@ -94,12 +93,11 @@ export function agentTransform(
 export function agentTranslate(
   instance: SanityInstance,
   options: AgentTranslateOptions,
+  resource?: DocumentResource,
 ): AgentTranslateResult {
-  return getClientState(instance, {
-    apiVersion: API_VERSION,
-    projectId: instance.config.projectId,
-    dataset: instance.config.dataset,
-  }).observable.pipe(switchMap((client) => client.observable.agent.action.translate(options)))
+  return getClientState(instance, {apiVersion: API_VERSION, resource}).observable.pipe(
+    switchMap((client) => client.observable.agent.action.translate(options)),
+  )
 }
 
 /**
@@ -112,12 +110,11 @@ export function agentTranslate(
 export function agentPrompt(
   instance: SanityInstance,
   options: AgentPromptOptions,
+  resource?: DocumentResource,
 ): Observable<AgentPromptResult> {
-  return getClientState(instance, {
-    apiVersion: API_VERSION,
-    projectId: instance.config.projectId,
-    dataset: instance.config.dataset,
-  }).observable.pipe(switchMap((client) => from(client.agent.action.prompt(options))))
+  return getClientState(instance, {apiVersion: API_VERSION, resource}).observable.pipe(
+    switchMap((client) => from(client.agent.action.prompt(options))),
+  )
 }
 
 /**
@@ -130,10 +127,9 @@ export function agentPrompt(
 export function agentPatch(
   instance: SanityInstance,
   options: AgentPatchOptions,
+  resource?: DocumentResource,
 ): Observable<AgentPatchResult> {
-  return getClientState(instance, {
-    apiVersion: API_VERSION,
-    projectId: instance.config.projectId,
-    dataset: instance.config.dataset,
-  }).observable.pipe(switchMap((client) => from(client.agent.action.patch(options))))
+  return getClientState(instance, {apiVersion: API_VERSION, resource}).observable.pipe(
+    switchMap((client) => from(client.agent.action.patch(options))),
+  )
 }

--- a/packages/core/src/client/clientStore.test.ts
+++ b/packages/core/src/client/clientStore.test.ts
@@ -191,29 +191,7 @@ describe('clientStore', () => {
   })
 
   describe('resource handling', () => {
-    it('should create client when resource is provided', () => {
-      const client = getClient(instance, {
-        apiVersion: '2024-11-12',
-        resource: {projectId: 'source-project', dataset: 'source-dataset'},
-      })
-
-      expect(vi.mocked(createClient)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          apiVersion: '2024-11-12',
-          resource: {type: 'dataset', id: 'source-project.source-dataset'},
-        }),
-      )
-      // Client should be projectless - no projectId/dataset in config
-      expect(client.config()).not.toHaveProperty('projectId')
-      expect(client.config()).not.toHaveProperty('dataset')
-      expect(client.config()).toEqual(
-        expect.objectContaining({
-          resource: {type: 'dataset', id: 'source-project.source-dataset'},
-        }),
-      )
-    })
-
-    it('should create resource when resource has array resourceId and be projectless', () => {
+    it('should create resource when media library resource is provided and be projectless', () => {
       const client = getClient(instance, {
         apiVersion: '2024-11-12',
         resource: {mediaLibraryId: 'media-lib-123'},
@@ -257,38 +235,24 @@ describe('clientStore', () => {
       )
     })
 
-    it('should create projectless client when resource is provided, ignoring instance config', () => {
+    it('should transform dataset resource to project-based config for now', () => {
       const client = getClient(instance, {
         apiVersion: '2024-11-12',
         resource: {projectId: 'source-project', dataset: 'source-dataset'},
       })
 
-      // Client should be projectless - resource takes precedence, instance config is ignored
-      expect(client.config()).not.toHaveProperty('projectId')
-      expect(client.config()).not.toHaveProperty('dataset')
-      expect(client.config()).toEqual(
+      expect(vi.mocked(createClient)).toHaveBeenCalledWith(
         expect.objectContaining({
-          resource: {type: 'dataset', id: 'source-project.source-dataset'},
+          projectId: 'source-project',
+          dataset: 'source-dataset',
         }),
       )
-    })
-
-    it('should warn when both resource and explicit projectId/dataset are provided', () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      const client = getClient(instance, {
-        apiVersion: '2024-11-12',
-        resource: {projectId: 'source-project', dataset: 'source-dataset'},
-        projectId: 'explicit-project',
-        dataset: 'explicit-dataset',
-      })
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Both resource and explicit projectId/dataset are provided. The resource will be used and projectId/dataset will be ignored.',
+      expect(client.config()).toEqual(
+        expect.objectContaining({
+          projectId: 'source-project',
+          dataset: 'source-dataset',
+        }),
       )
-      // Client should still be projectless despite explicit projectId/dataset
-      expect(client.config()).not.toHaveProperty('projectId')
-      expect(client.config()).not.toHaveProperty('dataset')
-      consoleSpy.mockRestore()
     })
 
     it('should create different clients for different resources', () => {

--- a/packages/core/src/client/clientStore.ts
+++ b/packages/core/src/client/clientStore.ts
@@ -178,24 +178,23 @@ export const getClient = bindActionGlobally(
 
     const tokenFromState = state.get().token
     const {clients, authMethod} = state.get()
+    let projectId = options.projectId ?? instance.config.projectId
+    let dataset = options.dataset ?? instance.config.dataset
 
     let resource: ClientConfig['resource'] | undefined
 
     if (options.resource) {
-      if (isDatasetResource(options.resource)) {
-        resource = {
-          type: 'dataset',
-          id: `${options.resource.projectId}.${options.resource.dataset}`,
-        }
-      } else if (isMediaLibraryResource(options.resource)) {
+      if (isMediaLibraryResource(options.resource)) {
         resource = {type: 'media-library', id: options.resource.mediaLibraryId}
       } else if (isCanvasResource(options.resource)) {
         resource = {type: 'canvas', id: options.resource.canvasId}
+      } else if (isDatasetResource(options.resource)) {
+        // use project-based routes for datasets to avoid existing CORS and Studio auth cookie issues
+        projectId = options.resource.projectId
+        dataset = options.resource.dataset
       }
     }
 
-    const projectId = options.projectId ?? instance.config.projectId
-    const dataset = options.dataset ?? instance.config.dataset
     const apiHost = options.apiHost ?? instance.config.auth?.apiHost ?? getStagingApiHost()
 
     const effectiveOptions: ClientConfig & {apiVersion: string} = {
@@ -213,12 +212,6 @@ export const getClient = bindActionGlobally(
     // The client code itself will ignore the non-resource config, so we do this to prevent confusing the user.
     // (ref: https://github.com/sanity-io/client/blob/5c23f81f5ab93a53f5b22b39845c867988508d84/src/data/dataMethods.ts#L691)
     if (resource) {
-      if (options.projectId || options.dataset) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'Both resource and explicit projectId/dataset are provided. The resource will be used and projectId/dataset will be ignored.',
-        )
-      }
       delete effectiveOptions.projectId
       delete effectiveOptions.dataset
     }

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -396,8 +396,7 @@ const subscribeToAppliedAndSubmitNextTransaction = ({
       withLatestFrom(
         getClientState(instance, {
           apiVersion: API_VERSION,
-          // TODO: remove in v3 when we're ready for everything to be queried via resource
-          resource: resource && !isDatasetResource(resource) ? resource : undefined,
+          resource,
         }).observable,
       ),
       concatMap(([outgoing, client]) => {
@@ -520,11 +519,7 @@ const subscribeToClientAndFetchDatasetAcl = ({
   state,
   key: {resource},
 }: StoreContext<DocumentStoreState, BoundResourceKey>) => {
-  const clientOptions: ClientOptions = {apiVersion: API_VERSION}
-  // TODO: remove in v3 when we're ready for everything to be queried via resource
-  if (resource && !isDatasetResource(resource)) {
-    clientOptions.resource = resource
-  }
+  const clientOptions: ClientOptions = {apiVersion: API_VERSION, resource}
 
   let uri: string
   if (resource && isDatasetResource(resource)) {

--- a/packages/core/src/document/sharedListener.ts
+++ b/packages/core/src/document/sharedListener.ts
@@ -14,7 +14,7 @@ import {
 } from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
-import {type DocumentResource, isDatasetResource} from '../config/sanityConfig'
+import {type DocumentResource} from '../config/sanityConfig'
 import {type SanityInstance} from '../store/createSanityInstance'
 
 const API_VERSION = 'v2025-05-06'
@@ -31,8 +31,7 @@ export function createSharedListener(
   const dispose$ = new Subject<void>()
   const events$ = getClientState(instance, {
     apiVersion: API_VERSION,
-    // TODO: remove in v3 when we're ready for everything to be queried via resource
-    resource: resource && !isDatasetResource(resource) ? resource : undefined,
+    resource,
   }).observable.pipe(
     switchMap((client) =>
       // TODO: it seems like the client.listen method is not emitting disconnected
@@ -72,8 +71,7 @@ export function createFetchDocument(instance: SanityInstance, resource?: Documen
   return function (documentId: string): Observable<SanityDocument | null> {
     return getClientState(instance, {
       apiVersion: API_VERSION,
-      // TODO: remove in v3 when we're ready for everything to be queried via resource
-      resource: resource && !isDatasetResource(resource) ? resource : undefined,
+      resource,
     }).observable.pipe(
       switchMap((client) => {
         // creates a observable request to the /doc/{documentId} endpoint for a given document id

--- a/packages/core/src/preview/previewProjectionUtils.ts
+++ b/packages/core/src/preview/previewProjectionUtils.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {createImageUrlBuilder} from '@sanity/image-url'
 
 import {getClient} from '../client/clientStore'
-import {type DocumentResource, isDatasetResource} from '../config/sanityConfig'
+import {type DocumentResource} from '../config/sanityConfig'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {isObject} from '../utils/object'
 import {SUBTITLE_CANDIDATES, TITLE_CANDIDATES} from './previewConstants'
@@ -80,8 +80,7 @@ export function transformProjectionToPreview(
   // Get a client for the resource (if provided) or use the instance config
   const client = getClient(instance, {
     apiVersion: API_VERSION,
-    // TODO: remove in v3 when we're ready for everything to be queried via resource
-    resource: resource && !isDatasetResource(resource) ? resource : undefined,
+    resource,
   })
 
   return {

--- a/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
+++ b/packages/core/src/projection/subscribeToStateAndFetchBatches.ts
@@ -16,7 +16,6 @@ import {
   tap,
 } from 'rxjs'
 
-import {isDatasetResource} from '../config/sanityConfig'
 import {getQueryState, resolveQuery} from '../query/queryStore'
 import {type BoundPerspectiveKey} from '../store/createActionBinder'
 import {type StoreContext} from '../store/defineStore'
@@ -113,8 +112,7 @@ export const subscribeToStateAndFetchBatches = ({
               tag: PROJECTION_TAG,
               perspective,
             },
-            // temporary guard here until we're ready for everything to be queried via global API
-            ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+            resource,
           })
 
           const querySource$ = defer(() => {
@@ -128,8 +126,7 @@ export const subscribeToStateAndFetchBatches = ({
                     signal: controller.signal,
                     perspective,
                   },
-                  // temporary guard here until we're ready for everything to be queried via global API in v3
-                  ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+                  resource,
                 }),
               ).pipe(switchMap(() => observable))
             }
@@ -154,8 +151,7 @@ export const subscribeToStateAndFetchBatches = ({
               tag: PROJECTION_TAG,
               perspective: 'raw',
             },
-            // temporary guard here until we're ready for everything to be queried via global API
-            ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+            resource,
           })
 
           const statusQuerySource$ = defer(() => {
@@ -169,8 +165,7 @@ export const subscribeToStateAndFetchBatches = ({
                     signal: controller.signal,
                     perspective: 'raw',
                   },
-                  // temporary guard here until we're ready for everything to be queried via global API
-                  ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+                  resource,
                 }),
               ).pipe(switchMap(() => observable))
             }

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -24,7 +24,7 @@ import {
 } from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
-import {type DatasetHandle, isDatasetResource} from '../config/sanityConfig'
+import {type DatasetHandle} from '../config/sanityConfig'
 /*
  * Although this is an import dependency cycle, it is not a logical cycle:
  * 1. queryStore uses getPerspectiveState when resolving release perspectives
@@ -230,8 +230,7 @@ const listenToLiveClientAndSetLastLiveEventIds = ({
 }: StoreContext<QueryStoreState, BoundResourceKey>) => {
   const liveMessages$ = getClientState(instance, {
     apiVersion: QUERY_STORE_API_VERSION,
-    // temporary guard here until we're ready for everything to be queried via global api
-    ...(resource && !isDatasetResource(resource) ? {resource} : {}),
+    resource,
   }).observable.pipe(
     switchMap((client) =>
       defer(() =>

--- a/packages/core/src/releases/releasesStore.test.ts
+++ b/packages/core/src/releases/releasesStore.test.ts
@@ -39,8 +39,8 @@ describe('releasesStore', () => {
       expect.objectContaining({
         query: 'releases::all()',
         perspective: 'raw',
-        resource: undefined,
         tag: 'releases',
+        resource: {dataset: 'test', projectId: 'test'},
       }),
     )
   })

--- a/packages/core/src/releases/releasesStore.ts
+++ b/packages/core/src/releases/releasesStore.ts
@@ -1,7 +1,7 @@
 import {type SanityDocument} from '@sanity/types'
 import {map} from 'rxjs'
 
-import {type DocumentResource, isDatasetResource} from '../config/sanityConfig'
+import {type DocumentResource} from '../config/sanityConfig'
 /*
  * Although this is an import dependency cycle, it is not a logical cycle:
  * 1. releasesStore uses queryStore as a data source
@@ -84,7 +84,7 @@ const subscribeToReleases = ({
   const {observable: releases$} = getQueryState<ReleaseDocument[]>(instance, {
     query: RELEASES_QUERY,
     perspective: 'raw',
-    resource: resource && !isDatasetResource(resource) ? resource : undefined,
+    resource,
     tag: 'releases',
   })
   return releases$

--- a/packages/react/src/_exports/index.ts
+++ b/packages/react/src/_exports/index.ts
@@ -1,2 +1,4 @@
 export * from './sdk-react.ts'
 export * from '@sanity/sdk'
+// React-layer handles shadow core equivalents when imported from @sanity/sdk-react
+export type {DocumentHandle, DocumentTypeHandle, ResourceHandle} from './sdk-react.ts'

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -4,6 +4,7 @@
 export {AuthBoundary, type AuthBoundaryProps} from '../components/auth/AuthBoundary'
 export {SanityApp, type SanityAppProps} from '../components/SanityApp'
 export {SDKProvider, type SDKProviderProps} from '../components/SDKProvider'
+export {type DocumentHandle, type DocumentTypeHandle, type ResourceHandle} from '../config/handles'
 export {ComlinkTokenRefreshProvider} from '../context/ComlinkTokenRefresh'
 export {renderSanityApp} from '../context/renderSanityApp'
 export {ResourceProvider, type ResourceProviderProps} from '../context/ResourceProvider'

--- a/packages/react/src/components/SDKProvider.tsx
+++ b/packages/react/src/components/SDKProvider.tsx
@@ -49,24 +49,25 @@ export function SDKProvider({
   const configs = (Array.isArray(config) ? config : [config]).slice().reverse()
   const projectIds = configs.map((c) => c.projectId).filter((id): id is string => !!id)
 
+  // Extract static fields so the memo below doesn't take a reference dependency
+  // on `config` — inline config objects change identity on every render.
+  const singleConfig = Array.isArray(config) ? null : config
+  const defaultProjectId = singleConfig?.projectId
+  const defaultDataset = singleConfig?.dataset
+
   // For a single config, synthesize a 'default' resource from its projectId/dataset
   // so that hooks can resolve it via resourceName: 'default' or fall back to it
   // automatically when no resource info is provided.
   const resourcesValue = useMemo(() => {
     const explicit = props.resources ?? {}
-    if (
-      !Array.isArray(config) &&
-      config.projectId &&
-      config.dataset &&
-      !Object.hasOwn(explicit, DEFAULT_RESOURCE_NAME)
-    ) {
+    if (defaultProjectId && defaultDataset && !Object.hasOwn(explicit, DEFAULT_RESOURCE_NAME)) {
       return {
-        [DEFAULT_RESOURCE_NAME]: {projectId: config.projectId, dataset: config.dataset},
+        [DEFAULT_RESOURCE_NAME]: {projectId: defaultProjectId, dataset: defaultDataset},
         ...explicit,
       }
     }
     return explicit
-  }, [config, props.resources])
+  }, [defaultProjectId, defaultDataset, props.resources])
 
   // Create a nested structure of ResourceProviders for each config
   const createNestedProviders = (index: number): ReactElement => {

--- a/packages/react/src/components/SDKProvider.tsx
+++ b/packages/react/src/components/SDKProvider.tsx
@@ -2,6 +2,7 @@ import {type DocumentResource, isImportError, type SanityConfig} from '@sanity/s
 import {type ReactElement, type ReactNode, useEffect, useMemo} from 'react'
 import {ErrorBoundary, type FallbackProps} from 'react-error-boundary'
 
+import {DEFAULT_RESOURCE_NAME} from '../constants'
 import {ResourceProvider} from '../context/ResourceProvider'
 import {ResourcesContext} from '../context/ResourcesContext'
 import {AuthBoundary, type AuthBoundaryProps} from './auth/AuthBoundary'
@@ -48,8 +49,24 @@ export function SDKProvider({
   const configs = (Array.isArray(config) ? config : [config]).slice().reverse()
   const projectIds = configs.map((c) => c.projectId).filter((id): id is string => !!id)
 
-  // Memoize resources to prevent creating a new empty object on every render
-  const resourcesValue = useMemo(() => props.resources ?? {}, [props.resources])
+  // For a single config, synthesize a 'default' resource from its projectId/dataset
+  // so that hooks can resolve it via resourceName: 'default' or fall back to it
+  // automatically when no resource info is provided.
+  const resourcesValue = useMemo(() => {
+    const explicit = props.resources ?? {}
+    if (
+      !Array.isArray(config) &&
+      config.projectId &&
+      config.dataset &&
+      !Object.hasOwn(explicit, DEFAULT_RESOURCE_NAME)
+    ) {
+      return {
+        [DEFAULT_RESOURCE_NAME]: {projectId: config.projectId, dataset: config.dataset},
+        ...explicit,
+      }
+    }
+    return explicit
+  }, [config, props.resources])
 
   // Create a nested structure of ResourceProviders for each config
   const createNestedProviders = (index: number): ReactElement => {

--- a/packages/react/src/config/handles.ts
+++ b/packages/react/src/config/handles.ts
@@ -1,0 +1,55 @@
+import {
+  type DatasetHandle,
+  type DocumentHandle as CoreDocumentHandle,
+  type DocumentTypeHandle as CoreDocumentTypeHandle,
+} from '@sanity/sdk'
+
+/**
+ * React SDK resource handle — extends the core DatasetHandle with `resourceName`
+ * for context-based resource resolution.
+ *
+ * Use this (or its subtypes) as the options type for custom hooks that need to
+ * accept a resource. It accepts a `resource` object, a `resourceName` registered
+ * via the `resources` prop on `<SanityApp>`, or a bare `projectId`/`dataset` pair
+ * for backward compatibility.
+ *
+ * @public
+ */
+export interface ResourceHandle<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends DatasetHandle<TDataset, TProjectId> {
+  /**
+   * Name of a resource registered via the `resources` prop on `<SanityApp>`.
+   * Resolved to a `DocumentResource` at the React layer.
+   */
+  resourceName?: string
+}
+
+/**
+ * React SDK document-type handle. Adds `resourceName` to the core `DocumentTypeHandle`.
+ * @public
+ */
+export interface DocumentTypeHandle<
+  TDocumentType extends string = string,
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends CoreDocumentTypeHandle<TDocumentType, TDataset, TProjectId> {
+  resourceName?: string
+}
+
+/**
+ * React SDK document handle. Adds `resourceName` to the core `DocumentHandle`.
+ *
+ * Import from `@sanity/sdk-react` (not `@sanity/sdk`) when writing option types
+ * for hooks — this version understands `resourceName` resolution.
+ *
+ * @public
+ */
+export interface DocumentHandle<
+  TDocumentType extends string = string,
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends CoreDocumentHandle<TDocumentType, TDataset, TProjectId> {
+  resourceName?: string
+}

--- a/packages/react/src/constants.ts
+++ b/packages/react/src/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * The name of the resource automatically registered from a single-config `<SanityApp>`.
+ * Hooks that receive no resource information fall back to this named resource.
+ * @public
+ */
+export const DEFAULT_RESOURCE_NAME = 'default'

--- a/packages/react/src/constants.ts
+++ b/packages/react/src/constants.ts
@@ -1,6 +1,5 @@
 /**
  * The name of the resource automatically registered from a single-config `<SanityApp>`.
  * Hooks that receive no resource information fall back to this named resource.
- * @public
  */
 export const DEFAULT_RESOURCE_NAME = 'default'

--- a/packages/react/src/context/DefaultResourceContext.ts
+++ b/packages/react/src/context/DefaultResourceContext.ts
@@ -1,0 +1,10 @@
+import {type DocumentResource} from '@sanity/sdk'
+import {createContext} from 'react'
+
+/**
+ * Provides the active DocumentResource for a subtree.
+ * Set by ResourceProvider; read by useNormalizedResourceOptions as a fallback
+ * when hooks receive no explicit resource or resourceName.
+ * @internal
+ */
+export const ResourceContext = createContext<DocumentResource | undefined>(undefined)

--- a/packages/react/src/context/PerspectiveContext.ts
+++ b/packages/react/src/context/PerspectiveContext.ts
@@ -1,0 +1,12 @@
+import {type PerspectiveHandle} from '@sanity/sdk'
+import {createContext} from 'react'
+
+/**
+ * Provides the active perspective for a subtree.
+ * Set by ResourceProvider; injected by useNormalizedResourceOptions when
+ * the hook's options don't include an explicit perspective.
+ * @internal
+ */
+export const PerspectiveContext = createContext<PerspectiveHandle['perspective'] | undefined>(
+  undefined,
+)

--- a/packages/react/src/context/ResourceProvider.tsx
+++ b/packages/react/src/context/ResourceProvider.tsx
@@ -1,7 +1,14 @@
-import {createSanityInstance, type SanityConfig, type SanityInstance} from '@sanity/sdk'
+import {
+  createSanityInstance,
+  type DocumentResource,
+  type SanityConfig,
+  type SanityInstance,
+} from '@sanity/sdk'
 import {initTelemetry} from '@sanity/sdk/_internal'
 import {useContext, useEffect, useMemo, useRef} from 'react'
 
+import {ResourceContext} from './DefaultResourceContext'
+import {PerspectiveContext} from './PerspectiveContext'
 import {SanityInstanceContext} from './SanityInstanceContext'
 import {SanityInstanceProvider} from './SanityInstanceProvider'
 
@@ -16,6 +23,11 @@ const DEFAULT_FALLBACK = (
  * @internal
  */
 export interface ResourceProviderProps extends SanityConfig {
+  /**
+   * The document resource for this subtree. Hooks that receive no explicit
+   * resource or resourceName will use this value via ResourceContext.
+   */
+  resource?: DocumentResource
   /**
    * React node to show while content is loading
    * Used as the fallback for the internal Suspense boundary
@@ -72,6 +84,7 @@ export interface ResourceProviderProps extends SanityConfig {
 export function ResourceProvider({
   children,
   fallback,
+  resource,
   ...config
 }: ResourceProviderProps): React.ReactNode {
   const parent = useContext(SanityInstanceContext)
@@ -112,7 +125,11 @@ export function ResourceProvider({
 
   return (
     <SanityInstanceProvider instance={instance} fallback={fallback ?? DEFAULT_FALLBACK}>
-      {children}
+      <ResourceContext.Provider value={resource}>
+        <PerspectiveContext.Provider value={config.perspective}>
+          {children}
+        </PerspectiveContext.Provider>
+      </ResourceContext.Provider>
     </SanityInstanceProvider>
   )
 }

--- a/packages/react/src/context/ResourceProvider.tsx
+++ b/packages/react/src/context/ResourceProvider.tsx
@@ -88,6 +88,7 @@ export function ResourceProvider({
   ...config
 }: ResourceProviderProps): React.ReactNode {
   const parent = useContext(SanityInstanceContext)
+  const parentPerspective = useContext(PerspectiveContext)
   const instance = useMemo(
     () => (parent ? parent.createChild(config) : createSanityInstance(config)),
     [config, parent],
@@ -126,7 +127,7 @@ export function ResourceProvider({
   return (
     <SanityInstanceProvider instance={instance} fallback={fallback ?? DEFAULT_FALLBACK}>
       <ResourceContext.Provider value={resource}>
-        <PerspectiveContext.Provider value={config.perspective}>
+        <PerspectiveContext.Provider value={config.perspective ?? parentPerspective}>
           {children}
         </PerspectiveContext.Provider>
       </ResourceContext.Provider>

--- a/packages/react/src/hooks/agent/agentActions.ts
+++ b/packages/react/src/hooks/agent/agentActions.ts
@@ -11,11 +11,13 @@ import {
   type AgentTransformOptions,
   agentTranslate,
   type AgentTranslateOptions,
-  type SanityInstance,
 } from '@sanity/sdk'
+import {useCallback} from 'react'
 import {firstValueFrom} from 'rxjs'
 
-import {createCallbackHook} from '../helpers/createCallbackHook'
+import {type ResourceHandle} from '../../config/handles'
+import {useSanityInstance} from '../context/useSanityInstance'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
 
 interface Subscription {
   unsubscribe(): void
@@ -103,10 +105,17 @@ interface Subscribable<T> {
  *
  * @category Agent Actions
  */
-export const useAgentGenerate: () => (options: AgentGenerateOptions) => Subscribable<unknown> =
-  createCallbackHook(agentGenerate) as unknown as () => (
-    options: AgentGenerateOptions,
-  ) => Subscribable<unknown>
+export function useAgentGenerate(
+  resourceHandle?: ResourceHandle,
+): (options: AgentGenerateOptions) => Subscribable<unknown> {
+  const instance = useSanityInstance()
+  const {resource} = useNormalizedResourceOptions(resourceHandle ?? {})
+  return useCallback(
+    (options: AgentGenerateOptions) =>
+      agentGenerate(instance, options, resource) as unknown as Subscribable<unknown>,
+    [instance, resource],
+  )
+}
 
 /**
  * @alpha
@@ -179,10 +188,17 @@ export const useAgentGenerate: () => (options: AgentGenerateOptions) => Subscrib
  *
  * @category Agent Actions
  */
-export const useAgentTransform: () => (options: AgentTransformOptions) => Subscribable<unknown> =
-  createCallbackHook(agentTransform) as unknown as () => (
-    options: AgentTransformOptions,
-  ) => Subscribable<unknown>
+export function useAgentTransform(
+  resourceHandle?: ResourceHandle,
+): (options: AgentTransformOptions) => Subscribable<unknown> {
+  const instance = useSanityInstance()
+  const {resource} = useNormalizedResourceOptions(resourceHandle ?? {})
+  return useCallback(
+    (options: AgentTransformOptions) =>
+      agentTransform(instance, options, resource) as unknown as Subscribable<unknown>,
+    [instance, resource],
+  )
+}
 
 /**
  * @alpha
@@ -274,20 +290,16 @@ export const useAgentTransform: () => (options: AgentTransformOptions) => Subscr
  *
  * @category Agent Actions
  */
-export const useAgentTranslate: () => (options: AgentTranslateOptions) => Subscribable<unknown> =
-  createCallbackHook(agentTranslate) as unknown as () => (
-    options: AgentTranslateOptions,
-  ) => Subscribable<unknown>
-
-/**
- * @internal
- * Adapter to convert the agentPrompt observable to a Promise.
- */
-function promptAdapter(
-  instance: SanityInstance,
-  options: AgentPromptOptions,
-): Promise<AgentPromptResult> {
-  return firstValueFrom(agentPrompt(instance, options))
+export function useAgentTranslate(
+  resourceHandle?: ResourceHandle,
+): (options: AgentTranslateOptions) => Subscribable<unknown> {
+  const instance = useSanityInstance()
+  const {resource} = useNormalizedResourceOptions(resourceHandle ?? {})
+  return useCallback(
+    (options: AgentTranslateOptions) =>
+      agentTranslate(instance, options, resource) as unknown as Subscribable<unknown>,
+    [instance, resource],
+  )
 }
 
 /**
@@ -384,18 +396,15 @@ function promptAdapter(
  *
  * @category Agent Actions
  */
-export const useAgentPrompt: () => (options: AgentPromptOptions) => Promise<AgentPromptResult> =
-  createCallbackHook(promptAdapter)
-
-/**
- * @internal
- * Adapter to convert the agentPatch observable to a Promise.
- */
-function patchAdapter(
-  instance: SanityInstance,
-  options: AgentPatchOptions,
-): Promise<AgentPatchResult> {
-  return firstValueFrom(agentPatch(instance, options))
+export function useAgentPrompt(
+  resourceHandle?: ResourceHandle,
+): (options: AgentPromptOptions) => Promise<AgentPromptResult> {
+  const instance = useSanityInstance()
+  const {resource} = useNormalizedResourceOptions(resourceHandle ?? {})
+  return useCallback(
+    (options: AgentPromptOptions) => firstValueFrom(agentPrompt(instance, options, resource)),
+    [instance, resource],
+  )
 }
 
 /**
@@ -547,5 +556,13 @@ function patchAdapter(
  *
  * @category Agent Actions
  */
-export const useAgentPatch: () => (options: AgentPatchOptions) => Promise<AgentPatchResult> =
-  createCallbackHook(patchAdapter)
+export function useAgentPatch(
+  resourceHandle?: ResourceHandle,
+): (options: AgentPatchOptions) => Promise<AgentPatchResult> {
+  const instance = useSanityInstance()
+  const {resource} = useNormalizedResourceOptions(resourceHandle ?? {})
+  return useCallback(
+    (options: AgentPatchOptions) => firstValueFrom(agentPatch(instance, options, resource)),
+    [instance, resource],
+  )
+}

--- a/packages/react/src/hooks/dashboard/useDispatchIntent.test.ts
+++ b/packages/react/src/hooks/dashboard/useDispatchIntent.test.ts
@@ -1,4 +1,5 @@
 import {type DocumentHandle} from '@sanity/sdk'
+import {renderHook as reactRenderHook} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {renderHook} from '../../../test/test-utils'
@@ -227,12 +228,14 @@ describe('useDispatchIntent', () => {
 
   describe('error handling', () => {
     it('should throw error when neither resource nor projectId/dataset is provided', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const invalidHandle = {
         documentId: 'test-document-id',
         documentType: 'test-document-type',
       }
 
-      const {result} = renderHook(() =>
+      // Use a minimal wrapper with no resource context so the normalization has nothing to fall back to
+      const {result} = reactRenderHook(() =>
         useDispatchIntent({
           action: 'edit',
           documentHandle: invalidHandle as unknown as DocumentHandle,
@@ -242,6 +245,7 @@ describe('useDispatchIntent', () => {
       expect(() => result.current.dispatchIntent()).toThrow(
         'useDispatchIntent: Unable to determine resource. Either `resource`, `resourceName`, or both `projectId` and `dataset` must be provided in documentHandle.',
       )
+      consoleErrorSpy.mockRestore()
     })
   })
 })

--- a/packages/react/src/hooks/dashboard/useDispatchIntent.ts
+++ b/packages/react/src/hooks/dashboard/useDispatchIntent.ts
@@ -1,9 +1,9 @@
 import {SDK_CHANNEL_NAME, SDK_NODE_NAME} from '@sanity/message-protocol'
-import {type DocumentHandle, type FrameMessage} from '@sanity/sdk'
+import {type FrameMessage} from '@sanity/sdk'
 import {useCallback} from 'react'
 
+import {type DocumentHandle} from '../../config/handles'
 import {useWindowConnection} from '../comlink/useWindowConnection'
-import {type WithResourceNameSupport} from '../helpers/useNormalizedResourceOptions'
 import {useResourceIdFromDocumentHandle} from './utils/useResourceIdFromDocumentHandle'
 
 /**
@@ -42,7 +42,7 @@ interface DispatchIntent {
 interface UseDispatchIntentParams {
   action?: 'edit'
   intentId?: string
-  documentHandle: WithResourceNameSupport<DocumentHandle>
+  documentHandle: DocumentHandle
   parameters?: Record<string, unknown>
 }
 

--- a/packages/react/src/hooks/dashboard/utils/useResourceIdFromDocumentHandle.ts
+++ b/packages/react/src/hooks/dashboard/utils/useResourceIdFromDocumentHandle.ts
@@ -19,13 +19,9 @@ export function useResourceIdFromDocumentHandle(
   documentHandle: DocumentHandle,
 ): DashboardMessageResource {
   const options = useNormalizedResourceOptions(documentHandle)
-  const {projectId, dataset, resource} = options
+  const {resource} = options
   let resourceId: string = ''
   let resourceType: 'media-library' | 'canvas' | undefined
-  if (projectId && dataset) {
-    resourceId = `${projectId}.${dataset}`
-  }
-
   if (resource) {
     if (isDatasetResource(resource)) {
       resourceId = `${resource.projectId}.${resource.dataset}`

--- a/packages/react/src/hooks/document/useApplyDocumentActions.test.ts
+++ b/packages/react/src/hooks/document/useApplyDocumentActions.test.ts
@@ -1,4 +1,4 @@
-import {applyDocumentActions, type SanityInstance} from '@sanity/sdk'
+import {applyDocumentActions, createSanityInstance} from '@sanity/sdk'
 import {describe, it} from 'vitest'
 
 import {renderHook} from '../../../test/test-utils'
@@ -12,18 +12,7 @@ vi.mock('@sanity/sdk', async (importOriginal) => {
 
 vi.mock('../context/useSanityInstance')
 
-// These are quite fragile mocks, but they are useful enough for now.
-const instances: Record<string, SanityInstance | undefined> = {
-  'p123.d': {__id: 'p123.d'} as unknown as SanityInstance,
-  'p.d123': {__id: 'p.d123'} as unknown as SanityInstance,
-  'p123.d123': {__id: 'p123.d123'} as unknown as SanityInstance,
-}
-
-const instance = {
-  match({projectId = 'p', dataset = 'd'}): SanityInstance | undefined {
-    return instances[`${projectId}.${dataset}`]
-  },
-} as unknown as SanityInstance
+const instance = createSanityInstance({projectId: 'p', dataset: 'd'})
 
 describe('useApplyDocumentActions', () => {
   beforeEach(() => {
@@ -45,41 +34,20 @@ describe('useApplyDocumentActions', () => {
           type: 'document.edit',
           documentType: 'post',
           documentId: 'abc',
+          resource: {projectId: 'p', dataset: 'd'},
         },
       ],
+      resource: {projectId: 'p', dataset: 'd'},
     })
   })
 
-  it('uses SanityInstance.match when projectId is overrideen', async () => {
+  it('resolves resource from projectId and dataset in action', async () => {
     const {result} = renderHook(() => useApplyDocumentActions())
     result.current({
       type: 'document.edit',
       documentType: 'post',
       documentId: 'abc',
-
-      projectId: 'p123',
-    })
-
-    expect(applyDocumentActions).toHaveBeenCalledExactlyOnceWith(instances['p123.d'], {
-      actions: [
-        {
-          type: 'document.edit',
-          documentType: 'post',
-          documentId: 'abc',
-
-          projectId: 'p123',
-        },
-      ],
-    })
-  })
-
-  it('uses SanityInstance when dataset is overrideen', async () => {
-    const {result} = renderHook(() => useApplyDocumentActions())
-    result.current({
-      type: 'document.edit',
-      documentType: 'post',
-      documentId: 'abc',
-
+      projectId: 'p',
       dataset: 'd123',
     })
 
@@ -89,49 +57,11 @@ describe('useApplyDocumentActions', () => {
           type: 'document.edit',
           documentType: 'post',
           documentId: 'abc',
-
-          dataset: 'd123',
+          resource: {projectId: 'p', dataset: 'd123'},
         },
       ],
+      resource: {projectId: 'p', dataset: 'd123'},
     })
-  })
-
-  it('uses SanityInstance.amcth when projectId and dataset is overrideen', async () => {
-    const {result} = renderHook(() => useApplyDocumentActions())
-    result.current({
-      type: 'document.edit',
-      documentType: 'post',
-      documentId: 'abc',
-
-      projectId: 'p123',
-      dataset: 'd123',
-    })
-
-    expect(applyDocumentActions).toHaveBeenCalledExactlyOnceWith(instances['p123.d123'], {
-      actions: [
-        {
-          type: 'document.edit',
-          documentType: 'post',
-          documentId: 'abc',
-
-          projectId: 'p123',
-          dataset: 'd123',
-        },
-      ],
-    })
-  })
-
-  it("throws if SanityInstance.match doesn't find anything", async () => {
-    const {result} = renderHook(() => useApplyDocumentActions())
-    expect(() => {
-      result.current({
-        type: 'document.edit',
-        documentType: 'post',
-        documentId: 'abc',
-
-        projectId: 'other',
-      })
-    }).toThrow()
   })
 
   it('throws when actions have mismatched project IDs', async () => {
@@ -143,15 +73,17 @@ describe('useApplyDocumentActions', () => {
           documentType: 'post',
           documentId: 'abc',
           projectId: 'p123',
+          dataset: 'd',
         },
         {
           type: 'document.edit',
           documentType: 'post',
           documentId: 'def',
           projectId: 'p456',
+          dataset: 'd',
         },
       ])
-    }).toThrow(/Mismatched project IDs found in actions/)
+    }).toThrow(/Mismatched resources found in actions/)
   })
 
   it('throws when actions have mismatched datasets', async () => {
@@ -173,7 +105,7 @@ describe('useApplyDocumentActions', () => {
           dataset: 'd2',
         },
       ])
-    }).toThrow(/Mismatched datasets found in actions/)
+    }).toThrow(/Mismatched resources found in actions/)
   })
 
   it('throws when actions have mismatched resources', async () => {
@@ -196,7 +128,7 @@ describe('useApplyDocumentActions', () => {
     }).toThrow(/Mismatched resources found in actions/)
   })
 
-  it('throws when mixing projectId and resource (projectId first)', async () => {
+  it('throws when mixing projectId/dataset and resource with a mismatch (projectId first)', async () => {
     const {result} = renderHook(() => useApplyDocumentActions())
     expect(() => {
       result.current([
@@ -204,19 +136,20 @@ describe('useApplyDocumentActions', () => {
           type: 'document.edit',
           documentType: 'post',
           documentId: 'abc',
-          projectId: 'p',
+          projectId: 'p1',
+          dataset: 'd',
         },
         {
           type: 'document.edit',
           documentType: 'post',
           documentId: 'def',
-          resource: {projectId: 'p', dataset: 'd'},
+          resource: {projectId: 'p2', dataset: 'd'},
         },
       ])
-    }).toThrow(/Mismatches between projectId\/dataset options and resource/)
+    }).toThrow(/Mismatched resources found in actions/)
   })
 
-  it('throws when mixing resource and projectId (resource first)', async () => {
+  it('throws when mixing resource and projectId/dataset with a mismatch (resource first)', async () => {
     const {result} = renderHook(() => useApplyDocumentActions())
     expect(() => {
       result.current([
@@ -224,15 +157,16 @@ describe('useApplyDocumentActions', () => {
           type: 'document.edit',
           documentType: 'post',
           documentId: 'abc',
-          resource: {projectId: 'p', dataset: 'd'},
+          resource: {projectId: 'p1', dataset: 'd'},
         },
         {
           type: 'document.edit',
           documentType: 'post',
           documentId: 'def',
-          projectId: 'p',
+          projectId: 'p2',
+          dataset: 'd',
         },
       ])
-    }).toThrow(/Mismatches between projectId\/dataset options and resource/)
+    }).toThrow(/Mismatched resources found in actions/)
   })
 })

--- a/packages/react/src/hooks/document/useApplyDocumentActions.test.tsx
+++ b/packages/react/src/hooks/document/useApplyDocumentActions.test.tsx
@@ -1,7 +1,9 @@
 import {applyDocumentActions, createSanityInstance} from '@sanity/sdk'
+import {renderHook as reactRenderHook} from '@testing-library/react'
 import {describe, it} from 'vitest'
 
 import {renderHook} from '../../../test/test-utils'
+import {SanityInstanceContext} from '../../context/SanityInstanceContext'
 import {useSanityInstance} from '../context/useSanityInstance'
 import {useApplyDocumentActions} from './useApplyDocumentActions'
 
@@ -20,13 +22,42 @@ describe('useApplyDocumentActions', () => {
     vi.mocked(useSanityInstance).mockReturnValueOnce(instance)
   })
 
-  it('uses the SanityInstance', async () => {
+  it('uses the effective context resource', async () => {
     const {result} = renderHook(() => useApplyDocumentActions())
     result.current({
       type: 'document.edit',
       documentType: 'post',
       documentId: 'abc',
     })
+
+    expect(applyDocumentActions).toHaveBeenCalledExactlyOnceWith(instance, {
+      actions: [
+        {
+          type: 'document.edit',
+          documentType: 'post',
+          documentId: 'abc',
+          // resource named in test-utils
+          resource: {projectId: 'test', dataset: 'test'},
+        },
+      ],
+      resource: {projectId: 'test', dataset: 'test'},
+    })
+  })
+
+  it('uses the SanityInstance when resource is not provided', async () => {
+    const {result} = reactRenderHook(() => useApplyDocumentActions(), {
+      wrapper: ({children}) => (
+        <SanityInstanceContext.Provider value={instance}>{children}</SanityInstanceContext.Provider>
+      ),
+    })
+    result.current(
+      {
+        type: 'document.edit',
+        documentType: 'post',
+        documentId: 'abc',
+      },
+      {},
+    )
 
     expect(applyDocumentActions).toHaveBeenCalledExactlyOnceWith(instance, {
       actions: [

--- a/packages/react/src/hooks/document/useApplyDocumentActions.ts
+++ b/packages/react/src/hooks/document/useApplyDocumentActions.ts
@@ -1,12 +1,15 @@
 import {type ActionsResult, applyDocumentActions, type DocumentAction} from '@sanity/sdk'
 import {isDeepEqual} from '@sanity/sdk/_internal'
+import {type SanityDocument} from 'groq'
 import {useContext} from 'react'
 
 import {type ResourceHandle} from '../../config/handles'
-import {ResourceContext} from '../../context/DefaultResourceContext'
 import {ResourcesContext} from '../../context/ResourcesContext'
 import {useSanityInstance} from '../context/useSanityInstance'
-import {normalizeResourceOptions} from '../helpers/useNormalizedResourceOptions'
+import {
+  normalizeResourceOptions,
+  useEffectiveContextResource,
+} from '../helpers/useNormalizedResourceOptions'
 // this import is used in an `{@link useEditDocument}`
 // eslint-disable-next-line unused-imports/no-unused-imports, import/consistent-type-specifier-style
 import type {useEditDocument} from './useEditDocument'
@@ -24,7 +27,7 @@ interface UseApplyDocumentActions {
       | DocumentAction<TDocumentType, TDataset, TProjectId>
       | DocumentAction<TDocumentType, TDataset, TProjectId>[],
     options?: ResourceHandle,
-  ) => Promise<ActionsResult>
+  ) => Promise<ActionsResult<SanityDocument<TDocumentType, `${TProjectId}.${TDataset}`>>>
 }
 
 /**
@@ -213,16 +216,7 @@ interface UseApplyDocumentActions {
 export const useApplyDocumentActions: UseApplyDocumentActions = () => {
   const instance = useSanityInstance()
   const resources = useContext(ResourcesContext)
-  const contextResource = useContext(ResourceContext)
-
-  // Tier (d): fall back to instance config when no context resource is set
-  let effectiveContextResource = contextResource
-  if (!effectiveContextResource) {
-    const {projectId, dataset} = instance.config
-    if (projectId && dataset) {
-      effectiveContextResource = {projectId, dataset}
-    }
-  }
+  const effectiveContextResource = useEffectiveContextResource()
 
   return (actionOrActions, options) => {
     const actions = Array.isArray(actionOrActions) ? actionOrActions : [actionOrActions]
@@ -250,7 +244,7 @@ export const useApplyDocumentActions: UseApplyDocumentActions = () => {
       )
     }
 
-    const effectiveResource = resource ?? optionsResource
+    const effectiveResource = resource ?? optionsResource ?? effectiveContextResource
     if (!effectiveResource) {
       throw new Error('No resource found. Provide a resource via the action handle or context.')
     }

--- a/packages/react/src/hooks/document/useApplyDocumentActions.ts
+++ b/packages/react/src/hooks/document/useApplyDocumentActions.ts
@@ -1,18 +1,12 @@
-import {
-  type ActionsResult,
-  applyDocumentActions,
-  type ApplyDocumentActionsOptions,
-  type DocumentAction,
-} from '@sanity/sdk'
-import {type SanityDocument} from 'groq'
+import {type ActionsResult, applyDocumentActions, type DocumentAction} from '@sanity/sdk'
+import {isDeepEqual} from '@sanity/sdk/_internal'
 import {useContext} from 'react'
 
+import {type ResourceHandle} from '../../config/handles'
+import {ResourceContext} from '../../context/DefaultResourceContext'
 import {ResourcesContext} from '../../context/ResourcesContext'
 import {useSanityInstance} from '../context/useSanityInstance'
-import {
-  normalizeResourceOptions,
-  type WithResourceNameSupport,
-} from '../helpers/useNormalizedResourceOptions'
+import {normalizeResourceOptions} from '../helpers/useNormalizedResourceOptions'
 // this import is used in an `{@link useEditDocument}`
 // eslint-disable-next-line unused-imports/no-unused-imports, import/consistent-type-specifier-style
 import type {useEditDocument} from './useEditDocument'
@@ -29,8 +23,8 @@ interface UseApplyDocumentActions {
     action:
       | DocumentAction<TDocumentType, TDataset, TProjectId>
       | DocumentAction<TDocumentType, TDataset, TProjectId>[],
-    options?: WithResourceNameSupport<ApplyDocumentActionsOptions>,
-  ) => Promise<ActionsResult<SanityDocument<TDocumentType, `${TProjectId}.${TDataset}`>>>
+    options?: ResourceHandle,
+  ) => Promise<ActionsResult>
 }
 
 /**
@@ -219,73 +213,51 @@ interface UseApplyDocumentActions {
 export const useApplyDocumentActions: UseApplyDocumentActions = () => {
   const instance = useSanityInstance()
   const resources = useContext(ResourcesContext)
+  const contextResource = useContext(ResourceContext)
+
+  // Tier (d): fall back to instance config when no context resource is set
+  let effectiveContextResource = contextResource
+  if (!effectiveContextResource) {
+    const {projectId, dataset} = instance.config
+    if (projectId && dataset) {
+      effectiveContextResource = {projectId, dataset}
+    }
+  }
 
   return (actionOrActions, options) => {
     const actions = Array.isArray(actionOrActions) ? actionOrActions : [actionOrActions]
-    const normalizedOptions = options ? normalizeResourceOptions(options, resources) : undefined
+    const optionsResource = options
+      ? normalizeResourceOptions(options, resources, effectiveContextResource).resource
+      : undefined
 
-    let projectId
-    let dataset
+    const normalizedActions = actions.map((action) =>
+      normalizeResourceOptions(action, resources, effectiveContextResource),
+    )
     let resource
-    for (const action of actions) {
-      if (action.projectId) {
-        if (resource) {
-          throw new Error(
-            `Mismatches between projectId/dataset options and resource in actions. Found projectId "${action.projectId}" and dataset "${action.dataset}" but expected resource "${resource}".`,
-          )
-        }
-        if (!projectId) projectId = action.projectId
-        if (action.projectId !== projectId) {
-          throw new Error(
-            `Mismatched project IDs found in actions. All actions must belong to the same project. Found "${action.projectId}" but expected "${projectId}".`,
-          )
-        }
 
-        if (action.dataset) {
-          if (!dataset) dataset = action.dataset
-          if (action.dataset !== dataset) {
-            throw new Error(
-              `Mismatched datasets found in actions. All actions must belong to the same dataset. Found "${action.dataset}" but expected "${dataset}".`,
-            )
-          }
-        }
-      }
-
-      if (action.resource) {
-        if (!resource) resource = action.resource
-        if (action.resource !== resource) {
-          throw new Error(
-            `Mismatched resources found in actions. All actions must belong to the same resource. Found "${action.resource}" but expected "${resource}".`,
-          )
-        }
-        if (projectId || dataset) {
-          throw new Error(
-            `Mismatches between projectId/dataset options and resource in actions. Found "${action.resource}" but expected project "${projectId}" and dataset "${dataset}".`,
-          )
-        }
+    for (const action of normalizedActions) {
+      if (!resource) resource = action.resource
+      if (!isDeepEqual(action.resource, resource)) {
+        throw new Error(
+          `Mismatched resources found in actions. All actions must belong to the same resource. Found "${JSON.stringify(action.resource)}" but expected "${JSON.stringify(resource)}".`,
+        )
       }
     }
 
-    if (projectId || dataset) {
-      const actualInstance = instance.match({projectId, dataset})
-      if (!actualInstance) {
-        throw new Error(
-          `Could not find a matching Sanity instance for the requested action: ${JSON.stringify({projectId, dataset}, null, 2)}.
-  Please ensure there is a ResourceProvider component with a matching configuration in the component hierarchy.`,
-        )
-      }
+    if (optionsResource && resource && !isDeepEqual(optionsResource, resource)) {
+      throw new Error(
+        `Mismatched resources found in actions. Found top-level resource "${JSON.stringify(optionsResource)}" but expected resource from action handles "${JSON.stringify(resource)}".`,
+      )
+    }
 
-      return applyDocumentActions(actualInstance, {
-        actions,
-        resource,
-        ...normalizedOptions,
-      })
+    const effectiveResource = resource ?? optionsResource
+    if (!effectiveResource) {
+      throw new Error('No resource found. Provide a resource via the action handle or context.')
     }
 
     return applyDocumentActions(instance, {
-      actions,
-      resource,
-      ...normalizedOptions,
+      actions: normalizedActions as DocumentAction[],
+      resource: effectiveResource,
     })
   }
 }

--- a/packages/react/src/hooks/document/useDocument.ts
+++ b/packages/react/src/hooks/document/useDocument.ts
@@ -2,11 +2,9 @@ import {type DocumentOptions, getDocumentState, type JsonMatch, resolveDocument}
 import {type SanityDocument} from 'groq'
 import {identity} from 'rxjs'
 
+import {type DocumentHandle} from '../../config/handles'
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
-import {
-  useNormalizedResourceOptions,
-  type WithResourceNameSupport,
-} from '../helpers/useNormalizedResourceOptions'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
 import {useTrackHookUsage} from '../helpers/useTrackHookUsage'
 // used in an `{@link useDocumentProjection}` and `{@link useQuery}`
 // eslint-disable-next-line import/consistent-type-specifier-style, unused-imports/no-unused-imports
@@ -43,7 +41,7 @@ type UseDocumentOptions<
   TDocumentType extends string = string,
   TDataset extends string = string,
   TProjectId extends string = string,
-> = WithResourceNameSupport<DocumentOptions<TPath, TDocumentType, TDataset, TProjectId>>
+> = DocumentHandle<TDocumentType, TDataset, TProjectId> & {path?: TPath}
 
 interface UseDocument {
   /** @internal */

--- a/packages/react/src/hooks/document/useDocumentEvent.ts
+++ b/packages/react/src/hooks/document/useDocumentEvent.ts
@@ -1,6 +1,7 @@
-import {type DatasetHandle, type DocumentEvent, subscribeDocumentEvents} from '@sanity/sdk'
+import {type DocumentEvent, subscribeDocumentEvents} from '@sanity/sdk'
 import {useCallback, useEffect, useInsertionEffect, useRef} from 'react'
 
+import {type ResourceHandle} from '../../config/handles'
 import {useSanityInstance} from '../context/useSanityInstance'
 import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
 import {useTrackHookUsage} from '../helpers/useTrackHookUsage'
@@ -11,7 +12,7 @@ import {useTrackHookUsage} from '../helpers/useTrackHookUsage'
 export interface UseDocumentEventOptions<
   TDataset extends string = string,
   TProjectId extends string = string,
-> extends DatasetHandle<TDataset, TProjectId> {
+> extends ResourceHandle<TDataset, TProjectId> {
   onEvent: (documentEvent: DocumentEvent) => void
 }
 
@@ -91,7 +92,7 @@ export function useDocumentEvent<
     return ref.current(documentEvent)
   }, [])
 
-  const instance = useSanityInstance(datasetHandle)
+  const instance = useSanityInstance()
   useEffect(() => {
     return subscribeDocumentEvents(instance, {
       eventHandler: stableHandler,

--- a/packages/react/src/hooks/document/useDocumentPermissions.test.tsx
+++ b/packages/react/src/hooks/document/useDocumentPermissions.test.tsx
@@ -1,8 +1,9 @@
 import {type DocumentAction, type DocumentPermissionsResult, getPermissionsState} from '@sanity/sdk'
-import {act, renderHook, waitFor} from '@testing-library/react'
+import {renderHook as reactRenderHook} from '@testing-library/react'
 import {BehaviorSubject, firstValueFrom, Observable} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
+import {act, renderHook, waitFor} from '../../../test/test-utils'
 import {ResourceProvider} from '../../context/ResourceProvider'
 import {useDocumentPermissions} from './useDocumentPermissions'
 
@@ -24,12 +25,12 @@ vi.mock('rxjs', async (importOriginal) => {
 })
 
 describe('usePermissions', () => {
+  const mockResource = {projectId: 'project1', dataset: 'dataset1'}
   const mockAction: DocumentAction = {
     type: 'document.publish',
     documentId: 'doc1',
     documentType: 'article',
-    projectId: 'project1',
-    dataset: 'dataset1',
+    resource: mockResource,
   }
 
   const mockPermissionAllowed: DocumentPermissionsResult = {allowed: true}
@@ -85,20 +86,13 @@ describe('usePermissions', () => {
       permissionsSubject.next(mockPermissionAllowed)
     })
 
-    const {result} = renderHook(() => useDocumentPermissions(mockAction), {
-      wrapper: ({children}) => (
-        <ResourceProvider
-          projectId={mockAction.projectId}
-          dataset={mockAction.dataset}
-          fallback={null}
-        >
-          {children}
-        </ResourceProvider>
-      ),
-    })
+    const {result} = renderHook(() => useDocumentPermissions(mockAction))
 
     // ResourceProvider handles the instance configuration
-    expect(getPermissionsState).toHaveBeenCalledWith(expect.any(Object), {actions: [mockAction]})
+    expect(getPermissionsState).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({actions: [mockAction], resource: mockResource}),
+    )
     expect(result.current).toEqual(mockPermissionAllowed)
   })
 
@@ -108,17 +102,7 @@ describe('usePermissions', () => {
       permissionsSubject.next(mockPermissionDenied)
     })
 
-    const {result} = renderHook(() => useDocumentPermissions(mockAction), {
-      wrapper: ({children}) => (
-        <ResourceProvider
-          projectId={mockAction.projectId}
-          dataset={mockAction.dataset}
-          fallback={null}
-        >
-          {children}
-        </ResourceProvider>
-      ),
-    })
+    const {result} = renderHook(() => useDocumentPermissions(mockAction))
 
     expect(result.current).toEqual(mockPermissionDenied)
     expect(result.current.allowed).toBe(false)
@@ -129,92 +113,45 @@ describe('usePermissions', () => {
   it('should accept an array of actions', () => {
     const actions = [mockAction, {...mockAction, documentId: 'doc2'}]
 
-    renderHook(() => useDocumentPermissions(actions), {
-      wrapper: ({children}) => (
-        <ResourceProvider
-          projectId={mockAction.projectId}
-          dataset={mockAction.dataset}
-          fallback={null}
-        >
-          {children}
-        </ResourceProvider>
-      ),
-    })
+    renderHook(() => useDocumentPermissions(actions))
 
-    expect(getPermissionsState).toHaveBeenCalledWith(expect.any(Object), {actions})
-  })
-
-  it('should throw an error if actions have mismatched project IDs', () => {
-    const actions = [
-      mockAction,
-      {...mockAction, projectId: 'different-project', documentId: 'doc2'},
-    ]
-
-    expect(() => {
-      renderHook(() => useDocumentPermissions(actions), {
-        wrapper: ({children}) => (
-          <ResourceProvider
-            projectId={mockAction.projectId}
-            dataset={mockAction.dataset}
-            fallback={null}
-          >
-            {children}
-          </ResourceProvider>
-        ),
-      })
-    }).toThrow(/Mismatched project IDs found in actions/)
-  })
-
-  it('should throw an error if actions have mismatched datasets', () => {
-    const actions = [mockAction, {...mockAction, dataset: 'different-dataset', documentId: 'doc2'}]
-
-    expect(() => {
-      renderHook(() => useDocumentPermissions(actions), {
-        wrapper: ({children}) => (
-          <ResourceProvider
-            projectId={mockAction.projectId}
-            dataset={mockAction.dataset}
-            fallback={null}
-          >
-            {children}
-          </ResourceProvider>
-        ),
-      })
-    }).toThrow(/Mismatched datasets found in actions/)
+    expect(getPermissionsState).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({actions, resource: mockResource}),
+    )
   })
 
   it('should throw an error if actions have mismatched resources', () => {
     const actions = [
+      mockAction,
       {
-        type: 'document.publish' as const,
-        documentId: 'doc1',
-        documentType: 'article',
-        resource: {projectId: 'p1', dataset: 'd1'},
-      },
-      {
-        type: 'document.publish' as const,
+        ...mockAction,
+        resource: {projectId: 'different-project', dataset: 'dataset1'},
         documentId: 'doc2',
-        documentType: 'article',
-        resource: {projectId: 'p2', dataset: 'd2'},
       },
     ]
 
     expect(() => {
-      renderHook(() => useDocumentPermissions(actions), {
-        wrapper: ({children}) => (
-          <ResourceProvider
-            projectId={mockAction.projectId}
-            dataset={mockAction.dataset}
-            fallback={null}
-          >
-            {children}
-          </ResourceProvider>
-        ),
-      })
+      renderHook(() => useDocumentPermissions(actions))
     }).toThrow(/Mismatched resources found in actions/)
   })
 
-  it('should throw an error when mixing projectId and resource (projectId first)', () => {
+  it('should throw an error if actions have mismatched datasets', () => {
+    const actions = [
+      mockAction,
+      {
+        ...mockAction,
+        resource: {projectId: 'project1', dataset: 'different-dataset'},
+        documentId: 'doc2',
+      },
+    ]
+
+    expect(() => {
+      renderHook(() => useDocumentPermissions(actions))
+    }).toThrow(/Mismatched resources found in actions/)
+  })
+
+  it('should throw an error when mixing different resources', () => {
     const actions = [
       mockAction,
       {
@@ -226,44 +163,8 @@ describe('usePermissions', () => {
     ]
 
     expect(() => {
-      renderHook(() => useDocumentPermissions(actions), {
-        wrapper: ({children}) => (
-          <ResourceProvider
-            projectId={mockAction.projectId}
-            dataset={mockAction.dataset}
-            fallback={null}
-          >
-            {children}
-          </ResourceProvider>
-        ),
-      })
-    }).toThrow(/Mismatches between projectId\/dataset options and resource/)
-  })
-
-  it('should throw an error when mixing resource and projectId (resource first)', () => {
-    const actions = [
-      {
-        type: 'document.publish' as const,
-        documentId: 'doc1',
-        documentType: 'article',
-        resource: {projectId: 'p', dataset: 'd'},
-      },
-      mockAction,
-    ]
-
-    expect(() => {
-      renderHook(() => useDocumentPermissions(actions), {
-        wrapper: ({children}) => (
-          <ResourceProvider
-            projectId={mockAction.projectId}
-            dataset={mockAction.dataset}
-            fallback={null}
-          >
-            {children}
-          </ResourceProvider>
-        ),
-      })
-    }).toThrow(/Mismatches between projectId\/dataset options and resource/)
+      renderHook(() => useDocumentPermissions(actions))
+    }).toThrow(/Mismatched resources found in actions/)
   })
 
   it('should wait for permissions to be ready before rendering', async () => {
@@ -277,7 +178,7 @@ describe('usePermissions', () => {
     vi.mocked(firstValueFrom).mockReturnValueOnce(mockPromise)
 
     // This should throw the promise and suspend
-    const {result} = renderHook(
+    const {result} = reactRenderHook(
       () => {
         try {
           return useDocumentPermissions(mockAction)
@@ -290,11 +191,7 @@ describe('usePermissions', () => {
       },
       {
         wrapper: ({children}) => (
-          <ResourceProvider
-            projectId={mockAction.projectId}
-            dataset={mockAction.dataset}
-            fallback={null}
-          >
+          <ResourceProvider resource={mockResource} fallback={null}>
             {children}
           </ResourceProvider>
         ),
@@ -310,8 +207,29 @@ describe('usePermissions', () => {
 
     // Now it should render properly
     await waitFor(() => {
-      expect(getPermissionsState).toHaveBeenCalledWith(expect.any(Object), {actions: [mockAction]})
+      expect(getPermissionsState).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({actions: [mockAction], resource: mockResource}),
+      )
     })
+  })
+
+  it('throws when no resource is found from action or context', () => {
+    // Provide SanityInstance via ResourceProvider but no resource, so contextResource is undefined
+    expect(() => {
+      reactRenderHook(
+        () =>
+          useDocumentPermissions({
+            type: 'document.publish',
+            documentId: 'doc1',
+            documentType: 'article',
+            // no resource
+          } as never),
+        {
+          wrapper: ({children}) => <ResourceProvider fallback={null}>{children}</ResourceProvider>,
+        },
+      )
+    }).toThrow(/No resource found/)
   })
 
   it('should react to permission state changes', async () => {
@@ -320,17 +238,7 @@ describe('usePermissions', () => {
       permissionsSubject.next(mockPermissionAllowed)
     })
 
-    const {result, rerender} = renderHook(() => useDocumentPermissions(mockAction), {
-      wrapper: ({children}) => (
-        <ResourceProvider
-          projectId={mockAction.projectId}
-          dataset={mockAction.dataset}
-          fallback={null}
-        >
-          {children}
-        </ResourceProvider>
-      ),
-    })
+    const {result, rerender} = renderHook(() => useDocumentPermissions(mockAction))
 
     expect(result.current).toEqual(mockPermissionAllowed)
 

--- a/packages/react/src/hooks/document/useDocumentPermissions.ts
+++ b/packages/react/src/hooks/document/useDocumentPermissions.ts
@@ -1,9 +1,19 @@
 import {type DocumentAction, type DocumentPermissionsResult, getPermissionsState} from '@sanity/sdk'
-import {useCallback, useMemo, useSyncExternalStore} from 'react'
+import {isDeepEqual} from '@sanity/sdk/_internal'
+import {useCallback, useContext, useMemo, useSyncExternalStore} from 'react'
 import {filter, firstValueFrom} from 'rxjs'
 
+import {ResourceContext} from '../../context/DefaultResourceContext'
+import {ResourcesContext} from '../../context/ResourcesContext'
 import {useSanityInstance} from '../context/useSanityInstance'
+import {
+  normalizeResourceOptions,
+  type WithResourceNameSupport,
+} from '../helpers/useNormalizedResourceOptions'
 import {trackHookUsage} from '../helpers/useTrackHookUsage'
+
+const noopSubscribe = () => () => {}
+const returnUndefined = () => undefined
 
 /**
  *
@@ -83,74 +93,91 @@ import {trackHookUsage} from '../helpers/useTrackHookUsage'
  * ```
  */
 export function useDocumentPermissions(
-  actionOrActions: DocumentAction | DocumentAction[],
+  actionOrActions:
+    | WithResourceNameSupport<DocumentAction>
+    | WithResourceNameSupport<DocumentAction>[],
 ): DocumentPermissionsResult {
-  const actions = useMemo(
-    () => (Array.isArray(actionOrActions) ? actionOrActions : [actionOrActions]),
-    [actionOrActions],
-  )
-  // if actions is an array, we need to check that all actions belong to the same project and dataset
-  let projectId
-  let dataset
-  let resource
+  const instance = useSanityInstance()
+  trackHookUsage(instance, 'useDocumentPermissions')
+  const contextResource = useContext(ResourceContext)
+  const resources = useContext(ResourcesContext)
 
-  for (const action of actions) {
-    if (action.projectId) {
-      if (resource) {
-        throw new Error(
-          `Mismatches between projectId/dataset options and resource in actions. Found projectId "${action.projectId}" and dataset "${action.dataset}" but expected resource "${resource}".`,
+  const {
+    actions: normalizedActions,
+    resource: actionResource,
+    error: validationError,
+  } = useMemo(() => {
+    const normalized = Array.isArray(actionOrActions)
+      ? actionOrActions.map((action) =>
+          normalizeResourceOptions(action, resources, contextResource),
         )
-      }
-      if (!projectId) projectId = action.projectId
-      if (action.projectId !== projectId) {
-        throw new Error(
-          `Mismatched project IDs found in actions. All actions must belong to the same project. Found "${action.projectId}" but expected "${projectId}".`,
-        )
-      }
+      : [normalizeResourceOptions(actionOrActions, resources, contextResource)]
 
-      if (action.dataset) {
-        if (!dataset) dataset = action.dataset
-        if (action.dataset !== dataset) {
-          throw new Error(
-            `Mismatched datasets found in actions. All actions must belong to the same dataset. Found "${action.dataset}" but expected "${dataset}".`,
-          )
+    let resource
+    for (const action of normalized) {
+      if (action.resource) {
+        if (!resource) resource = action.resource
+        if (!isDeepEqual(action.resource, resource)) {
+          return {
+            actions: normalized,
+            resource,
+            error: new Error(
+              `Mismatched resources found in actions. All actions must belong to the same resource. Found "${JSON.stringify(action.resource)}" but expected "${JSON.stringify(resource)}".`,
+            ),
+          }
         }
       }
     }
+    return {actions: normalized, resource, error: undefined}
+  }, [actionOrActions, resources, contextResource])
 
-    if (action.resource) {
-      if (!resource) resource = action.resource
-      if (action.resource !== resource) {
-        throw new Error(
-          `Mismatched resources found in actions. All actions must belong to the same resource. Found "${action.resource}" but expected "${resource}".`,
-        )
-      }
-      if (projectId || dataset) {
-        throw new Error(
-          `Mismatches between projectId/dataset options and resource in actions. Found "${action.resource}" but expected project "${projectId}" and dataset "${dataset}".`,
-        )
-      }
-    }
-  }
+  const effectiveResource = actionResource ?? contextResource
 
-  const instance = useSanityInstance({projectId, dataset})
-  trackHookUsage(instance, 'useDocumentPermissions')
-  const isDocumentReady = useCallback(
-    () => getPermissionsState(instance, {actions}).getCurrent() !== undefined,
-    [actions, instance],
+  // Keep hooks unconditional — validation errors and missing-resource errors are
+  // thrown after all hooks so that the hook call count stays stable across renders.
+  const permissionsOptions = useMemo(
+    () =>
+      effectiveResource
+        ? {
+            resource: effectiveResource,
+            // `Omit<>` on `DocumentAction` loses the discriminant; runtime values are still actions.
+            actions: normalizedActions as DocumentAction[],
+          }
+        : undefined,
+    [effectiveResource, normalizedActions],
   )
+
+  const isDocumentReady = useCallback(
+    () =>
+      permissionsOptions !== undefined &&
+      getPermissionsState(instance, permissionsOptions).getCurrent() !== undefined,
+    [permissionsOptions, instance],
+  )
+
+  const stateSource = useMemo(
+    () => (permissionsOptions ? getPermissionsState(instance, permissionsOptions) : undefined),
+    [permissionsOptions, instance],
+  )
+
+  const result = useSyncExternalStore(
+    stateSource?.subscribe ?? noopSubscribe,
+    stateSource?.getCurrent ?? returnUndefined,
+  )
+
+  // All hooks have been called — safe to throw now.
+  if (validationError) throw validationError
+  if (!effectiveResource) {
+    throw new Error(
+      'No resource found. Provide a resource via the action handle or wrap with a resource context.',
+    )
+  }
   if (!isDocumentReady()) {
     throw firstValueFrom(
-      getPermissionsState(instance, {actions}).observable.pipe(
-        filter((result) => result !== undefined),
+      getPermissionsState(instance, permissionsOptions!).observable.pipe(
+        filter((permissions) => permissions !== undefined),
       ),
     )
   }
 
-  const {subscribe, getCurrent} = useMemo(
-    () => getPermissionsState(instance, {actions}),
-    [actions, instance],
-  )
-
-  return useSyncExternalStore(subscribe, getCurrent) as DocumentPermissionsResult
+  return result as DocumentPermissionsResult
 }

--- a/packages/react/src/hooks/document/useDocumentPermissions.ts
+++ b/packages/react/src/hooks/document/useDocumentPermissions.ts
@@ -3,11 +3,11 @@ import {isDeepEqual} from '@sanity/sdk/_internal'
 import {useCallback, useContext, useMemo, useSyncExternalStore} from 'react'
 import {filter, firstValueFrom} from 'rxjs'
 
-import {ResourceContext} from '../../context/DefaultResourceContext'
 import {ResourcesContext} from '../../context/ResourcesContext'
 import {useSanityInstance} from '../context/useSanityInstance'
 import {
   normalizeResourceOptions,
+  useEffectiveContextResource,
   type WithResourceNameSupport,
 } from '../helpers/useNormalizedResourceOptions'
 import {trackHookUsage} from '../helpers/useTrackHookUsage'
@@ -99,7 +99,7 @@ export function useDocumentPermissions(
 ): DocumentPermissionsResult {
   const instance = useSanityInstance()
   trackHookUsage(instance, 'useDocumentPermissions')
-  const contextResource = useContext(ResourceContext)
+  const effectiveContextResource = useEffectiveContextResource()
   const resources = useContext(ResourcesContext)
 
   const {
@@ -109,9 +109,9 @@ export function useDocumentPermissions(
   } = useMemo(() => {
     const normalized = Array.isArray(actionOrActions)
       ? actionOrActions.map((action) =>
-          normalizeResourceOptions(action, resources, contextResource),
+          normalizeResourceOptions(action, resources, effectiveContextResource),
         )
-      : [normalizeResourceOptions(actionOrActions, resources, contextResource)]
+      : [normalizeResourceOptions(actionOrActions, resources, effectiveContextResource)]
 
     let resource
     for (const action of normalized) {
@@ -129,9 +129,9 @@ export function useDocumentPermissions(
       }
     }
     return {actions: normalized, resource, error: undefined}
-  }, [actionOrActions, resources, contextResource])
+  }, [actionOrActions, resources, effectiveContextResource])
 
-  const effectiveResource = actionResource ?? contextResource
+  const effectiveResource = actionResource ?? effectiveContextResource
 
   // Keep hooks unconditional — validation errors and missing-resource errors are
   // thrown after all hooks so that the hook call count stays stable across renders.
@@ -147,16 +147,14 @@ export function useDocumentPermissions(
     [effectiveResource, normalizedActions],
   )
 
-  const isDocumentReady = useCallback(
-    () =>
-      permissionsOptions !== undefined &&
-      getPermissionsState(instance, permissionsOptions).getCurrent() !== undefined,
-    [permissionsOptions, instance],
-  )
-
   const stateSource = useMemo(
     () => (permissionsOptions ? getPermissionsState(instance, permissionsOptions) : undefined),
     [permissionsOptions, instance],
+  )
+
+  const isDocumentReady = useCallback(
+    () => stateSource !== undefined && stateSource.getCurrent() !== undefined,
+    [stateSource],
   )
 
   const result = useSyncExternalStore(
@@ -173,9 +171,7 @@ export function useDocumentPermissions(
   }
   if (!isDocumentReady()) {
     throw firstValueFrom(
-      getPermissionsState(instance, permissionsOptions!).observable.pipe(
-        filter((permissions) => permissions !== undefined),
-      ),
+      stateSource!.observable.pipe(filter((permissions) => permissions !== undefined)),
     )
   }
 

--- a/packages/react/src/hooks/document/useEditDocument.test.tsx
+++ b/packages/react/src/hooks/document/useEditDocument.test.tsx
@@ -7,10 +7,9 @@ import {
   type StateSource,
 } from '@sanity/sdk'
 import {type SanityDocument} from '@sanity/types'
-import {renderHook} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {ResourceProvider} from '../../context/ResourceProvider'
+import {renderHook} from '../../../test/test-utils'
 import {useApplyDocumentActions} from './useApplyDocumentActions'
 import {useEditDocument} from './useEditDocument'
 
@@ -41,6 +40,11 @@ const docHandle = createDocumentHandle({
   documentId: 'doc1',
   documentType: 'book',
 })
+
+const normalizedDoc = {
+  ...docHandle,
+  resource: {projectId: 'test', dataset: 'test'},
+}
 
 // Define a single generic TestDocument type
 interface Book extends SanityDocument {
@@ -76,16 +80,10 @@ describe('useEditDocument hook', () => {
     const apply = vi.fn().mockResolvedValue({transactionId: 'tx1'})
     vi.mocked(useApplyDocumentActions).mockReturnValue(apply)
 
-    const {result} = renderHook(() => useEditDocument<string>({...docHandle, path: 'foo'}), {
-      wrapper: ({children}) => (
-        <ResourceProvider projectId="test-project" dataset="test-dataset" fallback={null}>
-          {children}
-        </ResourceProvider>
-      ),
-    })
+    const {result} = renderHook(() => useEditDocument<string>({...docHandle, path: 'foo'}))
     const promise = result.current('newValue')
-    expect(editDocument).toHaveBeenCalledWith(docHandle, {set: {foo: 'newValue'}})
-    expect(apply).toHaveBeenCalledWith(editDocument(docHandle, {set: {foo: 'newValue'}}))
+    expect(editDocument).toHaveBeenCalledWith(normalizedDoc, {set: {foo: 'newValue'}})
+    expect(apply).toHaveBeenCalledWith(editDocument(normalizedDoc, {set: {foo: 'newValue'}}))
     const actionsResult = await promise
     expect(actionsResult).toEqual({transactionId: 'tx1'})
   })
@@ -103,15 +101,9 @@ describe('useEditDocument hook', () => {
     const apply = vi.fn().mockResolvedValue({transactionId: 'tx2'})
     vi.mocked(useApplyDocumentActions).mockReturnValue(apply)
 
-    const {result} = renderHook(() => useEditDocument(docHandle), {
-      wrapper: ({children}) => (
-        <ResourceProvider projectId="test-project" dataset="test-dataset" fallback={null}>
-          {children}
-        </ResourceProvider>
-      ),
-    })
+    const {result} = renderHook(() => useEditDocument(docHandle))
     const promise = result.current({...doc, foo: 'baz', extra: 'old', _id: 'doc1'})
-    expect(apply).toHaveBeenCalledWith([editDocument(docHandle, {set: {foo: 'baz'}})])
+    expect(apply).toHaveBeenCalledWith([editDocument(normalizedDoc, {set: {foo: 'baz'}})])
     const actionsResult = await promise
     expect(actionsResult).toEqual({transactionId: 'tx2'})
   })
@@ -127,16 +119,10 @@ describe('useEditDocument hook', () => {
     const apply = vi.fn().mockResolvedValue({transactionId: 'tx3'})
     vi.mocked(useApplyDocumentActions).mockReturnValue(apply)
 
-    const {result} = renderHook(() => useEditDocument<string>({...docHandle, path: 'foo'}), {
-      wrapper: ({children}) => (
-        <ResourceProvider projectId="test-project" dataset="test-dataset" fallback={null}>
-          {children}
-        </ResourceProvider>
-      ),
-    })
+    const {result} = renderHook(() => useEditDocument<string>({...docHandle, path: 'foo'}))
     const promise = result.current((prev: unknown) => `${prev}Updated`) // 'bar' becomes 'barUpdated'
-    expect(editDocument).toHaveBeenCalledWith(docHandle, {set: {foo: 'barUpdated'}})
-    expect(apply).toHaveBeenCalledWith(editDocument(docHandle, {set: {foo: 'barUpdated'}}))
+    expect(editDocument).toHaveBeenCalledWith(normalizedDoc, {set: {foo: 'barUpdated'}})
+    expect(apply).toHaveBeenCalledWith(editDocument(normalizedDoc, {set: {foo: 'barUpdated'}}))
     const actionsResult = await promise
     expect(actionsResult).toEqual({transactionId: 'tx3'})
   })
@@ -153,15 +139,9 @@ describe('useEditDocument hook', () => {
     const apply = vi.fn().mockResolvedValue({transactionId: 'tx4'})
     vi.mocked(useApplyDocumentActions).mockReturnValue(apply)
 
-    const {result} = renderHook(() => useEditDocument(docHandle), {
-      wrapper: ({children}) => (
-        <ResourceProvider projectId="test-project" dataset="test-dataset" fallback={null}>
-          {children}
-        </ResourceProvider>
-      ),
-    })
-    const promise = result.current((prevDoc) => ({...prevDoc, foo: 'baz'}))
-    expect(apply).toHaveBeenCalledWith([editDocument(docHandle, {set: {foo: 'baz'}})])
+    const {result} = renderHook(() => useEditDocument(docHandle))
+    const promise = result.current((prevDoc: Book) => ({...prevDoc, foo: 'baz'}))
+    expect(apply).toHaveBeenCalledWith([editDocument(normalizedDoc, {set: {foo: 'baz'}})])
     const actionsResult = await promise
     expect(actionsResult).toEqual({transactionId: 'tx4'})
   })
@@ -177,13 +157,7 @@ describe('useEditDocument hook', () => {
     const fakeApply = vi.fn()
     vi.mocked(useApplyDocumentActions).mockReturnValue(fakeApply)
 
-    const {result} = renderHook(() => useEditDocument(docHandle), {
-      wrapper: ({children}) => (
-        <ResourceProvider projectId="test-project" dataset="test-dataset" fallback={null}>
-          {children}
-        </ResourceProvider>
-      ),
-    })
+    const {result} = renderHook(() => useEditDocument(docHandle))
     expect(() => result.current('notAnObject' as unknown as Book)).toThrowError(
       'No path was provided to `useEditDocument` and the value provided was not a document object.',
     )
@@ -203,22 +177,13 @@ describe('useEditDocument hook', () => {
     vi.mocked(resolveDocument).mockReturnValue(resolveDocPromise)
 
     // Render the hook and capture the thrown promise.
-    const {result} = renderHook(
-      () => {
-        try {
-          return useEditDocument(docHandle)
-        } catch (e) {
-          return e
-        }
-      },
-      {
-        wrapper: ({children}) => (
-          <ResourceProvider projectId="test-project" dataset="test-dataset" fallback={null}>
-            {children}
-          </ResourceProvider>
-        ),
-      },
-    )
+    const {result} = renderHook(() => {
+      try {
+        return useEditDocument(docHandle)
+      } catch (e) {
+        return e
+      }
+    })
 
     // When the document is not ready, the hook throws the promise from resolveDocument.
     expect(result.current).toBe(resolveDocPromise)

--- a/packages/react/src/hooks/document/useEditDocument.ts
+++ b/packages/react/src/hooks/document/useEditDocument.ts
@@ -286,7 +286,7 @@ export function useEditDocument({
   path,
   ...doc
 }: DocumentOptions<string | undefined>): (updater: Updater<unknown>) => Promise<ActionsResult> {
-  const instance = useSanityInstance(doc)
+  const instance = useSanityInstance()
   trackHookUsage(instance, 'useEditDocument')
   const normalizedDoc = useNormalizedResourceOptions(doc)
 

--- a/packages/react/src/hooks/documents/useDocuments.ts
+++ b/packages/react/src/hooks/documents/useDocuments.ts
@@ -286,7 +286,7 @@ export function useDocuments<
       ...params,
       // these are passed back to the user as part of each document handle
       __handle: {
-        // keep projectId/dataset for backward compat until v3; resource is added
+        // keep projectId/dataset for backward compat until v4; resource is added
         // intentionally so that hook consumers can resolve the correct resource
         ...(options.resource && isDatasetResource(options.resource)
           ? pickProperties(options.resource, ['projectId', 'dataset'])

--- a/packages/react/src/hooks/documents/useDocuments.ts
+++ b/packages/react/src/hooks/documents/useDocuments.ts
@@ -1,13 +1,15 @@
 import {
   createGroqSearchFilter,
-  type DatasetHandle,
   type DocumentHandle,
+  isDatasetResource,
   type QueryOptions,
 } from '@sanity/sdk'
+import {pickProperties} from '@sanity/sdk/_internal'
 import {type SortOrderingItem} from '@sanity/types'
 import {useCallback, useMemo, useState} from 'react'
 
-import {useSanityInstance} from '../context/useSanityInstance'
+import {type ResourceHandle} from '../../config/handles'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
 import {useTrackHookUsage} from '../helpers/useTrackHookUsage'
 import {useQuery} from '../query/useQuery'
 
@@ -24,7 +26,7 @@ export interface DocumentsOptions<
   TDataset extends string = string,
   TProjectId extends string = string,
 >
-  extends DatasetHandle<TDataset, TProjectId>, Pick<QueryOptions, 'perspective' | 'params'> {
+  extends ResourceHandle<TDataset, TProjectId>, Pick<QueryOptions, 'perspective' | 'params'> {
   /**
    * Filter documents by their `_type`. Can be a single type or an array of types.
    */
@@ -201,14 +203,14 @@ export function useDocuments<
   filter,
   orderings,
   documentType,
-  ...options
+  ...rawOptions
 }: DocumentsOptions<TDocumentType, TDataset, TProjectId>): DocumentsResponse<
   TDocumentType,
   TDataset,
   TProjectId
 > {
   useTrackHookUsage('useDocuments')
-  const instance = useSanityInstance(options)
+  const options = useNormalizedResourceOptions(rawOptions)
   const [limit, setLimit] = useState(batchSize)
   const documentTypes = useMemo(
     () =>
@@ -284,9 +286,12 @@ export function useDocuments<
       ...params,
       // these are passed back to the user as part of each document handle
       __handle: {
-        projectId: options.projectId ?? instance.config.projectId,
-        dataset: options.dataset ?? instance.config.dataset,
-        perspective: options.perspective ?? instance.config.perspective,
+        // keep projectId/dataset for backward compat until v3; resource is added
+        // intentionally so that hook consumers can resolve the correct resource
+        ...(options.resource && isDatasetResource(options.resource)
+          ? pickProperties(options.resource, ['projectId', 'dataset'])
+          : {}),
+        ...pickProperties(options, ['perspective', 'resource']),
       },
       __types: documentTypes,
     },

--- a/packages/react/src/hooks/helpers/createStateSourceHook.tsx
+++ b/packages/react/src/hooks/helpers/createStateSourceHook.tsx
@@ -19,11 +19,10 @@ export function createStateSourceHook<TParams extends unknown[], TState>(
   options: StateSourceFactory<TParams, TState> | CreateStateSourceHookOptions<TParams, TState>,
 ): (...params: TParams) => TState {
   const getState = typeof options === 'function' ? options : options.getState
-  const getConfig = 'getConfig' in options ? options.getConfig : undefined
   const suspense = 'shouldSuspend' in options && 'suspender' in options ? options : undefined
 
   function useHook(...params: TParams) {
-    const instance = useSanityInstance(getConfig?.(...params))
+    const instance = useSanityInstance()
 
     if (suspense?.suspender && suspense?.shouldSuspend?.(instance, ...params)) {
       throw suspense.suspender(instance, ...params)

--- a/packages/react/src/hooks/helpers/useNormalizedResourceOptions.ts
+++ b/packages/react/src/hooks/helpers/useNormalizedResourceOptions.ts
@@ -1,5 +1,5 @@
 import {type DocumentResource, type PerspectiveHandle} from '@sanity/sdk'
-import {useContext} from 'react'
+import {useContext, useMemo} from 'react'
 
 import {ResourceContext} from '../../context/DefaultResourceContext'
 import {PerspectiveContext} from '../../context/PerspectiveContext'
@@ -112,6 +112,25 @@ export function normalizeResourceOptions<
 }
 
 /**
+ * Returns the effective context resource: the `ResourceContext` value if set,
+ * otherwise a resource synthesized from the current `SanityInstance` config
+ * (tier-d fallback — returns `undefined` for studio-style configs with no project).
+ *
+ * @internal
+ */
+export function useEffectiveContextResource(): DocumentResource | undefined {
+  const contextResource = useContext(ResourceContext)
+  const instance = useContext(SanityInstanceContext)
+  const {projectId, dataset} = instance?.config ?? {}
+
+  return useMemo(() => {
+    if (contextResource) return contextResource
+    if (projectId && dataset) return {projectId, dataset}
+    return undefined
+  }, [contextResource, projectId, dataset])
+}
+
+/**
  * Normalizes hook options by resolving `resourceName` to a `DocumentResource`.
  *
  * Resolution priority for resource:
@@ -138,19 +157,8 @@ export function useNormalizedResourceOptions<
   },
 >(options: T): Omit<T, NormalizedResourceFields> {
   const resources = useContext(ResourcesContext)
-  const contextResource = useContext(ResourceContext)
+  const effectiveContextResource = useEffectiveContextResource()
   const contextPerspective = useContext(PerspectiveContext)
-  const instance = useContext(SanityInstanceContext)
-
-  // Tier (d): instance config fallback — synthesize resource from projectId/dataset
-  // when the higher tiers all come up empty
-  let effectiveContextResource = contextResource
-  if (!effectiveContextResource && instance) {
-    const {projectId, dataset} = instance.config
-    if (projectId && dataset) {
-      effectiveContextResource = {projectId, dataset}
-    }
-  }
 
   return normalizeResourceOptions(options, resources, effectiveContextResource, contextPerspective)
 }

--- a/packages/react/src/hooks/helpers/useNormalizedResourceOptions.ts
+++ b/packages/react/src/hooks/helpers/useNormalizedResourceOptions.ts
@@ -1,14 +1,18 @@
-import {type DocumentResource} from '@sanity/sdk'
+import {type DocumentResource, type PerspectiveHandle} from '@sanity/sdk'
 import {useContext} from 'react'
 
+import {ResourceContext} from '../../context/DefaultResourceContext'
+import {PerspectiveContext} from '../../context/PerspectiveContext'
 import {ResourcesContext} from '../../context/ResourcesContext'
+import {SanityInstanceContext} from '../../context/SanityInstanceContext'
+
+type NormalizedResourceFields = 'resourceName' | 'source' | 'sourceName' | 'projectId' | 'dataset'
 
 /**
  * Adds React hook support (resourceName resolution) to core types.
- * This wrapper allows hooks to accept `resourceName` as a convenience,
- * which is then resolved to a `DocumentResource` at the React layer.
- * For now, we are trying to avoid resource name resolution in core --
- * functions having resources explicitly passed will reduce complexity.
+ * Prefer using the React-layer handle types (ResourceHandle, DocumentHandle)
+ * from `@sanity/sdk-react` — this wrapper is kept for cases where overloads
+ * don't fit (e.g. non-handle options objects).
  *
  * @typeParam T - The core type to extend (must have optional `resource` field)
  * @beta
@@ -35,6 +39,8 @@ export type WithResourceNameSupport<T extends {resource?: DocumentResource}> = T
  * @typeParam T - The options type (must include optional resource field)
  * @param options - Options that may include `resourceName` and/or `resource`
  * @param resources - Map of resource names to DocumentResource (e.g. from ResourcesContext)
+ * @param contextResource - Resource from context (from ResourceContext)
+ * @param contextPerspective - Perspective from context (from PerspectiveContext)
  * @returns Normalized options with `resourceName` removed and `resource` resolved
  * @internal
  */
@@ -44,25 +50,23 @@ export function normalizeResourceOptions<
     resourceName?: string
     source?: DocumentResource
     sourceName?: string
+    projectId?: string
+    dataset?: string
+    perspective?: unknown
   },
 >(
   options: T,
   resources: Record<string, DocumentResource>,
-): Omit<T, 'resourceName' | 'source' | 'sourceName'> {
-  const {resourceName, sourceName, source, ...rest} = options
+  contextResource?: DocumentResource,
+  contextPerspective?: PerspectiveHandle['perspective'],
+): Omit<T, NormalizedResourceFields> {
+  const {resourceName, sourceName, source, projectId, dataset, ...rest} = options
 
   // Coalesce deprecated aliases to their canonical equivalents
   const effectiveResourceName = resourceName ?? sourceName
   const effectiveResource = options.resource ?? source
 
-  if (!effectiveResourceName && !effectiveResource) {
-    return rest as Omit<T, 'resourceName' | 'source' | 'sourceName'>
-  }
-
-  const hasNameKey = Object.hasOwn(options, 'resourceName') || Object.hasOwn(options, 'sourceName')
-  const hasResourceKey = Object.hasOwn(options, 'resource') || Object.hasOwn(options, 'source')
-
-  if (hasNameKey && hasResourceKey) {
+  if (effectiveResourceName && effectiveResource) {
     throw new Error(
       `Resource name ${JSON.stringify(effectiveResourceName)} and resource ${JSON.stringify(effectiveResource)} cannot be used together.`,
     )
@@ -70,53 +74,57 @@ export function normalizeResourceOptions<
 
   let resolvedResource: DocumentResource | undefined
 
+  // Tier (a): explicit resource object or resourceName lookup
   if (effectiveResource) {
     resolvedResource = effectiveResource
-  }
-
-  if (effectiveResourceName && !Object.hasOwn(resources, effectiveResourceName)) {
-    throw new Error(
-      `There's no resource named ${JSON.stringify(effectiveResourceName)} in context. Please use <ResourceProvider>.`,
-    )
-  }
-
-  if (effectiveResourceName && resources[effectiveResourceName]) {
+  } else if (effectiveResourceName) {
+    if (!Object.hasOwn(resources, effectiveResourceName)) {
+      throw new Error(
+        `There's no resource named ${JSON.stringify(effectiveResourceName)} in context. Please use <ResourceProvider>.`,
+      )
+    }
     resolvedResource = resources[effectiveResourceName]
   }
 
+  // Tier (b): projectId or dataset in options → synthesize a resource
+  if (!resolvedResource && projectId && dataset) {
+    resolvedResource = {
+      projectId,
+      dataset,
+    }
+  }
+
+  // Tier (c): fall back to whatever ResourceContext provides
+  if (!resolvedResource) {
+    resolvedResource = contextResource
+  }
+
+  // Inject perspective from context when not explicitly provided in options
+  const resolvedPerspective = Object.hasOwn(options, 'perspective')
+    ? options.perspective
+    : contextPerspective
+
   return {
     ...rest,
-    resource: resolvedResource,
+    ...(resolvedResource !== undefined && {resource: resolvedResource}),
+    ...(resolvedPerspective !== undefined && {perspective: resolvedPerspective}),
   }
 }
 
 /**
  * Normalizes hook options by resolving `resourceName` to a `DocumentResource`.
- * This hook ensures that options passed to core layer functions only contain
- * `resource` (never `resourceName`), preventing duplicate cache keys and maintaining
- * clean separation between React and core layers.
  *
- * @typeParam T - The options type (must include optional resource field)
- * @param options - Hook options that may include `resourceName` and/or `resource`
- * @returns Normalized options with `resourceName` removed and `resource` resolved
+ * Resolution priority for resource:
+ * 1. Explicit `resource` or `resourceName` in options
+ * 2. Bare `projectId`/`dataset` pair in options → synthesized into a resource
+ * 3. `ResourceContext` value (set by `ResourceProvider` / `SDKProvider`)
+ * 4. Current `SanityInstance` config — falls back to `undefined` for studio configs
  *
- * @remarks
- * Resolution priority:
- * 1. If `resourceName` is provided, resolves it via `ResourcesContext` and uses that
- * 2. Otherwise, uses the inline `resource` if provided
- * 3. If neither is provided, returns options without a resource field
+ * Resolution priority for perspective:
+ * 1. Explicit `perspective` in options
+ * 2. `PerspectiveContext` value (set by `ResourceProvider`)
  *
- * @example
- * ```tsx
- * function useQuery(options: WithResourceNameSupport<QueryOptions>) {
- *   const instance = useSanityInstance(options)
- *   const normalized = useNormalizedOptions(options)
- *   // normalized now has resource but never resourceName
- *   const queryKey = getQueryKey(normalized)
- * }
- * ```
- *
- * @beta
+ * @internal
  */
 export function useNormalizedResourceOptions<
   T extends {
@@ -124,8 +132,25 @@ export function useNormalizedResourceOptions<
     resourceName?: string
     source?: DocumentResource
     sourceName?: string
+    projectId?: string
+    dataset?: string
+    perspective?: unknown
   },
->(options: T): Omit<T, 'resourceName' | 'source' | 'sourceName'> {
+>(options: T): Omit<T, NormalizedResourceFields> {
   const resources = useContext(ResourcesContext)
-  return normalizeResourceOptions(options, resources)
+  const contextResource = useContext(ResourceContext)
+  const contextPerspective = useContext(PerspectiveContext)
+  const instance = useContext(SanityInstanceContext)
+
+  // Tier (d): instance config fallback — synthesize resource from projectId/dataset
+  // when the higher tiers all come up empty
+  let effectiveContextResource = contextResource
+  if (!effectiveContextResource && instance) {
+    const {projectId, dataset} = instance.config
+    if (projectId && dataset) {
+      effectiveContextResource = {projectId, dataset}
+    }
+  }
+
+  return normalizeResourceOptions(options, resources, effectiveContextResource, contextPerspective)
 }

--- a/packages/react/src/hooks/paginatedDocuments/usePaginatedDocuments.ts
+++ b/packages/react/src/hooks/paginatedDocuments/usePaginatedDocuments.ts
@@ -1,8 +1,17 @@
-import {createGroqSearchFilter, type DocumentHandle, type QueryOptions} from '@sanity/sdk'
+import {
+  createGroqSearchFilter,
+  type DocumentHandle,
+  isDatasetResource,
+  type QueryOptions,
+} from '@sanity/sdk'
+import {pickProperties} from '@sanity/sdk/_internal'
 import {type SortOrderingItem} from '@sanity/types'
 import {useCallback, useMemo, useState} from 'react'
 
-import {useSanityInstance} from '../context/useSanityInstance'
+import {
+  useNormalizedResourceOptions,
+  type WithResourceNameSupport,
+} from '../helpers/useNormalizedResourceOptions'
 import {useTrackHookUsage} from '../helpers/useTrackHookUsage'
 import {useQuery} from '../query/useQuery'
 
@@ -16,7 +25,9 @@ export interface PaginatedDocumentsOptions<
   TDocumentType extends string = string,
   TDataset extends string = string,
   TProjectId extends string = string,
-> extends Omit<QueryOptions<TDocumentType, TDataset, TProjectId>, 'query'> {
+> extends WithResourceNameSupport<
+  Omit<QueryOptions<TDocumentType, TDataset, TProjectId>, 'query'>
+> {
   documentType?: TDocumentType | TDocumentType[]
   /**
    * GROQ filter expression to apply to the query
@@ -232,14 +243,14 @@ export function usePaginatedDocuments<
   params = {},
   orderings,
   search,
-  ...options
+  ...rawOptions
 }: PaginatedDocumentsOptions<TDocumentType, TDataset, TProjectId>): PaginatedDocumentsResponse<
   TDocumentType,
   TDataset,
   TProjectId
 > {
   useTrackHookUsage('usePaginatedDocuments')
-  const instance = useSanityInstance(options)
+  const options = useNormalizedResourceOptions(rawOptions)
   const [pageIndex, setPageIndex] = useState(0)
   const key = JSON.stringify({filter, search, params, orderings, pageSize})
   // Reset pageIndex to 0 whenever any query parameter changes.
@@ -303,9 +314,12 @@ export function usePaginatedDocuments<
       ...params,
       __types: documentTypes,
       __handle: {
-        projectId: options.projectId ?? instance.config.projectId,
-        dataset: options.dataset ?? instance.config.dataset,
-        perspective: options.perspective ?? instance.config.perspective,
+        // keep projectId/dataset for backward compat until v3; resource is added
+        // intentionally so that hook consumers can resolve the correct resource
+        ...(options.resource && isDatasetResource(options.resource)
+          ? pickProperties(options.resource, ['projectId', 'dataset'])
+          : {}),
+        ...pickProperties(options, ['perspective', 'resource']),
       },
     },
   })

--- a/packages/react/src/hooks/paginatedDocuments/usePaginatedDocuments.ts
+++ b/packages/react/src/hooks/paginatedDocuments/usePaginatedDocuments.ts
@@ -252,7 +252,7 @@ export function usePaginatedDocuments<
   useTrackHookUsage('usePaginatedDocuments')
   const options = useNormalizedResourceOptions(rawOptions)
   const [pageIndex, setPageIndex] = useState(0)
-  const key = JSON.stringify({filter, search, params, orderings, pageSize})
+  const key = JSON.stringify({filter, search, params, orderings, pageSize, ...options})
   // Reset pageIndex to 0 whenever any query parameter changes.
   const [prevKey, setPrevKey] = useState(key)
   if (prevKey !== key) {
@@ -314,7 +314,7 @@ export function usePaginatedDocuments<
       ...params,
       __types: documentTypes,
       __handle: {
-        // keep projectId/dataset for backward compat until v3; resource is added
+        // keep projectId/dataset for backward compat until v4; resource is added
         // intentionally so that hook consumers can resolve the correct resource
         ...(options.resource && isDatasetResource(options.resource)
           ? pickProperties(options.resource, ['projectId', 'dataset'])

--- a/packages/react/src/hooks/presence/usePresence.ts
+++ b/packages/react/src/hooks/presence/usePresence.ts
@@ -1,23 +1,16 @@
-import {
-  type DatasetHandle,
-  getPresence,
-  isMediaLibraryResource,
-  type UserPresence,
-} from '@sanity/sdk'
+import {getPresence, isMediaLibraryResource, type UserPresence} from '@sanity/sdk'
 import {useCallback, useMemo, useSyncExternalStore} from 'react'
 
+import {type ResourceHandle} from '../../config/handles'
 import {useSanityInstance} from '../context/useSanityInstance'
-import {
-  useNormalizedResourceOptions,
-  type WithResourceNameSupport,
-} from '../helpers/useNormalizedResourceOptions'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
 import {trackHookUsage} from '../helpers/useTrackHookUsage'
 
 /**
  * A hook for subscribing to presence information for the current project or Canvas.
  * @public
  */
-export function usePresence(options: WithResourceNameSupport<DatasetHandle> = {}): {
+export function usePresence(options: ResourceHandle = {}): {
   locations: UserPresence[]
 } {
   const normalizedOptions = useNormalizedResourceOptions(options)

--- a/packages/react/src/hooks/preview/useDocumentPreview.tsx
+++ b/packages/react/src/hooks/preview/useDocumentPreview.tsx
@@ -1,5 +1,4 @@
 import {
-  type DocumentHandle,
   PREVIEW_PROJECTION,
   type PreviewQueryResult,
   type PreviewValue,
@@ -7,11 +6,9 @@ import {
 } from '@sanity/sdk'
 import {useMemo} from 'react'
 
+import {type DocumentHandle} from '../../config/handles'
 import {useSanityInstance} from '../context/useSanityInstance'
-import {
-  useNormalizedResourceOptions,
-  type WithResourceNameSupport,
-} from '../helpers/useNormalizedResourceOptions'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
 import {trackHookUsage} from '../helpers/useTrackHookUsage'
 import {useDocumentProjection} from '../projection/useDocumentProjection'
 
@@ -19,7 +16,7 @@ import {useDocumentProjection} from '../projection/useDocumentProjection'
  * @public
  * @category Types
  */
-export interface useDocumentPreviewOptions extends WithResourceNameSupport<DocumentHandle> {
+export interface useDocumentPreviewOptions extends DocumentHandle {
   /**
    * Optional ref object to track visibility. When provided, preview resolution
    * only occurs when the referenced element is visible in the viewport.
@@ -98,7 +95,7 @@ export function useDocumentPreview({
   ref,
   ...docHandle
 }: useDocumentPreviewOptions): useDocumentPreviewResults {
-  const instance = useSanityInstance(docHandle)
+  const instance = useSanityInstance()
   trackHookUsage(instance, 'useDocumentPreview')
   const normalizedDocHandle = useNormalizedResourceOptions(docHandle)
 

--- a/packages/react/src/hooks/projection/useDocumentProjection.ts
+++ b/packages/react/src/hooks/projection/useDocumentProjection.ts
@@ -1,13 +1,11 @@
-import {type DocumentHandle, getProjectionState, resolveProjection} from '@sanity/sdk'
+import {getProjectionState, resolveProjection} from '@sanity/sdk'
 import {type SanityProjectionResult} from 'groq'
 import {useCallback, useMemo, useSyncExternalStore} from 'react'
 import {distinctUntilChanged, EMPTY, Observable, startWith, switchMap} from 'rxjs'
 
+import {type DocumentHandle} from '../../config/handles'
 import {useSanityInstance} from '../context/useSanityInstance'
-import {
-  useNormalizedResourceOptions,
-  type WithResourceNameSupport,
-} from '../helpers/useNormalizedResourceOptions'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
 import {trackHookUsage} from '../helpers/useTrackHookUsage'
 
 /**
@@ -19,7 +17,7 @@ export interface useDocumentProjectionOptions<
   TDocumentType extends string = string,
   TDataset extends string = string,
   TProjectId extends string = string,
-> extends WithResourceNameSupport<DocumentHandle<TDocumentType, TDataset, TProjectId>> {
+> extends DocumentHandle<TDocumentType, TDataset, TProjectId> {
   /** The GROQ projection string */
   projection: TProjection
   /** Optional parameters for the projection query */
@@ -181,7 +179,7 @@ export function useDocumentProjection<TData extends object>({
   projection,
   ...docHandle
 }: useDocumentProjectionOptions): useDocumentProjectionResults<TData> {
-  const instance = useSanityInstance(docHandle)
+  const instance = useSanityInstance()
   trackHookUsage(instance, 'useDocumentProjection')
 
   // Normalize projection string to handle template literals with whitespace

--- a/packages/react/src/hooks/query/useQuery.ts
+++ b/packages/react/src/hooks/query/useQuery.ts
@@ -152,7 +152,7 @@ export function useQuery(options: WithResourceNameSupport<QueryOptions>): {
   isPending: boolean
 } {
   // Implementation returns unknown, overloads define specifics
-  const instance = useSanityInstance(options)
+  const instance = useSanityInstance()
   trackHookUsage(instance, 'useQuery')
 
   // Normalize options: resolve resourceName to resource and strip resourceName

--- a/packages/react/src/hooks/releases/useActiveReleases.ts
+++ b/packages/react/src/hooks/releases/useActiveReleases.ts
@@ -2,17 +2,14 @@ import {
   type DocumentResource,
   getActiveReleasesState,
   type ReleaseDocument,
-  type SanityConfig,
   type SanityInstance,
   type StateSource,
 } from '@sanity/sdk'
 import {filter, firstValueFrom} from 'rxjs'
 
+import {type ResourceHandle} from '../../config/handles'
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
-import {
-  useNormalizedResourceOptions,
-  type WithResourceNameSupport,
-} from '../helpers/useNormalizedResourceOptions'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
 
 /**
  * @public
@@ -29,11 +26,11 @@ import {
  * const activeReleases = useActiveReleases()
  * ```
  */
-type UseActiveReleases = {
-  (options?: WithResourceNameSupport<SanityConfig> | undefined): ReleaseDocument[]
+type UseActiveReleasesValue = {
+  (options?: {resource?: DocumentResource}): ReleaseDocument[]
 }
 
-const useActiveReleasesValue: UseActiveReleases = createStateSourceHook({
+const useActiveReleasesValue: UseActiveReleasesValue = createStateSourceHook({
   getState: getActiveReleasesState as (
     instance: SanityInstance,
     options?: {resource?: DocumentResource},
@@ -50,9 +47,7 @@ const useActiveReleasesValue: UseActiveReleases = createStateSourceHook({
  * @public
  * @function
  */
-export const useActiveReleases: UseActiveReleases = (
-  options: WithResourceNameSupport<{resource?: DocumentResource}> | undefined,
-) => {
+export function useActiveReleases(options?: ResourceHandle): ReleaseDocument[] {
   const normalizedOptions = useNormalizedResourceOptions(options ?? {})
   return useActiveReleasesValue(normalizedOptions)
 }

--- a/packages/react/src/hooks/releases/useActiveReleases.ts
+++ b/packages/react/src/hooks/releases/useActiveReleases.ts
@@ -2,14 +2,17 @@ import {
   type DocumentResource,
   getActiveReleasesState,
   type ReleaseDocument,
+  type SanityConfig,
   type SanityInstance,
   type StateSource,
 } from '@sanity/sdk'
 import {filter, firstValueFrom} from 'rxjs'
 
-import {type ResourceHandle} from '../../config/handles'
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
-import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
+import {
+  useNormalizedResourceOptions,
+  type WithResourceNameSupport,
+} from '../helpers/useNormalizedResourceOptions'
 
 /**
  * @public
@@ -47,7 +50,9 @@ const useActiveReleasesValue: UseActiveReleasesValue = createStateSourceHook({
  * @public
  * @function
  */
-export function useActiveReleases(options?: ResourceHandle): ReleaseDocument[] {
+export function useActiveReleases(
+  options?: WithResourceNameSupport<SanityConfig> | undefined,
+): ReleaseDocument[] {
   const normalizedOptions = useNormalizedResourceOptions(options ?? {})
   return useActiveReleasesValue(normalizedOptions)
 }

--- a/packages/react/src/hooks/releases/usePerspective.ts
+++ b/packages/react/src/hooks/releases/usePerspective.ts
@@ -1,5 +1,4 @@
 import {
-  type DatasetHandle,
   type DocumentResource,
   getPerspectiveState,
   type SanityInstance,
@@ -7,11 +6,9 @@ import {
 } from '@sanity/sdk'
 import {filter, firstValueFrom} from 'rxjs'
 
+import {type ResourceHandle} from '../../config/handles'
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
-import {
-  useNormalizedResourceOptions,
-  type WithResourceNameSupport,
-} from '../helpers/useNormalizedResourceOptions'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
 
 /**
  * @public
@@ -35,11 +32,11 @@ import {
  *
  * @returns The perspective for the given perspective handle.
  */
-type UsePerspective = {
-  (perspectiveHandle: DatasetHandle): string | string[]
+type UsePerspectiveValue = {
+  (perspectiveHandle: {resource?: DocumentResource}): string | string[]
 }
 
-const usePerspectiveValue: UsePerspective = createStateSourceHook({
+const usePerspectiveValue: UsePerspectiveValue = createStateSourceHook({
   getState: getPerspectiveState as (
     instance: SanityInstance,
     perspectiveHandle?: {resource?: DocumentResource},
@@ -54,9 +51,7 @@ const usePerspectiveValue: UsePerspective = createStateSourceHook({
  * @public
  * @function
  */
-export const usePerspective: UsePerspective = (
-  options: WithResourceNameSupport<DatasetHandle> | undefined,
-) => {
-  const normalizedOptions = useNormalizedResourceOptions(options ?? {})
+export function usePerspective(perspectiveHandle?: ResourceHandle): string | string[] {
+  const normalizedOptions = useNormalizedResourceOptions(perspectiveHandle ?? {})
   return usePerspectiveValue(normalizedOptions)
 }

--- a/packages/react/src/hooks/users/useUser.ts
+++ b/packages/react/src/hooks/users/useUser.ts
@@ -59,7 +59,7 @@ export interface UserResult {
  * ```
  */
 export function useUser(options: GetUserOptions): UserResult {
-  const instance = useSanityInstance(options)
+  const instance = useSanityInstance()
   trackHookUsage(instance, 'useUser')
   // Use React's useTransition to avoid UI jank when user options change
   const [isPending, startTransition] = useTransition()

--- a/packages/react/src/hooks/users/useUsers.ts
+++ b/packages/react/src/hooks/users/useUsers.ts
@@ -69,7 +69,7 @@ export interface UsersResult {
  * ```
  */
 export function useUsers(options?: GetUsersOptions): UsersResult {
-  const instance = useSanityInstance(options)
+  const instance = useSanityInstance()
   trackHookUsage(instance, 'useUsers')
   // Use React's useTransition to avoid UI jank when user options change
   const [isPending, startTransition] = useTransition()


### PR DESCRIPTION
### Description
This PR takes some of the logic from the old v3 branch in a non-breaking way. In anticipation of not having an instance inheritance system, or the instance as the source of truth for configuration, this PR boosts the resource normalization logic to use resources in context and only rely on the instance configuration as a final step. This will make moving to v4 easier since most instance logic now lives in only a few files.

This doesn't change functionality -- all actions are bound by resources (or otherwise not bound to instance config) so there's no need for finding specific instances.

### What to review
I've noted those places where I made choices that I could use feedback on, but really this is just rearranging parameters. Let me know if there's places I missed or where my logic is wrong.

### Testing
Tests were updated, added, or removed as needed.

### Fun gif
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExeDk2b3psZHJlNGRyZ3I3Z3ppZmtpZ2Z2dDQzdHViMHZyYTVwcnpldCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/utUEJY2cXzVvnrB152/giphy.gif)
