### PR TITLE
fix(telemetry): use URL as primary dev-mode signal in browser

### DIFF
--- a/packages/core/src/telemetry/devMode.test.ts
+++ b/packages/core/src/telemetry/devMode.test.ts
@@ -30,6 +30,14 @@ describe('isDevMode', () => {
     expect(isDevMode()).toBe(true)
   })
 
+  it('returns true on localhost even when NODE_ENV is production', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubGlobal('window', {
+      location: {href: 'http://localhost:3000/'},
+    })
+    expect(isDevMode()).toBe(true)
+  })
+
   it('returns false for a non-local URL', () => {
     vi.stubEnv('NODE_ENV', 'test')
     vi.stubGlobal('window', {

--- a/packages/core/src/telemetry/devMode.ts
+++ b/packages/core/src/telemetry/devMode.ts
@@ -17,21 +17,22 @@ function isLocalUrl(win: Window): boolean {
 }
 
 /**
- * Determines whether the SDK should enable dev-mode telemetry.
+ * Determines whether the SDK should enable dev-mode telemetry for the
+ * SDK consumer (i.e. a developer building an app with `@sanity/sdk`).
  *
- * Combines a browser URL check (localhost/127.0.0.1) with a Node.js
- * environment variable check (`NODE_ENV === 'development'`). Returns
- * false in production environments so bundlers can tree-shake the
- * telemetry code path entirely.
+ * Browser: returns true only when the URL is `localhost` or `127.0.0.1`.
+ * The URL check is the primary signal because consumer bundlers may or
+ * may not forward `NODE_ENV` to the browser reliably.
+ *
+ * Node (scripts / non-browser): falls back to `NODE_ENV === 'development'`.
+ *
+ * Bracket-notation `process.env['NODE_ENV']` is used to avoid bundler
+ * dead-code replacement.
  *
  * @returns True if the SDK is running in a development environment
  * @internal
  */
 export function isDevMode(): boolean {
-  if (typeof process !== 'undefined' && process.env?.['NODE_ENV'] === 'production') {
-    return false
-  }
-
   if (typeof window !== 'undefined') {
     return isLocalUrl(window)
   }


### PR DESCRIPTION
### Description

`isDevMode()` short-circuited to `false` whenever `process.env.NODE_ENV === 'production'`, so SDK consumers running their app on `localhost` whose bundler set `NODE_ENV=production` got no telemetry. Reorders the checks so the URL is the source of truth in the browser; `NODE_ENV` is only consulted in non-browser contexts.

Closes [SDK-1371](https://linear.app/sanity/issue/SDK-1371/fix-dev-mode-telemetry-detection-so-sdk-consumers-actually-emit-events).

### What to review

- `packages/core/src/telemetry/devMode.ts`: the production short-circuit is gone; browser path now relies solely on the URL check.
- `packages/core/src/telemetry/devMode.test.ts`: new test confirming `localhost` returns `true` even when `NODE_ENV=production`.

### Testing

Added a unit test for the regression case (`NODE_ENV=production` + localhost URL → `true`). Existing tests still pass.

### Fun gif
![stackingit](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2VoMDV3NHA5OW9kYmsyOHIyc3Vvb29xNndjcm1pbGhpNWVnNHhqbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SxXKRsI6QG3nO/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
