### PR TITLE
feat: add organization stores to the sdk

### DIFF
--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -157,6 +157,20 @@ export {type JsonMatch} from '../document/patchOperations'
 export {type DocumentPermissionsResult, type PermissionDeniedReason} from '../document/permissions'
 export type {FavoriteStatusResponse} from '../favorites/favorites'
 export {getFavoritesState, resolveFavoritesState} from '../favorites/favorites'
+export {
+  getOrganizationState,
+  type Organization,
+  type OrganizationBase,
+  type OrganizationMember,
+  type OrganizationOptions,
+  resolveOrganization,
+} from '../organization/organization'
+export {
+  getOrganizationsState,
+  type Organizations,
+  type OrganizationsOptions,
+  resolveOrganizations,
+} from '../organizations/organizations'
 export {getPresence} from '../presence/presenceStore'
 export type {
   DisconnectEvent,

--- a/packages/core/src/organization/organization.test-d.ts
+++ b/packages/core/src/organization/organization.test-d.ts
@@ -1,0 +1,102 @@
+import {expectTypeOf, test} from 'vitest'
+
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {
+  getOrganizationState,
+  type Organization,
+  type OrganizationBase,
+  type OrganizationMember,
+  resolveOrganization,
+} from './organization'
+
+const instance = {} as SanityInstance
+
+test('resolveOrganization — default call: members and features both omitted by default', () => {
+  expectTypeOf(resolveOrganization(instance, {organizationId: 'org_1'})).resolves.toEqualTypeOf<
+    Organization<false, false>
+  >()
+  type Result = Awaited<ReturnType<typeof resolveOrganization<false, false>>>
+  expectTypeOf<Result['id']>().toEqualTypeOf<string>()
+})
+
+test('resolveOrganization — includeMembers: true adds members to the type', () => {
+  expectTypeOf(
+    resolveOrganization(instance, {organizationId: 'org_1', includeMembers: true}),
+  ).resolves.toEqualTypeOf<Organization<true, false>>()
+  type Result = Awaited<ReturnType<typeof resolveOrganization<true, false>>>
+  expectTypeOf<Result['members']>().toEqualTypeOf<OrganizationMember[]>()
+})
+
+test('resolveOrganization — includeFeatures: true adds features to the type', () => {
+  expectTypeOf(
+    resolveOrganization(instance, {organizationId: 'org_1', includeFeatures: true}),
+  ).resolves.toEqualTypeOf<Organization<false, true>>()
+})
+
+test('resolveOrganization — both flags true → both arrays present', () => {
+  expectTypeOf(
+    resolveOrganization(instance, {
+      organizationId: 'org_1',
+      includeMembers: true,
+      includeFeatures: true,
+    }),
+  ).resolves.toEqualTypeOf<Organization<true, true>>()
+})
+
+test('resolveOrganization — rejects non-boolean flag values', () => {
+  // @ts-expect-error — includeMembers must be a boolean
+  void resolveOrganization(instance, {organizationId: 'org_1', includeMembers: 'yes'})
+})
+
+test('resolveOrganization — requires organizationId', () => {
+  // @ts-expect-error — organizationId is required
+  void resolveOrganization(instance, {})
+})
+
+test('resolveOrganization — non-literal boolean flag makes members optional', () => {
+  const includeMembers = false as boolean
+  expectTypeOf(
+    resolveOrganization(instance, {organizationId: 'org_1', includeMembers}),
+  ).resolves.toEqualTypeOf<Organization<boolean, false>>()
+})
+
+test('getOrganizationState — default call returns bare-base StateSource', () => {
+  expectTypeOf(getOrganizationState(instance, {organizationId: 'org_1'})).toEqualTypeOf<
+    StateSource<Organization<false, false> | undefined>
+  >()
+})
+
+test('getOrganizationState — both flags true narrows the StateSource value type', () => {
+  expectTypeOf(
+    getOrganizationState(instance, {
+      organizationId: 'org_1',
+      includeMembers: true,
+      includeFeatures: true,
+    }),
+  ).toEqualTypeOf<StateSource<Organization<true, true> | undefined>>()
+})
+
+test('Organization — wide boolean for IncludeMembers makes members optional', () => {
+  expectTypeOf<Organization<boolean, true>>().toEqualTypeOf<
+    OrganizationBase & {members?: OrganizationMember[]} & {features: string[]}
+  >()
+  expectTypeOf<Pick<Organization<boolean, true>, 'members'>>().toEqualTypeOf<{
+    members?: OrganizationMember[]
+  }>()
+})
+
+test('Organization — wide boolean for IncludeFeatures makes features optional', () => {
+  expectTypeOf<Organization<true, boolean>>().toEqualTypeOf<
+    OrganizationBase & {members: OrganizationMember[]} & {features?: string[]}
+  >()
+  expectTypeOf<Pick<Organization<true, boolean>, 'features'>>().toEqualTypeOf<{
+    features?: string[]
+  }>()
+})
+
+test('Organization — both wide booleans make both fields optional', () => {
+  expectTypeOf<Organization<boolean, boolean>>().toEqualTypeOf<
+    OrganizationBase & {members?: OrganizationMember[]} & {features?: string[]}
+  >()
+})

--- a/packages/core/src/organization/organization.test.ts
+++ b/packages/core/src/organization/organization.test.ts
@@ -1,0 +1,138 @@
+import {type SanityClient} from '@sanity/client'
+import {of} from 'rxjs'
+import {afterEach, beforeEach, describe, it} from 'vitest'
+
+import {getClientState} from '../client/clientStore'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {getOrganizationCacheKey, resolveOrganization} from './organization'
+
+vi.mock('../client/clientStore')
+
+describe('organization', () => {
+  let instance: SanityInstance
+
+  beforeEach(() => {
+    instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('calls `client.observable.request` against `/organizations/<id>` and returns the result', async () => {
+    const organization = {id: 'org_1'}
+    const request = vi.fn().mockReturnValue(of(organization))
+
+    const mockClient = {
+      observable: {request} as unknown as SanityClient['observable'],
+    } as SanityClient
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of(mockClient),
+    } as StateSource<SanityClient>)
+
+    const result = await resolveOrganization(instance, {organizationId: 'org_1'})
+    expect(result).toEqual(organization)
+    expect(request).toHaveBeenCalledWith({
+      uri: '/organizations/org_1',
+      query: {includeMembers: 'false', includeFeatures: 'false'},
+      tag: 'organization.get',
+    })
+  })
+
+  it('serializes query params (booleans → strings) and respects flags', async () => {
+    const request = vi.fn().mockReturnValue(of({id: 'org_1'}))
+    const mockClient = {
+      observable: {request} as unknown as SanityClient['observable'],
+    } as SanityClient
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of(mockClient),
+    } as StateSource<SanityClient>)
+
+    await resolveOrganization(instance, {
+      organizationId: 'org_1',
+      includeMembers: true,
+      includeFeatures: true,
+    })
+
+    expect(request).toHaveBeenCalledWith({
+      uri: '/organizations/org_1',
+      query: {
+        includeMembers: 'true',
+        includeFeatures: 'true',
+      },
+      tag: 'organization.get',
+    })
+  })
+
+  it('throws when no organizationId is provided', async () => {
+    await expect(resolveOrganization(instance, {organizationId: ''} as never)).rejects.toThrow(
+      'An organizationId is required to use the organization API.',
+    )
+  })
+})
+
+describe('organization cache key generation', () => {
+  let instance: SanityInstance
+
+  beforeEach(() => {
+    instance = createSanityInstance({})
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('default call excludes :members and :features (both default-false)', () => {
+    expect(getOrganizationCacheKey(instance, {organizationId: 'org_1'})).toBe('organization:org_1')
+  })
+
+  it('treats undefined and the matching default as the same key', () => {
+    expect(getOrganizationCacheKey(instance, {organizationId: 'org_1'})).toBe(
+      getOrganizationCacheKey(instance, {
+        organizationId: 'org_1',
+        includeMembers: false,
+        includeFeatures: false,
+      }),
+    )
+  })
+
+  it('explicit includeMembers: true appends :members', () => {
+    expect(getOrganizationCacheKey(instance, {organizationId: 'org_1', includeMembers: true})).toBe(
+      'organization:org_1:members',
+    )
+  })
+
+  it('explicit includeFeatures: true appends :features', () => {
+    expect(
+      getOrganizationCacheKey(instance, {organizationId: 'org_1', includeFeatures: true}),
+    ).toBe('organization:org_1:features')
+  })
+
+  it('combines all segments in order', () => {
+    expect(
+      getOrganizationCacheKey(instance, {
+        organizationId: 'org_1',
+        includeMembers: true,
+        includeFeatures: true,
+      }),
+    ).toBe('organization:org_1:members:features')
+  })
+
+  it('produces distinct keys for each meaningful option permutation', () => {
+    const keys = new Set([
+      getOrganizationCacheKey(instance, {organizationId: 'org_1'}),
+      getOrganizationCacheKey(instance, {organizationId: 'org_1', includeMembers: true}),
+      getOrganizationCacheKey(instance, {organizationId: 'org_1', includeFeatures: true}),
+      getOrganizationCacheKey(instance, {
+        organizationId: 'org_1',
+        includeMembers: true,
+        includeFeatures: true,
+      }),
+      getOrganizationCacheKey(instance, {organizationId: 'org_2'}),
+    ])
+    expect(keys.size).toBe(5)
+  })
+})

--- a/packages/core/src/organization/organization.ts
+++ b/packages/core/src/organization/organization.ts
@@ -1,0 +1,166 @@
+import {switchMap} from 'rxjs'
+
+import {getClientState} from '../client/clientStore'
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {createFetcherStore} from '../utils/createFetcherStore'
+
+const API_VERSION = 'v2025-02-19'
+
+/** @public */
+export interface OrganizationMember {
+  sanityUserId: string
+  isCurrentUser: boolean
+  user: {
+    id: string
+    displayName: string
+    familyName: string
+    givenName: string
+    middleName: string | null
+    imageUrl: string | null
+    email: string
+    loginProvider: string
+  }
+  roles: Array<{
+    name: string
+    title: string
+    description?: string
+  }>
+}
+
+/**
+ * The base fields returned from `/organizations/<id>` for every organization.
+ * @public
+ */
+export interface OrganizationBase {
+  id: string
+  name: string
+  slug: string | null
+  createdAt: string
+  createdByUserId: string
+  updatedAt: string
+  deletedAt: string | null
+  dashboardStatus: 'enabled' | 'disabled'
+  aiFeaturesStatus: 'enabled' | 'disabled'
+  mediaLibraryStatus: 'enabled' | 'disabled'
+  requestAccessStatus: 'allowed' | 'disabled'
+  telemetryConsentStatus: 'allowed' | 'msa_denied' | 'customer_denied'
+  oauthAppsStatus: 'allowed' | 'blocked'
+  defaultRoleName: string
+  domains: string[] | null
+}
+
+/** @public */
+export interface OrganizationOptions<
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = false,
+> {
+  includeMembers?: IncludeMembers
+  includeFeatures?: IncludeFeatures
+  organizationId: string
+}
+
+/**
+ * An `Organization` with `members` and/or `features` conditionally included
+ * based on the query options used to fetch it.
+ * @public
+ */
+export type Organization<
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = false,
+> = OrganizationBase &
+  // `boolean extends T` is non-distributive — true only when T is the wide
+  // `boolean`, in which case the field is optional. Literal `true`/`false`
+  // fall through to the strict branch.
+  (boolean extends IncludeMembers
+    ? {members?: OrganizationMember[]}
+    : IncludeMembers extends true
+      ? {members: OrganizationMember[]}
+      : unknown) &
+  (boolean extends IncludeFeatures
+    ? {features?: string[]}
+    : IncludeFeatures extends true
+      ? {features: string[]}
+      : unknown)
+
+function resolveOrganizationId(options?: OrganizationOptions<boolean, boolean>) {
+  const organizationId = options?.organizationId
+  if (!organizationId) {
+    throw new Error('An organizationId is required to use the organization API.')
+  }
+  return organizationId
+}
+
+function normalizeOrganizationOptions(options?: OrganizationOptions<boolean, boolean>) {
+  return {
+    includeMembers: options?.includeMembers ?? false,
+    includeFeatures: options?.includeFeatures ?? false,
+  }
+}
+
+/** @internal */
+export function getOrganizationCacheKey(
+  _instance: SanityInstance,
+  options?: OrganizationOptions<boolean, boolean>,
+): string {
+  const organizationId = resolveOrganizationId(options)
+  const {includeMembers, includeFeatures} = normalizeOrganizationOptions(options)
+  const membersKey = includeMembers ? ':members' : ''
+  const featuresKey = includeFeatures ? ':features' : ''
+  return `organization:${organizationId}${membersKey}${featuresKey}`
+}
+
+const organization = createFetcherStore({
+  name: 'Organization',
+  getKey: getOrganizationCacheKey,
+  fetcher: (instance) => (options?: OrganizationOptions<boolean, boolean>) => {
+    const organizationId = resolveOrganizationId(options)
+
+    return getClientState(instance, {
+      apiVersion: API_VERSION,
+      scope: 'global',
+    }).observable.pipe(
+      switchMap((client) => {
+        const normalized = normalizeOrganizationOptions(options)
+        const query = Object.fromEntries(
+          Object.entries(normalized)
+            .filter(([, value]) => value !== undefined)
+            .map(([key, value]) => [key, String(value)]),
+        )
+
+        return client.observable.request({
+          uri: `/organizations/${organizationId}`,
+          query,
+          tag: 'organization.get',
+        })
+      }),
+    )
+  },
+})
+
+/**
+ * Public signature for the organization state source. The conditional generics
+ * cannot flow through `BoundStoreAction`, so we declare the signature here
+ * and assign the (already-correct) runtime function to it.
+ */
+type GetOrganizationState = <
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = false,
+>(
+  instance: SanityInstance,
+  options: OrganizationOptions<IncludeMembers, IncludeFeatures>,
+) => StateSource<Organization<IncludeMembers, IncludeFeatures> | undefined>
+
+type ResolveOrganization = <
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = false,
+>(
+  instance: SanityInstance,
+  options: OrganizationOptions<IncludeMembers, IncludeFeatures>,
+) => Promise<Organization<IncludeMembers, IncludeFeatures>>
+
+/** @public */
+export const getOrganizationState: GetOrganizationState = organization.getState
+
+/** @public */
+export const resolveOrganization: ResolveOrganization = organization.resolveState

--- a/packages/core/src/organizations/organizations.test-d.ts
+++ b/packages/core/src/organizations/organizations.test-d.ts
@@ -1,0 +1,77 @@
+import {expectTypeOf, test} from 'vitest'
+
+import {type OrganizationMember} from '../organization/organization'
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {getOrganizationsState, type Organizations, resolveOrganizations} from './organizations'
+
+const instance = {} as SanityInstance
+
+test('resolveOrganizations — default call: bare list shape', () => {
+  expectTypeOf(resolveOrganizations(instance)).resolves.toEqualTypeOf<Organizations<false, false>>()
+})
+
+test('resolveOrganizations — includeMembers: true narrows the generic', () => {
+  expectTypeOf(resolveOrganizations(instance, {includeMembers: true})).resolves.toEqualTypeOf<
+    Organizations<true, false>
+  >()
+})
+
+test('resolveOrganizations — includeFeatures: true narrows the generic', () => {
+  expectTypeOf(resolveOrganizations(instance, {includeFeatures: true})).resolves.toEqualTypeOf<
+    Organizations<false, true>
+  >()
+})
+
+test('resolveOrganizations — both flags true', () => {
+  expectTypeOf(
+    resolveOrganizations(instance, {includeMembers: true, includeFeatures: true}),
+  ).resolves.toEqualTypeOf<Organizations<true, true>>()
+})
+
+test('resolveOrganizations — rejects non-boolean flag values', () => {
+  // @ts-expect-error — includeMembers must be a boolean
+  void resolveOrganizations(instance, {includeMembers: 'yes'})
+})
+
+test('resolveOrganizations — includeImplicitMemberships does not change the data shape', () => {
+  expectTypeOf(
+    resolveOrganizations(instance, {includeImplicitMemberships: true}),
+  ).resolves.toEqualTypeOf<Organizations<false, false>>()
+})
+
+test('Organizations — list items expose the documented subset of keys', () => {
+  type Keys = keyof Organizations<false, false>[number]
+  expectTypeOf<Keys>().toEqualTypeOf<
+    | 'id'
+    | 'name'
+    | 'slug'
+    | 'createdAt'
+    | 'updatedAt'
+    | 'defaultRoleName'
+    | 'dashboardStatus'
+    | 'aiFeaturesStatus'
+  >()
+})
+
+test('Organizations<true, false>[number] exposes members[]', () => {
+  type Item = Organizations<true, false>[number]
+  expectTypeOf<Item['members']>().toEqualTypeOf<OrganizationMember[]>()
+})
+
+test('Organizations<false, true>[number] exposes features[]', () => {
+  type Item = Organizations<false, true>[number]
+  expectTypeOf<Item['features']>().toEqualTypeOf<string[]>()
+})
+
+test('Organizations<true, true>[number] exposes both members[] and features[]', () => {
+  type Item = Organizations<true, true>[number]
+  expectTypeOf<Item['members']>().toEqualTypeOf<OrganizationMember[]>()
+  expectTypeOf<Item['features']>().toEqualTypeOf<string[]>()
+})
+
+test('getOrganizationsState — default call returns the bare-base StateSource', () => {
+  expectTypeOf(getOrganizationsState(instance)).toEqualTypeOf<
+    StateSource<Organizations<false, false> | undefined>
+  >()
+})

--- a/packages/core/src/organizations/organizations.test.ts
+++ b/packages/core/src/organizations/organizations.test.ts
@@ -1,0 +1,150 @@
+import {type SanityClient} from '@sanity/client'
+import {of} from 'rxjs'
+import {afterEach, beforeEach, describe, it} from 'vitest'
+
+import {getClientState} from '../client/clientStore'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {getOrganizationsCacheKey, resolveOrganizations} from './organizations'
+
+vi.mock('../client/clientStore')
+
+describe('organizations', () => {
+  let instance: SanityInstance
+
+  beforeEach(() => {
+    instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('calls `client.observable.request` against `/organizations` and returns the result', async () => {
+    const organizations = [{id: 'org_1'}, {id: 'org_2'}]
+    const request = vi.fn().mockReturnValue(of(organizations))
+
+    const mockClient = {
+      observable: {request} as unknown as SanityClient['observable'],
+    } as SanityClient
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of(mockClient),
+    } as StateSource<SanityClient>)
+
+    const result = await resolveOrganizations(instance)
+    expect(result).toEqual(organizations)
+    expect(request).toHaveBeenCalledWith({
+      uri: '/organizations',
+      query: {
+        includeImplicitMemberships: 'false',
+        includeMembers: 'false',
+        includeFeatures: 'false',
+      },
+      tag: 'organizations.get',
+    })
+  })
+
+  it('serializes query params (booleans → strings) and respects flags', async () => {
+    const request = vi.fn().mockReturnValue(of([]))
+    const mockClient = {
+      observable: {request} as unknown as SanityClient['observable'],
+    } as SanityClient
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of(mockClient),
+    } as StateSource<SanityClient>)
+
+    await resolveOrganizations(instance, {
+      includeMembers: true,
+      includeFeatures: true,
+      includeImplicitMemberships: true,
+    })
+
+    expect(request).toHaveBeenCalledWith({
+      uri: '/organizations',
+      query: {
+        includeImplicitMemberships: 'true',
+        includeMembers: 'true',
+        includeFeatures: 'true',
+      },
+      tag: 'organizations.get',
+    })
+  })
+})
+
+describe('organizations cache key generation', () => {
+  let instance: SanityInstance
+
+  beforeEach(() => {
+    instance = createSanityInstance({})
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('default call excludes all segments (all flags default-false)', () => {
+    expect(getOrganizationsCacheKey(instance)).toBe('organizations')
+  })
+
+  it('treats undefined and the matching default as the same key', () => {
+    expect(getOrganizationsCacheKey(instance)).toBe(
+      getOrganizationsCacheKey(instance, {
+        includeMembers: false,
+        includeFeatures: false,
+        includeImplicitMemberships: false,
+      }),
+    )
+  })
+
+  it('explicit includeMembers: true appends :members', () => {
+    expect(getOrganizationsCacheKey(instance, {includeMembers: true})).toBe('organizations:members')
+  })
+
+  it('explicit includeFeatures: true appends :features', () => {
+    expect(getOrganizationsCacheKey(instance, {includeFeatures: true})).toBe(
+      'organizations:features',
+    )
+  })
+
+  it('explicit includeImplicitMemberships: true appends :implicit', () => {
+    expect(getOrganizationsCacheKey(instance, {includeImplicitMemberships: true})).toBe(
+      'organizations:implicit',
+    )
+  })
+
+  it('combines all segments in order', () => {
+    expect(
+      getOrganizationsCacheKey(instance, {
+        includeMembers: true,
+        includeFeatures: true,
+        includeImplicitMemberships: true,
+      }),
+    ).toBe('organizations:members:features:implicit')
+  })
+
+  it('produces distinct keys for each meaningful option permutation', () => {
+    const keys = new Set([
+      getOrganizationsCacheKey(instance),
+      getOrganizationsCacheKey(instance, {includeMembers: true}),
+      getOrganizationsCacheKey(instance, {includeFeatures: true}),
+      getOrganizationsCacheKey(instance, {includeImplicitMemberships: true}),
+      getOrganizationsCacheKey(instance, {includeMembers: true, includeFeatures: true}),
+      getOrganizationsCacheKey(instance, {
+        includeMembers: true,
+        includeImplicitMemberships: true,
+      }),
+      getOrganizationsCacheKey(instance, {
+        includeFeatures: true,
+        includeImplicitMemberships: true,
+      }),
+      getOrganizationsCacheKey(instance, {
+        includeMembers: true,
+        includeFeatures: true,
+        includeImplicitMemberships: true,
+      }),
+    ])
+    expect(keys.size).toBe(8)
+  })
+})

--- a/packages/core/src/organizations/organizations.ts
+++ b/packages/core/src/organizations/organizations.ts
@@ -1,0 +1,132 @@
+import {switchMap} from 'rxjs'
+
+import {getClientState} from '../client/clientStore'
+import {
+  type OrganizationBase,
+  type OrganizationMember,
+  type OrganizationOptions,
+} from '../organization/organization'
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {createFetcherStore} from '../utils/createFetcherStore'
+
+const API_VERSION = 'v2025-02-19'
+
+/**
+ * The list shape returned from `/organizations`, with `members` and/or
+ * `features` conditionally included based on the query options used.
+ * @public
+ */
+export type Organizations<
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = false,
+> = (Pick<
+  OrganizationBase,
+  | 'id'
+  | 'name'
+  | 'slug'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'defaultRoleName'
+  | 'dashboardStatus'
+  | 'aiFeaturesStatus'
+> &
+  // `boolean extends T` is non-distributive — true only when T is the wide
+  // `boolean`, in which case the field is optional. Literal `true`/`false`
+  // fall through to the strict branch.
+  (boolean extends IncludeMembers
+    ? {members?: OrganizationMember[]}
+    : IncludeMembers extends true
+      ? {members: OrganizationMember[]}
+      : unknown) &
+  (boolean extends IncludeFeatures
+    ? {features?: string[]}
+    : IncludeFeatures extends true
+      ? {features: string[]}
+      : unknown))[]
+
+/** @public */
+export interface OrganizationsOptions<
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = false,
+> extends Omit<OrganizationOptions<IncludeMembers, IncludeFeatures>, 'organizationId'> {
+  /**
+   * When `true`, includes organisations the user has access to via
+   * project-level grants, not just direct organisation memberships.
+   */
+  includeImplicitMemberships?: boolean
+}
+
+function normalizeOrganizationOptions(options?: OrganizationsOptions<boolean, boolean>) {
+  return {
+    includeImplicitMemberships: options?.includeImplicitMemberships ?? false,
+    includeMembers: options?.includeMembers ?? false,
+    includeFeatures: options?.includeFeatures ?? false,
+  }
+}
+
+/** @internal */
+export function getOrganizationsCacheKey(
+  _instance: SanityInstance,
+  options?: OrganizationsOptions<boolean, boolean>,
+): string {
+  const {includeMembers, includeFeatures, includeImplicitMemberships} =
+    normalizeOrganizationOptions(options)
+  const membersKey = includeMembers ? ':members' : ''
+  const featuresKey = includeFeatures ? ':features' : ''
+  const implicitKey = includeImplicitMemberships ? ':implicit' : ''
+  return `organizations${membersKey}${featuresKey}${implicitKey}`
+}
+
+const organizations = createFetcherStore({
+  name: 'Organizations',
+  getKey: getOrganizationsCacheKey,
+  fetcher: (instance) => (options?: OrganizationsOptions<boolean, boolean>) => {
+    return getClientState(instance, {
+      apiVersion: API_VERSION,
+      scope: 'global',
+    }).observable.pipe(
+      switchMap((client) => {
+        const normalized = normalizeOrganizationOptions(options)
+        const query = Object.fromEntries(
+          Object.entries(normalized)
+            .filter(([, value]) => value !== undefined)
+            .map(([key, value]) => [key, String(value)]),
+        )
+
+        return client.observable.request({
+          uri: `/organizations`,
+          query,
+          tag: 'organizations.get',
+        })
+      }),
+    )
+  },
+})
+
+/**
+ * Public signature for the organization state source. The conditional generics
+ * cannot flow through `BoundStoreAction`, so we declare the signature here
+ * and assign the (already-correct) runtime function to it.
+ */
+type GetOrganizationsState = <
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = false,
+>(
+  instance: SanityInstance,
+  options?: OrganizationsOptions<IncludeMembers, IncludeFeatures>,
+) => StateSource<Organizations<IncludeMembers, IncludeFeatures> | undefined>
+
+type ResolveOrganizations = <
+  IncludeMembers extends boolean = false,
+  IncludeFeatures extends boolean = false,
+>(
+  instance: SanityInstance,
+  options?: OrganizationsOptions<IncludeMembers, IncludeFeatures>,
+) => Promise<Organizations<IncludeMembers, IncludeFeatures>>
+
+/** @public */
+export const getOrganizationsState: GetOrganizationsState = organizations.getState
+
+/** @public */
+export const resolveOrganizations: ResolveOrganizations = organizations.resolveState

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -69,6 +69,8 @@ export {
   type DocumentsResponse,
   useDocuments,
 } from '../hooks/documents/useDocuments'
+export {useOrganization} from '../hooks/organizations/useOrganization'
+export {useOrganizations} from '../hooks/organizations/useOrganizations'
 export {
   type PaginatedDocumentsOptions,
   type PaginatedDocumentsResponse,

--- a/packages/react/src/hooks/organizations/useOrganization.test-d.ts
+++ b/packages/react/src/hooks/organizations/useOrganization.test-d.ts
@@ -1,0 +1,53 @@
+import {type Organization, type OrganizationMember} from '@sanity/sdk'
+import {expectTypeOf, test} from 'vitest'
+
+import {useOrganization} from './useOrganization'
+
+test('useOrganization — no flags: members and features both omitted', () => {
+  expectTypeOf(useOrganization({organizationId: 'org_1'})).toEqualTypeOf<
+    Organization<false, false>
+  >()
+})
+
+test('useOrganization — includeMembers: true adds members to the type', () => {
+  expectTypeOf(useOrganization({organizationId: 'org_1', includeMembers: true})).toEqualTypeOf<
+    Organization<true, false>
+  >()
+  type Result = ReturnType<typeof useOrganization<true, false>>
+  expectTypeOf<Result['members']>().toEqualTypeOf<OrganizationMember[]>()
+})
+
+test('useOrganization — includeFeatures: true adds features to the type', () => {
+  expectTypeOf(useOrganization({organizationId: 'org_1', includeFeatures: true})).toEqualTypeOf<
+    Organization<false, true>
+  >()
+})
+
+test('useOrganization — both flags true → both arrays present', () => {
+  expectTypeOf(
+    useOrganization({organizationId: 'org_1', includeMembers: true, includeFeatures: true}),
+  ).toEqualTypeOf<Organization<true, true>>()
+})
+
+test('useOrganization — both flags false → bare base shape', () => {
+  expectTypeOf(
+    useOrganization({organizationId: 'org_1', includeMembers: false, includeFeatures: false}),
+  ).toEqualTypeOf<Organization<false, false>>()
+  type Result = ReturnType<typeof useOrganization<false, false>>
+  expectTypeOf<Result['id']>().toEqualTypeOf<string>()
+})
+
+test('useOrganization — rejects non-boolean flag values', () => {
+  // @ts-expect-error — includeMembers must be a boolean
+  void useOrganization({organizationId: 'org_1', includeMembers: 'yes'})
+})
+
+test('useOrganization — non-literal boolean flag makes members optional', () => {
+  const includeMembers = false as boolean
+  expectTypeOf(useOrganization({organizationId: 'org_1', includeMembers})).toEqualTypeOf<
+    Organization<boolean, false>
+  >()
+  type Result = ReturnType<typeof useOrganization<boolean, false>>
+  expectTypeOf<Result['members']>().toEqualTypeOf<OrganizationMember[] | undefined>()
+  expectTypeOf<Pick<Result, 'members'>>().toEqualTypeOf<{members?: OrganizationMember[]}>()
+})

--- a/packages/react/src/hooks/organizations/useOrganization.test.ts
+++ b/packages/react/src/hooks/organizations/useOrganization.test.ts
@@ -1,0 +1,65 @@
+import {getOrganizationState, type OrganizationOptions, type SanityInstance} from '@sanity/sdk'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createStateSourceHook} from '../helpers/createStateSourceHook'
+
+vi.mock('@sanity/sdk', () => ({
+  getOrganizationState: vi.fn(() => ({
+    getCurrent: vi.fn(() => undefined),
+  })),
+  resolveOrganization: vi.fn(),
+}))
+vi.mock('../helpers/createStateSourceHook', () => ({
+  createStateSourceHook: vi.fn(),
+}))
+
+describe('useOrganization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mock('@sanity/sdk', () => ({
+      getOrganizationState: vi.fn(() => ({
+        getCurrent: vi.fn(() => undefined),
+      })),
+      resolveOrganization: vi.fn(),
+    }))
+    vi.mock('../helpers/createStateSourceHook', () => ({
+      createStateSourceHook: vi.fn(),
+    }))
+  })
+
+  it('should call createStateSourceHook with correct arguments on import', async () => {
+    await import('./useOrganization')
+
+    expect(createStateSourceHook).toHaveBeenCalled()
+    expect(createStateSourceHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        getState: expect.any(Function),
+        shouldSuspend: expect.any(Function),
+        suspender: expect.any(Function),
+      }),
+    )
+  })
+
+  it('shouldSuspend should call getOrganizationState and getCurrent', async () => {
+    await import('./useOrganization')
+
+    const mockCreateStateSourceHook = createStateSourceHook as ReturnType<typeof vi.fn>
+    expect(mockCreateStateSourceHook.mock.calls.length).toBeGreaterThan(0)
+    const createStateSourceHookArgs = mockCreateStateSourceHook.mock.calls[0][0]
+    const shouldSuspend = createStateSourceHookArgs.shouldSuspend
+
+    const mockInstance = {} as SanityInstance
+    const mockOptions: OrganizationOptions = {organizationId: 'org_1'}
+
+    const result = shouldSuspend(mockInstance, mockOptions)
+
+    const mockGetOrganizationState = getOrganizationState as ReturnType<typeof vi.fn>
+    expect(mockGetOrganizationState).toHaveBeenCalledWith(mockInstance, mockOptions)
+
+    expect(mockGetOrganizationState.mock.results.length).toBeGreaterThan(0)
+    const getOrganizationStateMockResult = mockGetOrganizationState.mock.results[0].value
+    expect(getOrganizationStateMockResult.getCurrent).toHaveBeenCalled()
+
+    expect(result).toBe(true)
+  })
+})

--- a/packages/react/src/hooks/organizations/useOrganization.ts
+++ b/packages/react/src/hooks/organizations/useOrganization.ts
@@ -1,0 +1,40 @@
+import {
+  getOrganizationState,
+  type Organization,
+  type OrganizationOptions,
+  resolveOrganization,
+} from '@sanity/sdk'
+
+import {createStateSourceHook} from '../helpers/createStateSourceHook'
+
+/**
+ * Returns metadata for a given organisation.
+ *
+ * @category Organizations
+ * @param options - Configuration options
+ * @returns The metadata for the organisation. `members` is included only when
+ *   `includeMembers: true`; `features` is included only when `includeFeatures: true`.
+ * @example
+ * ```tsx
+ * function OrganizationName({organizationId}: {organizationId: string}) {
+ *   const organization = useOrganization({organizationId})
+ *
+ *   return <h1>{organization.name}</h1>
+ * }
+ * ```
+ * @example
+ * ```tsx
+ * const organizationWithMembers = useOrganization({organizationId, includeMembers: true})
+ * const organizationWithFeatures = useOrganization({organizationId, includeFeatures: true})
+ * ```
+ * @public
+ * @function
+ */
+export const useOrganization = createStateSourceHook({
+  getState: getOrganizationState,
+  shouldSuspend: (instance, ...params) =>
+    getOrganizationState(instance, ...params).getCurrent() === undefined,
+  suspender: resolveOrganization,
+}) as <IncludeMembers extends boolean = false, IncludeFeatures extends boolean = false>(
+  options: OrganizationOptions<IncludeMembers, IncludeFeatures>,
+) => Organization<IncludeMembers, IncludeFeatures>

--- a/packages/react/src/hooks/organizations/useOrganizations.test-d.ts
+++ b/packages/react/src/hooks/organizations/useOrganizations.test-d.ts
@@ -1,0 +1,55 @@
+import {type OrganizationMember, type Organizations} from '@sanity/sdk'
+import {expectTypeOf, test} from 'vitest'
+
+import {useOrganizations} from './useOrganizations'
+
+test('useOrganizations — no args: members and features both omitted', () => {
+  expectTypeOf(useOrganizations()).toEqualTypeOf<Organizations<false, false>>()
+})
+
+test('useOrganizations — includeMembers: true adds members to the type', () => {
+  expectTypeOf(useOrganizations({includeMembers: true})).toEqualTypeOf<Organizations<true, false>>()
+  type Result = ReturnType<typeof useOrganizations<true, false>>
+  expectTypeOf<Result[number]['members']>().toEqualTypeOf<OrganizationMember[]>()
+})
+
+test('useOrganizations — includeFeatures: true adds features to the type', () => {
+  expectTypeOf(useOrganizations({includeFeatures: true})).toEqualTypeOf<
+    Organizations<false, true>
+  >()
+})
+
+test('useOrganizations — both flags true → both arrays present', () => {
+  expectTypeOf(useOrganizations({includeMembers: true, includeFeatures: true})).toEqualTypeOf<
+    Organizations<true, true>
+  >()
+})
+
+test('useOrganizations — both flags false → bare base shape', () => {
+  expectTypeOf(useOrganizations({includeMembers: false, includeFeatures: false})).toEqualTypeOf<
+    Organizations<false, false>
+  >()
+  type Result = ReturnType<typeof useOrganizations<false, false>>
+  expectTypeOf<Result[number]['id']>().toEqualTypeOf<string>()
+})
+
+test('useOrganizations — rejects non-boolean flag values', () => {
+  // @ts-expect-error — includeMembers must be a boolean
+  void useOrganizations({includeMembers: 'yes'})
+})
+
+test('useOrganizations — includeImplicitMemberships does not change the data shape', () => {
+  expectTypeOf(useOrganizations({includeImplicitMemberships: true})).toEqualTypeOf<
+    Organizations<false, false>
+  >()
+})
+
+test('useOrganizations — non-literal boolean flag makes members optional', () => {
+  const includeMembers = false as boolean
+  expectTypeOf(useOrganizations({includeMembers})).toEqualTypeOf<Organizations<boolean, false>>()
+  type Result = ReturnType<typeof useOrganizations<boolean, false>>
+  expectTypeOf<Result[number]['members']>().toEqualTypeOf<OrganizationMember[] | undefined>()
+  expectTypeOf<Pick<Result[number], 'members'>>().toEqualTypeOf<{
+    members?: OrganizationMember[]
+  }>()
+})

--- a/packages/react/src/hooks/organizations/useOrganizations.test.ts
+++ b/packages/react/src/hooks/organizations/useOrganizations.test.ts
@@ -1,0 +1,85 @@
+import {getOrganizationsState, type SanityInstance} from '@sanity/sdk'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createStateSourceHook} from '../helpers/createStateSourceHook'
+
+vi.mock('@sanity/sdk', () => ({
+  getOrganizationsState: vi.fn(() => ({
+    getCurrent: vi.fn(() => undefined),
+  })),
+  resolveOrganizations: vi.fn(),
+}))
+vi.mock('../helpers/createStateSourceHook', () => ({
+  createStateSourceHook: vi.fn(),
+}))
+
+describe('useOrganizations', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mock('@sanity/sdk', () => ({
+      getOrganizationsState: vi.fn(() => ({
+        getCurrent: vi.fn(() => undefined),
+      })),
+      resolveOrganizations: vi.fn(),
+    }))
+    vi.mock('../helpers/createStateSourceHook', () => ({
+      createStateSourceHook: vi.fn(),
+    }))
+  })
+
+  it('should call createStateSourceHook with correct arguments on import', async () => {
+    await import('./useOrganizations')
+
+    expect(createStateSourceHook).toHaveBeenCalled()
+    expect(createStateSourceHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        getState: expect.any(Function),
+        shouldSuspend: expect.any(Function),
+        suspender: expect.any(Function),
+      }),
+    )
+  })
+
+  it('shouldSuspend should call getOrganizationsState and getCurrent', async () => {
+    await import('./useOrganizations')
+
+    const mockCreateStateSourceHook = createStateSourceHook as ReturnType<typeof vi.fn>
+    expect(mockCreateStateSourceHook.mock.calls.length).toBeGreaterThan(0)
+    const createStateSourceHookArgs = mockCreateStateSourceHook.mock.calls[0][0]
+    const shouldSuspend = createStateSourceHookArgs.shouldSuspend
+
+    const mockInstance = {} as SanityInstance
+
+    const result = shouldSuspend(mockInstance, undefined)
+
+    const mockGetOrganizationsState = getOrganizationsState as ReturnType<typeof vi.fn>
+    expect(mockGetOrganizationsState).toHaveBeenCalledWith(mockInstance, undefined)
+
+    expect(mockGetOrganizationsState.mock.results.length).toBeGreaterThan(0)
+    const getOrganizationsStateMockResult = mockGetOrganizationsState.mock.results[0].value
+    expect(getOrganizationsStateMockResult.getCurrent).toHaveBeenCalled()
+
+    expect(result).toBe(true)
+  })
+
+  it('should handle different parameter combinations in shouldSuspend', async () => {
+    await import('./useOrganizations')
+
+    const mockCreateStateSourceHook = createStateSourceHook as ReturnType<typeof vi.fn>
+    const createStateSourceHookArgs = mockCreateStateSourceHook.mock.calls[0][0]
+    const shouldSuspend = createStateSourceHookArgs.shouldSuspend
+
+    const mockInstance = {} as SanityInstance
+
+    expect(() => shouldSuspend(mockInstance, undefined)).not.toThrow()
+    expect(() => shouldSuspend(mockInstance, {includeMembers: true})).not.toThrow()
+    expect(() => shouldSuspend(mockInstance, {includeFeatures: true})).not.toThrow()
+    expect(() =>
+      shouldSuspend(mockInstance, {
+        includeMembers: true,
+        includeFeatures: true,
+        includeImplicitMemberships: true,
+      }),
+    ).not.toThrow()
+  })
+})

--- a/packages/react/src/hooks/organizations/useOrganizations.ts
+++ b/packages/react/src/hooks/organizations/useOrganizations.ts
@@ -1,0 +1,45 @@
+import {
+  getOrganizationsState,
+  type Organizations,
+  type OrganizationsOptions,
+  resolveOrganizations,
+} from '@sanity/sdk'
+
+import {createStateSourceHook} from '../helpers/createStateSourceHook'
+
+/**
+ * Returns metadata for each organisation the current user has access to.
+ *
+ * @category Organizations
+ * @param options - Configuration options
+ * @returns An array of organisation metadata. `members` is included only when
+ *   `includeMembers: true`; `features` is included only when `includeFeatures: true`.
+ * @example
+ * ```tsx
+ * const organizations = useOrganizations()
+ *
+ * return (
+ *   <select>
+ *     {organizations.map((organization) => (
+ *       <option key={organization.id}>{organization.name}</option>
+ *     ))}
+ *   </select>
+ * )
+ * ```
+ * @example
+ * ```tsx
+ * const organizationsWithMembers = useOrganizations({includeMembers: true})
+ * const organizationsWithFeatures = useOrganizations({includeFeatures: true})
+ * const organizationsIncludingImplicit = useOrganizations({includeImplicitMemberships: true})
+ * ```
+ * @public
+ * @function
+ */
+export const useOrganizations = createStateSourceHook({
+  getState: getOrganizationsState,
+  shouldSuspend: (instance, ...params) =>
+    getOrganizationsState(instance, ...params).getCurrent() === undefined,
+  suspender: resolveOrganizations,
+}) as <IncludeMembers extends boolean = false, IncludeFeatures extends boolean = false>(
+  options?: OrganizationsOptions<IncludeMembers, IncludeFeatures>,
+) => Organizations<IncludeMembers, IncludeFeatures>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- Adds `organization` and `organizations` stores with `getOrganizationState`, `resolveOrganization`, `getOrganizationsState`, and `resolveOrganizations`
- Introduces conditional `Organization<IncludeMembers>` type so the `members` field is present only when `includeMembers: true`
- Adds `useOrganization` and `useOrganizations` React hooks with suspense support
- Adds type-level tests (`.test-d.ts`) for all new stores and hooks
- Exports new public types: `Organization`, `OrganizationBase`, `OrganizationMember`, `OrganizationsOptions`


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

* Do we have a way to populate other stores from a list store? for example, if someone fetches all the organizations then it would be nice to populate single org stores by their id 🤔 
* Still wondering about branded ID types here, can see how they'd link up more as we grow.

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->

<img width="480" height="270" alt="sorry-ben-stiller-gif-by-apple-tv" src="https://github.com/user-attachments/assets/e8b86291-2d1b-4bf9-bf7c-bdab169917bb" />
