### PR TITLE
fix(core): use tag instead of requestTagPrefix on project calls

### DIFF
--- a/.cursor/rules/request-tag-conventions.mdc
+++ b/.cursor/rules/request-tag-conventions.mdc
@@ -14,7 +14,7 @@ All outgoing Sanity API requests from the SDK must use the `sanity.sdk.*` tag na
 
 ## Rules
 
-1. **Never use ad hoc `requestTagPrefix` strings.** Use `REQUEST_TAG_PREFIX` from `authConstants.ts` for auth code, or rely on the default `'sanity.sdk'` from `clientStore.ts` for everything else. The only exception is `projects.ts` which uses `'sanity.sdk.projects'` because the client convenience method doesn't support per-request tags.
+1. **Never use ad hoc `requestTagPrefix` strings.** Use `REQUEST_TAG_PREFIX` from `authConstants.ts` for auth code, or rely on the default `'sanity.sdk'` from `clientStore.ts` for everything else.
 
 2. **Every `.request()`, `.fetch()`, `.listen()`, and `.action()` call must include a `tag` property** that describes the operation (e.g., `'users.get-current'`, `'logout'`, `'document.action'`).
 

--- a/packages/core/src/project/project.test.ts
+++ b/packages/core/src/project/project.test.ts
@@ -37,6 +37,7 @@ describe('project', () => {
     expect(request).toHaveBeenCalledWith({
       uri: '/projects/a',
       query: {includeMembers: 'true', includeFeatures: 'true'},
+      tag: 'project.get',
     })
   })
 
@@ -62,6 +63,7 @@ describe('project', () => {
         includeMembers: 'false',
         includeFeatures: 'false',
       },
+      tag: 'project.get',
     })
   })
 
@@ -79,6 +81,7 @@ describe('project', () => {
     expect(request).toHaveBeenCalledWith({
       uri: '/projects/p',
       query: {includeMembers: 'true', includeFeatures: 'true'},
+      tag: 'project.get',
     })
   })
 })

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -120,7 +120,6 @@ const project = createFetcherStore({
     return getClientState(instance, {
       apiVersion: API_VERSION,
       scope: 'global',
-      requestTagPrefix: 'sanity.sdk.project',
     }).observable.pipe(
       switchMap((client) => {
         const normalized = normalizeProjectOptions(options)
@@ -133,6 +132,7 @@ const project = createFetcherStore({
         return client.observable.request({
           uri: `/projects/${projectId}`,
           query,
+          tag: 'project.get',
         })
       }),
     )

--- a/packages/core/src/projects/projects.test.ts
+++ b/packages/core/src/projects/projects.test.ts
@@ -37,6 +37,7 @@ describe('projects', () => {
     expect(request).toHaveBeenCalledWith({
       uri: '/projects',
       query: {includeMembers: 'false', includeFeatures: 'true', onlyExplicitMembership: 'false'},
+      tag: 'projects.get',
     })
   })
 
@@ -64,6 +65,7 @@ describe('projects', () => {
         includeFeatures: 'false',
         onlyExplicitMembership: 'false',
       },
+      tag: 'projects.get',
     })
   })
 })

--- a/packages/core/src/projects/projects.ts
+++ b/packages/core/src/projects/projects.ts
@@ -49,7 +49,6 @@ const projects = createFetcherStore({
     getClientState(instance, {
       apiVersion: API_VERSION,
       scope: 'global',
-      requestTagPrefix: 'sanity.sdk.projects',
     }).observable.pipe(
       switchMap((client) => {
         const normalized = normalizeProjectsOptions(options)
@@ -62,6 +61,7 @@ const projects = createFetcherStore({
         return client.observable.request({
           uri: '/projects',
           query,
+          tag: 'projects.get',
         })
       }),
     ),


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

In #865 we moved from using the `projects` methods on the client to raw request, I omitted adding a `tag` to the request and removing the `requestTagPrefix` as guided in here – https://github.com/sanity-io/sdk/blob/main/.cursor/rules/request-tag-conventions.mdc so heres that fix 👍🏼 

### Fun gif

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->

<img width="245" height="200" alt="sorry-michael-caine-gif" src="https://github.com/user-attachments/assets/a68dbc7a-13d4-4e0b-927c-db35eaf670ca" />
