### PR TITLE
fix(core): ignore unknown grants in createGrantsLookup

### DIFF
--- a/packages/core/src/document/permissions.test.ts
+++ b/packages/core/src/document/permissions.test.ts
@@ -52,6 +52,18 @@ describe('createGrantsLookup', () => {
       expect(evaluateSync(grants[key], {params: {document: dummyDoc}}).data).toBe(true)
     })
   })
+
+  it('should ignore unknown permissions like "manage"', () => {
+    const datasetAcl = [
+      {filter: '_id != null', permissions: ['history', 'read', 'update', 'create', 'manage']},
+    ] as DatasetAcl
+    const grants = createGrantsLookup(datasetAcl)
+    const dummyDoc = {_id: 'doc1'}
+    ;(['read', 'update', 'create', 'history'] as Grant[]).forEach((key) => {
+      expect(grants[key]).toBeDefined()
+      expect(evaluateSync(grants[key], {params: {document: dummyDoc}}).data).toBe(true)
+    })
+  })
 })
 
 describe('calculatePermissions', () => {

--- a/packages/core/src/document/permissions.ts
+++ b/packages/core/src/document/permissions.ts
@@ -29,6 +29,8 @@ export function createGrantsLookup(datasetAcl: DatasetAcl): Record<Grant, ExprNo
   for (const entry of datasetAcl) {
     for (const grant of entry.permissions) {
       const set = filtersByGrant[grant]
+      // Ignore permissions we don't model (e.g. "manage")
+      if (!set) continue
       set.add(entry.filter)
       filtersByGrant[grant] = set
     }


### PR DESCRIPTION
## Problem

`createGrantsLookup` crashes when the dataset ACL contains a permission that isn't modeled by the `Grant` type. The real ACL API can return values like `"manage"`, e.g. `["history", "read", "update", "create", "manage"]`.

The function indexes into a fixed record keyed by the four known grants:

```ts
const set = filtersByGrant[grant] // undefined when grant === "manage"
set.add(entry.filter)             // 💥 TypeError: Cannot read properties of undefined (reading 'add')
```

## Fix

Skip grants we don't model (`if (!set) continue`). Known grants still resolve correctly.

## Test

Added `should ignore unknown permissions like "manage"` to `permissions.test.ts`, which reproduced the crash before the fix and passes after.

> Note: `DatasetAcl.permissions` is typed as `Grant[]`, so the test casts the array. The real ACL API returning `"manage"` is the type-level mismatch that made this reachable in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)