### PR TITLE
fix(document): subscribe to listener on OutOfSync retry

### DIFF
--- a/packages/core/src/document/documentConstants.ts
+++ b/packages/core/src/document/documentConstants.ts
@@ -8,3 +8,10 @@
 export const DOCUMENT_STATE_CLEAR_DELAY = 1000
 export const INITIAL_OUTGOING_THROTTLE_TIME = 1000
 export const API_VERSION = 'v2025-05-06'
+
+/**
+ * Base delay (ms) before retrying a document listener after an `OutOfSyncError`.
+ * Backoff doubles on each successive retry, capped at {@link OUT_OF_SYNC_RETRY_MAX_DELAY}.
+ */
+export const OUT_OF_SYNC_RETRY_BASE_DELAY = 500
+export const OUT_OF_SYNC_RETRY_MAX_DELAY = 10_000

--- a/packages/core/src/document/documentStore.test.ts
+++ b/packages/core/src/document/documentStore.test.ts
@@ -42,6 +42,7 @@ import {
   subscribeDocumentEvents,
 } from './documentStore'
 import {type ActionErrorEvent, type TransactionRevertedEvent} from './events'
+import {DEFAULT_MAX_BUFFER_SIZE} from './listen'
 import {type DatasetAcl} from './permissions'
 import {type DocumentSet, processMutations} from './processMutations'
 import {type HttpAction} from './reducers'
@@ -1006,6 +1007,72 @@ it('version edits are isolated from draft state', async () => {
   unsubscribeDraft()
 })
 
+it('subscribeToSubscriptionsAndListenToDocuments recovers from an OutOfSyncError instead of failing the document store', async () => {
+  const documentId = DocumentId('doc-out-of-sync-recovery')
+  const doc = createDocumentHandle({documentId, documentType: 'article'})
+  const documentState = getDocumentState<TestDocument>(instance, doc)
+  const unsubscribe = documentState.subscribe()
+  const draftId = getDraftId(documentId)
+
+  // Establish a synced document so the listener has a base revision.
+  const created = await applyDocumentActions(instance, {
+    actions: [createDocument(doc), editDocument(doc, {set: {title: 'initial'}})],
+  })
+  await created.submitted()
+  expect(documentState.getCurrent()?.title).toBe('initial')
+
+  // Capture the fetchDocument spy so we can detect when the listener
+  // re-subscribes. (every frest subscription re-runs fetchDocument)
+  const fetchDocumentSpy = vi.mocked(createFetchDocument).mock.results.at(-1)?.value as ReturnType<
+    typeof vi.fn
+  >
+  const fetchCallsBefore = fetchDocumentSpy.mock.calls.filter(([id]) => id === draftId).length
+
+  // Inject DEFAULT_MAX_BUFFER_SIZE mutations whose previousRev doesn't chain
+  // to the base revision (basically forcing the error)
+  const sharedListener = (
+    createSharedListener as unknown as () => {events: Subject<ListenEvent<SanityDocument>>}
+  )()
+  for (let i = 0; i < DEFAULT_MAX_BUFFER_SIZE; i++) {
+    sharedListener.events.next({
+      type: 'mutation',
+      documentId: draftId,
+      eventId: `bad-${i}`,
+      identity: 'user',
+      mutations: [],
+      timestamp: new Date().toISOString(),
+      transactionId: `bad-tx-${i}`,
+      transactionCurrentEvent: 0,
+      transactionTotalEvents: 1,
+      previousRev: `dangling-rev-${i}`,
+      resultRev: `bad-rev-${i}`,
+      transition: 'update',
+      visibility: 'query',
+    })
+  }
+
+  // The above should have triggered a retry and re-subscribed to the listener
+  await vi.waitFor(() => {
+    expect(fetchDocumentSpy.mock.calls.filter(([id]) => id === draftId).length).toBeGreaterThan(
+      fetchCallsBefore,
+    )
+  })
+
+  // The store stayed healthy through the OutOfSyncError.
+  expect(() => documentState.getCurrent()).not.toThrow()
+  expect(() => getDocumentSyncStatus(instance, doc).getCurrent()).not.toThrow()
+
+  // A follow-up edit still propagates through the recovered listener.
+  const edited = await applyDocumentActions(instance, {
+    actions: [editDocument(doc, {set: {title: 'after-recovery'}})],
+    resource,
+  })
+  await edited.submitted()
+  expect(documentState.getCurrent()?.title).toBe('after-recovery')
+
+  unsubscribe()
+})
+
 vi.mock('../client/clientStore.ts', () => ({
   getClientState: vi.fn().mockReturnValue({observable: new ReplaySubject(1)}),
 }))
@@ -1039,6 +1106,8 @@ vi.mock('./documentConstants.ts', async (importOriginal) => {
     ...original,
     INITIAL_OUTGOING_THROTTLE_TIME: 0,
     DOCUMENT_STATE_CLEAR_DELAY: 25,
+    OUT_OF_SYNC_RETRY_BASE_DELAY: 0,
+    OUT_OF_SYNC_RETRY_MAX_DELAY: 0,
   }
 })
 

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -17,11 +17,13 @@ import {
   Observable,
   of,
   pairwise,
+  retry,
   startWith,
   Subject,
   switchMap,
   tap,
   throttle,
+  throwError,
   timer,
   withLatestFrom,
 } from 'rxjs'
@@ -44,7 +46,12 @@ import {type SanityInstance} from '../store/createSanityInstance'
 import {createStateSourceAction, type StateSource} from '../store/createStateSourceAction'
 import {defineStore, type StoreContext} from '../store/defineStore'
 import {type DocumentAction} from './actions'
-import {API_VERSION, INITIAL_OUTGOING_THROTTLE_TIME} from './documentConstants'
+import {
+  API_VERSION,
+  INITIAL_OUTGOING_THROTTLE_TIME,
+  OUT_OF_SYNC_RETRY_BASE_DELAY,
+  OUT_OF_SYNC_RETRY_MAX_DELAY,
+} from './documentConstants'
 import {
   type DocumentEvent,
   type DocumentTransactionSubmissionResult,
@@ -497,10 +504,15 @@ const subscribeToSubscriptionsAndListenToDocuments = (
           switchMap((e) => {
             if (!e.add) return EMPTY
             return listen(context, e.id).pipe(
-              catchError((error) => {
-                // retry on `OutOfSyncError`
-                if (error instanceof OutOfSyncError) listen(context, e.id)
-                throw error
+              retry({
+                delay: (error, retryCount) => {
+                  if (!(error instanceof OutOfSyncError)) return throwError(() => error)
+                  const backoff = Math.min(
+                    OUT_OF_SYNC_RETRY_BASE_DELAY * 2 ** (retryCount - 1),
+                    OUT_OF_SYNC_RETRY_MAX_DELAY,
+                  )
+                  return timer(backoff)
+                },
               }),
               tap((remote) =>
                 state.set('applyRemoteDocument', (prev) =>

--- a/packages/core/src/document/listen.ts
+++ b/packages/core/src/document/listen.ts
@@ -20,7 +20,7 @@ import {type StoreContext} from '../store/defineStore'
 import {type DocumentStoreState} from './documentStore'
 import {processMutations} from './processMutations'
 
-const DEFAULT_MAX_BUFFER_SIZE = 20
+export const DEFAULT_MAX_BUFFER_SIZE = 20
 const DEFAULT_DEADLINE_MS = 30000
 
 export interface RemoteDocument {


### PR DESCRIPTION
### Description
When listening for document changes, the document store sometimes throws an `OutOfSyncError` -- usually if the base revision that's kept in the optimistic store is not reconcilable with what's being received via the listener, or if we've received too many events that do not chain together. This should be recoverable, and shouldn't interrupt document operations.

However, the existing code just declared`listen(context, event.id)` on recovering that event, which doesn't make a ton of sense. That `listen` is  no-op and doesn't stop the `throw error` line below it from being thrown, because it's not being returned. (It's also a cold observable that's not being subscribed to). Worse, that error being thrown sends the whole store into an error state.

This change hopefully fixes both by ensuring that the listen function is always part of the chain and also returning before the error can be thrown.

### What to review
Does the logic make sense? Anything I should call out? Am I holding RxJS wrong?

### Testing
A test was added. You can validate this by restoring the document store and going to its old state while running the new test -- it should fail.

### Fun gif
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmczd2lyNHk5azU1dXM0aGRib2F6Y2Y3NGZoN3NhZGU5ZmN5ZnVpdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT0xeCaX5NCw6TGRAk/giphy.gif)