### PR TITLE
chore: add pnpm minimumReleaseAge cooldown

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,22 @@ packages:
 onlyBuiltDependencies:
   - esbuild
 
+minimumReleaseAge: 4320
+
+minimumReleaseAgeExclude:
+  - '@portabletext/*'
+  - '@sanity/*'
+  - '@types/*'
+  - 'groq-js'
+  - 'groq'
+  - 'lodash-es'
+  - 'react-rx'
+  - 'sanity'
+  - 'use-effect-event'
+  - 'dotenv'
+  - 'oxfmt'
+  - '@oxfmt/*'
+
 catalog:
   '@playwright/test': '^1.60.0'
   '@sanity/browserslist-config': '^1.0.5'


### PR DESCRIPTION
Set `minimumReleaseAge` to 4320 minutes (3 days) so pnpm only installs dependency versions that have been published for at least 3 days. This mitigates supply-chain risk from compromised or yanked fresh releases.

First-party and trusted packages are listed in `minimumReleaseAgeExclude` so they continue to install immediately:

- `@portabletext/*`, `@sanity/*`, `sanity`
- `@types/*`
- `groq`, `groq-js`
- `lodash-es`, `react-rx`, `use-effect-event`, `dotenv`
- `oxfmt`, `@oxfmt/*`

Requires pnpm >= 10.16 (repo pins `pnpm@10.33.4` via `packageManager`).