### PR TITLE
feat(core): add other param options to projectsStore

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -65,6 +65,7 @@ const baseConfig = {
       },
       project,
       entry: ['package.bundle.ts'],
+      ignore: ['src/**/*.test-d.ts', 'src/**/*.test-d.tsx'],
       ignoreDependencies: ['@sanity/browserslist-config', 'react-compiler-runtime'],
     },
     'packages/@repo/e2e': {
@@ -81,6 +82,7 @@ const baseConfig = {
       },
       project,
       entry: ['package.bundle.ts'],
+      ignore: ['src/**/*.test-d.ts'],
       ignoreDependencies: ['@sanity/browserslist-config'],
     },
   },

--- a/packages/@repo/config-eslint/index.mjs
+++ b/packages/@repo/config-eslint/index.mjs
@@ -56,6 +56,8 @@ export default [
           devDependencies: [
             '**/*.test.ts',
             '**/*.test.tsx',
+            '**/*.test-d.ts',
+            '**/*.test-d.tsx',
             '**/test/**',
             '**/e2e/**',
             '**/config-eslint/**',

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -178,11 +178,20 @@ export type {
   ValuePending,
 } from '../preview/types'
 export {type OrgVerificationResult} from '../project/organizationVerification'
-export {getProjectState, resolveProject} from '../project/project'
+export {
+  getProjectState,
+  type Project,
+  type ProjectBase,
+  type ProjectMember,
+  type ProjectMemberRole,
+  type ProjectMetadata,
+  type ProjectOptions,
+  resolveProject,
+} from '../project/project'
 export {getProjectionState} from '../projection/getProjectionState'
 export {resolveProjection} from '../projection/resolveProjection'
 export {type ProjectionValuePending, type ValidProjection} from '../projection/types'
-export {getProjectsState, resolveProjects} from '../projects/projects'
+export {getProjectsState, type ProjectsOptions, resolveProjects} from '../projects/projects'
 export {
   getQueryKey,
   getQueryState,

--- a/packages/core/src/project/project.test-d.ts
+++ b/packages/core/src/project/project.test-d.ts
@@ -1,0 +1,93 @@
+import {expectTypeOf, test} from 'vitest'
+
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {
+  getProjectState,
+  type Project,
+  type ProjectBase,
+  type ProjectMember,
+  resolveProject,
+} from './project'
+
+const instance = {} as SanityInstance
+
+test('resolveProject — default call: members and features both included by default', () => {
+  expectTypeOf(resolveProject(instance)).resolves.toEqualTypeOf<Project<true, true>>()
+  type Result = Awaited<ReturnType<typeof resolveProject<true, true>>>
+  expectTypeOf<Result['members']>().toEqualTypeOf<ProjectMember[]>()
+})
+
+test('resolveProject — includeMembers: false drops members from the type', () => {
+  expectTypeOf(resolveProject(instance, {includeMembers: false})).resolves.toEqualTypeOf<
+    Project<false, true>
+  >()
+})
+
+test('resolveProject — includeFeatures: false drops features from the type', () => {
+  expectTypeOf(resolveProject(instance, {includeFeatures: false})).resolves.toEqualTypeOf<
+    Project<true, false>
+  >()
+})
+
+test('resolveProject — both flags false → bare base shape', () => {
+  expectTypeOf(
+    resolveProject(instance, {includeMembers: false, includeFeatures: false}),
+  ).resolves.toEqualTypeOf<Project<false, false>>()
+  type Result = Awaited<ReturnType<typeof resolveProject<false, false>>>
+  expectTypeOf<Result['id']>().toEqualTypeOf<string>()
+})
+
+test('resolveProject — rejects non-boolean flag values', () => {
+  // @ts-expect-error — includeMembers must be a boolean
+  void resolveProject(instance, {includeMembers: 'yes'})
+})
+
+test('resolveProject — projectId alone does not change the data shape', () => {
+  expectTypeOf(resolveProject(instance, {projectId: 'p'})).resolves.toEqualTypeOf<
+    Project<true, true>
+  >()
+})
+
+test('resolveProject — non-literal boolean flag makes members optional', () => {
+  const includeMembers = false as boolean
+  expectTypeOf(resolveProject(instance, {includeMembers})).resolves.toEqualTypeOf<
+    Project<boolean, true>
+  >()
+})
+
+test('getProjectState — default call returns members + features StateSource', () => {
+  expectTypeOf(getProjectState(instance)).toEqualTypeOf<
+    StateSource<Project<true, true> | undefined>
+  >()
+})
+
+test('getProjectState — both flags false narrows to the bare base shape', () => {
+  expectTypeOf(
+    getProjectState(instance, {includeMembers: false, includeFeatures: false}),
+  ).toEqualTypeOf<StateSource<Project<false, false> | undefined>>()
+})
+
+test('Project — wide boolean for IncludeMembers makes members optional', () => {
+  expectTypeOf<Project<boolean, true>>().toEqualTypeOf<
+    ProjectBase & {members?: ProjectMember[]} & {features: string[]}
+  >()
+  expectTypeOf<Pick<Project<boolean, true>, 'members'>>().toEqualTypeOf<{
+    members?: ProjectMember[]
+  }>()
+})
+
+test('Project — wide boolean for IncludeFeatures makes features optional', () => {
+  expectTypeOf<Project<true, boolean>>().toEqualTypeOf<
+    ProjectBase & {members: ProjectMember[]} & {features?: string[]}
+  >()
+  expectTypeOf<Pick<Project<true, boolean>, 'features'>>().toEqualTypeOf<{
+    features?: string[]
+  }>()
+})
+
+test('Project — both wide booleans make both fields optional', () => {
+  expectTypeOf<Project<boolean, boolean>>().toEqualTypeOf<
+    ProjectBase & {members?: ProjectMember[]} & {features?: string[]}
+  >()
+})

--- a/packages/core/src/project/project.test.ts
+++ b/packages/core/src/project/project.test.ts
@@ -1,25 +1,31 @@
 import {type SanityClient} from '@sanity/client'
 import {of} from 'rxjs'
-import {describe, it} from 'vitest'
+import {afterEach, beforeEach, describe, it} from 'vitest'
 
 import {getClientState} from '../client/clientStore'
-import {createSanityInstance} from '../store/createSanityInstance'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
 import {resolveProject} from './project'
 
 vi.mock('../client/clientStore')
 
 describe('project', () => {
-  it('calls the `client.observable.projects.getById` method on the client and returns the result', async () => {
-    const instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+  let instance: SanityInstance
 
+  beforeEach(() => {
+    instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('calls `client.observable.request` against `/projects/<id>` and returns the result', async () => {
     const project = {id: 'a'}
-    const getById = vi.fn().mockReturnValue(of(project))
+    const request = vi.fn().mockReturnValue(of(project))
 
     const mockClient = {
-      observable: {
-        projects: {getById} as unknown as SanityClient['observable']['projects'],
-      },
+      observable: {request} as unknown as SanityClient['observable'],
     } as SanityClient
 
     vi.mocked(getClientState).mockReturnValue({
@@ -28,6 +34,111 @@ describe('project', () => {
 
     const result = await resolveProject(instance, {projectId: 'a'})
     expect(result).toEqual(project)
-    expect(getById).toHaveBeenCalledWith('a')
+    expect(request).toHaveBeenCalledWith({
+      uri: '/projects/a',
+      query: {includeMembers: 'true', includeFeatures: 'true'},
+    })
+  })
+
+  it('serializes query params (booleans → strings) and respects flags', async () => {
+    const request = vi.fn().mockReturnValue(of({id: 'a'}))
+    const mockClient = {
+      observable: {request} as unknown as SanityClient['observable'],
+    } as SanityClient
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of(mockClient),
+    } as StateSource<SanityClient>)
+
+    await resolveProject(instance, {
+      projectId: 'a',
+      includeMembers: false,
+      includeFeatures: false,
+    })
+
+    expect(request).toHaveBeenCalledWith({
+      uri: '/projects/a',
+      query: {
+        includeMembers: 'false',
+        includeFeatures: 'false',
+      },
+    })
+  })
+
+  it('falls back to the instance projectId when none is provided in options', async () => {
+    const request = vi.fn().mockReturnValue(of({id: 'p'}))
+    const mockClient = {
+      observable: {request} as unknown as SanityClient['observable'],
+    } as SanityClient
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of(mockClient),
+    } as StateSource<SanityClient>)
+
+    await resolveProject(instance)
+    expect(request).toHaveBeenCalledWith({
+      uri: '/projects/p',
+      query: {includeMembers: 'true', includeFeatures: 'true'},
+    })
+  })
+})
+
+describe('project cache key generation', () => {
+  const mockGetKey = (
+    instance: SanityInstance,
+    options?: {
+      projectId?: string
+      includeMembers?: boolean
+      includeFeatures?: boolean
+    },
+  ) => {
+    const projectId = options?.projectId ?? instance.config.projectId
+    const includeMembers = options?.includeMembers ?? true
+    const includeFeatures = options?.includeFeatures ?? true
+    const membersKey = includeMembers ? ':members' : ''
+    const featuresKey = includeFeatures ? ':features' : ''
+    return `project:${projectId}${membersKey}${featuresKey}`
+  }
+
+  const mockInstance = {config: {projectId: 'p'}} as SanityInstance
+
+  it('default call includes :members and :features (both default-true)', () => {
+    expect(mockGetKey(mockInstance)).toBe('project:p:members:features')
+  })
+
+  it('treats undefined and the matching default as the same key', () => {
+    expect(mockGetKey(mockInstance)).toBe(
+      mockGetKey(mockInstance, {includeMembers: true, includeFeatures: true}),
+    )
+  })
+
+  it('explicit includeFeatures: false drops the :features segment', () => {
+    expect(mockGetKey(mockInstance, {includeFeatures: false})).toBe('project:p:members')
+  })
+
+  it('explicit includeMembers: false drops the :members segment', () => {
+    expect(mockGetKey(mockInstance, {includeMembers: false})).toBe('project:p:features')
+  })
+
+  it('combines all segments in order', () => {
+    expect(
+      mockGetKey(mockInstance, {
+        projectId: 'a',
+        includeMembers: true,
+        includeFeatures: true,
+      }),
+    ).toBe('project:a:members:features')
+  })
+
+  it('produces distinct keys for each meaningful option permutation', () => {
+    const keys = new Set([
+      mockGetKey(mockInstance),
+      mockGetKey(mockInstance, {includeMembers: false}),
+      mockGetKey(mockInstance, {includeFeatures: false}),
+      mockGetKey(mockInstance, {includeMembers: false, includeFeatures: false}),
+      mockGetKey(mockInstance, {projectId: 'a'}),
+      mockGetKey(mockInstance, {projectId: 'b'}),
+    ])
+    expect(keys.size).toBe(6)
   })
 })

--- a/packages/core/src/project/project.test.ts
+++ b/packages/core/src/project/project.test.ts
@@ -5,7 +5,7 @@ import {afterEach, beforeEach, describe, it} from 'vitest'
 import {getClientState} from '../client/clientStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {resolveProject} from './project'
+import {getProjectCacheKey, resolveProject} from './project'
 
 vi.mock('../client/clientStore')
 
@@ -84,45 +84,29 @@ describe('project', () => {
 })
 
 describe('project cache key generation', () => {
-  const mockGetKey = (
-    instance: SanityInstance,
-    options?: {
-      projectId?: string
-      includeMembers?: boolean
-      includeFeatures?: boolean
-    },
-  ) => {
-    const projectId = options?.projectId ?? instance.config.projectId
-    const includeMembers = options?.includeMembers ?? true
-    const includeFeatures = options?.includeFeatures ?? true
-    const membersKey = includeMembers ? ':members' : ''
-    const featuresKey = includeFeatures ? ':features' : ''
-    return `project:${projectId}${membersKey}${featuresKey}`
-  }
-
   const mockInstance = {config: {projectId: 'p'}} as SanityInstance
 
   it('default call includes :members and :features (both default-true)', () => {
-    expect(mockGetKey(mockInstance)).toBe('project:p:members:features')
+    expect(getProjectCacheKey(mockInstance)).toBe('project:p:members:features')
   })
 
   it('treats undefined and the matching default as the same key', () => {
-    expect(mockGetKey(mockInstance)).toBe(
-      mockGetKey(mockInstance, {includeMembers: true, includeFeatures: true}),
+    expect(getProjectCacheKey(mockInstance)).toBe(
+      getProjectCacheKey(mockInstance, {includeMembers: true, includeFeatures: true}),
     )
   })
 
   it('explicit includeFeatures: false drops the :features segment', () => {
-    expect(mockGetKey(mockInstance, {includeFeatures: false})).toBe('project:p:members')
+    expect(getProjectCacheKey(mockInstance, {includeFeatures: false})).toBe('project:p:members')
   })
 
   it('explicit includeMembers: false drops the :members segment', () => {
-    expect(mockGetKey(mockInstance, {includeMembers: false})).toBe('project:p:features')
+    expect(getProjectCacheKey(mockInstance, {includeMembers: false})).toBe('project:p:features')
   })
 
   it('combines all segments in order', () => {
     expect(
-      mockGetKey(mockInstance, {
+      getProjectCacheKey(mockInstance, {
         projectId: 'a',
         includeMembers: true,
         includeFeatures: true,
@@ -132,12 +116,12 @@ describe('project cache key generation', () => {
 
   it('produces distinct keys for each meaningful option permutation', () => {
     const keys = new Set([
-      mockGetKey(mockInstance),
-      mockGetKey(mockInstance, {includeMembers: false}),
-      mockGetKey(mockInstance, {includeFeatures: false}),
-      mockGetKey(mockInstance, {includeMembers: false, includeFeatures: false}),
-      mockGetKey(mockInstance, {projectId: 'a'}),
-      mockGetKey(mockInstance, {projectId: 'b'}),
+      getProjectCacheKey(mockInstance),
+      getProjectCacheKey(mockInstance, {includeMembers: false}),
+      getProjectCacheKey(mockInstance, {includeFeatures: false}),
+      getProjectCacheKey(mockInstance, {includeMembers: false, includeFeatures: false}),
+      getProjectCacheKey(mockInstance, {projectId: 'a'}),
+      getProjectCacheKey(mockInstance, {projectId: 'b'}),
     ])
     expect(keys.size).toBe(6)
   })

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -2,40 +2,161 @@ import {switchMap} from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
 import {type ProjectHandle} from '../config/sanityConfig'
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
 import {createFetcherStore} from '../utils/createFetcherStore'
 
 const API_VERSION = 'v2025-02-19'
 
+/** @public */
+export interface ProjectMemberRole {
+  name: string
+  title: string
+  description: string
+}
+
+/** @public */
+export interface ProjectMember {
+  id: string
+  createdAt: string
+  updatedAt: string
+  isCurrentUser: boolean
+  isRobot: boolean
+  roles: ProjectMemberRole[]
+}
+
+/** @public */
+export interface ProjectMetadata {
+  color?: string
+  externalStudioHost?: string
+  initialTemplate?: string
+  cliInitializedAt?: string
+  integration: 'manage' | 'cli'
+}
+
+/**
+ * The base fields returned from `/projects` for every project.
+ * @public
+ */
+export interface ProjectBase {
+  id: string
+  displayName: string
+  studioHost: string | null
+  organizationId: string
+  metadata: ProjectMetadata
+  isBlocked: boolean
+  isDisabled: boolean
+  isDisabledByUser: boolean
+  activityFeedEnabled: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * A `Project` with `members` and/or `features` conditionally included
+ * based on the query options used to fetch it.
+ * @public
+ */
+export type Project<
+  IncludeMembers extends boolean = true,
+  IncludeFeatures extends boolean = true,
+> = ProjectBase &
+  // `boolean extends T` is non-distributive — true only when T is the wide
+  // `boolean`, in which case the field is optional. Literal `true`/`false`
+  // fall through to the strict branch.
+  (boolean extends IncludeMembers
+    ? {members?: ProjectMember[]}
+    : IncludeMembers extends true
+      ? {members: ProjectMember[]}
+      : unknown) &
+  (boolean extends IncludeFeatures
+    ? {features?: string[]}
+    : IncludeFeatures extends true
+      ? {features: string[]}
+      : unknown)
+
+/** @public */
+export interface ProjectOptions<
+  IncludeMembers extends boolean = true,
+  IncludeFeatures extends boolean = true,
+> extends ProjectHandle {
+  includeMembers?: IncludeMembers
+  includeFeatures?: IncludeFeatures
+}
+
+function normalizeProjectOptions(options?: ProjectOptions<boolean, boolean>) {
+  return {
+    includeMembers: options?.includeMembers ?? true,
+    includeFeatures: options?.includeFeatures ?? true,
+  }
+}
+
+function resolveProjectId(instance: SanityInstance, options?: ProjectOptions<boolean, boolean>) {
+  const projectId = options?.projectId ?? instance.config.projectId
+  if (!projectId) {
+    throw new Error('A projectId is required to use the project API.')
+  }
+  return projectId
+}
+
 const project = createFetcherStore({
   name: 'Project',
-  getKey: (instance, options?: ProjectHandle) => {
-    const projectId = options?.projectId ?? instance.config.projectId
-    if (!projectId) {
-      throw new Error('A projectId is required to use the project API.')
-    }
-    return projectId
+  getKey: (instance, options?: ProjectOptions<boolean, boolean>) => {
+    const projectId = resolveProjectId(instance, options)
+    const {includeMembers, includeFeatures} = normalizeProjectOptions(options)
+    const membersKey = includeMembers ? ':members' : ''
+    const featuresKey = includeFeatures ? ':features' : ''
+    return `project:${projectId}${membersKey}${featuresKey}`
   },
-  fetcher:
-    (instance) =>
-    (options: ProjectHandle = {}) => {
-      const projectId = options.projectId ?? instance.config.projectId
+  fetcher: (instance) => (options?: ProjectOptions<boolean, boolean>) => {
+    const projectId = resolveProjectId(instance, options)
 
-      return getClientState(instance, {
-        apiVersion: API_VERSION,
-        scope: 'global',
-        projectId,
-      }).observable.pipe(
-        switchMap((client) =>
-          client.observable.projects.getById(
-            // non-null assertion is fine with the above throwing
-            (projectId ?? instance.config.projectId)!,
-          ),
-        ),
-      )
-    },
+    return getClientState(instance, {
+      apiVersion: API_VERSION,
+      scope: 'global',
+      projectId,
+      requestTagPrefix: 'sanity.sdk.project',
+    }).observable.pipe(
+      switchMap((client) => {
+        const normalized = normalizeProjectOptions(options)
+        const query = Object.fromEntries(
+          Object.entries(normalized)
+            .filter(([, value]) => value !== undefined)
+            .map(([key, value]) => [key, String(value)]),
+        )
+
+        return client.observable.request({
+          uri: `/projects/${projectId}`,
+          query,
+        })
+      }),
+    )
+  },
 })
 
+/**
+ * Public signature for the project state source. The conditional generics
+ * cannot flow through `BoundStoreAction`, so we declare the signature here
+ * and assign the (already-correct) runtime function to it.
+ */
+type GetProjectState = <
+  IncludeMembers extends boolean = true,
+  IncludeFeatures extends boolean = true,
+>(
+  instance: SanityInstance,
+  options?: ProjectOptions<IncludeMembers, IncludeFeatures>,
+) => StateSource<Project<IncludeMembers, IncludeFeatures> | undefined>
+
+type ResolveProject = <
+  IncludeMembers extends boolean = true,
+  IncludeFeatures extends boolean = true,
+>(
+  instance: SanityInstance,
+  options?: ProjectOptions<IncludeMembers, IncludeFeatures>,
+) => Promise<Project<IncludeMembers, IncludeFeatures>>
+
 /** @public */
-export const getProjectState = project.getState
+export const getProjectState: GetProjectState = project.getState
+
 /** @public */
-export const resolveProject = project.resolveState
+export const resolveProject: ResolveProject = project.resolveState

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -99,22 +99,27 @@ function resolveProjectId(instance: SanityInstance, options?: ProjectOptions<boo
   return projectId
 }
 
+/** @internal */
+export function getProjectCacheKey(
+  instance: SanityInstance,
+  options?: ProjectOptions<boolean, boolean>,
+): string {
+  const projectId = resolveProjectId(instance, options)
+  const {includeMembers, includeFeatures} = normalizeProjectOptions(options)
+  const membersKey = includeMembers ? ':members' : ''
+  const featuresKey = includeFeatures ? ':features' : ''
+  return `project:${projectId}${membersKey}${featuresKey}`
+}
+
 const project = createFetcherStore({
   name: 'Project',
-  getKey: (instance, options?: ProjectOptions<boolean, boolean>) => {
-    const projectId = resolveProjectId(instance, options)
-    const {includeMembers, includeFeatures} = normalizeProjectOptions(options)
-    const membersKey = includeMembers ? ':members' : ''
-    const featuresKey = includeFeatures ? ':features' : ''
-    return `project:${projectId}${membersKey}${featuresKey}`
-  },
+  getKey: getProjectCacheKey,
   fetcher: (instance) => (options?: ProjectOptions<boolean, boolean>) => {
     const projectId = resolveProjectId(instance, options)
 
     return getClientState(instance, {
       apiVersion: API_VERSION,
       scope: 'global',
-      projectId,
       requestTagPrefix: 'sanity.sdk.project',
     }).observable.pipe(
       switchMap((client) => {

--- a/packages/core/src/projects/projects.test-d.ts
+++ b/packages/core/src/projects/projects.test-d.ts
@@ -1,0 +1,38 @@
+import {expectTypeOf, test} from 'vitest'
+
+import {type Project, type ProjectMember} from '../project/project'
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {getProjectsState, resolveProjects} from './projects'
+
+const instance = {} as SanityInstance
+
+test('resolveProjects — default call: features included, members omitted', () => {
+  expectTypeOf(resolveProjects(instance)).resolves.toEqualTypeOf<Project<false, true>[]>()
+})
+
+test('resolveProjects — includeMembers: true adds members to the type', () => {
+  expectTypeOf(resolveProjects(instance, {includeMembers: true})).resolves.toEqualTypeOf<
+    Project<true, true>[]
+  >()
+  type Result = Awaited<ReturnType<typeof resolveProjects<true, true>>>
+  expectTypeOf<Result[number]['members']>().toEqualTypeOf<ProjectMember[]>()
+})
+
+test('resolveProjects — includeFeatures: false drops features from the type', () => {
+  expectTypeOf(resolveProjects(instance, {includeFeatures: false})).resolves.toEqualTypeOf<
+    Project<false, false>[]
+  >()
+})
+
+test('resolveProjects — organizationId alone does not change the data shape', () => {
+  expectTypeOf(resolveProjects(instance, {organizationId: 'org_123'})).resolves.toEqualTypeOf<
+    Project<false, true>[]
+  >()
+})
+
+test('getProjectsState — default call returns features-only StateSource', () => {
+  expectTypeOf(getProjectsState(instance)).toEqualTypeOf<
+    StateSource<Project<false, true>[] | undefined>
+  >()
+})

--- a/packages/core/src/projects/projects.test.ts
+++ b/packages/core/src/projects/projects.test.ts
@@ -20,14 +20,12 @@ describe('projects', () => {
     instance.dispose()
   })
 
-  it('calls the `client.observable.projects.list` method on the client and returns the result', async () => {
+  it('calls `client.observable.request` against `/projects` and returns the result', async () => {
     const projects = [{id: 'a'}, {id: 'b'}]
-    const list = vi.fn().mockReturnValue(of(projects))
+    const request = vi.fn().mockReturnValue(of(projects))
 
     const mockClient = {
-      observable: {
-        projects: {list} as unknown as SanityClient['observable']['projects'],
-      },
+      observable: {request} as unknown as SanityClient['observable'],
     } as SanityClient
 
     vi.mocked(getClientState).mockReturnValue({
@@ -36,41 +34,119 @@ describe('projects', () => {
 
     const result = await resolveProjects(instance)
     expect(result).toEqual(projects)
-    expect(list).toHaveBeenCalledWith({includeMembers: false, organizationId: undefined})
+    expect(request).toHaveBeenCalledWith({
+      uri: '/projects',
+      query: {includeMembers: 'false', includeFeatures: 'true', onlyExplicitMembership: 'false'},
+    })
+  })
+
+  it('serializes query params (booleans → strings) and omits undefined values', async () => {
+    const request = vi.fn().mockReturnValue(of([]))
+    const mockClient = {
+      observable: {request} as unknown as SanityClient['observable'],
+    } as SanityClient
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of(mockClient),
+    } as StateSource<SanityClient>)
+
+    await resolveProjects(instance, {
+      organizationId: 'org123',
+      includeMembers: true,
+      includeFeatures: false,
+    })
+
+    expect(request).toHaveBeenCalledWith({
+      uri: '/projects',
+      query: {
+        organizationId: 'org123',
+        includeMembers: 'true',
+        includeFeatures: 'false',
+        onlyExplicitMembership: 'false',
+      },
+    })
   })
 })
 
 describe('projects cache key generation', () => {
-  it('generates correct cache keys for different parameter combinations', async () => {
-    // Test the getKey function directly by creating a mock store
-    const mockGetKey = (
-      _instance: SanityInstance,
-      options?: {organizationId?: string; includeMembers?: boolean},
-    ) => {
-      const orgKey = options?.organizationId ? `:org:${options.organizationId}` : ''
-      const membersKey = options?.includeMembers === false ? ':no-members' : ''
-      return `projects${orgKey}${membersKey}`
-    }
+  const mockGetKey = (
+    _instance: SanityInstance,
+    options?: {
+      organizationId?: string
+      includeMembers?: boolean
+      includeFeatures?: boolean
+      onlyExplicitMembership?: boolean
+    },
+  ) => {
+    const organizationId = options?.organizationId
+    const includeMembers = options?.includeMembers ?? false
+    const includeFeatures = options?.includeFeatures ?? true
+    const onlyExplicitMembership = options?.onlyExplicitMembership ?? false
+    const orgKey = organizationId ? `:org:${organizationId}` : ''
+    const membersKey = includeMembers ? ':members' : ''
+    const featuresKey = includeFeatures ? ':features' : ''
+    const explicitKey = onlyExplicitMembership ? ':explicit' : ''
+    return `projects${orgKey}${membersKey}${featuresKey}${explicitKey}`
+  }
 
-    const mockInstance = {} as SanityInstance
+  const mockInstance = {} as SanityInstance
 
-    // Test default behavior (no options)
-    const defaultKey = mockGetKey(mockInstance)
-    expect(defaultKey).toBe('projects')
+  it('default call includes :features (default-true) and excludes :members (default-false)', () => {
+    expect(mockGetKey(mockInstance)).toBe('projects:features')
+  })
 
-    // Test with organizationId only
-    const orgKey = mockGetKey(mockInstance, {organizationId: 'org123'})
-    expect(orgKey).toBe('projects:org:org123')
+  it('treats undefined and the matching default as the same key', () => {
+    expect(mockGetKey(mockInstance)).toBe(
+      mockGetKey(mockInstance, {includeMembers: false, includeFeatures: true}),
+    )
+  })
 
-    // Test with includeMembers: false only
-    const noMembersKey = mockGetKey(mockInstance, {includeMembers: false})
-    expect(noMembersKey).toBe('projects:no-members')
+  it('treats raw and explicit defaults equivalently', () => {
+    expect(mockGetKey(mockInstance, {organizationId: 'org123'})).toBe(
+      mockGetKey(mockInstance, {
+        organizationId: 'org123',
+        includeMembers: false,
+        includeFeatures: true,
+        onlyExplicitMembership: false,
+      }),
+    )
+  })
 
-    // Test with both parameters
-    const bothKey = mockGetKey(mockInstance, {
-      organizationId: 'org123',
-      includeMembers: false,
-    })
-    expect(bothKey).toBe('projects:org:org123:no-members')
+  it('explicit includeFeatures: false drops the :features segment', () => {
+    expect(mockGetKey(mockInstance, {includeFeatures: false})).toBe('projects')
+  })
+
+  it('appends an org segment when organizationId is set', () => {
+    expect(mockGetKey(mockInstance, {organizationId: 'org123'})).toBe(
+      'projects:org:org123:features',
+    )
+  })
+
+  it('appends :members when includeMembers is true', () => {
+    expect(mockGetKey(mockInstance, {includeMembers: true})).toBe('projects:members:features')
+  })
+
+  it('combines all segments in order', () => {
+    expect(
+      mockGetKey(mockInstance, {
+        organizationId: 'org123',
+        includeMembers: true,
+        includeFeatures: true,
+        onlyExplicitMembership: true,
+      }),
+    ).toBe('projects:org:org123:members:features:explicit')
+  })
+
+  it('produces distinct keys for each meaningful option permutation', () => {
+    const keys = new Set([
+      mockGetKey(mockInstance),
+      mockGetKey(mockInstance, {includeMembers: true}),
+      mockGetKey(mockInstance, {includeFeatures: false}),
+      mockGetKey(mockInstance, {includeMembers: true, includeFeatures: false}),
+      mockGetKey(mockInstance, {onlyExplicitMembership: true}),
+      mockGetKey(mockInstance, {organizationId: 'a'}),
+      mockGetKey(mockInstance, {organizationId: 'b'}),
+    ])
+    expect(keys.size).toBe(7)
   })
 })

--- a/packages/core/src/projects/projects.test.ts
+++ b/packages/core/src/projects/projects.test.ts
@@ -5,7 +5,7 @@ import {afterEach, beforeEach, describe, it} from 'vitest'
 import {getClientState} from '../client/clientStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {resolveProjects} from './projects'
+import {getProjectsCacheKey, resolveProjects} from './projects'
 
 vi.mock('../client/clientStore')
 
@@ -69,41 +69,29 @@ describe('projects', () => {
 })
 
 describe('projects cache key generation', () => {
-  const mockGetKey = (
-    _instance: SanityInstance,
-    options?: {
-      organizationId?: string
-      includeMembers?: boolean
-      includeFeatures?: boolean
-      onlyExplicitMembership?: boolean
-    },
-  ) => {
-    const organizationId = options?.organizationId
-    const includeMembers = options?.includeMembers ?? false
-    const includeFeatures = options?.includeFeatures ?? true
-    const onlyExplicitMembership = options?.onlyExplicitMembership ?? false
-    const orgKey = organizationId ? `:org:${organizationId}` : ''
-    const membersKey = includeMembers ? ':members' : ''
-    const featuresKey = includeFeatures ? ':features' : ''
-    const explicitKey = onlyExplicitMembership ? ':explicit' : ''
-    return `projects${orgKey}${membersKey}${featuresKey}${explicitKey}`
-  }
+  let instance: SanityInstance
 
-  const mockInstance = {} as SanityInstance
+  beforeEach(() => {
+    instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
 
   it('default call includes :features (default-true) and excludes :members (default-false)', () => {
-    expect(mockGetKey(mockInstance)).toBe('projects:features')
+    expect(getProjectsCacheKey(instance)).toBe('projects:features')
   })
 
   it('treats undefined and the matching default as the same key', () => {
-    expect(mockGetKey(mockInstance)).toBe(
-      mockGetKey(mockInstance, {includeMembers: false, includeFeatures: true}),
+    expect(getProjectsCacheKey(instance)).toBe(
+      getProjectsCacheKey(instance, {includeMembers: false, includeFeatures: true}),
     )
   })
 
   it('treats raw and explicit defaults equivalently', () => {
-    expect(mockGetKey(mockInstance, {organizationId: 'org123'})).toBe(
-      mockGetKey(mockInstance, {
+    expect(getProjectsCacheKey(instance, {organizationId: 'org123'})).toBe(
+      getProjectsCacheKey(instance, {
         organizationId: 'org123',
         includeMembers: false,
         includeFeatures: true,
@@ -113,22 +101,22 @@ describe('projects cache key generation', () => {
   })
 
   it('explicit includeFeatures: false drops the :features segment', () => {
-    expect(mockGetKey(mockInstance, {includeFeatures: false})).toBe('projects')
+    expect(getProjectsCacheKey(instance, {includeFeatures: false})).toBe('projects')
   })
 
   it('appends an org segment when organizationId is set', () => {
-    expect(mockGetKey(mockInstance, {organizationId: 'org123'})).toBe(
+    expect(getProjectsCacheKey(instance, {organizationId: 'org123'})).toBe(
       'projects:org:org123:features',
     )
   })
 
   it('appends :members when includeMembers is true', () => {
-    expect(mockGetKey(mockInstance, {includeMembers: true})).toBe('projects:members:features')
+    expect(getProjectsCacheKey(instance, {includeMembers: true})).toBe('projects:members:features')
   })
 
   it('combines all segments in order', () => {
     expect(
-      mockGetKey(mockInstance, {
+      getProjectsCacheKey(instance, {
         organizationId: 'org123',
         includeMembers: true,
         includeFeatures: true,
@@ -139,13 +127,13 @@ describe('projects cache key generation', () => {
 
   it('produces distinct keys for each meaningful option permutation', () => {
     const keys = new Set([
-      mockGetKey(mockInstance),
-      mockGetKey(mockInstance, {includeMembers: true}),
-      mockGetKey(mockInstance, {includeFeatures: false}),
-      mockGetKey(mockInstance, {includeMembers: true, includeFeatures: false}),
-      mockGetKey(mockInstance, {onlyExplicitMembership: true}),
-      mockGetKey(mockInstance, {organizationId: 'a'}),
-      mockGetKey(mockInstance, {organizationId: 'b'}),
+      getProjectsCacheKey(instance),
+      getProjectsCacheKey(instance, {includeMembers: true}),
+      getProjectsCacheKey(instance, {includeFeatures: false}),
+      getProjectsCacheKey(instance, {includeMembers: true, includeFeatures: false}),
+      getProjectsCacheKey(instance, {onlyExplicitMembership: true}),
+      getProjectsCacheKey(instance, {organizationId: 'a'}),
+      getProjectsCacheKey(instance, {organizationId: 'b'}),
     ])
     expect(keys.size).toBe(7)
   })

--- a/packages/core/src/projects/projects.ts
+++ b/packages/core/src/projects/projects.ts
@@ -28,17 +28,23 @@ function normalizeProjectsOptions(options?: ProjectsOptions<boolean, boolean>) {
   }
 }
 
+/** @internal */
+export function getProjectsCacheKey(
+  _instance: SanityInstance,
+  options?: ProjectsOptions<boolean, boolean>,
+): string {
+  const {organizationId, includeMembers, includeFeatures, onlyExplicitMembership} =
+    normalizeProjectsOptions(options)
+  const orgKey = organizationId ? `:org:${organizationId}` : ''
+  const membersKey = includeMembers ? ':members' : ''
+  const featuresKey = includeFeatures ? ':features' : ''
+  const explicitKey = onlyExplicitMembership ? ':explicit' : ''
+  return `projects${orgKey}${membersKey}${featuresKey}${explicitKey}`
+}
+
 const projects = createFetcherStore({
   name: 'Projects',
-  getKey: (_instance, options?: ProjectsOptions<boolean, boolean>) => {
-    const {organizationId, includeMembers, includeFeatures, onlyExplicitMembership} =
-      normalizeProjectsOptions(options)
-    const orgKey = organizationId ? `:org:${organizationId}` : ''
-    const membersKey = includeMembers ? ':members' : ''
-    const featuresKey = includeFeatures ? ':features' : ''
-    const explicitKey = onlyExplicitMembership ? ':explicit' : ''
-    return `projects${orgKey}${membersKey}${featuresKey}${explicitKey}`
-  },
+  getKey: getProjectsCacheKey,
   fetcher: (instance) => (options?: ProjectsOptions<boolean, boolean>) =>
     getClientState(instance, {
       apiVersion: API_VERSION,

--- a/packages/core/src/projects/projects.ts
+++ b/packages/core/src/projects/projects.ts
@@ -1,35 +1,89 @@
 import {switchMap} from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
+import {type Project} from '../project/project'
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
 import {createFetcherStore} from '../utils/createFetcherStore'
 
 const API_VERSION = 'v2025-02-19'
 
+/** @public */
+export interface ProjectsOptions<
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = true,
+> {
+  organizationId?: string
+  includeMembers?: IncludeMembers
+  includeFeatures?: IncludeFeatures
+  onlyExplicitMembership?: boolean
+}
+
+function normalizeProjectsOptions(options?: ProjectsOptions<boolean, boolean>) {
+  return {
+    organizationId: options?.organizationId,
+    includeMembers: options?.includeMembers ?? false,
+    includeFeatures: options?.includeFeatures ?? true,
+    onlyExplicitMembership: options?.onlyExplicitMembership ?? false,
+  }
+}
+
 const projects = createFetcherStore({
   name: 'Projects',
-  getKey: (_instance, options?: {organizationId?: string; includeMembers?: boolean}) => {
-    const orgKey = options?.organizationId ? `:org:${options.organizationId}` : ''
-    const membersKey = options?.includeMembers === false ? ':no-members' : ''
-    return `projects${orgKey}${membersKey}`
+  getKey: (_instance, options?: ProjectsOptions<boolean, boolean>) => {
+    const {organizationId, includeMembers, includeFeatures, onlyExplicitMembership} =
+      normalizeProjectsOptions(options)
+    const orgKey = organizationId ? `:org:${organizationId}` : ''
+    const membersKey = includeMembers ? ':members' : ''
+    const featuresKey = includeFeatures ? ':features' : ''
+    const explicitKey = onlyExplicitMembership ? ':explicit' : ''
+    return `projects${orgKey}${membersKey}${featuresKey}${explicitKey}`
   },
-  fetcher: (instance) => (options?: {organizationId?: string; includeMembers?: boolean}) =>
+  fetcher: (instance) => (options?: ProjectsOptions<boolean, boolean>) =>
     getClientState(instance, {
       apiVersion: API_VERSION,
       scope: 'global',
       requestTagPrefix: 'sanity.sdk.projects',
     }).observable.pipe(
       switchMap((client) => {
-        const organizationId = options?.organizationId
-        return client.observable.projects.list({
-          // client method has a type that expects false | undefined
-          includeMembers: !options?.includeMembers ? false : undefined,
-          organizationId,
+        const normalized = normalizeProjectsOptions(options)
+        const query = Object.fromEntries(
+          Object.entries(normalized)
+            .filter(([, value]) => value !== undefined)
+            .map(([key, value]) => [key, String(value)]),
+        )
+
+        return client.observable.request({
+          uri: '/projects',
+          query,
         })
       }),
     ),
 })
 
+/**
+ * Public signature for the projects state source. The conditional generics
+ * cannot flow through `BoundStoreAction`, so we declare the signature here
+ * and assign the (already-correct) runtime function to it.
+ */
+type GetProjectsState = <
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = true,
+>(
+  instance: SanityInstance,
+  options?: ProjectsOptions<IncludeMembers, IncludeFeatures>,
+) => StateSource<Project<IncludeMembers, IncludeFeatures>[] | undefined>
+
+type ResolveProjects = <
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = true,
+>(
+  instance: SanityInstance,
+  options?: ProjectsOptions<IncludeMembers, IncludeFeatures>,
+) => Promise<Project<IncludeMembers, IncludeFeatures>[]>
+
 /** @public */
-export const getProjectsState = projects.getState
+export const getProjectsState: GetProjectsState = projects.getState
+
 /** @public */
-export const resolveProjects = projects.resolveState
+export const resolveProjects: ResolveProjects = projects.resolveState

--- a/packages/core/tsconfig.dist.json
+++ b/packages/core/tsconfig.dist.json
@@ -6,6 +6,8 @@
     "./src/**/__mocks__",
     "./src/**/__workshop__",
     "./src/**/*.test.ts",
-    "./src/**/*.test.tsx"
+    "./src/**/*.test.tsx",
+    "./src/**/*.test-d.ts",
+    "./src/**/*.test-d.tsx"
   ]
 }

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -84,7 +84,7 @@ export {
   type useDocumentProjectionResults,
 } from '../hooks/projection/useDocumentProjection'
 export {useProject} from '../hooks/projects/useProject'
-export {useProjects} from '../hooks/projects/useProjects'
+export {type ProjectWithoutMembers, useProjects} from '../hooks/projects/useProjects'
 export {useQuery} from '../hooks/query/useQuery'
 export {useActiveReleases} from '../hooks/releases/useActiveReleases'
 export {usePerspective} from '../hooks/releases/usePerspective'

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -84,7 +84,7 @@ export {
   type useDocumentProjectionResults,
 } from '../hooks/projection/useDocumentProjection'
 export {useProject} from '../hooks/projects/useProject'
-export {type ProjectWithoutMembers, useProjects} from '../hooks/projects/useProjects'
+export {useProjects} from '../hooks/projects/useProjects'
 export {useQuery} from '../hooks/query/useQuery'
 export {useActiveReleases} from '../hooks/releases/useActiveReleases'
 export {usePerspective} from '../hooks/releases/usePerspective'

--- a/packages/react/src/hooks/projects/useProject.test-d.ts
+++ b/packages/react/src/hooks/projects/useProject.test-d.ts
@@ -1,0 +1,49 @@
+import {type Project, type ProjectMember} from '@sanity/sdk'
+import {expectTypeOf, test} from 'vitest'
+
+import {useProject} from './useProject'
+
+test('useProject — no args: members and features both included by default', () => {
+  expectTypeOf(useProject()).toEqualTypeOf<Project<true, true>>()
+  type Result = ReturnType<typeof useProject<true, true>>
+  expectTypeOf<Result['members']>().toEqualTypeOf<ProjectMember[]>()
+})
+
+test('useProject — includeMembers: false drops members from the type', () => {
+  expectTypeOf(useProject({includeMembers: false})).toEqualTypeOf<Project<false, true>>()
+})
+
+test('useProject — includeFeatures: false drops features from the type', () => {
+  expectTypeOf(useProject({includeFeatures: false})).toEqualTypeOf<Project<true, false>>()
+})
+
+test('useProject — both flags true → both arrays present', () => {
+  expectTypeOf(useProject({includeMembers: true, includeFeatures: true})).toEqualTypeOf<
+    Project<true, true>
+  >()
+})
+
+test('useProject — both flags false → bare base shape', () => {
+  expectTypeOf(useProject({includeMembers: false, includeFeatures: false})).toEqualTypeOf<
+    Project<false, false>
+  >()
+  type Result = ReturnType<typeof useProject<false, false>>
+  expectTypeOf<Result['id']>().toEqualTypeOf<string>()
+})
+
+test('useProject — rejects non-boolean flag values', () => {
+  // @ts-expect-error — includeMembers must be a boolean
+  void useProject({includeMembers: 'yes'})
+})
+
+test('useProject — projectId alone does not change the data shape', () => {
+  expectTypeOf(useProject({projectId: 'p'})).toEqualTypeOf<Project<true, true>>()
+})
+
+test('useProject — non-literal boolean flag makes members optional', () => {
+  const includeMembers = false as boolean
+  expectTypeOf(useProject({includeMembers})).toEqualTypeOf<Project<boolean, true>>()
+  type Result = ReturnType<typeof useProject<boolean, true>>
+  expectTypeOf<Result['members']>().toEqualTypeOf<ProjectMember[] | undefined>()
+  expectTypeOf<Pick<Result, 'members'>>().toEqualTypeOf<{members?: ProjectMember[]}>()
+})

--- a/packages/react/src/hooks/projects/useProject.ts
+++ b/packages/react/src/hooks/projects/useProject.ts
@@ -24,7 +24,9 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
  * ```
  * @example
  * ```tsx
+ * const projectWithMembersAndFeatures = useProject({projectId})
  * const projectWithMembers = useProject({projectId, includeMembers: true})
+ * const projectWithoutMembers = useProject({projectId, includeMembers: false})
  * const projectWithoutFeatures = useProject({projectId, includeFeatures: false})
  * ```
  * @public

--- a/packages/react/src/hooks/projects/useProject.ts
+++ b/packages/react/src/hooks/projects/useProject.ts
@@ -1,51 +1,41 @@
-import {
-  getProjectState,
-  type ProjectHandle,
-  resolveProject,
-  type SanityInstance,
-  type SanityProject,
-  type StateSource,
-} from '@sanity/sdk'
+import {getProjectState, type Project, type ProjectOptions, resolveProject} from '@sanity/sdk'
 import {identity} from 'rxjs'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
 
-type UseProject = {
-  /**
-   *
-   * Returns metadata for a given project
-   *
-   * @category Projects
-   * @param projectId - The ID of the project to retrieve metadata for
-   * @returns The metadata for the project
-   * @example
-   * ```tsx
-   *  function ProjectMetadata({ projectId }: { projectId: string }) {
-   *    const project = useProject(projectId)
-   *
-   *    return (
-   *      <figure style={{ backgroundColor: project.metadata.color || 'lavender'}}>
-   *        <h1>{project.displayName}</h1>
-   *      </figure>
-   *    )
-   *  }
-   * ```
-   */
-  (projectHandle?: ProjectHandle): SanityProject
-}
-
 /**
+ * Returns metadata for a given project.
+ *
+ * @category Projects
+ * @param options - Configuration options
+ * @returns The metadata for the project. `members` is included only when
+ *   `includeMembers: true`; `features` is included unless `includeFeatures: false`.
+ * @example
+ * ```tsx
+ * function ProjectMetadata({projectId}: {projectId: string}) {
+ *   const project = useProject({projectId})
+ *
+ *   return (
+ *     <figure style={{backgroundColor: project.metadata.color || 'lavender'}}>
+ *       <h1>{project.displayName}</h1>
+ *     </figure>
+ *   )
+ * }
+ * ```
+ * @example
+ * ```tsx
+ * const projectWithMembers = useProject({projectId, includeMembers: true})
+ * const projectWithoutFeatures = useProject({projectId, includeFeatures: false})
+ * ```
  * @public
  * @function
  */
-export const useProject: UseProject = createStateSourceHook({
-  // remove `undefined` since we're suspending when that is the case
-  getState: getProjectState as (
-    instance: SanityInstance,
-    projectHandle?: ProjectHandle,
-  ) => StateSource<SanityProject>,
-  shouldSuspend: (instance, projectHandle) =>
-    getProjectState(instance, projectHandle).getCurrent() === undefined,
+export const useProject = createStateSourceHook({
+  getState: getProjectState,
+  shouldSuspend: (instance, ...params) =>
+    getProjectState(instance, ...params).getCurrent() === undefined,
   suspender: resolveProject,
   getConfig: identity,
-})
+}) as <IncludeMembers extends boolean = true, IncludeFeatures extends boolean = true>(
+  options?: ProjectOptions<IncludeMembers, IncludeFeatures>,
+) => Project<IncludeMembers, IncludeFeatures>

--- a/packages/react/src/hooks/projects/useProjects.test-d.ts
+++ b/packages/react/src/hooks/projects/useProjects.test-d.ts
@@ -1,0 +1,49 @@
+import {type Project, type ProjectMember} from '@sanity/sdk'
+import {expectTypeOf, test} from 'vitest'
+
+import {useProjects} from './useProjects'
+
+test('useProjects — no args: features included, members omitted', () => {
+  expectTypeOf(useProjects()).toEqualTypeOf<Project<false, true>[]>()
+})
+
+test('useProjects — includeMembers: true adds members to the type', () => {
+  expectTypeOf(useProjects({includeMembers: true})).toEqualTypeOf<Project<true, true>[]>()
+  type Result = ReturnType<typeof useProjects<true, true>>
+  expectTypeOf<Result[number]['members']>().toEqualTypeOf<ProjectMember[]>()
+})
+
+test('useProjects — includeFeatures: false drops features from the type', () => {
+  expectTypeOf(useProjects({includeFeatures: false})).toEqualTypeOf<Project<false, false>[]>()
+})
+
+test('useProjects — both flags true → both arrays present', () => {
+  expectTypeOf(useProjects({includeMembers: true, includeFeatures: true})).toEqualTypeOf<
+    Project<true, true>[]
+  >()
+})
+
+test('useProjects — both flags false → bare base shape', () => {
+  expectTypeOf(useProjects({includeMembers: false, includeFeatures: false})).toEqualTypeOf<
+    Project<false, false>[]
+  >()
+  type Result = ReturnType<typeof useProjects<false, false>>
+  expectTypeOf<Result[number]['id']>().toEqualTypeOf<string>()
+})
+
+test('useProjects — rejects non-boolean flag values', () => {
+  // @ts-expect-error — includeMembers must be a boolean
+  void useProjects({includeMembers: 'yes'})
+})
+
+test('useProjects — organizationId alone does not change the data shape', () => {
+  expectTypeOf(useProjects({organizationId: 'org_123'})).toEqualTypeOf<Project<false, true>[]>()
+})
+
+test('useProjects — non-literal boolean flag makes members optional', () => {
+  const includeMembers = false as boolean
+  expectTypeOf(useProjects({includeMembers})).toEqualTypeOf<Project<boolean, true>[]>()
+  type Result = ReturnType<typeof useProjects<boolean, true>>
+  expectTypeOf<Result[number]['members']>().toEqualTypeOf<ProjectMember[] | undefined>()
+  expectTypeOf<Pick<Result[number], 'members'>>().toEqualTypeOf<{members?: ProjectMember[]}>()
+})

--- a/packages/react/src/hooks/projects/useProjects.ts
+++ b/packages/react/src/hooks/projects/useProjects.ts
@@ -31,6 +31,8 @@ export type ProjectWithoutMembers = Project
  * ```
  * @example
  * ```tsx
+ * const projects = useProjects()
+ * const projectsWithFeatures = useProjects()
  * const projectsWithMembers = useProjects({includeMembers: true})
  * const projectsWithoutMembers = useProjects({includeMembers: false})
  * const projectsWithoutFeatures = useProjects({includeFeatures: false})

--- a/packages/react/src/hooks/projects/useProjects.ts
+++ b/packages/react/src/hooks/projects/useProjects.ts
@@ -1,5 +1,4 @@
-import {type SanityProject} from '@sanity/client'
-import {getProjectsState, resolveProjects, type SanityInstance, type StateSource} from '@sanity/sdk'
+import {getProjectsState, type Project, type ProjectsOptions, resolveProjects} from '@sanity/sdk'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
 
@@ -7,24 +6,17 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
  * @public
  * @category Types
  * @interface
+ * @deprecated use the Project type directly.
  */
-export type ProjectWithoutMembers = Omit<SanityProject, 'members'>
-
-/**
- * @public
- * @category Types
- */
-type UseProjects = <TIncludeMembers extends boolean = false>(options?: {
-  organizationId?: string
-  includeMembers?: TIncludeMembers
-}) => TIncludeMembers extends true ? SanityProject[] : ProjectWithoutMembers[]
+export type ProjectWithoutMembers = Project
 
 /**
  * Returns metadata for each project you have access to.
  *
  * @category Projects
  * @param options - Configuration options
- * @returns An array of project metadata. If includeMembers is true, returns full SanityProject objects. Otherwise, returns ProjectWithoutMembers objects.
+ * @returns An array of project metadata. `members` is included only when
+ *   `includeMembers: true`; `features` is included unless `includeFeatures: false`.
  * @example
  * ```tsx
  * const projects = useProjects()
@@ -39,18 +31,18 @@ type UseProjects = <TIncludeMembers extends boolean = false>(options?: {
  * ```
  * @example
  * ```tsx
- * const projectsWithMembers = useProjects({ includeMembers: true })
- * const projectsWithoutMembers = useProjects({ includeMembers: false })
+ * const projectsWithMembers = useProjects({includeMembers: true})
+ * const projectsWithoutMembers = useProjects({includeMembers: false})
+ * const projectsWithoutFeatures = useProjects({includeFeatures: false})
  * ```
  * @public
  * @function
  */
-export const useProjects: UseProjects = createStateSourceHook({
-  getState: getProjectsState as (
-    instance: SanityInstance,
-    options?: {organizationId?: string; includeMembers?: boolean},
-  ) => StateSource<SanityProject[] | ProjectWithoutMembers[]>,
-  shouldSuspend: (instance, options) =>
-    getProjectsState(instance, options).getCurrent() === undefined,
+export const useProjects = createStateSourceHook({
+  getState: getProjectsState,
+  shouldSuspend: (instance, ...params) =>
+    getProjectsState(instance, ...params).getCurrent() === undefined,
   suspender: resolveProjects,
-}) as UseProjects
+}) as <IncludeMembers extends boolean = false, IncludeFeatures extends boolean = true>(
+  options?: ProjectsOptions<IncludeMembers, IncludeFeatures>,
+) => Project<IncludeMembers, IncludeFeatures>[]

--- a/packages/react/tsconfig.dist.json
+++ b/packages/react/tsconfig.dist.json
@@ -6,6 +6,8 @@
     "./src/**/__mocks__",
     "./src/**/__workshop__",
     "./src/**/*.test.ts",
-    "./src/**/*.test.tsx"
+    "./src/**/*.test.tsx",
+    "./src/**/*.test-d.ts",
+    "./src/**/*.test-d.tsx"
   ]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
       reporter: ['html', 'json', 'json-summary'],
       include: ['packages/*/src/**/*.{ts,tsx}'],
       exclude: [
-        '**/*.{test,spec,stories,d}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+        '**/*.{test,test-d,spec,stories,d}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
         'packages/core/src/_exports/*.ts',
         'packages/react/src/_exports/*.ts',
         'packages/core/src/utils/getEnv.ts',


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- Adds `includeFeatures`, `onlyExplicitMembership`, and `organizationId` as typed options to the projects store, replacing the previous minimal inline types with a full `ProjectsOptions` generic interface
- Introduces conditional `Project<IncludeMembers, IncludeFeatures>` type so `members` and `features` fields are present/absent based on the query flags
- Switches from `client.projects.list()` to a raw `client.request()` against `/projects` to pass all query params directly
- Adds type-level tests (`.test-d.ts`) for both `@sanity/sdk` and `@sanity/sdk-react` to verify generic narrowing across all flag combinations
- Exports new public types: `Project`, `ProjectBase`, `ProjectMember`, `ProjectMemberRole`, `ProjectMetadata`, `ProjectsOptions`


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

* Do we see any breaking changes here? I've preserved the current behaviour with the correct defaults and depreacted the type we used to export from the react layer.
* Be interested if we want to start branding types e.g. `id` instead of `string` would be `ProjectId` – we could then in theory developer a better DX for hooks like `access` etc. by narrowing the resource type to a specific form of `id`.

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->

<img width="480" height="270" alt="looking-around-adam-scott-gif-by-apple-tv" src="https://github.com/user-attachments/assets/362c15e1-ad46-4c9b-bfb3-6d5727c60ca0" />
