### PR TITLE
chore(renovate): pin groq to typegen-experimental tag

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,11 @@
   },
   "packageRules": [
     {
+      "description": "Pin groq to the typegen-experimental prerelease tag. The SDK depends on typegen APIs that only exist on this branch; do not let Renovate move it to a stable release. Revisit once typegen lands in a regular groq release.",
+      "matchPackageNames": ["groq"],
+      "enabled": false
+    },
+    {
       "description": "Automerge all devDependencies (non-major)",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],


### PR DESCRIPTION
### Description

`packages/core` depends on `groq@3.88.1-typegen-experimental.0`, a prerelease that carries typegen APIs the SDK relies on but which aren't published on the regular `groq` release line. Renovate has been repeatedly opening PRs to "upgrade" this to a stable version, which would break our typegen integration.

This adds a `packageRules` entry that disables Renovate for the `groq` package entirely. The rule's `description` documents both the reason and the exit criteria (revisit once typegen lands in a regular `groq` release) so the pin doesn't outlive its purpose.

### What to review

- Confirm the `packageRules` entry in `.github/renovate.json` is what we want. `enabled: false` is Renovate's documented way to ignore a package: no PRs and no Dependency Dashboard entries.

### Testing

No automated test, this is config. The change is verifiable by:

1. JSON parses (`node -e "JSON.parse(require('fs').readFileSync('.github/renovate.json'))"`) — confirmed locally.
2. Next Renovate run should stop surfacing `groq` updates in the Dependency Dashboard and stop opening upgrade PRs against it.

### Fun gif
![pinned](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMHZ1NnBtdzVkd3Zrc3phOHpucHlubjRoa3M0NjY4N3d1ajJzNW01bCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tUL52cE2KOEZrNVBEk/giphy.gif)
