### PR TITLE
chore(renovate): use preset release-age defaults, raise PR limits

### DIFF
--- a/.github/RENOVATE_STRATEGY.md
+++ b/.github/RENOVATE_STRATEGY.md
@@ -9,7 +9,7 @@ For Renovate's own docs, see [Dependency Dashboard](https://docs.renovatebot.com
 1. **Automerge by default**, with CI as the safety net.
 2. **Production dep updates trigger a patch release** via `fix(deps)` commits, aligning with release-please.
 3. **Manual review for high-risk changes**: production majors, peer deps, TypeScript majors.
-4. **14-day release age for external deps, 3 days for Sanity-maintained**, to balance supply-chain safety against keeping current.
+4. **3-day release age for external deps, 0 days for trusted upstream packages** (Sanity-maintained, React, Next, `@types/*`, and the rest of the [preset exemption list](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json)), to balance supply-chain safety against keeping current. Both values come from the upstream [`sanity-io/renovate-config`](https://github.com/sanity-io/renovate-config) preset; we don't override.
 
 ## Where to look
 
@@ -31,7 +31,7 @@ Renovate will create these PRs at its next scheduled run (currently `before 5am`
 
 ### Rate-Limited (automatic, but capped)
 
-We set `prConcurrentLimit: 10`. Once 10 Renovate PRs are open, additional updates queue here. If this section grows long, drain it by merging or reviewing open Renovate PRs.
+We set `prConcurrentLimit: 20` (max open PRs at once) and `prHourlyLimit: 5` (max PRs created per hour). New updates queue here when either ceiling is hit. The hourly cap is usually the bottleneck during a backlog; drain it by merging open Renovate PRs, or temporarily raise either limit in `.github/renovate.json`.
 
 ### Pending Status Checks (should stay empty)
 
@@ -51,23 +51,29 @@ Neither usually appears. If one does, check the Renovate run logs linked from th
 
 ## Automerge policy
 
-| Dependency type                                                           | Update type    | Auto/Manual | Release age | Commit type        | Triggers release?                                                   |
-| ------------------------------------------------------------------------- | -------------- | ----------- | ----------- | ------------------ | ------------------------------------------------------------------- |
-| devDependencies                                                           | patch/minor    | Auto        | 14 days     | `chore(dev-deps)`  | No                                                                  |
-| devDependencies (except TypeScript)                                       | major          | Auto        | 14 days     | `chore(dev-deps)`  | No                                                                  |
-| TypeScript                                                                | major          | Manual      | 14 days     | `chore(tooling)`   | No                                                                  |
-| Production deps (in `packages/core`, `packages/react`)                    | patch/minor    | Auto        | 14 days     | `fix(deps)`        | **Yes, patch**                                                      |
-| Production deps (in `packages/core`, `packages/react`)                    | major          | Manual      | 14 days     | `fix(deps)`        | **Yes, patch** (override to `feat!` at squash for breaking changes) |
-| Peer deps                                                                 | any            | Manual      | 14 days     | `chore(peer-deps)` | No                                                                  |
-| App deps (`apps/**`)                                                      | any            | Auto        | 14 days     | `chore(apps)`      | No                                                                  |
-| **Sanity-maintained packages** (`@sanity/*`, `sanity`, `groq`, `groq-js`) | inherits above | inherits    | **3 days**  | inherits           | inherits                                                            |
-| High-severity security (any)                                              | any            | Manual      | 0 days      | varies             | varies                                                              |
+| Dependency type                                                                                                                                                              | Update type    | Auto/Manual | Release age | Commit type        | Triggers release?                                                   |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ----------- | ----------- | ------------------ | ------------------------------------------------------------------- |
+| devDependencies                                                                                                                                                              | patch/minor    | Auto        | 3 days      | `chore(dev-deps)`  | No                                                                  |
+| devDependencies (except TypeScript)                                                                                                                                          | major          | Auto        | 3 days      | `chore(dev-deps)`  | No                                                                  |
+| TypeScript                                                                                                                                                                   | major          | Manual      | 3 days      | `chore(tooling)`   | No                                                                  |
+| Production deps (in `packages/core`, `packages/react`)                                                                                                                       | patch/minor    | Auto        | 3 days      | `fix(deps)`        | **Yes, patch**                                                      |
+| Production deps (in `packages/core`, `packages/react`)                                                                                                                       | major          | Manual      | 3 days      | `fix(deps)`        | **Yes, patch** (override to `feat!` at squash for breaking changes) |
+| Peer deps                                                                                                                                                                    | any            | Manual      | 3 days      | `chore(peer-deps)` | No                                                                  |
+| App deps (`apps/**`)                                                                                                                                                         | any            | Auto        | 3 days      | `chore(apps)`      | No                                                                  |
+| **Trusted upstream packages** (Sanity-maintained, React, Next, `@types/*`, full list in [preset](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json)) | inherits above | inherits    | **0 days**  | inherits           | inherits                                                            |
+| High-severity security (any)                                                                                                                                                 | any            | Manual      | 0 days      | varies             | varies                                                              |
 
-### Why 14 days for external packages
+### Why 3 days for external packages
 
-Renovate recommends a 14-day [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) for any dep you automerge from third parties. The delay gives npm and upstream maintainers time to pull malicious or broken releases before they reach our CI. Supply-chain attacks in the JS ecosystem typically get spotted within that window.
+We inherit a 3-day [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) from the [`min-age-3days`](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json) preset. We don't override it. Three days aligns with npm's 72-hour unpublish window: if a malicious release gets pulled within that grace period, we never installed it. It also matches where industry guidance is converging, including [Datadog Security Labs](https://securitylabs.datadoghq.com/articles/dependency-cooldowns/), the [npm `min-release-age` proposals](https://github.com/npm/cli/pull/9173), and the pnpm/Yarn defaults, which all cluster in the 3-7 day range.
 
-For packages Sanity publishes, we have direct visibility into the release process, so 3 days is enough to catch obvious mistakes without slowing our own work.
+The wait only protects automerged paths. On manual-review tracks (production majors, peer deps, TypeScript major) the human review is the actual safety net.
+
+Vulnerability alerts bypass the delay entirely (`vulnerabilityAlerts.minimumReleaseAge: null`), so security advisories from the GitHub Advisory Database land immediately.
+
+### Why 0 days for trusted upstream packages
+
+The Sanity preset exempts packages we trust from the minimum-age delay: our own (`@sanity/*`, `sanity`, `groq`, `groq-js`) and framework deps we use heavily (`react*`, `next*`, `@types/*`, `pnpm`, `@portabletext/*`, etc.). We have direct relationships or strong visibility into these release processes, so the wait would slow our work without meaningful safety benefit. Full list lives in [`min-age-3days.json`](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json).
 
 ## Commit messages and releases
 
@@ -146,7 +152,7 @@ Find it in "PR Closed (Blocked)" on the dashboard and tick the box.
 
 ### The rate-limited queue is huge
 
-Either merge/close open Renovate PRs to drain the queue, or temporarily bump `prConcurrentLimit` in `renovate.json` and revert once drained.
+Either merge/close open Renovate PRs to drain the queue, or temporarily bump `prHourlyLimit` (the creation throttle) and/or `prConcurrentLimit` (the open-PR ceiling) in `renovate.json`, then revert once drained. The hourly cap is usually the bottleneck.
 
 ### I'm bumping the repo's pnpm version
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,15 +12,15 @@
   },
   "postUpdateOptions": ["pnpmDedupe"],
   "schedule": ["before 5am"],
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 5,
   "automerge": true,
   "platformAutomerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "dependencyDashboard": true,
   "dependencyDashboardApproval": false,
-  "dependencyDashboardHeader": "## How to use this dashboard\n\nFull playbook: [RENOVATE_STRATEGY.md](../blob/main/.github/RENOVATE_STRATEGY.md)\n\n**Quick section reference**\n\n- **Pending Approval**: tick a checkbox to open the PR. Only tick items worth trying.\n- **Awaiting Schedule** / **Rate-Limited**: automatic, no action needed.\n- **Pending Status Checks**: should stay empty. Renovate PRs open immediately so CI runs on the PR itself.\n- **PR Closed (Blocked)**: previously closed. Only tick to retry.\n- **Detected Dependencies**: reference only.\n\n<details>\n<summary><b>Automerge policy</b></summary>\n\n| Dependency type | Auto/Manual | Release age | Commit type | Triggers release? |\n| --- | --- | --- | --- | --- |\n| devDependencies (patch/minor/major) | Auto | 14 days | `chore(dev-deps)` | No |\n| TypeScript (major) | Manual | 14 days | `chore(tooling)` | No |\n| Production deps patch/minor (`packages/core`, `packages/react`) | Auto | 14 days | `fix(deps)` | **Yes, patch** |\n| Production deps major (`packages/core`, `packages/react`) | Manual | 14 days | `fix(deps)` | **Yes, patch**<br/>(override to `feat!` at squash if breaking) |\n| Peer deps | Manual | 14 days | `chore(peer-deps)` | No |\n| App deps (`apps/**`) | Auto | 14 days | `chore(apps)` | No |\n| High-severity security | Manual | 0 days | varies | varies |\n| Sanity-maintained (`@sanity/*`, `sanity`, `groq`, `groq-js`) | inherits | **3 days** | inherits | inherits |\n\n</details>\n\n<details>\n<summary><b>Common actions</b></summary>\n\n**Retry a closed PR**: find it under \"PR Closed (Blocked)\" and tick the box.\n\n**Approve a major dep update**: tick its checkbox under \"Pending Approval\". This only opens the PR; you still review and squash-merge manually. If the upgrade is a breaking change for our consumers, change the commit type from `fix(deps)` to `feat(deps)!` at squash time so release-please produces a major/minor bump.\n\n**A PR won't automerge**: check CI status, that the PR is approved, and that it's not labeled `needs-review`, `major-update`, or `breaking-change`.\n\n**A lockfile looks broken**: run `pnpm install` locally, commit, and push to the Renovate branch. Renovate won't overwrite manual commits.\n\n**Rate-limited queue is huge**: drain it by merging open Renovate PRs, or temporarily raise `prConcurrentLimit` in `.github/renovate.json`.\n\n**Bumping the repo's pnpm version**: also update `constraints.pnpm` in `.github/renovate.json` to match.\n\n</details>\n\n<details>\n<summary><b>Weekly checklist</b></summary>\n\n- Check this dashboard for pending approvals.\n- Review any failed automerge PRs.\n- Merge the release-please PR if ready.\n- Note any major updates that need planning.\n\n</details>",
-  "minimumReleaseAge": "14 days",
+  "dependencyDashboardHeader": "## How to use this dashboard\n\nFull playbook: [RENOVATE_STRATEGY.md](../blob/main/.github/RENOVATE_STRATEGY.md)\n\n**Quick section reference**\n\n- **Pending Approval**: tick a checkbox to open the PR. Only tick items worth trying.\n- **Awaiting Schedule** / **Rate-Limited**: automatic, no action needed.\n- **Pending Status Checks**: should stay empty. Renovate PRs open immediately so CI runs on the PR itself.\n- **PR Closed (Blocked)**: previously closed. Only tick to retry.\n- **Detected Dependencies**: reference only.\n\n<details>\n<summary><b>Automerge policy</b></summary>\n\n| Dependency type | Auto/Manual | Release age | Commit type | Triggers release? |\n| --- | --- | --- | --- | --- |\n| devDependencies (patch/minor/major) | Auto | 3 days | `chore(dev-deps)` | No |\n| TypeScript (major) | Manual | 3 days | `chore(tooling)` | No |\n| Production deps patch/minor (`packages/core`, `packages/react`) | Auto | 3 days | `fix(deps)` | **Yes, patch** |\n| Production deps major (`packages/core`, `packages/react`) | Manual | 3 days | `fix(deps)` | **Yes, patch**<br/>(override to `feat!` at squash if breaking) |\n| Peer deps | Manual | 3 days | `chore(peer-deps)` | No |\n| App deps (`apps/**`) | Auto | 3 days | `chore(apps)` | No |\n| High-severity security | Manual | 0 days | varies | varies |\n| Trusted upstream (Sanity-maintained, React, Next, `@types/*`, etc.; full list in [preset](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json)) | inherits | **0 days** | inherits | inherits |\n\n</details>\n\n<details>\n<summary><b>Common actions</b></summary>\n\n**Retry a closed PR**: find it under \"PR Closed (Blocked)\" and tick the box.\n\n**Approve a major dep update**: tick its checkbox under \"Pending Approval\". This only opens the PR; you still review and squash-merge manually. If the upgrade is a breaking change for our consumers, change the commit type from `fix(deps)` to `feat(deps)!` at squash time so release-please produces a major/minor bump.\n\n**A PR won't automerge**: check CI status, that the PR is approved, and that it's not labeled `needs-review`, `major-update`, or `breaking-change`.\n\n**A lockfile looks broken**: run `pnpm install` locally, commit, and push to the Renovate branch. Renovate won't overwrite manual commits.\n\n**Rate-limited queue is huge**: drain it by merging open Renovate PRs. The throttles are `prHourlyLimit` (currently 5, the creation rate) and `prConcurrentLimit` (currently 20, the open-PR ceiling) in `.github/renovate.json`; raise either temporarily if needed.\n\n**Bumping the repo's pnpm version**: also update `constraints.pnpm` in `.github/renovate.json` to match.\n\n</details>\n\n<details>\n<summary><b>Weekly checklist</b></summary>\n\n- Check this dashboard for pending approvals.\n- Review any failed automerge PRs.\n- Merge the release-please PR if ready.\n- Note any major updates that need planning.\n\n</details>",
   "prCreation": "immediate",
   "vulnerabilityAlerts": {
     "enabled": true,
@@ -35,7 +35,6 @@
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "devDependencies (non-major)",
       "automerge": true,
-      "minimumReleaseAge": "14 days",
       "semanticCommitType": "chore",
       "semanticCommitScope": "dev-deps"
     },
@@ -44,7 +43,6 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["major"],
       "automerge": true,
-      "minimumReleaseAge": "14 days",
       "labels": ["major-update"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "dev-deps",
@@ -56,7 +54,6 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "dependencyDashboardApproval": true,
-      "minimumReleaseAge": "14 days",
       "labels": ["typescript", "major-update", "breaking-change"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "tooling"
@@ -67,7 +64,6 @@
       "matchFileNames": ["packages/core/package.json", "packages/react/package.json"],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
-      "minimumReleaseAge": "14 days",
       "labels": ["dependencies", "automerge"],
       "semanticCommitType": "fix",
       "semanticCommitScope": "deps"
@@ -79,7 +75,6 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "dependencyDashboardApproval": true,
-      "minimumReleaseAge": "14 days",
       "labels": ["dependencies", "major-update", "breaking-change", "needs-review"],
       "semanticCommitType": "fix",
       "semanticCommitScope": "deps"
@@ -95,7 +90,6 @@
       "matchDepTypes": ["peerDependencies"],
       "automerge": false,
       "dependencyDashboardApproval": true,
-      "minimumReleaseAge": "14 days",
       "labels": ["peer-dependencies", "needs-review"],
       "rangeStrategy": "widen",
       "semanticCommitType": "chore",
@@ -106,7 +100,6 @@
       "groupName": "typescript-tooling",
       "matchPackageNames": ["@sanity/pkg-utils", "@sanity/tsdoc"],
       "automerge": true,
-      "minimumReleaseAge": "14 days",
       "semanticCommitType": "chore",
       "semanticCommitScope": "tooling"
     },
@@ -121,7 +114,6 @@
         "typescript-eslint"
       ],
       "automerge": true,
-      "minimumReleaseAge": "14 days",
       "semanticCommitType": "chore",
       "semanticCommitScope": "tooling"
     },
@@ -138,14 +130,8 @@
       "matchFileNames": ["apps/**/package.json"],
       "groupName": "app dependencies",
       "automerge": true,
-      "minimumReleaseAge": "14 days",
       "semanticCommitType": "chore",
       "semanticCommitScope": "apps"
-    },
-    {
-      "description": "Sanity-maintained packages - shorter release age since we have direct visibility into releases and can react quickly to issues",
-      "matchPackageNames": ["@sanity/*", "sanity", "groq", "groq-js"],
-      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
### Description
Removes the local `minimumReleaseAge` overrides in `.github/renovate.json` so the upstream [`sanity-io/renovate-config:min-age-3days`](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json) preset applies: 3 days for external deps, 0 days for the trusted-upstream exemption list (Sanity-maintained, React, Next, `@types/*`, etc.). Keeps `vulnerabilityAlerts.minimumReleaseAge: null` so security advisories still bypass the wait.
Three days aligns with npm's 72-hour unpublish window and where current ecosystem guidance is converging ([Datadog](https://securitylabs.datadoghq.com/articles/dependency-cooldowns/), the [npm `min-release-age` proposals](https://github.com/npm/cli/pull/9173), pnpm/Yarn defaults all cluster at 3-7 days). The previous 14-day value was more conservative than what published guidance supports, especially given that the `vulnerabilityAlerts` bypass already covers the "we'd be slow to receive security patches" concern.
Also raises PR limits so the dashboard backlog can drain at a usable rate:
- `prConcurrentLimit`: 10 → 20 (the previous value just shadowed the inherited default and did nothing)
- `prHourlyLimit`: 2 → 5 (this was the actual throttle)
`RENOVATE_STRATEGY.md` and the embedded dashboard header are synced with the new policy.

### What to review
- `.github/renovate.json` should now have only one remaining `minimumReleaseAge` reference: the `null` bypass on `vulnerabilityAlerts`.
- The "Why 3 days for external packages" and "Why 0 days for trusted upstream packages" sections of `RENOVATE_STRATEGY.md` capture the new framing and link to the preset and supporting research.
- The dashboard header rerenders on Renovate's next scheduled run, visible on the [Dependency Dashboard issue](../../issues/9).


### Testing
Config-only change. JSON validated locally with `node -e "JSON.parse(...)"`. No automated test covers Renovate's runtime behavior, so we'll monitor the dashboard over the next 24-48 hours to confirm:
1. PRs already in "Awaiting Schedule" / "Rate-Limited" start flowing through faster.
2. New external deps wait 3 days instead of 14.
3. Trusted-upstream packages skip the wait entirely.

### Fun gif
![bye 2 weeks](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWYxYjNyNDdkcjRrc3RzdHd1enQ3czZrODJzZnFlbTlzOWM0MnFpbyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/s3vwh1LY1fUUU/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
