### PR TITLE
fix(auth): keep subscription alive after /users/me fetch error

### DIFF
--- a/packages/core/src/auth/subscribeToStateAndFetchCurrentUser.test.ts
+++ b/packages/core/src/auth/subscribeToStateAndFetchCurrentUser.test.ts
@@ -112,4 +112,120 @@ describe('subscribeToStateAndFetchCurrentUser', () => {
 
     subscription.unsubscribe()
   })
+
+  it('recovers from a fetch error when a new token is set', () => {
+    const error = new Error('Unauthorized')
+    const mockUser = {id: 'recovered-user'} as CurrentUser
+    const mockRequest = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => error))
+      .mockReturnValueOnce(of(mockUser))
+    const mockClient = {observable: {request: mockRequest}}
+    const clientFactory = vi.fn().mockReturnValue(mockClient)
+    const instance = createSanityInstance({projectId: 'p', dataset: 'd', auth: {clientFactory}})
+
+    const state = createStoreState(authStore.getInitialState(instance, null))
+    const subscription = subscribeToStateAndFetchCurrentUser({state, instance, key: null})
+
+    // First token causes a 401 — state should transition to ERROR
+    state.set('setLoggedIn', {
+      authState: {type: AuthStateType.LOGGED_IN, token: 'expired-token', currentUser: null},
+    })
+    expect(state.get()).toMatchObject({authState: {type: AuthStateType.ERROR, error}})
+
+    // Simulate comlink providing a fresh token (setAuthToken sets LOGGED_IN with new token)
+    state.set('setNewToken', {
+      authState: {type: AuthStateType.LOGGED_IN, token: 'fresh-token', currentUser: null},
+    })
+
+    // Subscription should still be alive — re-fetches /users/me with the new token
+    expect(state.get()).toMatchObject({
+      authState: {type: AuthStateType.LOGGED_IN, token: 'fresh-token', currentUser: mockUser},
+    })
+    expect(mockRequest).toHaveBeenCalledTimes(2)
+
+    subscription.unsubscribe()
+  })
+
+  it('recovers from multiple consecutive fetch errors', () => {
+    const error1 = new Error('Unauthorized')
+    const error2 = new Error('Unauthorized again')
+    const mockUser = {id: 'finally-recovered'} as CurrentUser
+    const mockRequest = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => error1))
+      .mockReturnValueOnce(throwError(() => error2))
+      .mockReturnValueOnce(of(mockUser))
+    const mockClient = {observable: {request: mockRequest}}
+    const clientFactory = vi.fn().mockReturnValue(mockClient)
+    const instance = createSanityInstance({projectId: 'p', dataset: 'd', auth: {clientFactory}})
+
+    const state = createStoreState(authStore.getInitialState(instance, null))
+    const subscription = subscribeToStateAndFetchCurrentUser({state, instance, key: null})
+
+    // First attempt fails
+    state.set('setLoggedIn', {
+      authState: {type: AuthStateType.LOGGED_IN, token: 'token-1', currentUser: null},
+    })
+    expect(state.get()).toMatchObject({authState: {type: AuthStateType.ERROR, error: error1}})
+
+    // Second attempt also fails
+    state.set('setNewToken', {
+      authState: {type: AuthStateType.LOGGED_IN, token: 'token-2', currentUser: null},
+    })
+    expect(state.get()).toMatchObject({authState: {type: AuthStateType.ERROR, error: error2}})
+
+    // Third attempt succeeds
+    state.set('setNewToken', {
+      authState: {type: AuthStateType.LOGGED_IN, token: 'token-3', currentUser: null},
+    })
+    expect(state.get()).toMatchObject({
+      authState: {type: AuthStateType.LOGGED_IN, token: 'token-3', currentUser: mockUser},
+    })
+    expect(mockRequest).toHaveBeenCalledTimes(3)
+
+    subscription.unsubscribe()
+  })
+
+  it('does not re-fetch with the same token but recovers with a different token', () => {
+    const error = new Error('Unauthorized')
+    const mockUser = {id: 'recovered-user'} as CurrentUser
+    const mockRequest = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => error))
+      .mockReturnValueOnce(of(mockUser))
+    const mockClient = {observable: {request: mockRequest}}
+    const clientFactory = vi.fn().mockReturnValue(mockClient)
+    const instance = createSanityInstance({projectId: 'p', dataset: 'd', auth: {clientFactory}})
+
+    const state = createStoreState(authStore.getInitialState(instance, null))
+    const subscription = subscribeToStateAndFetchCurrentUser({state, instance, key: null})
+
+    // First attempt fails
+    state.set('setLoggedIn', {
+      authState: {type: AuthStateType.LOGGED_IN, token: 'same-token', currentUser: null},
+    })
+    expect(state.get()).toMatchObject({authState: {type: AuthStateType.ERROR, error}})
+
+    // Same token should be blocked by distinctUntilChanged — no re-fetch
+    state.set('setNewToken', {
+      authState: {type: AuthStateType.LOGGED_IN, token: 'same-token', currentUser: null},
+    })
+    expect(mockRequest).toHaveBeenCalledTimes(1)
+
+    // A different token should pass distinctUntilChanged and trigger recovery
+    state.set('setNewToken', {
+      authState: {type: AuthStateType.LOGGED_IN, token: 'different-token', currentUser: null},
+    })
+    expect(state.get()).toMatchObject({
+      authState: {
+        type: AuthStateType.LOGGED_IN,
+        token: 'different-token',
+        currentUser: mockUser,
+      },
+    })
+    expect(mockRequest).toHaveBeenCalledTimes(2)
+
+    subscription.unsubscribe()
+  })
 })

--- a/packages/core/src/auth/subscribeToStateAndFetchCurrentUser.ts
+++ b/packages/core/src/auth/subscribeToStateAndFetchCurrentUser.ts
@@ -1,5 +1,13 @@
 import {type CurrentUser} from '@sanity/types'
-import {distinctUntilChanged, filter, map, type Subscription, switchMap} from 'rxjs'
+import {
+  catchError,
+  distinctUntilChanged,
+  EMPTY,
+  filter,
+  map,
+  type Subscription,
+  switchMap,
+} from 'rxjs'
 
 import {type StoreContext} from '../store/defineStore'
 import {DEFAULT_API_VERSION, REQUEST_TAG_PREFIX} from './authConstants'
@@ -60,11 +68,24 @@ export const subscribeToStateAndFetchCurrentUser = (
         }),
       ),
       switchMap((client) =>
-        client.observable.request<CurrentUser>({
-          uri: '/users/me',
-          method: 'GET',
-          tag: 'users.get-current',
-        }),
+        client.observable
+          .request<CurrentUser>({
+            uri: '/users/me',
+            method: 'GET',
+            tag: 'users.get-current',
+          })
+          .pipe(
+            /**
+             * Catch inside switchMap so the outer subscription survives.
+             * Without this, a 401 terminates the subscription permanently
+             * and subsequent token refreshes via comlink never re-fetch /users/me.
+             * @see SDK-1409
+             */
+            catchError((error) => {
+              state.set('setError', {authState: {type: AuthStateType.ERROR, error}})
+              return EMPTY
+            }),
+          ),
       ),
     )
 
@@ -76,9 +97,6 @@ export const subscribeToStateAndFetchCurrentUser = (
             ? {...prev.authState, currentUser}
             : prev.authState,
       }))
-    },
-    error: (error) => {
-      state.set('setError', {authState: {type: AuthStateType.ERROR, error}})
     },
   })
 }


### PR DESCRIPTION
### Problem

When `/users/me` returns a 401 in dashboard mode, the RxJS subscription in `subscribeToStateAndFetchCurrentUser` terminates permanently. Even after `ComlinkTokenRefresh` obtains a fresh token from the parent frame, the dead subscription never re-fetches `/users/me` — leaving the user stuck at `LOGGED_IN` with `currentUser: null`.

### Solution

Move error handling from the subscriber's `error` callback into a `catchError` operator inside `switchMap`, returning `EMPTY`. This keeps the outer subscription alive so new tokens trigger a retry. Matches the established pattern in `usersStore`, `queryStore`, and `favorites`.