### PR TITLE
feat!: drop support for Node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24]
       fail-fast: false
 
     steps:

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Depcheck
         run: pnpm depcheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Build SDK packages
         run: pnpm build:packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24]
       fail-fast: false
 
     steps:

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Type Check
         run: pnpm ts:check

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Build Docs
         run: pnpm build:docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Before contributing, please read our [code of conduct](https://github.com/sanity
 
 ### Prerequisites
 
-- Node.js: Version 20.x or higher (we recommend using the LTS version)
+- Node.js: Version 22.13 or higher (we recommend using the active LTS version)
 - pnpm: Version 8.x or higher
 
 Check your versions:

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "packageManager": "pnpm@10.8.0",
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.13"
   },
   "pnpm": {
     "overrides": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -99,7 +99,7 @@
   },
   "packageManager": "pnpm@10.8.0",
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.13"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -101,7 +101,7 @@
   },
   "packageManager": "pnpm@10.8.0",
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.13"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### Description

Drops support for Node.js 20, which reached end-of-life on April 30, 2026. Node 22 is now the only Active LTS until Node 24 takes that slot in October 2026. Bringing the SDK's supported runtime in line with upstream avoids shipping fixes against an unsupported runtime and lets downstream tooling we depend on (Vitest 4, jsdom 29, etc.) drop their own Node 20 compatibility shims.

**Breaking change for consumers:** anyone still installing `@sanity/sdk` or `@sanity/sdk-react` on Node 20 will now see an `EBADENGINE` warning (or a hard install failure with `engine-strict=true`). They need to upgrade to Node 22.13 or later. The commit type is `feat!:`, which release-please will pick up as a major bump (both packages move from 2.9.0 → 3.0.0).

What changed:

- `engines.node` floor raised from `>=20.19` to `>=22.13` in `package.json`, `packages/core/package.json`, and `packages/react/package.json`. The 22.13 floor matches what Vitest 4 and jsdom 29 effectively require on the v22 line, so consumers on a properly-supported v22 won't hit a transitive engines mismatch.
- CI matrices for `Test` and `Build` move from `[20, 22]` to `[22, 24]`. The existing `matrix.node-version == 22` conditional in `test.yml` is unchanged, so coverage is still produced on 22 and consumed by `report-coverage`.
- Five single-version workflows (`lint`, `depcheck`, `type-check`, `upload-docs`, `pkg-pr-new`) move from Node 20 to Node 22.
- `CONTRIBUTING.md` prerequisite text updated from "Version 20.x or higher" to "Version 22.13 or higher".

What's intentionally not in this PR:

- `@types/node` stays at `^22.x`. Pinning the lowest supported runtime keeps the typings honest. The Renovate `^24.12.2` major can be taken later if/when we decide to move the floor again.
- `.circleci/config.yml` and `.github/workflows/deploy-kitchensink.yml` are unchanged here. The pending Renovate PR `update node.js to v24.15.0` covers them (CircleCI patch from 24.13.0 → 24.15.0 and the kitchensink deploy from 22.22.0 → 24.15.0) and can land after this one without conflict.
- `release-please.yml` and `release-rc.yml` use `lts/*`, which auto-resolves; no edit needed.
- `bundle-stats.yml` and `e2e.yml` are already on Node 24 / 22 respectively.

> [!IMPORTANT]
> **TODO before merge: update branch protection.**
>
> The "Main ruleset" on `main` (ID `2451995`) currently requires `build (20)` and `test (20)` as status checks. After this PR's matrix swap to `[22, 24]`, those check contexts will never be reported and the PR cannot satisfy required checks.
>
> Repo admin needs to:
> 1. Settings → Rules → Rulesets → "Main ruleset" → Required status checks
> 2. Remove `build (20)` and `test (20)`
> 3. Add `build (24)` and `test (24)` (using the same GitHub Actions integration as the existing `(22)` entries)
> 4. Save
>
> Heads-up: other open PRs still on the `[20, 22]` matrix from `main` will go red against the new requirements until they rebase. The Renovate PR(s) will self-rebase once `main` moves.

### What to review

- Confirm the `engines.node` floor of `>=22.13` is the right call vs. a softer `>=22.12` (Vitest 4's stated floor) or a harder `>=24` (skip Node 22 entirely). Recommendation in the PR is 22.13 because Node 22 is the active LTS through April 2027, so most consumers will be there.
- Sanity check the test/build matrix swap: `[20, 22]` → `[22, 24]`. The coverage-producing leg is still pinned to `22` via the `matrix.node-version == "22"` conditional in `test.yml` (lines 37 and 45), and `report-coverage` still runs on 22 (line 63), so coverage flow is unchanged.
- Verify that none of the five single-version workflows have an undocumented reason to stay on Node 20.
- Check that the commit message body lands correctly with release-please. The `BREAKING CHANGE:` footer should produce a 3.0.0 changelog entry for both `@sanity/sdk` and `@sanity/sdk-react` (`always-link-local: true` keeps them in lockstep).

### Testing

No tests added; this is a runtime/CI configuration change.

CI itself is the test plan: the new `[22, 24]` matrix legs of `Test` and `Build` will exercise the SDK on both supported runtimes. `lint`, `depcheck`, `type-check`, `upload-docs`, and `pkg-pr-new` will each run on Node 22 and confirm nothing in tooling broke. `report-coverage` will continue to publish from the 22 leg.

After this lands and `release-please` opens the 3.0.0 release PR, worth eyeballing the generated changelog to confirm the breaking-change call-out is present.

### Fun gif
![22 as a default](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExaG16Ymg0anlmNXZ1ZDN5aHU2NGsxY3RhdjZyb3M5cW80OTM5NGNoMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3otWpxGR3xQLnlQb5e/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
