### PR TITLE
fix(projection): notify on intersection re-entry for fresh data

### DIFF
--- a/packages/react/src/hooks/projection/useDocumentProjection.test.tsx
+++ b/packages/react/src/hooks/projection/useDocumentProjection.test.tsx
@@ -114,6 +114,47 @@ describe('useDocumentProjection', () => {
     expect(eventsUnsubscribe).toHaveBeenCalled()
   })
 
+  test('it re-reads the current snapshot when the element becomes visible again after an off-screen update', async () => {
+    // The store notifies subscribers only on changes *after* subscribe (it skips the
+    // value current at subscribe time), so the mocked subscribe never invokes its
+    // callback — matching real behavior. The hook must therefore re-read getCurrent()
+    // itself whenever the visibility gate (re)opens, otherwise a value that updated
+    // while the element was off-screen stays frozen on screen.
+    getCurrent.mockReturnValue({
+      data: {title: 'Initial Title', description: 'Initial Description'},
+      isPending: false,
+    })
+    const eventsUnsubscribe = vi.fn()
+    subscribe.mockImplementation(() => eventsUnsubscribe)
+
+    render(
+      <ResourceProvider fallback={<div>Loading...</div>}>
+        <TestComponent document={mockDocument} projection="{name, description}" />
+      </ResourceProvider>,
+    )
+
+    // Become visible, then hidden — mirrors a card being scrolled out of view.
+    await act(async () => {
+      intersectionObserverCallback([{isIntersecting: true} as IntersectionObserverEntry])
+    })
+    await act(async () => {
+      intersectionObserverCallback([{isIntersecting: false} as IntersectionObserverEntry])
+    })
+
+    // The underlying document changes while the element is off-screen.
+    getCurrent.mockReturnValue({
+      data: {title: 'Updated Title', description: 'Updated Description'},
+      isPending: false,
+    })
+
+    // Becoming visible again must surface the value that changed while hidden.
+    await act(async () => {
+      intersectionObserverCallback([{isIntersecting: true} as IntersectionObserverEntry])
+    })
+
+    expect(screen.getByText('Updated Title')).toBeInTheDocument()
+  })
+
   test('it suspends and resolves data when element becomes visible', async () => {
     // Mock the initial state to trigger suspense
     getCurrent.mockReturnValueOnce({

--- a/packages/react/src/hooks/projection/useDocumentProjection.ts
+++ b/packages/react/src/hooks/projection/useDocumentProjection.ts
@@ -235,6 +235,12 @@ export function useDocumentProjection<TData extends object>({
           switchMap((isVisible) =>
             isVisible
               ? new Observable<void>((obs) => {
+                  // `stateSource.subscribe` skips the value current at subscribe time;
+                  // (intentionally -- we only want new events)
+                  // but in this case the store might have updated while the element was off-screen;
+                  // so we fire an immediate notification here to make useSyncExternalStore
+                  // re-read getCurrent() and pick up the fresh value.
+                  obs.next()
                   return stateSource.subscribe(() => obs.next())
                 })
               : EMPTY,


### PR DESCRIPTION
### Description
Fixing the flaky multi-resource tests revealed a bug where we were fetching new content but the display of the preview and projection cards weren't updating. This was because the value in the store had changed but we just re-subscribe when something comes back into view. This fix forces the hook to use `getCurrent` to refresh the data.

(This shouldn't result in re-fetching -- all of that logic is in re-subscribing which we're doing anyway. We're just creating a new notification for getSyncExternalStore).

### What to review
Actual fix is a one-liner and a comment. Hopefully it makes sense.

### Testing
A test was added; removing the line will make it fail. 

### Fun gif
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ2lla3QzbGhkdmJ2cTZvOWp0OWp1dzViaXYxaGk5NzViNGExbXMyeiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/dWjJTtcbTbMunxv9gp/giphy.gif)
