### PR TITLE
ci(e2e): enable turbo remote cache and move e2e-only secrets out of globalEnv

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,9 @@ jobs:
   # shared setup: install deps and warm Playwright browser cache for downstream jobs
   setup:
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -59,6 +62,8 @@ jobs:
 
     # Shared env required by the SDK E2E helpers. Configure these in the repo → Settings → Secrets / Variables
     env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       SDK_E2E_PROJECT_ID: ${{ secrets.SDK_E2E_PROJECT_ID }}
       SDK_E2E_ORGANIZATION_ID: ${{ secrets.SDK_E2E_ORGANIZATION_ID }}
       SDK_E2E_DATASET_0: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}-{2}', github.event.number, matrix.browser, github.run_id) || format('main-{0}-{1}', matrix.browser, github.run_id) }}

--- a/turbo.json
+++ b/turbo.json
@@ -7,9 +7,7 @@
     "PKG_VERSION",
     "NPM_CONFIG_PROVENANCE",
     "CI",
-    "SANITY_INTERNAL_ENV",
-    "RECAPTCHA_E2E_STAGING_KEY",
-    "VERCEL_AUTOMATION_BYPASS_SECRET"
+    "SANITY_INTERNAL_ENV"
   ],
   "tasks": {
     "build": {
@@ -35,7 +33,7 @@
     "clean": {},
     "cleanup": {
       "cache": false,
-      "env": ["SDK_E2E_*"]
+      "env": ["SDK_E2E_*", "RECAPTCHA_E2E_STAGING_KEY", "VERCEL_AUTOMATION_BYPASS_SECRET"]
     },
     "depcheck": {
       "env": ["DEPCHECK"]

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,9 @@
     "PKG_VERSION",
     "NPM_CONFIG_PROVENANCE",
     "CI",
-    "SANITY_INTERNAL_ENV"
+    "SANITY_INTERNAL_ENV",
+    "RECAPTCHA_E2E_STAGING_KEY",
+    "VERCEL_AUTOMATION_BYPASS_SECRET"
   ],
   "tasks": {
     "build": {

--- a/turbo.json
+++ b/turbo.json
@@ -7,15 +7,17 @@
     "PKG_VERSION",
     "NPM_CONFIG_PROVENANCE",
     "CI",
-    "SDK_E2E_*",
-    "SANITY_INTERNAL_ENV",
-    "RECAPTCHA_E2E_STAGING_KEY",
-    "VERCEL_AUTOMATION_BYPASS_SECRET"
+    "SANITY_INTERNAL_ENV"
   ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
+    },
+    "@sanity/kitchensink-react#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "env": ["SDK_E2E_*"]
     },
     "build:bundle": {
       "dependsOn": ["^build:bundle"],


### PR DESCRIPTION
### Description
The `End-to-End Tests` workflow was rebuilding everything from scratch for each browser in the matrix because it never set `TURBO_TOKEN` / `TURBO_TEAM`. Turbo logged `Remote caching disabled` and reported `0 cached, 5 total` per job, even though the same package builds had just been produced and uploaded to the remote cache by the `Build` workflow seconds earlier. On a recent run that was roughly 45s of duplicated build work for every browser (chromium / firefox / webkit).
Three small changes:
1. **Enable turbo remote caching in `e2e.yml`.** Add `TURBO_TOKEN` / `TURBO_TEAM` to the env block of both the `setup` job and the `playwright-tests` matrix job, matching what `build.yml`, `test.yml`, `lint.yml`, etc. already do.
2. **Move `SDK_E2E_*` from `globalEnv` onto the one task that actually bakes them in.** The dataset names are only consumed at build time by `apps/kitchensink-react/vite.config.mjs`'s `define` block, so they only need to be part of `@sanity/kitchensink-react#build`'s cache key. Leaving them in `globalEnv` was busting the cache key of every other task whenever a per-browser dataset name changed.
3. **Move `RECAPTCHA_E2E_STAGING_KEY` and `VERCEL_AUTOMATION_BYPASS_SECRET` from `globalEnv` onto the `cleanup` task.** These two are only set in the e2e workflow (never in `Build`), so keeping them in `globalEnv` made every package build hash differ between workflows and prevented cross-workflow cache hits. `test:e2e` already declared them; `cleanup` needed to as well because it transitively imports `getE2EEnv()`, which validates the full env on module load and was crashing in strict env mode without them.
### What to review
- `.github/workflows/e2e.yml`: confirm `TURBO_TOKEN` / `TURBO_TEAM` land on both jobs and don't shadow anything we need from secrets.
- `turbo.json`:
  - New `@sanity/kitchensink-react#build` override carries the right `dependsOn` / `outputs` (turbo overrides replace rather than merge).
  - `cleanup` task now declares all three env groups it needs (`SDK_E2E_*`, `RECAPTCHA_E2E_STAGING_KEY`, `VERCEL_AUTOMATION_BYPASS_SECRET`).
  - Nothing else in the repo was relying on those vars being globally hashed.

### Fun gif

![turbo](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExbzUwb2lyNTlxZHQ5ZXJ5bWUyYzZhOHBoZWxvemdxcDZpMXdlM2V5MyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/cRH5deQTgTMR2/giphy.gif)