### PR TITLE
chore(renovate): align pnpm constraint with packageManager (10.33.4)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
   ],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
   "constraints": {
-    "pnpm": "10.8.0"
+    "pnpm": "10.33.4"
   },
   "postUpdateOptions": ["pnpmDedupe"],
   "schedule": ["before 5am"],


### PR DESCRIPTION
### Description

Bump `constraints.pnpm` in `.github/renovate.json` from `10.8.0` to `10.33.4` so it matches `packageManager` in `package.json`.

PR #885 bumped `packageManager` to `pnpm@10.33.4` but didn't update the matching constraint in the Renovate config (the dashboard playbook calls this out, but it was missed). Since then, Renovate's hosted runner has been failing to switch pnpm to `10.33.4` while preparing PRs:

```
ERROR  Failed to switch pnpm to v10.33.4. Looks like pnpm CLI is missing
at "/home/ubuntu/.local/share/pnpm/.tools/pnpm/10.33.4/bin" or is incorrect
spawnSync /home/ubuntu/.local/share/pnpm/.tools/pnpm/10.33.4/bin/pnpm ENOENT
```

When that step fails, Renovate skips updating `pnpm-lock.yaml`, so every dependency PR it has opened lands with a stale lockfile and CI's `pnpm install --frozen-lockfile` fails with `ERR_PNPM_OUTDATED_LOCKFILE`. Visible on #888, #889, #890, #892.

Aligning the constraint should let Renovate provision the correct pnpm version on its next run.

### What to review

- Single-line change in `.github/renovate.json` (`constraints.pnpm: "10.8.0"` → `"10.33.4"`).
- Confirm it matches `packageManager` in `package.json` (`pnpm@10.33.4`).

After this lands, the four already-open Renovate PRs (#888, #889, #890, #892) still need a one-time push of an updated lockfile each, per the dashboard's "A lockfile looks broken" recovery step. New Renovate runs should self-heal.

### Testing

No automated test. Verified locally that:
- `pnpm install --frozen-lockfile` succeeds against `main`.
- The reported CI failures on the affected PRs are `ERR_PNPM_OUTDATED_LOCKFILE` traced back to Renovate's pnpm-version switch failure, not a lockfile drift on `main`.

The real validation is the next Renovate run picking up the new constraint and successfully regenerating lockfiles. If it doesn't, fallback is to temporarily roll `packageManager` (and this constraint) back to a version Mend's hosted environment definitely supports.

### Fun gif
![crossed](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXFyc2lqZW1lMHZzZnVpMTh4M3lqaWZhb3RtNGVjYW03cmU0ejdoMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/y31UU15vlUO0zzJRrl/giphy.gif)
<!-- pick something appropriate -->
