### PR TITLE
revert: drop support for Node 20

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Before contributing, please read our [code of conduct](https://github.com/sanity
 
 ### Prerequisites
 
-- Node.js: Version 22.13 or higher (we recommend using the active LTS version)
+- Node.js: Version 20.x or higher (we recommend using the LTS version)
 - pnpm: Version 8.x or higher
 
 Check your versions:

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "packageManager": "pnpm@10.8.0",
   "engines": {
-    "node": ">=22.13"
+    "node": ">=20.19"
   },
   "pnpm": {
     "overrides": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,7 +100,7 @@
   },
   "packageManager": "pnpm@10.8.0",
   "engines": {
-    "node": ">=22.13"
+    "node": ">=20.19"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -101,7 +101,7 @@
   },
   "packageManager": "pnpm@10.8.0",
   "engines": {
-    "node": ">=22.13"
+    "node": ">=20.19"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Reverts sanity-io/sdk#846

Reverts the `engines.node` portion of #846. **Scope reduced** from the original wholesale revert: this only touches the engines field and the `CONTRIBUTING.md` prerequisite line. The CI hardening from #846 (Node 22/24 matrix, Node 22 single-version workflows) is preserved.

## What this PR changes

Reverted:

- `engines.node` back to `>=20.19` in `package.json`, `packages/core/package.json`, and `packages/react/package.json`
- `CONTRIBUTING.md` Node prerequisite back to "Version 20.x or higher"

Preserved from #846:

- Build and test matrix on `[22, 24]` in `build.yml` and `test.yml`
- `lint`, `depcheck`, `type-check`, `upload-docs`, `pkg-pr-new` on Node 22

## Why

The `feat!:` framing in #846 was overstated. `engines.node` is advisory: we don't set `engine-strict=true`, and runtime support is already gated by transitive deps (`@sanity/client@7` requires `>=20`, `@sanity/image-url` requires `>=20.19.0`). The "this lets upstream tooling drop Node 20" claim from #846 also didn't hold up against the lockfile: `vitest@4.1.5`, `jsdom@29.1.1`, and `vite@7.3.2` all still declare Node 20 in their engines as of writing.

A follow-up PR will remove `engines.node` from the published packages entirely, matching `@sanity/types` and other Sanity browser libraries that publish without an engines field.

## Release impact

The commit message includes `Release-As: 2.11.0` in the body, which forces release-please (#857) to 2.11.0 instead of 3.0.0. The `revert:` type with the standard `This reverts commit d8ddee9...` line should also let conventional-commits-parser pair this with the original `feat!:` and elide both from the changelog. If pairing fails, `Release-As` is the safety net.