### PR TITLE
feat(core): add release actions to document store

### DIFF
--- a/apps/kitchensink-react/src/routes/releases/ReleasesAutocomplete.tsx
+++ b/apps/kitchensink-react/src/routes/releases/ReleasesAutocomplete.tsx
@@ -22,7 +22,7 @@ export function ReleasesAutocomplete({
       <Autocomplete
         id="release-autocomplete"
         filterOption={(query, option) =>
-          option.payload.metadata.title.toLowerCase().indexOf(query.toLowerCase()) > -1
+          (option.payload.metadata.title ?? '').toLowerCase().indexOf(query.toLowerCase()) > -1
         }
         fontSize={[2, 2, 3]}
         icon={<SearchIcon style={{width: '1.5em', height: '1.5em'}} />}

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -136,7 +136,6 @@ export {
   publishRelease,
   type PublishReleaseAction,
   type ReleaseAction,
-  type ReleaseActionMetadata,
   scheduleRelease,
   type ScheduleReleaseAction,
   unarchiveRelease,
@@ -235,7 +234,7 @@ export {
   resolveQuery,
 } from '../query/queryStore'
 export {getPerspectiveState} from '../releases/getPerspectiveState'
-export type {ReleaseDocument, ReleaseState} from '../releases/releasesStore'
+export type {ReleaseState} from '../releases/releasesStore'
 export {getActiveReleasesState, getAllReleasesState} from '../releases/releasesStore'
 export {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 export {type Selector, type StateSource} from '../store/createStateSourceAction'
@@ -265,6 +264,7 @@ export {defineIntent, type Intent, type IntentFilter} from '../utils/defineInten
 export {getCorsErrorProjectId} from '../utils/getCorsErrorProjectId'
 export {isImportError} from '../utils/isImportError'
 export {CORE_SDK_VERSION} from '../version'
+export type {ReleaseDocument} from '@sanity/client'
 export {
   getIndexForKey,
   getPathDepth,

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -105,6 +105,7 @@ export {
   type MediaLibrarySource,
   type PerspectiveHandle,
   type ProjectHandle,
+  type ReleaseHandle,
   type ReleasePerspective,
   type SanityConfig,
   type StudioConfig,
@@ -112,19 +113,38 @@ export {
 } from '../config/sanityConfig'
 export {getDatasetsState, resolveDatasets} from '../datasets/datasets'
 export {
+  type Action,
+  archiveRelease,
+  type ArchiveReleaseAction,
   createDocument,
   type CreateDocumentAction,
+  createRelease,
+  type CreateReleaseAction,
   deleteDocument,
   type DeleteDocumentAction,
+  deleteRelease,
+  type DeleteReleaseAction,
   discardDocument,
   type DiscardDocumentAction,
   type DocumentAction,
   editDocument,
   type EditDocumentAction,
+  editRelease,
+  type EditReleaseAction,
   publishDocument,
   type PublishDocumentAction,
+  publishRelease,
+  type PublishReleaseAction,
+  type ReleaseAction,
+  type ReleaseActionMetadata,
+  scheduleRelease,
+  type ScheduleReleaseAction,
+  unarchiveRelease,
+  type UnarchiveReleaseAction,
   unpublishDocument,
   type UnpublishDocumentAction,
+  unscheduleRelease,
+  type UnscheduleReleaseAction,
 } from '../document/actions'
 export {
   type ActionsResult,
@@ -155,6 +175,7 @@ export {
 } from '../document/events'
 export {type JsonMatch} from '../document/patchOperations'
 export {type DocumentPermissionsResult, type PermissionDeniedReason} from '../document/permissions'
+export {getReleaseDocumentId} from '../document/processActions/releaseUtil'
 export type {FavoriteStatusResponse} from '../favorites/favorites'
 export {getFavoritesState, resolveFavoritesState} from '../favorites/favorites'
 export {

--- a/packages/core/src/config/sanityConfig.ts
+++ b/packages/core/src/config/sanityConfig.ts
@@ -123,12 +123,10 @@ export interface DocumentHandle<
  * `name` parameter on the release document (e.g. `{name: 'r41035a4'}`).
  * The underlying release document ID is `_.releases.<releaseId>`.
  * It's also the `id` parameter sent to the Actions API.
+ * (This type doesn't need to have ProjectId / Dataset generics since it's always the same shape)
  * @beta
  */
-export interface ReleaseHandle<
-  TDataset extends string = string,
-  TProjectId extends string = string,
-> extends DatasetHandle<TDataset, TProjectId> {
+export interface ReleaseHandle extends DatasetHandle {
   releaseId: string
 }
 

--- a/packages/core/src/config/sanityConfig.ts
+++ b/packages/core/src/config/sanityConfig.ts
@@ -119,6 +119,20 @@ export interface DocumentHandle<
 }
 
 /**
+ * Identifies a release within a Sanity dataset and project. `releaseId` is the
+ * `name` parameter on the release document (e.g. `{name: 'r41035a4'}`).
+ * The underlying release document ID is `_.releases.<releaseId>`.
+ * It's also the `id` parameter sent to the Actions API.
+ * @beta
+ */
+export interface ReleaseHandle<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends DatasetHandle<TDataset, TProjectId> {
+  releaseId: string
+}
+
+/**
  * Represents the complete configuration for a Sanity SDK instance
  * @public
  */

--- a/packages/core/src/document/actions.test.ts
+++ b/packages/core/src/document/actions.test.ts
@@ -2,14 +2,23 @@ import {at, patch, set, setIfMissing} from '@sanity/mutate'
 import {type PatchOperations} from '@sanity/types'
 import {describe, expect, it} from 'vitest'
 
-import {type DocumentHandle} from '../config/sanityConfig'
+import {type DocumentHandle, type ReleaseHandle} from '../config/sanityConfig'
 import {
+  archiveRelease,
   createDocument,
+  createRelease,
   deleteDocument,
+  deleteRelease,
   discardDocument,
   editDocument,
+  editRelease,
   publishDocument,
+  publishRelease,
+  type ReleaseActionMetadata,
+  scheduleRelease,
+  unarchiveRelease,
   unpublishDocument,
+  unscheduleRelease,
 } from '../document/actions'
 
 const dummyPatch: PatchOperations = {
@@ -18,6 +27,9 @@ const dummyPatch: PatchOperations = {
 
 const dummyDocHandle: DocumentHandle = {documentId: 'drafts.abc123', documentType: 'testType'}
 const dummyDocString = {documentId: 'drafts.abc123', documentType: 'testType'}
+
+const dummyReleaseHandle: ReleaseHandle = {releaseId: 'my-release'}
+const dummyReleasePatch: PatchOperations = {set: {'metadata.title': 'Updated title'}}
 
 describe('document actions', () => {
   describe('createDocument', () => {
@@ -204,6 +216,112 @@ describe('document actions', () => {
         documentId: 'abc123',
         documentType: dummyDocHandle.documentType,
       })
+    })
+  })
+})
+
+describe('release actions', () => {
+  describe('createRelease', () => {
+    it('creates a release action from a release handle', () => {
+      const action = createRelease(dummyReleaseHandle)
+      expect(action).toEqual({
+        type: 'release.create',
+        releaseId: 'my-release',
+      })
+    })
+
+    it('creates a release action with metadata', () => {
+      const metadata: ReleaseActionMetadata = {
+        title: 'My release',
+        description: 'Some description',
+        releaseType: 'scheduled',
+        intendedPublishAt: '2026-01-01T00:00:00.000Z',
+      }
+      const action = createRelease(dummyReleaseHandle, metadata)
+      expect(action).toEqual({
+        type: 'release.create',
+        releaseId: 'my-release',
+        metadata,
+      })
+    })
+
+    it('omits metadata when not provided', () => {
+      const action = createRelease(dummyReleaseHandle, undefined)
+      expect(action).toEqual({
+        type: 'release.create',
+        releaseId: 'my-release',
+      })
+      expect(action).not.toHaveProperty('metadata')
+    })
+
+    it('preserves resource fields from the handle', () => {
+      const action = createRelease({
+        releaseId: 'my-release',
+        resource: {dataset: 'production', projectId: 'abc123'},
+      })
+      expect(action).toEqual({
+        type: 'release.create',
+        releaseId: 'my-release',
+        resource: {dataset: 'production', projectId: 'abc123'},
+      })
+    })
+  })
+
+  describe('editRelease', () => {
+    it('creates a release.edit action with a patch', () => {
+      const action = editRelease(dummyReleaseHandle, dummyReleasePatch)
+      expect(action).toEqual({
+        type: 'release.edit',
+        releaseId: 'my-release',
+        patch: dummyReleasePatch,
+      })
+    })
+  })
+
+  describe('publishRelease', () => {
+    it('creates a release.publish action from a release handle', () => {
+      const action = publishRelease(dummyReleaseHandle)
+      expect(action).toEqual({type: 'release.publish', releaseId: 'my-release'})
+    })
+  })
+
+  describe('scheduleRelease', () => {
+    it('creates a release.schedule action with publishAt', () => {
+      const publishAt = '2026-01-01T00:00:00.000Z'
+      const action = scheduleRelease(dummyReleaseHandle, publishAt)
+      expect(action).toEqual({
+        type: 'release.schedule',
+        releaseId: 'my-release',
+        publishAt,
+      })
+    })
+  })
+
+  describe('unscheduleRelease', () => {
+    it('creates a release.unschedule action from a release handle', () => {
+      const action = unscheduleRelease(dummyReleaseHandle)
+      expect(action).toEqual({type: 'release.unschedule', releaseId: 'my-release'})
+    })
+  })
+
+  describe('archiveRelease', () => {
+    it('creates a release.archive action from a release handle', () => {
+      const action = archiveRelease(dummyReleaseHandle)
+      expect(action).toEqual({type: 'release.archive', releaseId: 'my-release'})
+    })
+  })
+
+  describe('unarchiveRelease', () => {
+    it('creates a release.unarchive action from a release handle', () => {
+      const action = unarchiveRelease(dummyReleaseHandle)
+      expect(action).toEqual({type: 'release.unarchive', releaseId: 'my-release'})
+    })
+  })
+
+  describe('deleteRelease', () => {
+    it('creates a release.delete action from a release handle', () => {
+      const action = deleteRelease(dummyReleaseHandle)
+      expect(action).toEqual({type: 'release.delete', releaseId: 'my-release'})
     })
   })
 })

--- a/packages/core/src/document/actions.test.ts
+++ b/packages/core/src/document/actions.test.ts
@@ -1,3 +1,4 @@
+import {type ReleaseDocument} from '@sanity/client'
 import {at, patch, set, setIfMissing} from '@sanity/mutate'
 import {type PatchOperations} from '@sanity/types'
 import {describe, expect, it} from 'vitest'
@@ -14,7 +15,6 @@ import {
   editRelease,
   publishDocument,
   publishRelease,
-  type ReleaseActionMetadata,
   scheduleRelease,
   unarchiveRelease,
   unpublishDocument,
@@ -227,11 +227,12 @@ describe('release actions', () => {
       expect(action).toEqual({
         type: 'release.create',
         releaseId: 'my-release',
+        metadata: {releaseType: 'undecided'},
       })
     })
 
     it('creates a release action with metadata', () => {
-      const metadata: ReleaseActionMetadata = {
+      const metadata: ReleaseDocument['metadata'] = {
         title: 'My release',
         description: 'Some description',
         releaseType: 'scheduled',
@@ -245,15 +246,6 @@ describe('release actions', () => {
       })
     })
 
-    it('omits metadata when not provided', () => {
-      const action = createRelease(dummyReleaseHandle, undefined)
-      expect(action).toEqual({
-        type: 'release.create',
-        releaseId: 'my-release',
-      })
-      expect(action).not.toHaveProperty('metadata')
-    })
-
     it('preserves resource fields from the handle', () => {
       const action = createRelease({
         releaseId: 'my-release',
@@ -263,6 +255,7 @@ describe('release actions', () => {
         type: 'release.create',
         releaseId: 'my-release',
         resource: {dataset: 'production', projectId: 'abc123'},
+        metadata: {releaseType: 'undecided'},
       })
     })
   })

--- a/packages/core/src/document/actions.ts
+++ b/packages/core/src/document/actions.ts
@@ -3,7 +3,11 @@ import {type PatchMutation as SanityMutatePatchMutation} from '@sanity/mutate/_u
 import {type PatchMutation, type PatchOperations} from '@sanity/types'
 import {type SanityDocument} from 'groq'
 
-import {type DocumentHandle, type DocumentTypeHandle} from '../config/sanityConfig'
+import {
+  type DocumentHandle,
+  type DocumentTypeHandle,
+  type ReleaseHandle,
+} from '../config/sanityConfig'
 import {getEffectiveDocumentId} from './util'
 
 const isSanityMutatePatch = (value: unknown): value is SanityMutatePatchMutation => {
@@ -119,6 +123,17 @@ export type DocumentAction<
   | PublishDocumentAction<TDocumentType, TDataset, TProjectId>
   | UnpublishDocumentAction<TDocumentType, TDataset, TProjectId>
   | DiscardDocumentAction<TDocumentType, TDataset, TProjectId>
+
+/**
+ * Union of every action accepted by `applyDocumentActions` — both document-
+ * level actions and release-lifecycle actions.
+ * @beta
+ */
+export type Action<
+  TDocumentType extends string = string,
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> = DocumentAction<TDocumentType, TDataset, TProjectId> | ReleaseAction<TDataset, TProjectId>
 
 /**
  * Creates a `CreateDocumentAction` object.
@@ -315,4 +330,195 @@ export function discardDocument<
     ...doc,
     documentId: effectiveDocumentId,
   }
+}
+
+/**
+ * The release metadata shape accepted by the create/edit release actions.
+ * Mirrors the server-side release document metadata.
+ * @beta
+ */
+export interface ReleaseActionMetadata {
+  title?: string
+  description?: string
+  intendedPublishAt?: string
+  releaseType?: 'asap' | 'scheduled' | 'undecided'
+  cardinality?: 'one' | 'many'
+}
+
+/**
+ * Creates a new release. The `releaseId` must be unique within the current
+ * retention period.
+ * @beta
+ */
+export interface CreateReleaseAction<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends ReleaseHandle<TDataset, TProjectId> {
+  type: 'release.create'
+  metadata?: ReleaseActionMetadata
+}
+
+/**
+ * Patches the metadata of an existing release.
+ * @beta
+ */
+export interface EditReleaseAction<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends ReleaseHandle<TDataset, TProjectId> {
+  type: 'release.edit'
+  patch: PatchOperations
+}
+
+/**
+ * Publishes all version documents in a release.
+ * @beta
+ */
+export interface PublishReleaseAction<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends ReleaseHandle<TDataset, TProjectId> {
+  type: 'release.publish'
+}
+
+/**
+ * Schedules a release to be published at the given UTC time. Locks the
+ * version documents server-side until the release is unscheduled or published.
+ * @beta
+ */
+export interface ScheduleReleaseAction<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends ReleaseHandle<TDataset, TProjectId> {
+  type: 'release.schedule'
+  publishAt: string
+}
+
+/**
+ * Unschedules a release that was previously scheduled, returning it to the
+ * active editable state.
+ * @beta
+ */
+export interface UnscheduleReleaseAction<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends ReleaseHandle<TDataset, TProjectId> {
+  type: 'release.unschedule'
+}
+
+/**
+ * Archives an active release. Version documents within the release are
+ * removed and no longer queryable, though still recoverable through history
+ * during the retention period.
+ * @beta
+ */
+export interface ArchiveReleaseAction<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends ReleaseHandle<TDataset, TProjectId> {
+  type: 'release.archive'
+}
+
+/**
+ * Restores an archived release. Only possible during the retention period.
+ * @beta
+ */
+export interface UnarchiveReleaseAction<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends ReleaseHandle<TDataset, TProjectId> {
+  type: 'release.unarchive'
+}
+
+/**
+ * Permanently deletes an archived or published release. To remove an active
+ * release, use the archive action first.
+ * @beta
+ */
+export interface DeleteReleaseAction<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+> extends ReleaseHandle<TDataset, TProjectId> {
+  type: 'release.delete'
+}
+
+/**
+ * Union of all release actions that can be dispatched alongside document
+ * actions through `applyDocumentActions`.
+ * @beta
+ */
+export type ReleaseAction<TDataset extends string = string, TProjectId extends string = string> =
+  | CreateReleaseAction<TDataset, TProjectId>
+  | EditReleaseAction<TDataset, TProjectId>
+  | PublishReleaseAction<TDataset, TProjectId>
+  | ScheduleReleaseAction<TDataset, TProjectId>
+  | UnscheduleReleaseAction<TDataset, TProjectId>
+  | ArchiveReleaseAction<TDataset, TProjectId>
+  | UnarchiveReleaseAction<TDataset, TProjectId>
+  | DeleteReleaseAction<TDataset, TProjectId>
+
+/** @beta */
+export function createRelease<TDataset extends string = string, TProjectId extends string = string>(
+  handle: ReleaseHandle<TDataset, TProjectId>,
+  metadata?: ReleaseActionMetadata,
+): CreateReleaseAction<TDataset, TProjectId> {
+  return {type: 'release.create', ...handle, ...(metadata && {metadata})}
+}
+
+/** @beta */
+export function editRelease<TDataset extends string = string, TProjectId extends string = string>(
+  handle: ReleaseHandle<TDataset, TProjectId>,
+  patch: PatchOperations,
+): EditReleaseAction<TDataset, TProjectId> {
+  return {type: 'release.edit', ...handle, patch}
+}
+
+/** @beta */
+export function publishRelease<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+>(handle: ReleaseHandle<TDataset, TProjectId>): PublishReleaseAction<TDataset, TProjectId> {
+  return {type: 'release.publish', ...handle}
+}
+
+/** @beta */
+export function scheduleRelease<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+>(
+  handle: ReleaseHandle<TDataset, TProjectId>,
+  publishAt: string,
+): ScheduleReleaseAction<TDataset, TProjectId> {
+  return {type: 'release.schedule', ...handle, publishAt}
+}
+
+/** @beta */
+export function unscheduleRelease<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+>(handle: ReleaseHandle<TDataset, TProjectId>): UnscheduleReleaseAction<TDataset, TProjectId> {
+  return {type: 'release.unschedule', ...handle}
+}
+
+/** @beta */
+export function archiveRelease<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+>(handle: ReleaseHandle<TDataset, TProjectId>): ArchiveReleaseAction<TDataset, TProjectId> {
+  return {type: 'release.archive', ...handle}
+}
+
+/** @beta */
+export function unarchiveRelease<
+  TDataset extends string = string,
+  TProjectId extends string = string,
+>(handle: ReleaseHandle<TDataset, TProjectId>): UnarchiveReleaseAction<TDataset, TProjectId> {
+  return {type: 'release.unarchive', ...handle}
+}
+
+/** @beta */
+export function deleteRelease<TDataset extends string = string, TProjectId extends string = string>(
+  handle: ReleaseHandle<TDataset, TProjectId>,
+): DeleteReleaseAction<TDataset, TProjectId> {
+  return {type: 'release.delete', ...handle}
 }

--- a/packages/core/src/document/actions.ts
+++ b/packages/core/src/document/actions.ts
@@ -1,3 +1,4 @@
+import {type ReleaseDocument} from '@sanity/client'
 import {SanityEncoder} from '@sanity/mutate'
 import {type PatchMutation as SanityMutatePatchMutation} from '@sanity/mutate/_unstable_store'
 import {type PatchMutation, type PatchOperations} from '@sanity/types'
@@ -133,7 +134,7 @@ export type Action<
   TDocumentType extends string = string,
   TDataset extends string = string,
   TProjectId extends string = string,
-> = DocumentAction<TDocumentType, TDataset, TProjectId> | ReleaseAction<TDataset, TProjectId>
+> = DocumentAction<TDocumentType, TDataset, TProjectId> | ReleaseAction
 
 /**
  * Creates a `CreateDocumentAction` object.
@@ -333,39 +334,20 @@ export function discardDocument<
 }
 
 /**
- * The release metadata shape accepted by the create/edit release actions.
- * Mirrors the server-side release document metadata.
- * @beta
- */
-export interface ReleaseActionMetadata {
-  title?: string
-  description?: string
-  intendedPublishAt?: string
-  releaseType?: 'asap' | 'scheduled' | 'undecided'
-  cardinality?: 'one' | 'many'
-}
-
-/**
  * Creates a new release. The `releaseId` must be unique within the current
  * retention period.
  * @beta
  */
-export interface CreateReleaseAction<
-  TDataset extends string = string,
-  TProjectId extends string = string,
-> extends ReleaseHandle<TDataset, TProjectId> {
+export interface CreateReleaseAction extends ReleaseHandle {
   type: 'release.create'
-  metadata?: ReleaseActionMetadata
+  metadata: ReleaseDocument['metadata']
 }
 
 /**
  * Patches the metadata of an existing release.
  * @beta
  */
-export interface EditReleaseAction<
-  TDataset extends string = string,
-  TProjectId extends string = string,
-> extends ReleaseHandle<TDataset, TProjectId> {
+export interface EditReleaseAction extends ReleaseHandle {
   type: 'release.edit'
   patch: PatchOperations
 }
@@ -374,10 +356,7 @@ export interface EditReleaseAction<
  * Publishes all version documents in a release.
  * @beta
  */
-export interface PublishReleaseAction<
-  TDataset extends string = string,
-  TProjectId extends string = string,
-> extends ReleaseHandle<TDataset, TProjectId> {
+export interface PublishReleaseAction extends ReleaseHandle {
   type: 'release.publish'
 }
 
@@ -386,10 +365,7 @@ export interface PublishReleaseAction<
  * version documents server-side until the release is unscheduled or published.
  * @beta
  */
-export interface ScheduleReleaseAction<
-  TDataset extends string = string,
-  TProjectId extends string = string,
-> extends ReleaseHandle<TDataset, TProjectId> {
+export interface ScheduleReleaseAction extends ReleaseHandle {
   type: 'release.schedule'
   publishAt: string
 }
@@ -399,10 +375,7 @@ export interface ScheduleReleaseAction<
  * active editable state.
  * @beta
  */
-export interface UnscheduleReleaseAction<
-  TDataset extends string = string,
-  TProjectId extends string = string,
-> extends ReleaseHandle<TDataset, TProjectId> {
+export interface UnscheduleReleaseAction extends ReleaseHandle {
   type: 'release.unschedule'
 }
 
@@ -412,10 +385,7 @@ export interface UnscheduleReleaseAction<
  * during the retention period.
  * @beta
  */
-export interface ArchiveReleaseAction<
-  TDataset extends string = string,
-  TProjectId extends string = string,
-> extends ReleaseHandle<TDataset, TProjectId> {
+export interface ArchiveReleaseAction extends ReleaseHandle {
   type: 'release.archive'
 }
 
@@ -423,10 +393,7 @@ export interface ArchiveReleaseAction<
  * Restores an archived release. Only possible during the retention period.
  * @beta
  */
-export interface UnarchiveReleaseAction<
-  TDataset extends string = string,
-  TProjectId extends string = string,
-> extends ReleaseHandle<TDataset, TProjectId> {
+export interface UnarchiveReleaseAction extends ReleaseHandle {
   type: 'release.unarchive'
 }
 
@@ -435,10 +402,7 @@ export interface UnarchiveReleaseAction<
  * release, use the archive action first.
  * @beta
  */
-export interface DeleteReleaseAction<
-  TDataset extends string = string,
-  TProjectId extends string = string,
-> extends ReleaseHandle<TDataset, TProjectId> {
+export interface DeleteReleaseAction extends ReleaseHandle {
   type: 'release.delete'
 }
 
@@ -447,78 +411,55 @@ export interface DeleteReleaseAction<
  * actions through `applyDocumentActions`.
  * @beta
  */
-export type ReleaseAction<TDataset extends string = string, TProjectId extends string = string> =
-  | CreateReleaseAction<TDataset, TProjectId>
-  | EditReleaseAction<TDataset, TProjectId>
-  | PublishReleaseAction<TDataset, TProjectId>
-  | ScheduleReleaseAction<TDataset, TProjectId>
-  | UnscheduleReleaseAction<TDataset, TProjectId>
-  | ArchiveReleaseAction<TDataset, TProjectId>
-  | UnarchiveReleaseAction<TDataset, TProjectId>
-  | DeleteReleaseAction<TDataset, TProjectId>
+export type ReleaseAction =
+  | CreateReleaseAction
+  | EditReleaseAction
+  | PublishReleaseAction
+  | ScheduleReleaseAction
+  | UnscheduleReleaseAction
+  | ArchiveReleaseAction
+  | UnarchiveReleaseAction
+  | DeleteReleaseAction
 
 /** @beta */
-export function createRelease<TDataset extends string = string, TProjectId extends string = string>(
-  handle: ReleaseHandle<TDataset, TProjectId>,
-  metadata?: ReleaseActionMetadata,
-): CreateReleaseAction<TDataset, TProjectId> {
-  return {type: 'release.create', ...handle, ...(metadata && {metadata})}
+export function createRelease(
+  handle: ReleaseHandle,
+  metadata: ReleaseDocument['metadata'] = {releaseType: 'undecided'},
+): CreateReleaseAction {
+  return {type: 'release.create', ...handle, metadata}
 }
 
 /** @beta */
-export function editRelease<TDataset extends string = string, TProjectId extends string = string>(
-  handle: ReleaseHandle<TDataset, TProjectId>,
-  patch: PatchOperations,
-): EditReleaseAction<TDataset, TProjectId> {
+export function editRelease(handle: ReleaseHandle, patch: PatchOperations): EditReleaseAction {
   return {type: 'release.edit', ...handle, patch}
 }
 
 /** @beta */
-export function publishRelease<
-  TDataset extends string = string,
-  TProjectId extends string = string,
->(handle: ReleaseHandle<TDataset, TProjectId>): PublishReleaseAction<TDataset, TProjectId> {
+export function publishRelease(handle: ReleaseHandle): PublishReleaseAction {
   return {type: 'release.publish', ...handle}
 }
 
 /** @beta */
-export function scheduleRelease<
-  TDataset extends string = string,
-  TProjectId extends string = string,
->(
-  handle: ReleaseHandle<TDataset, TProjectId>,
-  publishAt: string,
-): ScheduleReleaseAction<TDataset, TProjectId> {
+export function scheduleRelease(handle: ReleaseHandle, publishAt: string): ScheduleReleaseAction {
   return {type: 'release.schedule', ...handle, publishAt}
 }
 
 /** @beta */
-export function unscheduleRelease<
-  TDataset extends string = string,
-  TProjectId extends string = string,
->(handle: ReleaseHandle<TDataset, TProjectId>): UnscheduleReleaseAction<TDataset, TProjectId> {
+export function unscheduleRelease(handle: ReleaseHandle): UnscheduleReleaseAction {
   return {type: 'release.unschedule', ...handle}
 }
 
 /** @beta */
-export function archiveRelease<
-  TDataset extends string = string,
-  TProjectId extends string = string,
->(handle: ReleaseHandle<TDataset, TProjectId>): ArchiveReleaseAction<TDataset, TProjectId> {
+export function archiveRelease(handle: ReleaseHandle): ArchiveReleaseAction {
   return {type: 'release.archive', ...handle}
 }
 
 /** @beta */
-export function unarchiveRelease<
-  TDataset extends string = string,
-  TProjectId extends string = string,
->(handle: ReleaseHandle<TDataset, TProjectId>): UnarchiveReleaseAction<TDataset, TProjectId> {
+export function unarchiveRelease(handle: ReleaseHandle): UnarchiveReleaseAction {
   return {type: 'release.unarchive', ...handle}
 }
 
 /** @beta */
-export function deleteRelease<TDataset extends string = string, TProjectId extends string = string>(
-  handle: ReleaseHandle<TDataset, TProjectId>,
-): DeleteReleaseAction<TDataset, TProjectId> {
+export function deleteRelease(handle: ReleaseHandle): DeleteReleaseAction {
   return {type: 'release.delete', ...handle}
 }

--- a/packages/core/src/document/applyDocumentActions.ts
+++ b/packages/core/src/document/applyDocumentActions.ts
@@ -5,7 +5,7 @@ import {type DocumentResource} from '../config/sanityConfig'
 import {bindActionByResource} from '../store/createActionBinder'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {type StoreContext} from '../store/defineStore'
-import {type DocumentAction} from './actions'
+import {type Action} from './actions'
 import {documentStore, type DocumentStoreState} from './documentStore'
 import {type DocumentTransactionSubmissionResult} from './events'
 import {type DocumentSet} from './processMutations'
@@ -26,9 +26,10 @@ export interface ActionsResult<TDocument extends SanityDocument = SanityDocument
 /** @beta */
 export interface ApplyDocumentActionsOptions {
   /**
-   * List of actions to apply.
+   * List of actions to apply. Accepts both document actions and release
+   * lifecycle actions because they share the same transaction pipeline.
    */
-  actions: DocumentAction[]
+  actions: Action[]
 
   /**
    * The resource to which the documents being acted on belong.

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -60,6 +60,7 @@ import {
   type Grant,
 } from './permissions'
 import {ActionError} from './processActions/processActions'
+import {isReleaseAction} from './processActions/releaseUtil'
 import {
   type AppliedTransaction,
   applyFirstQueuedTransaction,
@@ -414,10 +415,11 @@ const subscribeToAppliedAndSubmitNextTransaction = ({
           outgoing,
         }))
 
-        // Any liveEdit action in the batch routes to the mutations API. For mixed batches
-        // non-liveEdit operations (e.g. publish) lose atomicity, but that is acceptable
-        // given how rare mixed batches are.
-        if (outgoing.actions.some((action) => action.liveEdit)) {
+        // liveEdit transactions route to the mutations API; everything else routes
+        // to the actions API. processActions rejects transactions that mix the two,
+        // and reducers won't batch across that boundary, so a batch is always
+        // entirely liveEdit or entirely not.
+        if (outgoing.actions.some((action) => !isReleaseAction(action) && action.liveEdit)) {
           return client.observable
             .mutate(outgoing.outgoingMutations as Mutation[], {
               transactionId: outgoing.transactionId,
@@ -430,7 +432,6 @@ const subscribeToAppliedAndSubmitNextTransaction = ({
             .pipe(revertOnError, toResult)
         }
 
-        // Pure non-liveEdit transactions use the actions API.
         return client.observable
           .action(outgoing.outgoingActions as Action[], {
             transactionId: outgoing.transactionId,

--- a/packages/core/src/document/events.test.ts
+++ b/packages/core/src/document/events.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {type DocumentAction} from '../document/actions'
+import {type Action, type DocumentAction} from '../document/actions'
 import {type DocumentEvent, getDocumentEvents} from '../document/events'
 import {type OutgoingTransaction} from '../document/reducers'
 
@@ -41,11 +41,66 @@ describe('getDocumentEvents', () => {
     expect(events).toHaveLength(outgoing.actions.length)
     events.forEach((event) => {
       const action = outgoing.actions.find(
-        (a) => 'documentId' in event && event.documentId === a.documentId,
+        (a) => 'documentId' in a && 'documentId' in event && event.documentId === a.documentId,
       )
       expect(action).toBeDefined()
       expect(event.type).toEqual(expectedMap[action!.type])
       expect((event as Extract<DocumentEvent, {outgoing: unknown}>).outgoing).toBe(outgoing)
     })
+  })
+
+  it('emits created/edited/deleted events for release.create/edit/delete with release doc IDs', () => {
+    const outgoing: OutgoingTransaction = {
+      transactionId: 'txn-release',
+      actions: [
+        {type: 'release.create', releaseId: 'r1'} as Action,
+        {type: 'release.edit', releaseId: 'r2', patch: {set: {}}} as Action,
+        {type: 'release.delete', releaseId: 'r3'} as Action,
+      ],
+      disableBatching: false,
+      batchedTransactionIds: [],
+      outgoingActions: [],
+      outgoingMutations: [],
+      base: {},
+      working: {},
+      previous: {},
+      previousRevs: {},
+      timestamp: '2025-02-06T00:00:00.000Z',
+    }
+
+    const events = getDocumentEvents(outgoing)
+    expect(events).toEqual([
+      {type: 'created', documentId: '_.releases.r1', outgoing},
+      {type: 'edited', documentId: '_.releases.r2', outgoing},
+      {type: 'deleted', documentId: '_.releases.r3', outgoing},
+    ])
+  })
+
+  it('skips release actions that have no local mutation (publish/schedule/archive/etc.)', () => {
+    const outgoing: OutgoingTransaction = {
+      transactionId: 'txn-release-noop',
+      actions: [
+        {type: 'release.publish', releaseId: 'r1'} as Action,
+        {
+          type: 'release.schedule',
+          releaseId: 'r2',
+          publishAt: '2026-01-01T00:00:00.000Z',
+        } as Action,
+        {type: 'release.unschedule', releaseId: 'r3'} as Action,
+        {type: 'release.archive', releaseId: 'r4'} as Action,
+        {type: 'release.unarchive', releaseId: 'r5'} as Action,
+      ],
+      disableBatching: false,
+      batchedTransactionIds: [],
+      outgoingActions: [],
+      outgoingMutations: [],
+      base: {},
+      working: {},
+      previous: {},
+      previousRevs: {},
+      timestamp: '2025-02-06T00:00:00.000Z',
+    }
+
+    expect(getDocumentEvents(outgoing)).toEqual([])
   })
 })

--- a/packages/core/src/document/events.ts
+++ b/packages/core/src/document/events.ts
@@ -1,6 +1,7 @@
 import {type MultipleMutationResult, type SanityClient} from '@sanity/client'
 
-import {type DocumentAction} from './actions'
+import {type DocumentAction, type ReleaseAction} from './actions'
+import {getReleaseDocumentId, isReleaseAction} from './processActions/releaseUtil'
 import {type OutgoingTransaction} from './reducers'
 
 /** @beta Response body from submitting an outgoing transaction (actions or mutations API). */
@@ -118,31 +119,49 @@ export interface DocumentDiscardedEvent {
   outgoing: OutgoingTransaction
 }
 
+// Release actions that write a mutation to the local release doc map onto
+// the regular per-document events with `documentId = '_.releases.<releaseId>'`.
+// The other release actions (publish/schedule/unschedule/archive/unarchive)
+// don't mutate local state, so they aren't in the map and get skipped — they
+// surface through the transaction-level `accepted`/`reverted` events instead.
+const actionMap = {
+  'document.create': 'created',
+  'document.delete': 'deleted',
+  'document.discard': 'discarded',
+  'document.edit': 'edited',
+  'document.publish': 'published',
+  'document.unpublish': 'unpublished',
+  'release.create': 'created',
+  'release.edit': 'edited',
+  'release.delete': 'deleted',
+} satisfies Partial<Record<DocumentAction['type'] | ReleaseAction['type'], DocumentEvent['type']>>
+
+type MappedActionType = keyof typeof actionMap
+
 export function getDocumentEvents(outgoing: OutgoingTransaction): DocumentEvent[] {
-  const documentIdsByAction = Object.entries(
-    outgoing.actions.reduce(
-      (acc, {type, documentId}) => {
-        const ids = acc[type] || new Set()
-        if (documentId) ids.add(documentId)
-        acc[type] = ids
-        return acc
-      },
-      {} as Record<DocumentAction['type'], Set<string>>,
-    ),
-  ) as [DocumentAction['type'], Set<string>][]
+  const documentIdsByAction = outgoing.actions.reduce(
+    (acc, action) => {
+      if (!(action.type in actionMap)) return acc
+      const documentId = isReleaseAction(action)
+        ? getReleaseDocumentId(action.releaseId)
+        : action.documentId
+      if (!documentId) return acc
+      const type = action.type as MappedActionType
+      const ids = acc[type] ?? new Set<string>()
+      ids.add(documentId)
+      acc[type] = ids
+      return acc
+    },
+    {} as Partial<Record<MappedActionType, Set<string>>>,
+  )
 
-  const actionMap = {
-    'document.create': 'created',
-    'document.delete': 'deleted',
-    'document.discard': 'discarded',
-    'document.edit': 'edited',
-    'document.publish': 'published',
-    'document.unpublish': 'unpublished',
-  } satisfies Record<DocumentAction['type'], DocumentEvent['type']>
-
-  return documentIdsByAction.flatMap(([actionType, documentIds]) =>
-    Array.from(documentIds).map(
-      (documentId): DocumentEvent => ({type: actionMap[actionType], documentId, outgoing}),
+  return Object.entries(documentIdsByAction).flatMap(([actionType, documentIds]) =>
+    Array.from(documentIds ?? []).map(
+      (documentId): DocumentEvent => ({
+        type: actionMap[actionType as MappedActionType],
+        documentId,
+        outgoing,
+      }),
     ),
   )
 }

--- a/packages/core/src/document/processActions.test.ts
+++ b/packages/core/src/document/processActions.test.ts
@@ -1425,18 +1425,17 @@ describe('processActions', () => {
     const releaseName = 'my-release'
     const releaseDocId = `_.releases.${releaseName}`
 
-    const createReleaseDoc = (overrides: Partial<SanityDocument> = {}): SanityDocument =>
-      ({
-        _id: releaseDocId,
-        _type: 'system.release',
-        _createdAt: '2025-01-01T00:00:00.000Z',
-        _updatedAt: '2025-01-01T00:00:00.000Z',
-        _rev: 'initial',
-        name: releaseName,
-        state: 'active',
-        metadata: {releaseType: 'undecided'},
-        ...overrides,
-      }) as SanityDocument
+    const createReleaseDoc = (overrides: Partial<SanityDocument> = {}): SanityDocument => ({
+      _id: releaseDocId,
+      _type: 'system.release',
+      _createdAt: '2025-01-01T00:00:00.000Z',
+      _updatedAt: '2025-01-01T00:00:00.000Z',
+      _rev: 'initial',
+      name: releaseName,
+      state: 'active',
+      metadata: {releaseType: 'undecided'},
+      ...overrides,
+    })
 
     describe('release.create', () => {
       it('inserts an optimistic release doc and emits a release.create action', () => {
@@ -1479,7 +1478,13 @@ describe('processActions', () => {
         const existing = createReleaseDoc()
         expect(() =>
           processActions({
-            actions: [{type: 'release.create', releaseId: releaseName}],
+            actions: [
+              {
+                type: 'release.create',
+                releaseId: releaseName,
+                metadata: {releaseType: 'undecided'},
+              },
+            ],
             transactionId,
             base: {[releaseDocId]: existing},
             working: {[releaseDocId]: existing},
@@ -1492,7 +1497,13 @@ describe('processActions', () => {
       it('throws PermissionActionError when the create grant is denied', () => {
         expect(() =>
           processActions({
-            actions: [{type: 'release.create', releaseId: releaseName}],
+            actions: [
+              {
+                type: 'release.create',
+                releaseId: releaseName,
+                metadata: {releaseType: 'undecided'},
+              },
+            ],
             transactionId,
             base: {},
             working: {},
@@ -1771,7 +1782,7 @@ describe('processActions', () => {
         _createdAt: '2025-01-01T00:00:00.000Z',
         _updatedAt: '2025-01-01T00:00:00.000Z',
         _rev: 'initial',
-      } as SanityDocument
+      }
       const liveEditAction = {
         type: 'document.edit',
         documentId: liveEditDocId,
@@ -1784,7 +1795,11 @@ describe('processActions', () => {
         expect(() =>
           processActions({
             actions: [
-              {type: 'release.create', releaseId: releaseName},
+              {
+                type: 'release.create',
+                releaseId: releaseName,
+                metadata: {releaseType: 'undecided'},
+              },
               liveEditAction as unknown as Action,
             ],
             transactionId,

--- a/packages/core/src/document/processActions.test.ts
+++ b/packages/core/src/document/processActions.test.ts
@@ -2,7 +2,7 @@ import {type CreateMutation, type Reference, type SanityDocument} from '@sanity/
 import {parse} from 'groq-js'
 import {describe, expect, it} from 'vitest'
 
-import {type DocumentAction} from './actions'
+import {type Action, type DocumentAction} from './actions'
 import {ActionError, processActions} from './processActions/processActions'
 import {type DocumentSet} from './processMutations'
 
@@ -1417,6 +1417,413 @@ describe('processActions', () => {
         expect(() =>
           processActions({actions, transactionId, base, working, timestamp, grants: defaultGrants}),
         ).toThrow(/Cannot delete a version document/)
+      })
+    })
+  })
+
+  describe('release actions', () => {
+    const releaseName = 'my-release'
+    const releaseDocId = `_.releases.${releaseName}`
+
+    const createReleaseDoc = (overrides: Partial<SanityDocument> = {}): SanityDocument =>
+      ({
+        _id: releaseDocId,
+        _type: 'system.release',
+        _createdAt: '2025-01-01T00:00:00.000Z',
+        _updatedAt: '2025-01-01T00:00:00.000Z',
+        _rev: 'initial',
+        name: releaseName,
+        state: 'active',
+        metadata: {releaseType: 'undecided'},
+        ...overrides,
+      }) as SanityDocument
+
+    describe('release.create', () => {
+      it('inserts an optimistic release doc and emits a release.create action', () => {
+        const base: DocumentSet = {}
+        const working: DocumentSet = {}
+        const actions: Action[] = [
+          {
+            type: 'release.create',
+            releaseId: releaseName,
+            metadata: {title: 'My release', releaseType: 'asap'},
+          },
+        ]
+
+        const result = processActions({
+          actions,
+          transactionId,
+          base,
+          working,
+          timestamp,
+          grants: defaultGrants,
+        })
+
+        const doc = result.working[releaseDocId]
+        expect(doc).toBeDefined()
+        expect(doc?._type).toBe('system.release')
+        expect(doc?.['name']).toBe(releaseName)
+        expect(doc?.['state']).toBe('active')
+        expect(doc?.['metadata']).toEqual({title: 'My release', releaseType: 'asap'})
+
+        expect(result.outgoingActions).toEqual([
+          {
+            actionType: 'sanity.action.release.create',
+            releaseId: releaseName,
+            metadata: {title: 'My release', releaseType: 'asap'},
+          },
+        ])
+      })
+
+      it('throws if the release already exists in base or working', () => {
+        const existing = createReleaseDoc()
+        expect(() =>
+          processActions({
+            actions: [{type: 'release.create', releaseId: releaseName}],
+            transactionId,
+            base: {[releaseDocId]: existing},
+            working: {[releaseDocId]: existing},
+            timestamp,
+            grants: defaultGrants,
+          }),
+        ).toThrow(/already exists/)
+      })
+
+      it('throws PermissionActionError when the create grant is denied', () => {
+        expect(() =>
+          processActions({
+            actions: [{type: 'release.create', releaseId: releaseName}],
+            transactionId,
+            base: {},
+            working: {},
+            timestamp,
+            grants: {...defaultGrants, create: alwaysDeny},
+          }),
+        ).toThrow(/permission to create release/)
+      })
+    })
+
+    describe('release.edit', () => {
+      it('applies the patch optimistically and forwards the original patch to the outgoing action', () => {
+        const existing = createReleaseDoc({
+          metadata: {releaseType: 'undecided'},
+        } as Partial<SanityDocument>)
+        const patch = {set: {'metadata.title': 'Updated title'}}
+
+        const result = processActions({
+          actions: [{type: 'release.edit', releaseId: releaseName, patch}],
+          transactionId,
+          base: {[releaseDocId]: existing},
+          working: {[releaseDocId]: existing},
+          timestamp,
+          grants: defaultGrants,
+        })
+
+        const updated = result.working[releaseDocId] as SanityDocument & {
+          metadata: {title?: string; releaseType: string}
+        }
+        expect(updated.metadata.title).toBe('Updated title')
+        // releaseType wasn't unset
+        expect(updated.metadata.releaseType).toBe('undecided')
+
+        expect(result.outgoingActions).toEqual([
+          {
+            actionType: 'sanity.action.release.edit',
+            releaseId: releaseName,
+            patch,
+          },
+        ])
+      })
+
+      it('throws when editing a release that does not exist', () => {
+        expect(() =>
+          processActions({
+            actions: [
+              {
+                type: 'release.edit',
+                releaseId: releaseName,
+                patch: {set: {'metadata.title': 'x'}},
+              },
+            ],
+            transactionId,
+            base: {},
+            working: {},
+            timestamp,
+            grants: defaultGrants,
+          }),
+        ).toThrow(/does not exist/)
+      })
+
+      it('throws PermissionActionError when the working release fails the update grant', () => {
+        const existing = createReleaseDoc()
+        expect(() =>
+          processActions({
+            actions: [
+              {
+                type: 'release.edit',
+                releaseId: releaseName,
+                patch: {set: {'metadata.title': 'x'}},
+              },
+            ],
+            transactionId,
+            base: {[releaseDocId]: existing},
+            working: {[releaseDocId]: existing},
+            timestamp,
+            grants: {...defaultGrants, update: alwaysDeny},
+          }),
+        ).toThrow(/permission to edit release/)
+      })
+    })
+
+    describe('fire-and-forget actions', () => {
+      const existing = createReleaseDoc()
+      const cases: Array<{
+        name: string
+        action: Action
+        expectedOutgoing: Record<string, unknown>
+      }> = [
+        {
+          name: 'release.publish',
+          action: {type: 'release.publish', releaseId: releaseName},
+          expectedOutgoing: {actionType: 'sanity.action.release.publish', releaseId: releaseName},
+        },
+        {
+          name: 'release.schedule',
+          action: {
+            type: 'release.schedule',
+            releaseId: releaseName,
+            publishAt: '2026-01-01T00:00:00.000Z',
+          },
+          expectedOutgoing: {
+            actionType: 'sanity.action.release.schedule',
+            releaseId: releaseName,
+            publishAt: '2026-01-01T00:00:00.000Z',
+          },
+        },
+        {
+          name: 'release.unschedule',
+          action: {type: 'release.unschedule', releaseId: releaseName},
+          expectedOutgoing: {
+            actionType: 'sanity.action.release.unschedule',
+            releaseId: releaseName,
+          },
+        },
+        {
+          name: 'release.archive',
+          action: {type: 'release.archive', releaseId: releaseName},
+          expectedOutgoing: {actionType: 'sanity.action.release.archive', releaseId: releaseName},
+        },
+        {
+          name: 'release.unarchive',
+          action: {type: 'release.unarchive', releaseId: releaseName},
+          expectedOutgoing: {actionType: 'sanity.action.release.unarchive', releaseId: releaseName},
+        },
+      ]
+
+      it.each(cases)(
+        '$name does not mutate local state and emits the matching outgoing action',
+        ({action, expectedOutgoing}) => {
+          const base: DocumentSet = {[releaseDocId]: existing}
+          const working: DocumentSet = {[releaseDocId]: existing}
+
+          const result = processActions({
+            actions: [action],
+            transactionId,
+            base,
+            working,
+            timestamp,
+            grants: defaultGrants,
+          })
+
+          // working and base reference the same doc instance — no optimistic
+          // mutation was applied
+          expect(result.working[releaseDocId]).toBe(existing)
+          expect(result.outgoingActions).toEqual([expectedOutgoing])
+          expect(result.outgoingMutations).toEqual([])
+        },
+      )
+
+      it.each(cases)('$name throws if the release does not exist', ({action}) => {
+        expect(() =>
+          processActions({
+            actions: [action],
+            transactionId,
+            base: {},
+            working: {},
+            timestamp,
+            grants: defaultGrants,
+          }),
+        ).toThrow(ActionError)
+      })
+
+      it.each(cases)(
+        '$name throws PermissionActionError when update grant is denied',
+        ({action}) => {
+          const base: DocumentSet = {[releaseDocId]: existing}
+          const working: DocumentSet = {[releaseDocId]: existing}
+          expect(() =>
+            processActions({
+              actions: [action],
+              transactionId,
+              base,
+              working,
+              timestamp,
+              grants: {...defaultGrants, update: alwaysDeny},
+            }),
+          ).toThrow(/permission to/)
+        },
+      )
+    })
+
+    describe('release.schedule publishAt validation', () => {
+      const existing = createReleaseDoc()
+
+      it.each(['not-a-date', '', '2026-13-40T99:99:99Z'])(
+        'throws ActionError when publishAt is not a valid timestamp (%s)',
+        (publishAt) => {
+          expect(() =>
+            processActions({
+              actions: [{type: 'release.schedule', releaseId: releaseName, publishAt}],
+              transactionId,
+              base: {[releaseDocId]: existing},
+              working: {[releaseDocId]: existing},
+              timestamp,
+              grants: defaultGrants,
+            }),
+          ).toThrow(/must be a valid ISO 8601 timestamp/)
+        },
+      )
+    })
+
+    describe('release.delete', () => {
+      it.each(['archived', 'published'] as const)(
+        'optimistically removes the local release when state is %s',
+        (state) => {
+          const existing = createReleaseDoc({state} as Partial<SanityDocument>)
+          const result = processActions({
+            actions: [{type: 'release.delete', releaseId: releaseName}],
+            transactionId,
+            base: {[releaseDocId]: existing},
+            working: {[releaseDocId]: existing},
+            timestamp,
+            grants: defaultGrants,
+          })
+
+          // processMutations sets deleted entries to null
+          expect(result.working[releaseDocId]).toBeNull()
+          expect(result.outgoingMutations).toEqual([{delete: {id: releaseDocId}}])
+          expect(result.outgoingActions).toEqual([
+            {actionType: 'sanity.action.release.delete', releaseId: releaseName},
+          ])
+        },
+      )
+
+      it.each(['active', 'scheduled', 'archiving', 'publishing'] as const)(
+        'throws when state is %s (server only accepts archived/published)',
+        (state) => {
+          const existing = createReleaseDoc({state} as Partial<SanityDocument>)
+          expect(() =>
+            processActions({
+              actions: [{type: 'release.delete', releaseId: releaseName}],
+              transactionId,
+              base: {[releaseDocId]: existing},
+              working: {[releaseDocId]: existing},
+              timestamp,
+              grants: defaultGrants,
+            }),
+          ).toThrow(/Archive it first/)
+        },
+      )
+
+      it('throws if the release does not exist', () => {
+        expect(() =>
+          processActions({
+            actions: [{type: 'release.delete', releaseId: releaseName}],
+            transactionId,
+            base: {},
+            working: {},
+            timestamp,
+            grants: defaultGrants,
+          }),
+        ).toThrow(/does not exist/)
+      })
+
+      it('throws PermissionActionError when the update grant is denied', () => {
+        const existing = createReleaseDoc({state: 'archived'} as Partial<SanityDocument>)
+        expect(() =>
+          processActions({
+            actions: [{type: 'release.delete', releaseId: releaseName}],
+            transactionId,
+            base: {[releaseDocId]: existing},
+            working: {[releaseDocId]: existing},
+            timestamp,
+            grants: {...defaultGrants, update: alwaysDeny},
+          }),
+        ).toThrow(/permission to delete release/)
+      })
+    })
+
+    describe('mixed with liveEdit document actions', () => {
+      const liveEditDocId = 'live-edit-doc'
+      const liveEditDoc = {
+        _id: liveEditDocId,
+        _type: 'liveEditType',
+        _createdAt: '2025-01-01T00:00:00.000Z',
+        _updatedAt: '2025-01-01T00:00:00.000Z',
+        _rev: 'initial',
+      } as SanityDocument
+      const liveEditAction = {
+        type: 'document.edit',
+        documentId: liveEditDocId,
+        documentType: 'liveEditType',
+        liveEdit: true,
+        patches: [{set: {title: 'x'}}],
+      } as const
+
+      it('throws ActionError when a transaction mixes a release action with a liveEdit document action', () => {
+        expect(() =>
+          processActions({
+            actions: [
+              {type: 'release.create', releaseId: releaseName},
+              liveEditAction as unknown as Action,
+            ],
+            transactionId,
+            base: {[liveEditDocId]: liveEditDoc},
+            working: {[liveEditDocId]: liveEditDoc},
+            timestamp,
+            grants: defaultGrants,
+          }),
+        ).toThrow(/Cannot combine liveEdit document actions with other actions/)
+      })
+
+      it('throws ActionError when a transaction mixes a non-liveEdit document action with a liveEdit document action', () => {
+        const otherDocId = 'other-doc'
+        const otherDoc = {
+          _id: otherDocId,
+          _type: 'someType',
+          _createdAt: '2025-01-01T00:00:00.000Z',
+          _updatedAt: '2025-01-01T00:00:00.000Z',
+          _rev: 'initial',
+        } as SanityDocument
+
+        expect(() =>
+          processActions({
+            actions: [
+              {
+                type: 'document.edit',
+                documentId: otherDocId,
+                documentType: 'someType',
+                patches: [{set: {title: 'y'}}],
+              },
+              liveEditAction as unknown as Action,
+            ],
+            transactionId,
+            base: {[liveEditDocId]: liveEditDoc, [otherDocId]: otherDoc},
+            working: {[liveEditDocId]: liveEditDoc, [otherDocId]: otherDoc},
+            timestamp,
+            grants: defaultGrants,
+          }),
+        ).toThrow(/Cannot combine liveEdit document actions with other actions/)
       })
     })
   })

--- a/packages/core/src/document/processActions/edit.ts
+++ b/packages/core/src/document/processActions/edit.ts
@@ -9,6 +9,7 @@ import {
   ActionError,
   type ActionHandlerContext,
   type ActionHandlerResult,
+  applySingleDocPatch,
   checkGrant,
   PermissionActionError,
 } from './shared'
@@ -23,54 +24,18 @@ export function handleEdit(
   const documentId = getId(action.documentId)
 
   if (action.liveEdit) {
-    // Single-document mode (liveEdit or release perspective): edit directly without draft logic
-    const userPatches = action.patches?.map((patch) => ({patch: {id: documentId, ...patch}}))
-
-    // skip this action if there are no associated patches
-    if (!userPatches?.length) return {base, working}
-
-    if (!working[documentId] || !base[documentId]) {
-      throw new ActionError({
-        documentId,
-        transactionId,
-        message: `Cannot edit document because it does not exist.`,
-      })
-    }
-
-    const baseBefore = base[documentId] as SanityDocument
-    if (userPatches) {
-      base = processMutations({
-        documents: base,
-        transactionId,
-        mutations: userPatches,
-        timestamp,
-      })
-    }
-
-    const baseAfter = base[documentId] as SanityDocument
-    const patches = diffValue(baseBefore, baseAfter)
-
-    const workingBefore = working[documentId] as SanityDocument
-    if (!checkGrant(grants.update, workingBefore)) {
-      throw new PermissionActionError({
-        documentId,
-        transactionId,
-        message: `You do not have permission to edit document "${documentId}".`,
-      })
-    }
-
-    const workingMutations = patches.map((patch) => ({patch: {id: documentId, ...patch}}))
-
-    working = processMutations({
-      documents: working,
+    const result = applySingleDocPatch({
+      base,
+      working,
+      documentId,
+      patches: action.patches,
       transactionId,
-      mutations: workingMutations,
       timestamp,
+      grants,
     })
-
     // liveEdit documents use the mutation endpoint directly -- we don't send actions
-    outgoingMutations.push(...workingMutations)
-    return {base, working}
+    outgoingMutations.push(...result.workingMutations)
+    return {base: result.base, working: result.working}
   }
 
   const versionId = isReleasePerspective(action.perspective)

--- a/packages/core/src/document/processActions/processActions.ts
+++ b/packages/core/src/document/processActions/processActions.ts
@@ -1,7 +1,7 @@
 import {type Mutation} from '@sanity/types'
 import {type ExprNode} from 'groq-js'
 
-import {type DocumentAction} from '../actions'
+import {type Action, type DocumentAction} from '../actions'
 import {type Grant} from '../permissions'
 import {type DocumentSet} from '../processMutations'
 import {type HttpAction} from '../reducers'
@@ -10,6 +10,13 @@ import {handleDelete} from './delete'
 import {handleDiscard} from './discard'
 import {handleEdit} from './edit'
 import {handlePublish} from './publish'
+import {handleReleaseArchive, handleReleaseUnarchive} from './releaseArchive'
+import {handleReleaseCreate} from './releaseCreate'
+import {handleReleaseDelete} from './releaseDelete'
+import {handleReleaseEdit} from './releaseEdit'
+import {handleReleasePublish} from './releasePublish'
+import {handleReleaseSchedule, handleReleaseUnschedule} from './releaseSchedule'
+import {isReleaseAction} from './releaseUtil'
 import {
   ActionError,
   type ActionHandlerContext,
@@ -30,7 +37,7 @@ interface ProcessActionsOptions {
   /**
    * The actions to apply to the given documents
    */
-  actions: DocumentAction[]
+  actions: Action[]
 
   /**
    * The set of documents these actions were intended to be applied to. These
@@ -116,6 +123,24 @@ export function processActions({
   const outgoingActions: HttpAction[] = []
   const outgoingMutations: Mutation[] = []
 
+  // liveEdit document actions go to the mutations API, since the actions API
+  // requires a draft+published pair. Mixing them with anything else in the same
+  // transaction would silently lose atomicity for the non-liveEdit operations,
+  // so require users to split the transaction.
+  // (Note that the reducers already does this for us -- you'd have to try hard to mix them.)
+  const liveEditAction = actions.find((action) => !isReleaseAction(action) && action.liveEdit) as
+    | DocumentAction
+    | undefined
+  const otherAction = actions.find((action) => isReleaseAction(action) || !action.liveEdit)
+  if (liveEditAction && otherAction) {
+    throw new ActionError({
+      documentId: liveEditAction.documentId!,
+      transactionId,
+      message:
+        'Cannot combine liveEdit document actions with other actions in the same transaction. Submit them as separate transactions.',
+    })
+  }
+
   for (const action of actions) {
     const result = dispatch(action, {
       base,
@@ -143,7 +168,7 @@ export function processActions({
   }
 }
 
-function dispatch(action: DocumentAction, ctx: ActionHandlerContext): ActionHandlerResult {
+function dispatch(action: Action, ctx: ActionHandlerContext): ActionHandlerResult {
   switch (action.type) {
     case 'document.create':
       return handleCreate(action, ctx)
@@ -157,6 +182,22 @@ function dispatch(action: DocumentAction, ctx: ActionHandlerContext): ActionHand
       return handlePublish(action, ctx)
     case 'document.unpublish':
       return handleUnpublish(action, ctx)
+    case 'release.create':
+      return handleReleaseCreate(action, ctx)
+    case 'release.edit':
+      return handleReleaseEdit(action, ctx)
+    case 'release.publish':
+      return handleReleasePublish(action, ctx)
+    case 'release.schedule':
+      return handleReleaseSchedule(action, ctx)
+    case 'release.unschedule':
+      return handleReleaseUnschedule(action, ctx)
+    case 'release.archive':
+      return handleReleaseArchive(action, ctx)
+    case 'release.unarchive':
+      return handleReleaseUnarchive(action, ctx)
+    case 'release.delete':
+      return handleReleaseDelete(action, ctx)
     default:
       throw new Error(
         `Unknown action type: "${

--- a/packages/core/src/document/processActions/releaseArchive.ts
+++ b/packages/core/src/document/processActions/releaseArchive.ts
@@ -1,0 +1,77 @@
+import {type ArchiveReleaseAction, type UnarchiveReleaseAction} from '../actions'
+import {getReleaseDocumentId} from './releaseUtil'
+import {
+  ActionError,
+  type ActionHandlerContext,
+  type ActionHandlerResult,
+  checkGrant,
+  PermissionActionError,
+} from './shared'
+
+export function handleReleaseArchive(
+  action: ArchiveReleaseAction,
+  ctx: ActionHandlerContext,
+): ActionHandlerResult {
+  const {base, working, grants, outgoingActions, transactionId} = ctx
+
+  const releaseDocumentId = getReleaseDocumentId(action.releaseId)
+  const existing = working[releaseDocumentId] ?? base[releaseDocumentId]
+  if (!existing) {
+    throw new ActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `Cannot archive release "${action.releaseId}" because it does not exist.`,
+    })
+  }
+
+  if (!checkGrant(grants.update, existing)) {
+    throw new PermissionActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `You do not have permission to archive release "${action.releaseId}".`,
+    })
+  }
+
+  // Archiving deletes every version document in the release server-side.
+  // Although technically we could search through the document store for all related
+  // version documents, for now it's simpler to just let the server handle it.
+  // (Those local documents will be eventually updated by the listener.)
+  outgoingActions.push({
+    actionType: 'sanity.action.release.archive',
+    releaseId: action.releaseId,
+  })
+
+  return {base, working}
+}
+
+export function handleReleaseUnarchive(
+  action: UnarchiveReleaseAction,
+  ctx: ActionHandlerContext,
+): ActionHandlerResult {
+  const {base, working, grants, outgoingActions, transactionId} = ctx
+
+  const releaseDocumentId = getReleaseDocumentId(action.releaseId)
+  const existing = working[releaseDocumentId] ?? base[releaseDocumentId]
+  if (!existing) {
+    throw new ActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `Cannot unarchive release "${action.releaseId}" because it does not exist.`,
+    })
+  }
+
+  if (!checkGrant(grants.update, existing)) {
+    throw new PermissionActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `You do not have permission to unarchive release "${action.releaseId}".`,
+    })
+  }
+
+  outgoingActions.push({
+    actionType: 'sanity.action.release.unarchive',
+    releaseId: action.releaseId,
+  })
+
+  return {base, working}
+}

--- a/packages/core/src/document/processActions/releaseCreate.ts
+++ b/packages/core/src/document/processActions/releaseCreate.ts
@@ -52,7 +52,7 @@ export function handleReleaseCreate(
   outgoingActions.push({
     actionType: 'sanity.action.release.create',
     releaseId: action.releaseId,
-    ...(action.metadata && {metadata: action.metadata}),
+    metadata: action.metadata,
   })
 
   return {base, working}

--- a/packages/core/src/document/processActions/releaseCreate.ts
+++ b/packages/core/src/document/processActions/releaseCreate.ts
@@ -1,0 +1,59 @@
+import {type Mutation, type SanityDocument} from '@sanity/types'
+
+import {type CreateReleaseAction} from '../actions'
+import {processMutations} from '../processMutations'
+import {getReleaseDocumentId} from './releaseUtil'
+import {
+  ActionError,
+  type ActionHandlerContext,
+  type ActionHandlerResult,
+  checkGrant,
+  PermissionActionError,
+} from './shared'
+
+export function handleReleaseCreate(
+  action: CreateReleaseAction,
+  ctx: ActionHandlerContext,
+): ActionHandlerResult {
+  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  let {base, working} = ctx
+
+  const releaseDocumentId = getReleaseDocumentId(action.releaseId)
+
+  if (working[releaseDocumentId] || base[releaseDocumentId]) {
+    throw new ActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `A release with id "${action.releaseId}" already exists.`,
+    })
+  }
+  // Optimistic local release doc
+  const releaseDoc = {
+    _id: releaseDocumentId,
+    _type: 'system.release',
+    name: action.releaseId,
+    state: 'active',
+    metadata: action.metadata,
+  }
+  const mutations: Mutation[] = [{create: releaseDoc}]
+
+  base = processMutations({documents: base, transactionId, mutations, timestamp})
+  working = processMutations({documents: working, transactionId, mutations, timestamp})
+
+  if (!checkGrant(grants.create, working[releaseDocumentId] as SanityDocument)) {
+    throw new PermissionActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `You do not have permission to create release "${action.releaseId}".`,
+    })
+  }
+
+  outgoingMutations.push(...mutations)
+  outgoingActions.push({
+    actionType: 'sanity.action.release.create',
+    releaseId: action.releaseId,
+    ...(action.metadata && {metadata: action.metadata}),
+  })
+
+  return {base, working}
+}

--- a/packages/core/src/document/processActions/releaseDelete.ts
+++ b/packages/core/src/document/processActions/releaseDelete.ts
@@ -1,0 +1,65 @@
+import {type Mutation} from '@sanity/types'
+
+import {type DeleteReleaseAction} from '../actions'
+import {processMutations} from '../processMutations'
+import {getReleaseDocumentId} from './releaseUtil'
+import {
+  ActionError,
+  type ActionHandlerContext,
+  type ActionHandlerResult,
+  checkGrant,
+  PermissionActionError,
+} from './shared'
+
+// you can only delete archived or published releases
+// https://www.sanity.io/docs/content-lake/dispatch-actions#k22ab37420f3c
+const DELETABLE_STATES = new Set(['archived', 'published'])
+
+export function handleReleaseDelete(
+  action: DeleteReleaseAction,
+  ctx: ActionHandlerContext,
+): ActionHandlerResult {
+  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  let {base, working} = ctx
+
+  const releaseDocumentId = getReleaseDocumentId(action.releaseId)
+  const existing = working[releaseDocumentId] ?? base[releaseDocumentId]
+
+  if (!existing) {
+    throw new ActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `Cannot delete release "${action.releaseId}" because it does not exist.`,
+    })
+  }
+
+  const state = existing['state']
+  if (state && typeof state === 'string' && !DELETABLE_STATES.has(state)) {
+    throw new ActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `Cannot delete release "${action.releaseId}" while it is "${state}". Archive it first.`,
+    })
+  }
+
+  if (!checkGrant(grants.update, existing)) {
+    throw new PermissionActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `You do not have permission to delete release "${action.releaseId}".`,
+    })
+  }
+
+  const mutations: Mutation[] = [{delete: {id: releaseDocumentId}}]
+
+  base = processMutations({documents: base, transactionId, mutations, timestamp})
+  working = processMutations({documents: working, transactionId, mutations, timestamp})
+
+  outgoingMutations.push(...mutations)
+  outgoingActions.push({
+    actionType: 'sanity.action.release.delete',
+    releaseId: action.releaseId,
+  })
+
+  return {base, working}
+}

--- a/packages/core/src/document/processActions/releaseEdit.ts
+++ b/packages/core/src/document/processActions/releaseEdit.ts
@@ -1,0 +1,36 @@
+import {type EditReleaseAction} from '../actions'
+import {getReleaseDocumentId} from './releaseUtil'
+import {type ActionHandlerContext, type ActionHandlerResult, applySingleDocPatch} from './shared'
+
+export function handleReleaseEdit(
+  action: EditReleaseAction,
+  ctx: ActionHandlerContext,
+): ActionHandlerResult {
+  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  const {base, working} = ctx
+
+  const releaseDocumentId = getReleaseDocumentId(action.releaseId)
+
+  const result = applySingleDocPatch({
+    base,
+    working,
+    documentId: releaseDocumentId,
+    patches: [action.patch],
+    transactionId,
+    timestamp,
+    grants,
+    notFoundMessage: `Cannot edit release "${action.releaseId}" because it does not exist.`,
+    permissionMessage: `You do not have permission to edit release "${action.releaseId}".`,
+  })
+
+  outgoingMutations.push(...result.workingMutations)
+  outgoingActions.push(
+    ...result.diffedPatches.map((patch) => ({
+      actionType: 'sanity.action.release.edit' as const,
+      releaseId: action.releaseId,
+      patch,
+    })),
+  )
+
+  return {base: result.base, working: result.working}
+}

--- a/packages/core/src/document/processActions/releasePublish.ts
+++ b/packages/core/src/document/processActions/releasePublish.ts
@@ -1,5 +1,3 @@
-import {type SanityDocument} from '@sanity/types'
-
 import {type PublishReleaseAction} from '../actions'
 import {getReleaseDocumentId} from './releaseUtil'
 import {
@@ -26,7 +24,7 @@ export function handleReleasePublish(
     })
   }
 
-  if (!checkGrant(grants.update, existing as SanityDocument)) {
+  if (!checkGrant(grants.update, existing)) {
     throw new PermissionActionError({
       documentId: releaseDocumentId,
       transactionId,

--- a/packages/core/src/document/processActions/releasePublish.ts
+++ b/packages/core/src/document/processActions/releasePublish.ts
@@ -1,0 +1,47 @@
+import {type SanityDocument} from '@sanity/types'
+
+import {type PublishReleaseAction} from '../actions'
+import {getReleaseDocumentId} from './releaseUtil'
+import {
+  ActionError,
+  type ActionHandlerContext,
+  type ActionHandlerResult,
+  checkGrant,
+  PermissionActionError,
+} from './shared'
+
+export function handleReleasePublish(
+  action: PublishReleaseAction,
+  ctx: ActionHandlerContext,
+): ActionHandlerResult {
+  const {base, working, grants, outgoingActions, transactionId} = ctx
+
+  const releaseDocumentId = getReleaseDocumentId(action.releaseId)
+  const existing = working[releaseDocumentId] ?? base[releaseDocumentId]
+  if (!existing) {
+    throw new ActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `Cannot publish release "${action.releaseId}" because it does not exist.`,
+    })
+  }
+
+  if (!checkGrant(grants.update, existing as SanityDocument)) {
+    throw new PermissionActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `You do not have permission to publish release "${action.releaseId}".`,
+    })
+  }
+
+  // a release publish cascades to every version document in the release
+  // although technically we could search through the document store for all related
+  // version documents, for now it's simpler to just let the server handle it.
+  // (Those local documents will be eventually updated by the listener.)
+  outgoingActions.push({
+    actionType: 'sanity.action.release.publish',
+    releaseId: action.releaseId,
+  })
+
+  return {base, working}
+}

--- a/packages/core/src/document/processActions/releaseSchedule.ts
+++ b/packages/core/src/document/processActions/releaseSchedule.ts
@@ -1,0 +1,87 @@
+import {type ScheduleReleaseAction, type UnscheduleReleaseAction} from '../actions'
+import {getReleaseDocumentId} from './releaseUtil'
+import {
+  ActionError,
+  type ActionHandlerContext,
+  type ActionHandlerResult,
+  checkGrant,
+  PermissionActionError,
+} from './shared'
+
+export function handleReleaseSchedule(
+  action: ScheduleReleaseAction,
+  ctx: ActionHandlerContext,
+): ActionHandlerResult {
+  const {base, working, grants, outgoingActions, transactionId} = ctx
+
+  const releaseDocumentId = getReleaseDocumentId(action.releaseId)
+
+  if (Number.isNaN(Date.parse(action.publishAt))) {
+    throw new ActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `Cannot schedule release "${action.releaseId}": "publishAt" must be a valid ISO 8601 timestamp (received "${action.publishAt}").`,
+    })
+  }
+
+  const existing = working[releaseDocumentId] ?? base[releaseDocumentId]
+  if (!existing) {
+    throw new ActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `Cannot schedule release "${action.releaseId}" because it does not exist.`,
+    })
+  }
+
+  if (!checkGrant(grants.update, existing)) {
+    throw new PermissionActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `You do not have permission to schedule release "${action.releaseId}".`,
+    })
+  }
+
+  // Scheduling flips `state` to 'scheduled' and locks version documents
+  // server-side. We don't model the lock locally yet — local edits to those
+  // version docs will be rejected at submit time. The listener will sync the
+  // updated release state.
+  outgoingActions.push({
+    actionType: 'sanity.action.release.schedule',
+    releaseId: action.releaseId,
+    publishAt: action.publishAt,
+  })
+
+  return {base, working}
+}
+
+export function handleReleaseUnschedule(
+  action: UnscheduleReleaseAction,
+  ctx: ActionHandlerContext,
+): ActionHandlerResult {
+  const {base, working, grants, outgoingActions, transactionId} = ctx
+
+  const releaseDocumentId = getReleaseDocumentId(action.releaseId)
+  const existing = working[releaseDocumentId] ?? base[releaseDocumentId]
+  if (!existing) {
+    throw new ActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `Cannot unschedule release "${action.releaseId}" because it does not exist.`,
+    })
+  }
+
+  if (!checkGrant(grants.update, existing)) {
+    throw new PermissionActionError({
+      documentId: releaseDocumentId,
+      transactionId,
+      message: `You do not have permission to unschedule release "${action.releaseId}".`,
+    })
+  }
+
+  outgoingActions.push({
+    actionType: 'sanity.action.release.unschedule',
+    releaseId: action.releaseId,
+  })
+
+  return {base, working}
+}

--- a/packages/core/src/document/processActions/releaseUtil.ts
+++ b/packages/core/src/document/processActions/releaseUtil.ts
@@ -1,0 +1,31 @@
+import {type Action, type ReleaseAction} from '../actions'
+
+/**
+ * Path prefix shared by every release document. Matches studio's
+ * `RELEASE_DOCUMENTS_PATH` constant.
+ */
+const RELEASE_DOCUMENTS_PATH = '_.releases'
+
+/**
+ * Returns the full release document ID for the given release name.
+ * e.g. `getReleaseDocumentId('my-release') === '_.releases.my-release'`
+ * @beta
+ */
+export function getReleaseDocumentId(releaseId: string): string {
+  return `${RELEASE_DOCUMENTS_PATH}.${releaseId}`
+}
+
+const RELEASE_ACTION_TYPES = new Set([
+  'release.create',
+  'release.edit',
+  'release.publish',
+  'release.schedule',
+  'release.unschedule',
+  'release.archive',
+  'release.unarchive',
+  'release.delete',
+])
+
+export function isReleaseAction(action: Action): action is ReleaseAction {
+  return RELEASE_ACTION_TYPES.has(action.type)
+}

--- a/packages/core/src/document/processActions/shared.ts
+++ b/packages/core/src/document/processActions/shared.ts
@@ -114,9 +114,9 @@ export function applySingleDocPatch({
     throw new ActionError({documentId, transactionId, message: notFoundMessage})
   }
 
-  const baseBefore = base[documentId] as SanityDocument
+  const baseBefore = base[documentId]
   base = processMutations({documents: base, transactionId, mutations: userPatches, timestamp})
-  const baseAfter = base[documentId] as SanityDocument
+  const baseAfter = base[documentId]
   const diffedPatches = diffValue(baseBefore, baseAfter) as PatchOperations[]
 
   const workingBefore = working[documentId] as SanityDocument

--- a/packages/core/src/document/processActions/shared.ts
+++ b/packages/core/src/document/processActions/shared.ts
@@ -1,8 +1,9 @@
-import {type Mutation, type SanityDocument} from '@sanity/types'
+import {diffValue} from '@sanity/diff-patch'
+import {type Mutation, type PatchOperations, type SanityDocument} from '@sanity/types'
 import {evaluateSync, type ExprNode} from 'groq-js'
 
 import {type Grant} from '../permissions'
-import {type DocumentSet} from '../processMutations'
+import {type DocumentSet, processMutations} from '../processMutations'
 import {type HttpAction} from '../reducers'
 
 export interface ActionHandlerContext {
@@ -45,3 +46,94 @@ export class ActionError extends Error implements ActionErrorOptions {
 }
 
 export class PermissionActionError extends ActionError {}
+
+interface ApplySingleDocPatchOptions {
+  base: DocumentSet
+  working: DocumentSet
+  documentId: string
+  patches: PatchOperations[] | undefined
+  transactionId: string
+  timestamp: string
+  grants: Record<Grant, ExprNode>
+  /**
+   * Error message thrown when the target document does not exist in either
+   * the base or working set.
+   */
+  notFoundMessage?: string
+  /**
+   * Error message thrown when the working document fails the `update` grant.
+   */
+  permissionMessage?: string
+}
+
+interface ApplySingleDocPatchResult {
+  base: DocumentSet
+  working: DocumentSet
+  /**
+   * Patch operations representing the minimal diff between base before and
+   * after the user's patches were applied. These are the patches that should
+   * be sent to the server (or applied to the working set as mutations).
+   */
+  diffedPatches: PatchOperations[]
+  /**
+   * Mutation envelopes for `diffedPatches` already keyed to `documentId`.
+   * Useful for callers that want to push them to `outgoingMutations`.
+   */
+  workingMutations: Mutation[]
+}
+
+/**
+ * Shared logic for applying user-provided patches to a single document that
+ * is identified by an exact ID (no draft/published wrapping). Used by the
+ * liveEdit branch of `document.edit` and by `release.edit`.
+ *
+ * Returns the updated base + working sets, plus the diffed patches in both
+ * raw and mutation form so the caller can decide what to send to the server.
+ */
+export function applySingleDocPatch({
+  base: initialBase,
+  working: initialWorking,
+  documentId,
+  patches,
+  transactionId,
+  timestamp,
+  grants,
+  notFoundMessage = 'Cannot edit document because it does not exist.',
+  permissionMessage = `You do not have permission to edit document "${documentId}".`,
+}: ApplySingleDocPatchOptions): ApplySingleDocPatchResult {
+  let base = initialBase
+  let working = initialWorking
+
+  const userPatches = patches?.map((patch) => ({patch: {id: documentId, ...patch}}))
+
+  if (!userPatches?.length) {
+    return {base, working, diffedPatches: [], workingMutations: []}
+  }
+
+  if (!working[documentId] || !base[documentId]) {
+    throw new ActionError({documentId, transactionId, message: notFoundMessage})
+  }
+
+  const baseBefore = base[documentId] as SanityDocument
+  base = processMutations({documents: base, transactionId, mutations: userPatches, timestamp})
+  const baseAfter = base[documentId] as SanityDocument
+  const diffedPatches = diffValue(baseBefore, baseAfter) as PatchOperations[]
+
+  const workingBefore = working[documentId] as SanityDocument
+  if (!checkGrant(grants.update, workingBefore)) {
+    throw new PermissionActionError({documentId, transactionId, message: permissionMessage})
+  }
+
+  const workingMutations: Mutation[] = diffedPatches.map((patch) => ({
+    patch: {id: documentId, ...patch},
+  }))
+
+  working = processMutations({
+    documents: working,
+    transactionId,
+    mutations: workingMutations,
+    timestamp,
+  })
+
+  return {base, working, diffedPatches, workingMutations}
+}

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -7,11 +7,12 @@ import {type StoreContext} from '../store/defineStore'
 import {insecureRandomId} from '../utils/ids'
 import {omitProperty} from '../utils/object'
 import {setCleanupTimeout} from '../utils/setCleanupTimeout'
-import {type DocumentAction} from './actions'
+import {type Action} from './actions'
 import {DOCUMENT_STATE_CLEAR_DELAY} from './documentConstants'
 import {type DocumentState, type DocumentStoreState} from './documentStore'
 import {type RemoteDocument} from './listen'
 import {ActionError, processActions} from './processActions/processActions'
+import {getReleaseDocumentId, isReleaseAction} from './processActions/releaseUtil'
 import {type DocumentSet} from './processMutations'
 
 const EMPTY_REVISIONS: NonNullable<Required<DocumentState['unverifiedRevisions']>> = {}
@@ -33,11 +34,27 @@ type ActionMap = {
   delete: 'sanity.action.document.delete'
   edit: 'sanity.action.document.edit'
   publish: 'sanity.action.document.publish'
+  releaseCreate: 'sanity.action.release.create'
+  releaseEdit: 'sanity.action.release.edit'
+  releasePublish: 'sanity.action.release.publish'
+  releaseSchedule: 'sanity.action.release.schedule'
+  releaseUnschedule: 'sanity.action.release.unschedule'
+  releaseArchive: 'sanity.action.release.archive'
+  releaseUnarchive: 'sanity.action.release.unarchive'
+  releaseDelete: 'sanity.action.release.delete'
 }
 
 type OptimisticLock = {
   ifDraftRevisionId?: string
   ifPublishedRevisionId?: string
+}
+
+interface ReleaseMetadataPayload {
+  title?: string
+  description?: string
+  intendedPublishAt?: string
+  releaseType?: 'asap' | 'scheduled' | 'undecided'
+  cardinality?: 'one' | 'many'
 }
 
 export type HttpAction =
@@ -47,6 +64,18 @@ export type HttpAction =
   | {actionType: ActionMap['delete']; publishedId: string; includeDrafts?: string[]}
   | {actionType: ActionMap['edit']; draftId: string; publishedId: string; patch: PatchOperations}
   | ({actionType: ActionMap['publish']; draftId: string; publishedId: string} & OptimisticLock)
+  | {
+      actionType: ActionMap['releaseCreate']
+      releaseId: string
+      metadata?: ReleaseMetadataPayload
+    }
+  | {actionType: ActionMap['releaseEdit']; releaseId: string; patch: PatchOperations}
+  | {actionType: ActionMap['releasePublish']; releaseId: string}
+  | {actionType: ActionMap['releaseSchedule']; releaseId: string; publishAt: string}
+  | {actionType: ActionMap['releaseUnschedule']; releaseId: string}
+  | {actionType: ActionMap['releaseArchive']; releaseId: string}
+  | {actionType: ActionMap['releaseUnarchive']; releaseId: string}
+  | {actionType: ActionMap['releaseDelete']; releaseId: string}
 
 /**
  * Represents a transaction that is queued to be applied but has not yet been
@@ -63,7 +92,7 @@ export interface QueuedTransaction {
    * actions don't mention draft IDs and is meant to abstract away the draft
    * model from users.
    */
-  actions: DocumentAction[]
+  actions: Action[]
   /**
    * An optional flag set to disable this transaction from being batched with
    * other transactions.
@@ -272,7 +301,9 @@ export function batchAppliedTransactions([curr, ...rest]: AppliedTransaction[]):
   if (next.disableBatching) return editAction
 
   // Don't batch a liveEdit edit with a non-liveEdit edit — they route to different APIs
-  if (!!action.liveEdit !== !!next.actions[0]?.liveEdit) return editAction
+  const nextFirst = next.actions[0]
+  const nextLiveEdit = nextFirst && 'liveEdit' in nextFirst ? nextFirst.liveEdit : false
+  if (!!action.liveEdit !== !!nextLiveEdit) return editAction
 
   return {
     disableBatching: false,
@@ -586,9 +617,13 @@ export function manageSubscriberIds(
 
 // document handles are passed in via the public facing API, but we also need to
 // pull the correct document ids from action bodies, which have similar but not
-// identical shapes to the document handles.
-function getDocumentIdsFromHandleLikes(handles: DocumentHandleLike[]): string[] {
+// identical shapes to the document handles. release actions also flow through
+// here, and resolve to the underlying release document id.
+function getDocumentIdsFromHandleLikes(handles: (DocumentHandleLike | Action)[]): string[] {
   return handles.flatMap((handle) => {
+    if ('type' in handle && isReleaseAction(handle)) {
+      return [getReleaseDocumentId(handle.releaseId)]
+    }
     const idsForDocument = []
     if (!handle.documentId) return []
     if (handle.liveEdit) {

--- a/packages/core/src/releases/getPerspectiveState.test.ts
+++ b/packages/core/src/releases/getPerspectiveState.test.ts
@@ -1,3 +1,4 @@
+import {type ReleaseDocument} from '@sanity/client'
 import {filter, firstValueFrom, of, Subject, take} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
@@ -6,7 +7,6 @@ import {getQueryState} from '../query/queryStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
 import {getPerspectiveState} from './getPerspectiveState'
-import {type ReleaseDocument} from './releasesStore'
 
 vi.mock('../query/queryStore')
 

--- a/packages/core/src/releases/releasesStore.test.ts
+++ b/packages/core/src/releases/releasesStore.test.ts
@@ -1,10 +1,11 @@
+import {type ReleaseDocument} from '@sanity/client'
 import {NEVER, Observable, type Observer, of, Subject} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {getQueryState, resolveQuery} from '../query/queryStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {getActiveReleasesState, getAllReleasesState, type ReleaseDocument} from './releasesStore'
+import {getActiveReleasesState, getAllReleasesState} from './releasesStore'
 
 // Mock dependencies
 vi.mock('../query/queryStore')

--- a/packages/core/src/releases/releasesStore.ts
+++ b/packages/core/src/releases/releasesStore.ts
@@ -23,7 +23,7 @@ const STABLE_EMPTY_RELEASES: ReleaseDocument[] = []
 /**
  * Lifecycle states a release document can be in. Mirrors the server's
  * `ReleaseState`.
- * @internal
+ * @beta
  */
 export type ReleaseState =
   | 'active'
@@ -36,18 +36,40 @@ export type ReleaseState =
   | 'scheduling'
 
 /**
- * Represents a document in a Sanity dataset that represents release options.
- * @internal
+ * Represents a release document (`_.releases.<name>`) in a Sanity dataset.
+ * The shape mirrors the server-side release document and is wider than the
+ * subset surfaced through `getActiveReleasesState` (which filters to active
+ * releases only).
+ * @beta
  */
 export type ReleaseDocument = SanityDocument & {
+  _type: 'system.release'
   name: string
-  publishAt?: string
   state: ReleaseState
+  /**
+   * Server-set time at which a scheduled release will be published. Takes
+   * precedence over `metadata.intendedPublishAt`.
+   */
+  publishAt?: string
+  /**
+   * Server-set time at which the release was actually published.
+   */
+  publishedAt?: string
+  /**
+   * Populated when a release transition fails on the server.
+   */
+  error?: {message: string}
+  /**
+   * Populated for `published` releases — captures the final IDs of documents
+   * the release published.
+   */
+  finalDocumentStates?: {id: string}[]
   metadata: {
-    title: string
-    releaseType: 'asap' | 'scheduled' | 'undecided'
-    intendedPublishAt?: string
+    title?: string
     description?: string
+    intendedPublishAt?: string
+    releaseType: 'asap' | 'scheduled' | 'undecided'
+    cardinality?: 'one' | 'many'
   }
 }
 

--- a/packages/core/src/releases/releasesStore.ts
+++ b/packages/core/src/releases/releasesStore.ts
@@ -1,4 +1,4 @@
-import {type SanityDocument} from '@sanity/types'
+import {type ReleaseDocument} from '@sanity/client'
 import {map} from 'rxjs'
 
 import {type DocumentResource} from '../config/sanityConfig'
@@ -34,44 +34,6 @@ export type ReleaseState =
   | 'publishing'
   | 'scheduled'
   | 'scheduling'
-
-/**
- * Represents a release document (`_.releases.<name>`) in a Sanity dataset.
- * The shape mirrors the server-side release document and is wider than the
- * subset surfaced through `getActiveReleasesState` (which filters to active
- * releases only).
- * @beta
- */
-export type ReleaseDocument = SanityDocument & {
-  _type: 'system.release'
-  name: string
-  state: ReleaseState
-  /**
-   * Server-set time at which a scheduled release will be published. Takes
-   * precedence over `metadata.intendedPublishAt`.
-   */
-  publishAt?: string
-  /**
-   * Server-set time at which the release was actually published.
-   */
-  publishedAt?: string
-  /**
-   * Populated when a release transition fails on the server.
-   */
-  error?: {message: string}
-  /**
-   * Populated for `published` releases — captures the final IDs of documents
-   * the release published.
-   */
-  finalDocumentStates?: {id: string}[]
-  metadata: {
-    title?: string
-    description?: string
-    intendedPublishAt?: string
-    releaseType: 'asap' | 'scheduled' | 'undecided'
-    cardinality?: 'one' | 'many'
-  }
-}
 
 export interface ReleasesStoreState {
   activeReleases?: ReleaseDocument[]

--- a/packages/core/src/releases/utils/sortReleases.test.ts
+++ b/packages/core/src/releases/utils/sortReleases.test.ts
@@ -15,7 +15,7 @@ function createReleaseMock(
   return {
     _id: id,
     _rev: 'rev',
-    _type: 'release',
+    _type: 'system.release',
     _createdAt: new Date().toISOString(),
     _updatedAt: new Date().toISOString(),
     state: 'active',

--- a/packages/core/src/releases/utils/sortReleases.test.ts
+++ b/packages/core/src/releases/utils/sortReleases.test.ts
@@ -1,6 +1,6 @@
+import {type ReleaseDocument} from '@sanity/client'
 import {describe, expect, it} from 'vitest'
 
-import {type ReleaseDocument} from '../releasesStore'
 import {sortReleases} from './sortReleases'
 
 // Mock function to create a release document

--- a/packages/core/src/releases/utils/sortReleases.ts
+++ b/packages/core/src/releases/utils/sortReleases.ts
@@ -1,4 +1,4 @@
-import {type ReleaseDocument} from '../releasesStore'
+import {type ReleaseDocument} from '@sanity/client'
 
 // mirrors the order of the releases in the releases list in Studio
 // https://github.com/sanity-io/sanity/blob/main/packages/sanity/src/core/releases/hooks/utils.ts

--- a/packages/react/src/hooks/releases/useActiveReleases.test.tsx
+++ b/packages/react/src/hooks/releases/useActiveReleases.test.tsx
@@ -53,7 +53,9 @@ describe('useActiveReleases', () => {
     expect(result.current).toBeInstanceOf(Promise)
     expect(mockStateSource.getCurrent).toHaveBeenCalled()
 
-    const resolved: ReleaseDocument[] = [{_id: 'release1', _type: 'release'} as ReleaseDocument]
+    const resolved: ReleaseDocument[] = [
+      {_id: 'release1', _type: 'release'} as unknown as ReleaseDocument,
+    ]
     mockSubject.next(resolved)
 
     await expect(result.current).resolves.toEqual(resolved)
@@ -61,8 +63,8 @@ describe('useActiveReleases', () => {
 
   it('should resolve with releases when data is available', () => {
     const mockReleases: ReleaseDocument[] = [
-      {_id: 'release1', _type: 'release'} as ReleaseDocument,
-      {_id: 'release2', _type: 'release'} as ReleaseDocument,
+      {_id: 'release1', _type: 'release'} as unknown as ReleaseDocument,
+      {_id: 'release2', _type: 'release'} as unknown as ReleaseDocument,
     ]
 
     const mockSubject = new BehaviorSubject<ReleaseDocument[]>(mockReleases)

--- a/packages/react/src/hooks/releases/usePerspective.test.tsx
+++ b/packages/react/src/hooks/releases/usePerspective.test.tsx
@@ -47,7 +47,7 @@ describe('usePerspective', () => {
     // Mock the active releases observable for the suspender
     const mockReleaseDoc: ReleaseDocument = {
       _id: 'release1',
-      _type: 'release',
+      _type: 'system.release',
       _createdAt: '2021-01-01T00:00:00Z',
       _updatedAt: '2021-01-01T00:00:00Z',
       _rev: 'rev1',


### PR DESCRIPTION
### Description
This PR adds the core release API actions to the document store. I chose to put them in the document store because there's so much overlap and logic, and releases are, technically, documents. This PR should hopefully complete our coverage of the Actions API.

React hooks and e2e tests will come in a follow-up PR; I wanted to prevent the size of this PR from growing too much.

### What to review
I made a few choices here:
1. This doesn't update `getActiveReleases` or get the releaseStore to be hooked up via the document's optimistic store. I don't think it's fully required, and would, again, make this PR pretty noisy.
2. The Release type was updated to reflect all the things that a release can actually be. This did mean changing the metadata title field to be possibly undefined, but that's in a type marked `beta` and anyone depending on that field to be defined would have run into issues in the real world; consider it more of a bugfix.
3. Some of the naming -- it's a little funky that we have `releaseName` in the releases store and `releaseId` here. also the files being called `releaseCreate` etc. This is more to match the Actions API, which take a `releaseId` (not a `documentId`) and has actions like `release.create`.
4. Decided to fully error out if an actions API change and mutation (via liveEdit) were in the same batch; if a release document got caught in there, it would result in a no-op and be a bug for the user. Again, this is a pretty rare (possibly impossible) occurrence.

### Testing
Vitest tests were added for the new actions and the new utils.

### Fun gif
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmt1N3o2bHE1dno4NGRzemVoZmdicHpyeG9zMzNvMG80amh4dGFkdiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/CDZwopbecAbIc/giphy.gif)
