### PR TITLE
fix(document): pass identity to local acl evaluations

### DIFF
--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -573,5 +573,9 @@ const subscribeToCurrentUserAndSetIdentity = ({
 }: StoreContext<DocumentStoreState, BoundResourceKey>) =>
   getCurrentUserState(instance).observable.subscribe({
     next: (currentUser) => state.set('setIdentity', {identity: currentUser?.id}),
-    error: (error) => state.set('setError', {error}),
+    // A transient identity-fetch failure (network blip, expired token, or a
+    // normal logout/re-login transition) should not brick all document
+    // operations. Reset the identity to `undefined` and keep going — GROQ's
+    // `identity()` then evaluates to null, matching the unauthenticated state.
+    error: () => state.set('setIdentity', {identity: undefined}),
   })

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -28,6 +28,7 @@ import {
   withLatestFrom,
 } from 'rxjs'
 
+import {getCurrentUserState} from '../auth/authStore'
 import {type ClientOptions, getClientState} from '../client/clientStore'
 import {
   type DocumentHandle,
@@ -89,6 +90,10 @@ export interface DocumentStoreState {
   applied: AppliedTransaction[]
   outgoing?: OutgoingTransaction
   grants?: Record<Grant, ExprNode>
+  /**
+   * The current user's identity (their user ID).
+   */
+  identity?: string
   error?: unknown
   sharedListener: SharedListener
   fetchDocument: (documentId: string) => Observable<SanityDocument | null>
@@ -148,6 +153,7 @@ export const documentStore = defineStore<DocumentStoreState, BoundResourceKey>({
       subscribeToSubscriptionsAndListenToDocuments(context),
       subscribeToAppliedAndSubmitNextTransaction(context),
       subscribeToClientAndFetchDatasetAcl(context),
+      subscribeToCurrentUserAndSetIdentity(context),
     ]
 
     return () => {
@@ -560,3 +566,12 @@ const subscribeToClientAndFetchDatasetAcl = ({
       error: (error) => state.set('setError', {error}),
     })
 }
+
+const subscribeToCurrentUserAndSetIdentity = ({
+  instance,
+  state,
+}: StoreContext<DocumentStoreState, BoundResourceKey>) =>
+  getCurrentUserState(instance).observable.subscribe({
+    next: (currentUser) => state.set('setIdentity', {identity: currentUser?.id}),
+    error: (error) => state.set('setError', {error}),
+  })

--- a/packages/core/src/document/permissions.test.ts
+++ b/packages/core/src/document/permissions.test.ts
@@ -32,9 +32,11 @@ const alwaysDeny = parse('false')
 const createState = (
   docStates: Record<string, {local: unknown}>,
   grants?: Record<Grant, ExprNode>,
+  identity?: string,
 ): SyncTransactionState => ({
   documentStates: docStates as SyncTransactionState['documentStates'],
   grants,
+  identity,
   queued: [],
   applied: [],
 })
@@ -233,5 +235,75 @@ describe('calculatePermissions', () => {
     const result1 = calculatePermissions({instance, state}, {actions: [{...action}]})
     const result2 = calculatePermissions({instance, state}, {actions: [{...action}]})
     expect(result1).toBe(result2)
+  })
+
+  describe('identity-aware grants', () => {
+    // Mirrors the canvas ACL filter shape: only the document's creator may
+    // update it. Without an identity passed to groq, `identity()` is null and
+    // the expression collapses to null — which used to read as "denied".
+    const canvasUpdateAcl: DatasetAcl = [
+      {
+        filter: '_type == "sanity.canvas.document" && _system.createdBy == identity()',
+        permissions: ['read', 'update'],
+      },
+    ]
+
+    const canvasDoc = (createdBy: string): SanityDocument => ({
+      _id: 'canvas-1',
+      _type: 'sanity.canvas.document',
+      _createdAt: '2025-01-01T00:00:00.000Z',
+      _updatedAt: '2025-01-01T00:00:00.000Z',
+      _rev: 'rev-1',
+      _system: {createdBy},
+    })
+
+    const editAction: DocumentAction = {
+      documentId: 'canvas-1',
+      documentType: 'sanity.canvas.document',
+      type: 'document.edit',
+      liveEdit: true,
+    }
+
+    it('allows edits when identity matches the document creator', () => {
+      const state = createState(
+        {'canvas-1': {local: canvasDoc('user-A')}},
+        createGrantsLookup(canvasUpdateAcl),
+        'user-A',
+      )
+      expect(calculatePermissions({instance, state}, {actions: [editAction]})).toEqual({
+        allowed: true,
+      })
+    })
+
+    it('denies edits when identity does not match the document creator', () => {
+      const state = createState(
+        {'canvas-1': {local: canvasDoc('user-A')}},
+        createGrantsLookup(canvasUpdateAcl),
+        'user-B',
+      )
+      const result = calculatePermissions({instance, state}, {actions: [editAction]})
+      expect(result?.allowed).toBe(false)
+      expect(result?.reasons).toEqual(
+        expect.arrayContaining([expect.objectContaining({type: 'access', documentId: 'canvas-1'})]),
+      )
+    })
+
+    it('denies edits when identity is not yet loaded (regression test for SDK-1429)', () => {
+      // Before the fix, identity() in the ACL filter always evaluated to null,
+      // so this filter collapsed to null and the user was denied even when
+      // they actually were the creator. Now that we pass identity through, a
+      // missing identity correctly fails the check rather than masquerading as
+      // an evaluation success.
+      const state = createState(
+        {'canvas-1': {local: canvasDoc('user-A')}},
+        createGrantsLookup(canvasUpdateAcl),
+        undefined,
+      )
+      const result = calculatePermissions({instance, state}, {actions: [editAction]})
+      expect(result?.allowed).toBe(false)
+      expect(result?.reasons).toEqual(
+        expect.arrayContaining([expect.objectContaining({type: 'access', documentId: 'canvas-1'})]),
+      )
+    })
   })
 })

--- a/packages/core/src/document/permissions.test.ts
+++ b/packages/core/src/document/permissions.test.ts
@@ -288,12 +288,7 @@ describe('calculatePermissions', () => {
       )
     })
 
-    it('denies edits when identity is not yet loaded (regression test for SDK-1429)', () => {
-      // Before the fix, identity() in the ACL filter always evaluated to null,
-      // so this filter collapsed to null and the user was denied even when
-      // they actually were the creator. Now that we pass identity through, a
-      // missing identity correctly fails the check rather than masquerading as
-      // an evaluation success.
+    it('denies edits when identity is not yet loaded', () => {
       const state = createState(
         {'canvas-1': {local: canvasDoc('user-A')}},
         createGrantsLookup(canvasUpdateAcl),

--- a/packages/core/src/document/permissions.ts
+++ b/packages/core/src/document/permissions.ts
@@ -1,6 +1,6 @@
 import {DocumentId, getDraftId, getPublishedId, getVersionId} from '@sanity/id-utils'
 import {type SanityDocument} from '@sanity/types'
-import {evaluateSync, type ExprNode, parse} from 'groq-js'
+import {type ExprNode, parse} from 'groq-js'
 import {createSelector} from 'reselect'
 
 import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
@@ -8,6 +8,7 @@ import {type SelectorContext} from '../store/createStateSourceAction'
 import {MultiKeyWeakMap} from '../utils/MultiKeyWeakMap'
 import {type DocumentAction} from './actions'
 import {ActionError, PermissionActionError, processActions} from './processActions/processActions'
+import {checkGrant} from './processActions/shared'
 import {type DocumentSet} from './processMutations'
 import {type SyncTransactionState} from './reducers'
 
@@ -139,15 +140,6 @@ const memoizedActionsSelector = createSelector(
     return normalizedActions
   },
 )
-
-function checkGrant(
-  grantExpr: ExprNode,
-  document: SanityDocument,
-  identity: string | undefined,
-): boolean {
-  const value = evaluateSync(grantExpr, {params: {document}, identity})
-  return value.type === 'boolean' && value.data
-}
 
 /** @beta */
 export interface PermissionDeniedReason {

--- a/packages/core/src/document/permissions.ts
+++ b/packages/core/src/document/permissions.ts
@@ -140,8 +140,12 @@ const memoizedActionsSelector = createSelector(
   },
 )
 
-function checkGrant(grantExpr: ExprNode, document: SanityDocument): boolean {
-  const value = evaluateSync(grantExpr, {params: {document}})
+function checkGrant(
+  grantExpr: ExprNode,
+  document: SanityDocument,
+  identity: string | undefined,
+): boolean {
+  const value = evaluateSync(grantExpr, {params: {document}, identity})
   return value.type === 'boolean' && value.data
 }
 
@@ -172,11 +176,13 @@ export function calculatePermissions(
 const _calculatePermissions = createSelector(
   [
     ({state: {grants}}: SelectorContext<SyncTransactionState>) => grants,
+    ({state: {identity}}: SelectorContext<SyncTransactionState>) => identity,
     documentsSelector,
     memoizedActionsSelector,
   ],
   (
     grants: Record<Grant, ExprNode> | undefined,
+    identity: string | undefined,
     documents: DocumentSet | undefined,
     actions: DocumentAction[] | undefined,
   ): DocumentPermissionsResult | undefined => {
@@ -195,6 +201,7 @@ const _calculatePermissions = createSelector(
         base: documents,
         timestamp,
         grants,
+        identity,
       })
     } catch (error) {
       if (error instanceof PermissionActionError) {
@@ -244,7 +251,7 @@ const _calculatePermissions = createSelector(
               documentId: docId,
             })
           }
-        } else if (!checkGrant(grants.update, doc)) {
+        } else if (!checkGrant(grants.update, doc, identity)) {
           reasons.push({
             type: 'access',
             message: `You are not allowed to edit the document with ID "${docId}".`,

--- a/packages/core/src/document/processActions/create.ts
+++ b/packages/core/src/document/processActions/create.ts
@@ -16,7 +16,7 @@ export function handleCreate(
   action: CreateDocumentAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  const {transactionId, timestamp, grants, identity, outgoingActions, outgoingMutations} = ctx
   let {base, working} = ctx
 
   const documentId = getId(action.documentId)
@@ -51,7 +51,7 @@ export function handleCreate(
       timestamp,
     })
 
-    if (!checkGrant(grants.create, working[documentId] as SanityDocument)) {
+    if (!checkGrant(grants.create, working[documentId] as SanityDocument, identity)) {
       throw new PermissionActionError({
         documentId,
         transactionId,
@@ -111,13 +111,16 @@ export function handleCreate(
     timestamp,
   })
 
-  if (versionId && !checkGrant(grants.create, working[versionId] as SanityDocument)) {
+  if (versionId && !checkGrant(grants.create, working[versionId] as SanityDocument, identity)) {
     throw new PermissionActionError({
       documentId,
       transactionId,
       message: `You do not have permission to create a release version for document "${documentId}".`,
     })
-  } else if (!versionId && !checkGrant(grants.create, working[draftId] as SanityDocument)) {
+  } else if (
+    !versionId &&
+    !checkGrant(grants.create, working[draftId] as SanityDocument, identity)
+  ) {
     throw new PermissionActionError({
       documentId,
       transactionId,

--- a/packages/core/src/document/processActions/delete.ts
+++ b/packages/core/src/document/processActions/delete.ts
@@ -16,7 +16,7 @@ export function handleDelete(
   action: DeleteDocumentAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  const {transactionId, timestamp, grants, identity, outgoingActions, outgoingMutations} = ctx
   let {base, working} = ctx
 
   const documentId = action.documentId
@@ -38,7 +38,7 @@ export function handleDelete(
       })
     }
 
-    if (!checkGrant(grants.update, working[documentId])) {
+    if (!checkGrant(grants.update, working[documentId], identity)) {
       throw new PermissionActionError({
         documentId,
         transactionId,
@@ -72,9 +72,9 @@ export function handleDelete(
     })
   }
 
-  const cantDeleteDraft = working[draftId] && !checkGrant(grants.update, working[draftId])
+  const cantDeleteDraft = working[draftId] && !checkGrant(grants.update, working[draftId], identity)
   const cantDeletePublished =
-    working[publishedId] && !checkGrant(grants.update, working[publishedId])
+    working[publishedId] && !checkGrant(grants.update, working[publishedId], identity)
 
   if (cantDeleteDraft || cantDeletePublished) {
     throw new PermissionActionError({

--- a/packages/core/src/document/processActions/discard.ts
+++ b/packages/core/src/document/processActions/discard.ts
@@ -16,7 +16,7 @@ export function handleDiscard(
   action: DiscardDocumentAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  const {transactionId, timestamp, grants, identity, outgoingActions, outgoingMutations} = ctx
   let {base, working} = ctx
 
   const documentId = getId(action.documentId)
@@ -43,7 +43,7 @@ export function handleDiscard(
     })
   }
 
-  if (!checkGrant(grants.update, working[versionId])) {
+  if (!checkGrant(grants.update, working[versionId], identity)) {
     throw new PermissionActionError({
       documentId,
       transactionId,

--- a/packages/core/src/document/processActions/edit.ts
+++ b/packages/core/src/document/processActions/edit.ts
@@ -18,7 +18,7 @@ export function handleEdit(
   action: EditDocumentAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  const {transactionId, timestamp, grants, identity, outgoingActions, outgoingMutations} = ctx
   let {base, working} = ctx
 
   const documentId = getId(action.documentId)
@@ -32,6 +32,7 @@ export function handleEdit(
       transactionId,
       timestamp,
       grants,
+      identity,
     })
     // liveEdit documents use the mutation endpoint directly -- we don't send actions
     outgoingMutations.push(...result.workingMutations)
@@ -98,7 +99,7 @@ export function handleEdit(
   if (!isReleasePerspective(action.perspective) && !working[draftId] && working[publishedId]) {
     const newDraftFromPublished = {...working[publishedId], _id: draftId}
 
-    if (!checkGrant(grants.create, newDraftFromPublished)) {
+    if (!checkGrant(grants.create, newDraftFromPublished, identity)) {
       throw new PermissionActionError({
         documentId,
         transactionId,
@@ -111,7 +112,7 @@ export function handleEdit(
 
   // the first if statement should make this never be null or undefined
   const workingBefore = working[patchDocumentId] ?? working[publishedId]
-  if (!checkGrant(grants.update, workingBefore!)) {
+  if (!checkGrant(grants.update, workingBefore!, identity)) {
     throw new PermissionActionError({
       documentId,
       transactionId,

--- a/packages/core/src/document/processActions/processActions.ts
+++ b/packages/core/src/document/processActions/processActions.ts
@@ -65,6 +65,13 @@ interface ProcessActionsOptions {
    */
   grants: Record<Grant, ExprNode>
 
+  /**
+   * The current user's ID, passed to GROQ as the value of `identity()` when
+   * evaluating ACL filters. Optional because the user may not have loaded yet;
+   * filters that reference `identity()` will evaluate to null in that case.
+   */
+  identity?: string
+
   // // TODO: implement initial values from the schema?
   // initialValues?: {[TDocumentType in string]?: {_type: string}}
 }
@@ -116,6 +123,7 @@ export function processActions({
   base: initialBase,
   timestamp,
   grants,
+  identity,
 }: ProcessActionsOptions): ProcessActionsResult {
   let base: DocumentSet = {...initialBase}
   let working: DocumentSet = {...initialWorking}
@@ -148,6 +156,7 @@ export function processActions({
       transactionId,
       timestamp,
       grants,
+      identity,
       outgoingActions,
       outgoingMutations,
     })

--- a/packages/core/src/document/processActions/publish.ts
+++ b/packages/core/src/document/processActions/publish.ts
@@ -17,7 +17,7 @@ export function handlePublish(
   action: PublishDocumentAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  const {transactionId, timestamp, grants, identity, outgoingActions, outgoingMutations} = ctx
   let {base, working} = ctx
 
   const documentId = getId(action.documentId)
@@ -58,7 +58,7 @@ export function handlePublish(
 
   const mutations: Mutation[] = [{delete: {id: draftId}}, {createOrReplace: newPublishedFromDraft}]
 
-  if (working[draftId] && !checkGrant(grants.update, working[draftId])) {
+  if (working[draftId] && !checkGrant(grants.update, working[draftId], identity)) {
     throw new PermissionActionError({
       documentId,
       transactionId,
@@ -66,13 +66,13 @@ export function handlePublish(
     })
   }
 
-  if (working[publishedId] && !checkGrant(grants.update, newPublishedFromDraft)) {
+  if (working[publishedId] && !checkGrant(grants.update, newPublishedFromDraft, identity)) {
     throw new PermissionActionError({
       documentId,
       transactionId,
       message: `Publish failed: You do not have permission to update the published version of "${documentId}".`,
     })
-  } else if (!working[publishedId] && !checkGrant(grants.create, newPublishedFromDraft)) {
+  } else if (!working[publishedId] && !checkGrant(grants.create, newPublishedFromDraft, identity)) {
     throw new PermissionActionError({
       documentId,
       transactionId,

--- a/packages/core/src/document/processActions/releaseArchive.ts
+++ b/packages/core/src/document/processActions/releaseArchive.ts
@@ -12,7 +12,7 @@ export function handleReleaseArchive(
   action: ArchiveReleaseAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {base, working, grants, outgoingActions, transactionId} = ctx
+  const {base, working, grants, outgoingActions, transactionId, identity} = ctx
 
   const releaseDocumentId = getReleaseDocumentId(action.releaseId)
   const existing = working[releaseDocumentId] ?? base[releaseDocumentId]
@@ -24,7 +24,7 @@ export function handleReleaseArchive(
     })
   }
 
-  if (!checkGrant(grants.update, existing)) {
+  if (!checkGrant(grants.update, existing, identity)) {
     throw new PermissionActionError({
       documentId: releaseDocumentId,
       transactionId,
@@ -48,7 +48,7 @@ export function handleReleaseUnarchive(
   action: UnarchiveReleaseAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {base, working, grants, outgoingActions, transactionId} = ctx
+  const {base, working, grants, outgoingActions, transactionId, identity} = ctx
 
   const releaseDocumentId = getReleaseDocumentId(action.releaseId)
   const existing = working[releaseDocumentId] ?? base[releaseDocumentId]
@@ -60,7 +60,7 @@ export function handleReleaseUnarchive(
     })
   }
 
-  if (!checkGrant(grants.update, existing)) {
+  if (!checkGrant(grants.update, existing, identity)) {
     throw new PermissionActionError({
       documentId: releaseDocumentId,
       transactionId,

--- a/packages/core/src/document/processActions/releaseCreate.ts
+++ b/packages/core/src/document/processActions/releaseCreate.ts
@@ -15,7 +15,7 @@ export function handleReleaseCreate(
   action: CreateReleaseAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations, identity} = ctx
   let {base, working} = ctx
 
   const releaseDocumentId = getReleaseDocumentId(action.releaseId)
@@ -40,7 +40,7 @@ export function handleReleaseCreate(
   base = processMutations({documents: base, transactionId, mutations, timestamp})
   working = processMutations({documents: working, transactionId, mutations, timestamp})
 
-  if (!checkGrant(grants.create, working[releaseDocumentId] as SanityDocument)) {
+  if (!checkGrant(grants.create, working[releaseDocumentId] as SanityDocument, identity)) {
     throw new PermissionActionError({
       documentId: releaseDocumentId,
       transactionId,

--- a/packages/core/src/document/processActions/releaseDelete.ts
+++ b/packages/core/src/document/processActions/releaseDelete.ts
@@ -19,7 +19,7 @@ export function handleReleaseDelete(
   action: DeleteReleaseAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations, identity} = ctx
   let {base, working} = ctx
 
   const releaseDocumentId = getReleaseDocumentId(action.releaseId)
@@ -42,7 +42,7 @@ export function handleReleaseDelete(
     })
   }
 
-  if (!checkGrant(grants.update, existing)) {
+  if (!checkGrant(grants.update, existing, identity)) {
     throw new PermissionActionError({
       documentId: releaseDocumentId,
       transactionId,

--- a/packages/core/src/document/processActions/releaseEdit.ts
+++ b/packages/core/src/document/processActions/releaseEdit.ts
@@ -6,7 +6,7 @@ export function handleReleaseEdit(
   action: EditReleaseAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations, identity} = ctx
   const {base, working} = ctx
 
   const releaseDocumentId = getReleaseDocumentId(action.releaseId)
@@ -19,6 +19,7 @@ export function handleReleaseEdit(
     transactionId,
     timestamp,
     grants,
+    identity,
     notFoundMessage: `Cannot edit release "${action.releaseId}" because it does not exist.`,
     permissionMessage: `You do not have permission to edit release "${action.releaseId}".`,
   })

--- a/packages/core/src/document/processActions/releasePublish.ts
+++ b/packages/core/src/document/processActions/releasePublish.ts
@@ -12,7 +12,7 @@ export function handleReleasePublish(
   action: PublishReleaseAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {base, working, grants, outgoingActions, transactionId} = ctx
+  const {base, working, grants, outgoingActions, transactionId, identity} = ctx
 
   const releaseDocumentId = getReleaseDocumentId(action.releaseId)
   const existing = working[releaseDocumentId] ?? base[releaseDocumentId]
@@ -24,7 +24,7 @@ export function handleReleasePublish(
     })
   }
 
-  if (!checkGrant(grants.update, existing)) {
+  if (!checkGrant(grants.update, existing, identity)) {
     throw new PermissionActionError({
       documentId: releaseDocumentId,
       transactionId,

--- a/packages/core/src/document/processActions/releaseSchedule.ts
+++ b/packages/core/src/document/processActions/releaseSchedule.ts
@@ -12,7 +12,7 @@ export function handleReleaseSchedule(
   action: ScheduleReleaseAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {base, working, grants, outgoingActions, transactionId} = ctx
+  const {base, working, grants, outgoingActions, transactionId, identity} = ctx
 
   const releaseDocumentId = getReleaseDocumentId(action.releaseId)
 
@@ -33,7 +33,7 @@ export function handleReleaseSchedule(
     })
   }
 
-  if (!checkGrant(grants.update, existing)) {
+  if (!checkGrant(grants.update, existing, identity)) {
     throw new PermissionActionError({
       documentId: releaseDocumentId,
       transactionId,
@@ -58,7 +58,7 @@ export function handleReleaseUnschedule(
   action: UnscheduleReleaseAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {base, working, grants, outgoingActions, transactionId} = ctx
+  const {base, working, grants, outgoingActions, transactionId, identity} = ctx
 
   const releaseDocumentId = getReleaseDocumentId(action.releaseId)
   const existing = working[releaseDocumentId] ?? base[releaseDocumentId]
@@ -70,7 +70,7 @@ export function handleReleaseUnschedule(
     })
   }
 
-  if (!checkGrant(grants.update, existing)) {
+  if (!checkGrant(grants.update, existing, identity)) {
     throw new PermissionActionError({
       documentId: releaseDocumentId,
       transactionId,

--- a/packages/core/src/document/processActions/shared.ts
+++ b/packages/core/src/document/processActions/shared.ts
@@ -12,6 +12,12 @@ export interface ActionHandlerContext {
   transactionId: string
   timestamp: string
   grants: Record<Grant, ExprNode>
+  /**
+   * The current user's ID, used by GROQ's `identity()` when evaluating ACL
+   * filters. May be `undefined` before the user has loaded; in that case
+   * `identity()` evaluates to null.
+   */
+  identity: string | undefined
   outgoingActions: HttpAction[]
   outgoingMutations: Mutation[]
 }
@@ -21,8 +27,12 @@ export interface ActionHandlerResult {
   working: DocumentSet
 }
 
-export function checkGrant(grantExpr: ExprNode, document: SanityDocument): boolean {
-  const value = evaluateSync(grantExpr, {params: {document}})
+export function checkGrant(
+  grantExpr: ExprNode,
+  document: SanityDocument,
+  identity: string | undefined,
+): boolean {
+  const value = evaluateSync(grantExpr, {params: {document}, identity})
   return value.type === 'boolean' && value.data
 }
 
@@ -55,6 +65,7 @@ interface ApplySingleDocPatchOptions {
   transactionId: string
   timestamp: string
   grants: Record<Grant, ExprNode>
+  identity: string | undefined
   /**
    * Error message thrown when the target document does not exist in either
    * the base or working set.
@@ -98,6 +109,7 @@ export function applySingleDocPatch({
   transactionId,
   timestamp,
   grants,
+  identity,
   notFoundMessage = 'Cannot edit document because it does not exist.',
   permissionMessage = `You do not have permission to edit document "${documentId}".`,
 }: ApplySingleDocPatchOptions): ApplySingleDocPatchResult {
@@ -120,7 +132,7 @@ export function applySingleDocPatch({
   const diffedPatches = diffValue(baseBefore, baseAfter) as PatchOperations[]
 
   const workingBefore = working[documentId] as SanityDocument
-  if (!checkGrant(grants.update, workingBefore)) {
+  if (!checkGrant(grants.update, workingBefore, identity)) {
     throw new PermissionActionError({documentId, transactionId, message: permissionMessage})
   }
 

--- a/packages/core/src/document/processActions/unpublish.ts
+++ b/packages/core/src/document/processActions/unpublish.ts
@@ -16,7 +16,7 @@ export function handleUnpublish(
   action: UnpublishDocumentAction,
   ctx: ActionHandlerContext,
 ): ActionHandlerResult {
-  const {transactionId, timestamp, grants, outgoingActions, outgoingMutations} = ctx
+  const {transactionId, timestamp, grants, identity, outgoingActions, outgoingMutations} = ctx
   let {base, working} = ctx
 
   const documentId = getId(action.documentId)
@@ -48,7 +48,7 @@ export function handleUnpublish(
     {createIfNotExists: newDraftFromPublished},
   ]
 
-  if (!checkGrant(grants.update, sourceDoc)) {
+  if (!checkGrant(grants.update, sourceDoc, identity)) {
     throw new PermissionActionError({
       documentId,
       transactionId,
@@ -56,7 +56,7 @@ export function handleUnpublish(
     })
   }
 
-  if (!working[draftId] && !checkGrant(grants.create, newDraftFromPublished)) {
+  if (!working[draftId] && !checkGrant(grants.create, newDraftFromPublished, identity)) {
     throw new PermissionActionError({
       documentId,
       transactionId,

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -19,7 +19,7 @@ const EMPTY_REVISIONS: NonNullable<Required<DocumentState['unverifiedRevisions']
 
 export type SyncTransactionState = Pick<
   DocumentStoreState,
-  'queued' | 'applied' | 'documentStates' | 'outgoing' | 'grants'
+  'queued' | 'applied' | 'documentStates' | 'outgoing' | 'grants' | 'identity'
 >
 
 type DocumentHandleLike = Pick<DocumentHandle, 'perspective'> & {
@@ -232,6 +232,7 @@ export function applyFirstQueuedTransaction(prev: SyncTransactionState): SyncTra
     base: working,
     timestamp,
     grants: prev.grants,
+    identity: prev.identity,
   })
   const applied: AppliedTransaction = {
     ...queued,
@@ -399,7 +400,7 @@ export function revertOutgoingTransaction(prev: SyncTransactionState): SyncTrans
 
   for (const t of prev.applied) {
     try {
-      const next = processActions({...t, working, grants: prev.grants})
+      const next = processActions({...t, working, grants: prev.grants, identity: prev.identity})
       working = next.working
       nextApplied.push({...t, ...next})
     } catch (error) {
@@ -506,7 +507,7 @@ export function applyRemoteDocument(
   // transaction again through the listener and this same flow will run then
   for (const curr of prev.applied) {
     try {
-      const next = processActions({...curr, working, grants: prev.grants})
+      const next = processActions({...curr, working, grants: prev.grants, identity: prev.identity})
       working = next.working
       // next includes an updated `previous` set and `working` set and updates
       // the `outgoingAction` and `outgoingMutations`. the `base` set from the


### PR DESCRIPTION
### Description
Canvas and some user-defined roles use the `$identity` or `identity()` parameter in their grant definitions, where `$identity` refers to the current user. There previously no concept of this in the document store. This PR adds a subscription to the current user and injects it in those places in the grants evaluation so that we can accurately pass those filters.

(Note that this only affected the optimistic store calculations, but those are required to work correctly without breaking the whole document store).

### What to review
Any cases I'm missing? Is there a better way?

### Testing
Tests were added.

### Fun gif
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmcxZGNueDNjYzZwMHk5Y2ducHg4amtjdDdvYzl1cnBxaHV4bzdjbiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/H7Fbn0QHGDWW4/giphy.gif)