### PR TITLE
chore(ci): use org level linear api key

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Mark SDK issues as done
         uses: sanity-labs/mark-issues-done-action@88e6a3e6bc5a9c86d45873c4dba3302a4cafcb65 # main
         with:
-          linear_api_key: ${{secrets.LINEAR_API_TOKEN}}
+          linear_api_key: ${{secrets.LINEAR_API_KEY}}
           repository_name: ${{github.event.repository.name}}
           # Label: In Staging
           initial_state_id: "c56956cd-c281-4ca5-889f-6189ce231a6d"


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Use the org level linear key instead of a PAT

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense, verified the token exits on org level but might have to add permissions to it, but hopefully it just works

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Tested in a release