### PR TITLE
chore(ci): pass --ignore-scripts to pnpm install in release-rc

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           cache: pnpm
           node-version: lts/*
-      - run: pnpm install
+      - run: pnpm install --ignore-scripts
       - run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}


### PR DESCRIPTION
### Description

Pass `--ignore-scripts` to `pnpm install` in `.github/workflows/release-rc.yml` so dependency lifecycle scripts (`preinstall`, `install`, `postinstall`, `prepare`) don't execute in the same job that holds `NPM_PUBLISH_TOKEN`, `id-token: write`, and a GitHub App push token.

Without this flag, a compromised dependency or transitive dependency in `pnpm-lock.yaml` could run code during `pnpm install`, plant a payload, and exfiltrate the publish token when the later `pnpm release:rc` step writes it to `~/.npmrc`. That's the Shai-Hulud / Mini Shai-Hulud distribution model in a nutshell. The production release workflow (`release-please.yml`, line 55) already does this; this brings the RC workflow in line.

Resolves SDK-1414.

### What to review

- `.github/workflows/release-rc.yml`: the only change is `pnpm install` → `pnpm install --ignore-scripts`.
- Confirm no extra build step is needed. `pnpm release:rc` runs `scripts/release-rc.mts`, which calls `pnpm build` itself (line 32) before publishing, and each public package's `prepublishOnly: pnpm run build` also fires during `pnpm publish`. So the dependency tree is materialized, then our own build runs against it, then publish happens. `release-please.yml` runs the same way and works.
- Worth double-checking against the next RC publish: if any dependency turns out to require a `postinstall` build (native module, etc.), follow up with a targeted `pnpm rebuild <pkg>` or a separate explicit build step. Unlikely given `release-please.yml` already runs clean with `--ignore-scripts`.

### Testing

No automated test for workflow changes. Verification plan:

- After merge, trigger the RC workflow via `workflow_dispatch` on a branch and confirm it bumps versions, builds, and publishes to the `rc` npm tag successfully.
- Spot-check that `@sanity/sdk@<rc>` and `@sanity/sdk-react@<rc>` install cleanly into a consumer.

### Fun gif

![dune worm](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZnR1MjIwcDJhMHprdzlyc2l0MHkwdjEzcjk3aHA2YmJzNGp0bHI0ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/AkwcbzEPIfZ48i44kx/giphy.gif)