### PR TITLE
chore(deps): drop redundant form-data and basic-ftp overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,6 @@
   "pnpm": {
     "overrides": {
       "@babel/types": "7.29.7",
-      "basic-ftp@<5.3.1": "^5.3.1",
-      "form-data@<2.5.4": "^2.5.4",
       "tsx": "<4.22.0"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,6 @@ settings:
 
 overrides:
   '@babel/types': 7.29.7
-  basic-ftp@<5.3.1: ^5.3.1
-  form-data@<2.5.4: ^2.5.4
   tsx: <4.22.0
 
 importers:


### PR DESCRIPTION
## What

Removes two now-redundant pnpm `overrides`:

```diff
   "overrides": {
     "@babel/types": "7.29.7",
-    "basic-ftp@<5.3.1": "^5.3.1",
-    "form-data@<2.5.4": "^2.5.4",
     "tsx": "<4.22.0"
   }
```

## Why

Both were added in #908 to force vulnerable transitive deps up to patched versions. They no longer do anything — the upstream ranges already resolve to safe versions:

| Package | Declared range | Resolves to | Override target | Fires? |
|---|---|---|---|---|
| `form-data` | `^2.5.0` (`@types/request`) | `2.5.5` | `<2.5.4` → `^2.5.4` | ❌ no |
| `basic-ftp` | `^5.0.2` (`get-uri`/proxy-agent) | `5.3.1` | `<5.3.1` → `^5.3.1` | ❌ no |

Each override key only matches versions *below* the patched release, but natural resolution already lands on the patched version (the latest in its range). Removing the overrides leaves **every resolved version unchanged** — the lockfile diff is just the two `overrides:` lines.

Both transitive deps come in via `devDependencies` (`@google-cloud/storage`, `@sanity/import`).

The `tsx: "<4.22.0"` override is intentionally kept — it's a real ceiling for the Node 24 regression.

## Verification

- Removed overrides, ran `pnpm install` + `pnpm dedupe`
- `pnpm why form-data` → `2.5.5`; `basic-ftp` installed at `5.3.1` (unchanged)
- Lockfile diff contains no resolution changes, only the removed override lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)