### PR TITLE
chore(deps): pin basic-ftp and form-data overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
   "packageManager": "pnpm@10.33.4",
   "pnpm": {
     "overrides": {
-      "@babel/types": "7.29.0"
+      "@babel/types": "7.29.0",
+      "basic-ftp@<5.3.1": "^5.3.1",
+      "form-data@<2.5.4": "^2.5.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   '@babel/types': 7.29.0
+  basic-ftp@<5.3.1: ^5.3.1
+  form-data@<2.5.4: ^2.5.4
 
 importers:
 
@@ -4469,10 +4471,9 @@ packages:
     resolution: {integrity: sha512-Y1fOuNDowLfgKOypdc9SPABfoWXuZHBOyCS4cD52IeZBhr4Md6CLLs6atcxVrzRmQ06E7hSlm5bHHApPKR/byA==}
     hasBin: true
 
-  basic-ftp@5.1.0:
-    resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
@@ -5575,8 +5576,8 @@ packages:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
 
-  form-data@2.5.3:
-    resolution: {integrity: sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==}
+  form-data@2.5.5:
+    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
     engines: {node: '>= 0.12'}
 
   form-data@4.0.5:
@@ -12612,7 +12613,7 @@ snapshots:
       '@types/caseless': 0.12.5
       '@types/node': 24.12.3
       '@types/tough-cookie': 4.0.5
-      form-data: 2.5.3
+      form-data: 2.5.5
 
   '@types/resolve@1.20.2': {}
 
@@ -13340,7 +13341,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.8: {}
 
-  basic-ftp@5.1.0: {}
+  basic-ftp@5.3.1: {}
 
   before-after-hook@2.2.3: {}
 
@@ -14655,11 +14656,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@2.5.3:
+  form-data@2.5.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
       safe-buffer: 5.2.1
 
@@ -14803,7 +14805,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.1.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:


### PR DESCRIPTION
### Description

Closes two critical Dependabot alerts on `pnpm-lock.yaml` by adding bounded `pnpm.overrides` for `basic-ftp` and `form-data`. Both vulnerabilities live in the dev-tree only, neither package appears in the runtime dependency graph of the published `@sanity/sdk` or `@sanity/sdk-react`, so consumers of the SDK aren't affected. The patches are applied here to keep `npm audit` / Dependabot quiet and avoid leaving known-vulnerable code in the dev install:

- `basic-ftp@5.1.0 → 5.3.1` (critical path traversal in `downloadToDir()`, plus three high-severity basic-ftp alerts in the same range). Comes in via `sanity@5.5.0 → @sanity/import → get-uri`.
- `form-data@2.5.3 → 2.5.5` (critical unsafe boundary RNG). Comes in via `@google-cloud/storage → retry-request → @types/request`.

### Why overrides instead of letting Dependabot do it?

Clicking "Create Dependabot security update" on both alerts returns `security_update_not_possible` with `latest-resolvable-version: 5.1.0 / 2.5.3` and `lowest-non-vulnerable-version: 5.3.1 / 2.5.4`. [Dependabot can't rewrite these particular pnpm transitive resolutions on its own ](https://github.com/sanity-io/sdk/security/dependabot/47)even though the upstream semver constraints (`^5.0.2`, `^2.5.0`) would technically accept the patched versions. The override is the only mechanism that forces resolution.

The override syntax is range-bounded:

```json
"basic-ftp@<5.3.1": "^5.3.1",
"form-data@<2.5.4": "^2.5.4"
```

This means the override is a no-op once upstream packages naturally resolve to a patched version, so it stays out of the way of future updates and can be deleted with confidence then.

### What to review

- `package.json`: two new entries in `pnpm.overrides`.
- `pnpm-lock.yaml`: `basic-ftp` and `form-data` resolved versions updated, plus the snapshots of their direct consumers (`get-uri@6.0.5`, `@types/request@2.48.12`) re-pointed at the new versions. No other package movement.
- Confirm the diff is *only* these two packages by reading `git diff pnpm-lock.yaml` end-to-end. Total churn should be ~22 lines of lockfile.
- Sanity check the override scoping: `pnpm why basic-ftp` and `pnpm why form-data` should report `basic-ftp@5.3.1` and `form-data@2.5.5` (the `4.0.5` copy of form-data via `sanity → form-data` is already patched and isn't affected).

### Testing

No new tests; this is a pure dep-graph change. Verified locally by:

- `pnpm install` runs clean.
- The `apps/kitchensink-react` `postinstall` (schema extract + typegen) still completes successfully.
- `pnpm why basic-ftp` and `pnpm why form-data` show only patched versions in the tree.

### Follow-ups not in this PR

- The only consumer-impacting open alert is `lodash` (high severity, via `@sanity/mutate@0.16.1` and `@sanity/id-utils@1.0.0`, both runtime deps of `@sanity/sdk`). The fix is bumping `@sanity/mutate` to `^0.18.0` in `packages/core/package.json` once that release is cut (sanity-io/mutate#126 is merged, waiting on the release PR sanity-io/mutate#121). Not in this PR to avoid coupling a published-package change to a dev-tree hygiene change.
- Opening an issue on `sanity-io/id-utils` to raise its lodash floor to `^4.18.1` is the longer-term hardening for the second lodash path.

### Fun gif

![hackers](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3MwNTEycWEydzd4OTExNmtzOTFnMzZsaHI5eXppZWRyMjF5ZzhqMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/L0Sn35PPrpfXjBlH9c/giphy.gif)
