### PR TITLE
feat(ailf): add docs improvement agent job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,12 @@ SDK_E2E_CANVAS_TOKEN=
 
 # This token allows you to run the AILF task suite locally. If you are a Sanity employee, you can find it in 1pass.
 AILF_API_KEY=
+
+# Token for the docs-improvement job (`pnpm improve-docs` in packages/@repo/ailf-eval),
+# which proposes docs fixes from the latest AILF score report.
+# Should be read-only.
+SANITY_DOCS_READ_TOKEN=
+
+# Anthropic API key for the docs-improvement job — it runs a headless Claude
+# agent over the score report. Required alongside SANITY_DOCS_READ_TOKEN.
+ANTHROPIC_API_KEY=

--- a/.github/workflows/ailf-eval.yml
+++ b/.github/workflows/ailf-eval.yml
@@ -1,27 +1,29 @@
 name: AILF Eval
 
 on:
-  # Run on demand from the Actions tab.
+  # Run on demand from the Actions tab
   workflow_dispatch:
-  # Run weekly against main. Docs and the live Sanity dataset drift
-  # independently of code releases, so a scheduled run is the highest-signal
-  # trigger. Thursday 10:00 UTC (mid-morning).
+  # Run weekly against main
   schedule:
     - cron: "0 10 * * 4"
-  # Evaluate on PRs. The `decide` job below works out whether to actually run:
-  # automatically when task/config files change, or on demand via the
-  # `trigger: ailf` label. `synchronize` re-runs on new commits.
+  # Evaluate on PRs
+  # The `decide` job below works out whether to actually run:
+  # - automatically when task/config files change
+  # - on demand via the `trigger: ailf` label
+  # - automatically when PRs are synchronized (new commits)
   pull_request:
     types: [labeled, synchronize, opened, reopened]
 
+# One run per branch at a time; a new push cancels the in-flight run so we
+# never evaluate stale commits (and don't pay for two agent runs in parallel)
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Decide whether the eval should run. Schedule and manual runs always do.
-  # PRs run when they touch the AILF config/tasks, or carry the
-  # `trigger: ailf` label as a manual override.
+  # Decide whether the eval should run
+  # - Schedule and manual runs always do
+  # - PRs run when they touch the AILF config/tasks, or have the `trigger: ailf` label
   decide:
     runs-on: ubuntu-latest
     outputs:
@@ -66,9 +68,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # The remote eval long-polls the AILF API and can run several minutes;
-    # cap it so a hung job doesn't sit on a runner for the 6h default.
-    timeout-minutes: 30
+    # The remote eval long-polls the AILF API and can run several minutes,
+    # and the docs-improvement agent run afterwards can take 10-15 more
+    # cap it here so we don't have a hung runner
+    timeout-minutes: 45
 
     permissions:
       contents: read
@@ -84,18 +87,13 @@ jobs:
           node-version: 22
 
       - name: Run AILF eval
-        run: pnpm ailf
+        run: pnpm ailf:eval
         env:
           AILF_API_KEY: ${{ secrets.AILF_API_KEY }}
-          # Override via a repo/org `vars` entry to point at staging or a
-          # preview gateway; falls back to production.
           AILF_API_URL: ${{ vars.AILF_API_URL || 'https://ailf-api.sanity.build' }}
 
-      # Surface a link to the report on the Sanity dashboard in the job
-      # summary. The org handle and application id are fixed for the AILF
-      # studio app; only the report id varies per run.
       - name: Link to report
-        if: always()
+        if: always() # always run, even if the eval fails -- the dashboard will show where we failed
         env:
           DASHBOARD_BASE: https://www.sanity.io/@oSyH1iET5/application/l3gwk99w5xtv3dl8wxv94uny
         run: |
@@ -115,4 +113,22 @@ jobs:
             echo "[View report on the Sanity dashboard]($URL)"
             echo ""
             echo "Report ID: \`$REPORT_ID\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Run a read-only agent against the docs dataset; see packages/@repo/ailf-eval/scripts/improve-docs.ts
+      # continue-on-error keeps a flaky agent run from masking the eval result
+      - name: Propose docs improvements
+        continue-on-error: true
+        env:
+          SANITY_DOCS_READ_TOKEN: ${{ secrets.SANITY_DOCS_READ_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # --verbose streams the agent's tool calls to the step log; the
+          # proposal itself lands in docs-improvement.md next to the report.
+          pnpm ailf:improve-docs --verbose
+          {
+            echo ""
+            echo "---"
+            echo ""
+            cat packages/@repo/ailf-eval/.ailf/results/latest/docs-improvement.md
           } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "author": "Sanity <developers@sanity.io>",
   "sideEffects": false,
   "scripts": {
-    "ailf": "pnpm --filter @repo/ailf-eval eval",
+    "ailf:eval": "pnpm --filter @repo/ailf-eval eval",
+    "ailf:improve-docs": "pnpm --filter @repo/ailf-eval improve-docs",
     "all": "turbo run build && turbo run lint && turbo run test:coverage && pnpm build:docs && pnpm depcheck",
     "build": "turbo run build --filter='./packages/*' --filter='./apps/*'",
     "build:bundle": "turbo run build:bundle --filter='./packages/*' --filter='!./packages/@repo/*'",

--- a/packages/@repo/ailf-eval/.ailf/ailf.config.ts
+++ b/packages/@repo/ailf-eval/.ailf/ailf.config.ts
@@ -10,7 +10,7 @@
 import {defineRepoConfig} from '@sanity/ailf'
 
 export default defineRepoConfig({
-  // Which Sanity project/dataset holds the docs under test.
+  // Which Sanity project/dataset holds the docs being tested
   source: {
     projectId: '3do82whm',
     dataset: 'next',

--- a/packages/@repo/ailf-eval/.ailf/tasks/sdk-list-documents.task.ts
+++ b/packages/@repo/ailf-eval/.ailf/tasks/sdk-list-documents.task.ts
@@ -24,6 +24,10 @@ export default defineSdkTask({
         slug: 'sdk-react-hooks',
         reason: 'Reference for useDocuments and useDocumentProjection hooks',
       },
+      {
+        slug: 'sdk-best-practices',
+        reason: 'Discusses things that are relevant to the usage of most SDK hooks',
+      },
     ],
   },
   docCoverage: true,
@@ -49,7 +53,7 @@ Only the title of each post should be rendered. There may be many posts, so the 
         },
         {
           id: 'projects-title',
-          text: 'Renders each document title via useDocumentProjection or useDocumentPreview inside a Suspense boundary',
+          text: 'Renders each document title via useDocumentProjection inside a Suspense boundary',
         },
         {
           id: 'paginates-with-load-more',
@@ -67,7 +71,7 @@ Only the title of each post should be rendered. There may be many posts, so the 
         },
         {
           id: 'passes-document-handle',
-          text: 'Passes the full document handle through to useDocumentProjection or useDocumentPreview',
+          text: 'Passes the full document handle through to useDocumentProjection',
         },
       ],
     },

--- a/packages/@repo/ailf-eval/README.md
+++ b/packages/@repo/ailf-eval/README.md
@@ -6,10 +6,10 @@ AILF evaluates how well the SDK docs enable AI coding tools to implement feature
 
 ## Layout
 
-- `.ailf/ailf.config.ts` — project configuration (authored with `defineRepoConfig` from `@sanity/ailf`): the docs source (Sanity project/dataset/site URL) and the `taskSource` (set to `repo` so AILF reads the tasks in this package). This is the only config file `ailf run` reads.
-- `.ailf/tasks/*.task.ts` — task definitions, authored with `defineTask` from [`@sanity/ailf`](https://www.npmjs.com/package/@sanity/ailf). Each task evaluates whether an AI coding agent can implement a feature using the docs as context. `sdk-list-documents.task.ts` is the starter task: it checks that an agent can build a paginated document list with the App SDK's `useDocuments` hook.
+- `.ailf/ailf.config.ts` — project configuration (authored with `defineRepoConfig` from `@sanity/ailf`): the docs source (Sanity project/dataset/site URL) and the `taskSource` (set to `repo` so AILF reads the tasks in this package).
+- `.ailf/tasks/*.task.ts` — task definitions, authored with `defineTask` from [`@sanity/ailf`](https://www.npmjs.com/package/@sanity/ailf), with a `defineSdkTask` which also injects the API reference docs. Each task evaluates whether an AI coding agent can implement a feature using the docs as context. `sdk-list-documents.task.ts` is the starter task: it checks that an agent can build a paginated document list with the App SDK's `useDocuments` hook.
 
-The workflow that runs evaluations lives at [`.github/workflows/ailf-eval.yml`](../../../.github/workflows/ailf-eval.yml) in the repo root.
+The workflow that runs evaluations lives at [`.github/workflows/ailf-eval.yml`](../../../.github/workflows/ailf-eval.yml) in the repo root. After each eval it also runs the docs-improvement job and appends the proposal to the run summary, below the dashboard report link (needs the `SANITY_DOCS_READ_TOKEN` and `ANTHROPIC_API_KEY` repo secrets).
 
 ## Authoring a task
 
@@ -19,6 +19,20 @@ Full field reference: https://github.com/sanity-labs/ai-literacy-framework/blob/
 
 ## Scripts
 
-- `pnpm eval` — submit the tasks in this package to the AILF API and write a score report (needs `AILF_API_KEY`). Run from the repo root as `pnpm ailf`.
+- `pnpm eval` — submit the tasks in this package to the AILF API and write a score report (needs `AILF_API_KEY`). Run from the repo root as `pnpm ailf:eval`.
+- `pnpm improve-docs` — run from the repo root as `pnpm ailf:improve-docs`. This will run headless Claude over the latest score report with read-only access to the docs dataset, and print proposed docs fixes as markdown to stdout (also saved next to the report as `docs-improvement.md`).
+  Needs `SANITY_DOCS_READ_TOKEN` (please use a token that doesn't have write access) and `ANTHROPIC_API_KEY` (the agent runs against the Anthropic API). Applying proposals will be the next step, and will likely have a separate read token. See `scripts/improve-docs.ts` for the trust model.
 - `pnpm lint` — lint the config and task files.
 - `pnpm ts:check` — type-check the config and task files.
+
+## Environment variables
+
+Copy the repo-root `.env.example` to `.env.local` and fill in what you need (`.env.local` is git-ignored). `pnpm improve-docs` loads the repo-root `.env.local` automatically and tolerates it being absent (e.g. in CI, where the values come from secrets). `pnpm eval` does not read `.env.local` — export `AILF_API_KEY` in your shell (variables set in your shell also work for `improve-docs`, and take precedence over the file).
+
+| Variable                 | Used by             | Notes                                                                                                                                |
+| ------------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `AILF_API_KEY`           | `pnpm eval`         | Auth for the AILF API. Sanity employees can find it in 1Password.                                                                    |
+| `SANITY_DOCS_READ_TOKEN` | `pnpm improve-docs` | Token with read access to the docs dataset — prefer one that cannot write at all (see the trust model in `scripts/improve-docs.ts`). |
+| `ANTHROPIC_API_KEY`      | `pnpm improve-docs` | Auth for the Anthropic API — the docs-improvement job runs a headless Claude agent.                                                  |
+
+The docs project/dataset are not configurable via env — both jobs read them from `source` in `.ailf/ailf.config.ts` (`3do82whm`/`next`).

--- a/packages/@repo/ailf-eval/package.json
+++ b/packages/@repo/ailf-eval/package.json
@@ -6,11 +6,13 @@
   "type": "module",
   "scripts": {
     "eval": "ailf run --mode literacy --variant baseline --remote",
+    "improve-docs": "node --env-file-if-exists=../../../.env.local scripts/improve-docs.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.168",
     "@sanity/ailf": "^7.6.0"
   },
   "devDependencies": {

--- a/packages/@repo/ailf-eval/scripts/improve-docs.ts
+++ b/packages/@repo/ailf-eval/scripts/improve-docs.ts
@@ -1,0 +1,275 @@
+/**
+ * This script does the following:
+ * 1. checks your config (see "Env" below to see what's needed)
+ * 2. Creates a prompt for a Claude agent (via its SDK) which:
+ *    - reads the latest AILF score report
+ *    - locates the affected articles in the docs dataset
+ *    - prints proposed changes as markdown to stdout
+ * It's also using the Sanity MCP server pointed (read-only)
+ * at the docs project/dataset.
+ *
+ * It's intentionally limited; we try to enforce read-only tools and it's highly encouraged to use a read-only token.
+ * (We could add another step to check the token's permissions if deemed necessary)
+ *
+ * Usage:
+ *   pnpm ailf:improve-docs [--verbose]
+ *
+ * Flags:
+ *   --verbose                  stream the agent's tool calls to stderr while
+ *                              it works (stdout still ends up as the proposal
+ *                              markdown)
+ *
+ * Env:
+ *   SANITY_DOCS_READ_TOKEN     required; read access to the docs dataset is
+ *                              enough — prefer a token that cannot write at all and is only scoped to publicly available content.
+ *   ANTHROPIC_API_KEY          required; auth for the Anthropic API the agent runs against.
+ *
+ * The docs project/dataset come from .ailf/ailf.config.ts.
+ */
+
+import {createWriteStream, existsSync} from 'node:fs'
+import {readFile, writeFile} from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import {pathToFileURL} from 'node:url'
+
+import {query} from '@anthropic-ai/claude-agent-sdk'
+
+const PKG_DIR = path.dirname(import.meta.dirname)
+const AILF_DIR = path.join(PKG_DIR, '.ailf')
+const CONFIG = path.join(AILF_DIR, 'ailf.config.ts')
+const REPORT = path.join(AILF_DIR, 'results', 'latest', 'report.md') // we could turn this into a variable later
+const METADATA = path.join(path.dirname(REPORT), 'job-metadata.json')
+const OUT_DIR = path.dirname(REPORT)
+
+const VERBOSE = process.argv.includes('--verbose')
+
+function fail(message: string): never {
+  // eslint-disable-next-line no-console
+  console.error(`error: ${message}`)
+  process.exit(1)
+}
+
+// Progress narration goes to stderr not because it's an error,
+// but because we want stdout to stay clean for the report.
+// in other words, `pnpm improve-docs > proposal.md` must produce just the proposal markdown.
+function progress(message = ''): void {
+  // eslint-disable-next-line no-console
+  console.error(message)
+}
+
+if (!existsSync(REPORT)) fail(`no AILF report at ${REPORT} — run 'pnpm eval' first`)
+const SANITY_DOCS_READ_TOKEN =
+  process.env['SANITY_DOCS_READ_TOKEN'] ??
+  fail('Set SANITY_DOCS_READ_TOKEN (read access to the docs dataset)')
+
+if (!process.env['ANTHROPIC_API_KEY']) fail('Set ANTHROPIC_API_KEY (auth for the Anthropic API)')
+
+// The docs project/dataset come from the config file, so we're reading and writing to the same source of truth.
+// Node ≥22.18 strips TS types natively, so the config loads as a real module.
+if (!existsSync(CONFIG)) fail(`missing ${CONFIG}`)
+let cfgProject = ''
+let cfgDataset = ''
+try {
+  const mod = await import(pathToFileURL(CONFIG).href)
+  const src = mod.default?.source ?? {}
+  cfgProject = src.projectId ?? ''
+  cfgDataset = src.dataset ?? ''
+} catch (err) {
+  fail(`could not evaluate ${CONFIG}: ${err}`)
+}
+const PROJECT_ID = cfgProject || fail(`set source.projectId in ${CONFIG}`)
+const DATASET = cfgDataset || fail(`set source.dataset in ${CONFIG}`)
+
+const REPORT_ID = await readFile(METADATA, 'utf8')
+  .then((raw) => JSON.parse(raw).reportId ?? 'unknown')
+  .catch(() => 'unknown')
+
+progress('AILF docs improvement proposals')
+progress(`  docs source : ${PROJECT_ID}/${DATASET} (read-only)`)
+progress(`  report      : ${REPORT} (id: ${REPORT_ID})`)
+progress()
+
+// Specify read-only tools
+const ALLOWED_TOOLS = [
+  'mcp__sanity-docs__get_schema',
+  'mcp__sanity-docs__query_documents',
+  'mcp__sanity-docs__get_document',
+  'mcp__sanity-docs__semantic_search',
+  'mcp__sanity-docs__list_embeddings_indices',
+  'mcp__sanity-docs__search_docs',
+  'mcp__sanity-docs__read_docs',
+  'mcp__sanity-docs__list_sanity_rules',
+  'mcp__sanity-docs__get_sanity_rules',
+]
+const DISALLOWED_TOOLS = [
+  'mcp__sanity-docs__publish_documents',
+  'mcp__sanity-docs__publish_document',
+  'mcp__sanity-docs__publish_release',
+  'mcp__sanity-docs__create_release',
+  'mcp__sanity-docs__edit_release',
+  'mcp__sanity-docs__schedule_release',
+  'mcp__sanity-docs__create_version',
+  'mcp__sanity-docs__version_replace_document',
+  'mcp__sanity-docs__version_discard',
+  'mcp__sanity-docs__version_unpublish_document',
+  'mcp__sanity-docs__unpublish_documents',
+  'mcp__sanity-docs__discard_drafts',
+  'mcp__sanity-docs__edit_document',
+  'mcp__sanity-docs__create_documents',
+  'mcp__sanity-docs__create_document',
+  'mcp__sanity-docs__patch_document',
+  'mcp__sanity-docs__delete_document',
+  'mcp__sanity-docs__transform_document',
+  'mcp__sanity-docs__translate_document',
+  'mcp__sanity-docs__deploy_schema',
+  'mcp__sanity-docs__deploy_studio',
+  'mcp__sanity-docs__create_dataset',
+  'mcp__sanity-docs__update_dataset',
+  'mcp__sanity-docs__create_project',
+  'mcp__sanity-docs__add_cors_origin',
+  'mcp__sanity-docs__generate_image',
+  'mcp__sanity-docs__transform_image',
+]
+
+const report = await readFile(REPORT, 'utf8')
+
+const prompt = `You are a senior documentation engineer reviewing the Sanity docs against an
+AI Literacy Framework (AILF) evaluation report. AILF measures how well the
+docs enable AI coding tools to implement features correctly; the low-scoring
+judgments below mean agents misused or invented APIs because the docs were
+missing, ambiguous, or incomplete.
+
+Docs content lake: project ${PROJECT_ID}, dataset ${DATASET}. You have READ-ONLY
+access. Do not attempt to write, and do not propose that you write — your
+entire deliverable is the markdown proposal described at the end.
+
+## Your job
+
+1. Call get_schema first, so you understand the docs document types before
+   querying.
+2. Study the report below, especially the "Low-Scoring Judgments". Distill a
+   SHORT list of concrete documentation gaps. Good gap statements name the
+   exact API surface, e.g. "usePaginatedDocuments' return shape (loadMore,
+   hasMore, isPending) is not documented" — not vague advice like "improve
+   the hooks docs".
+3. For each gap, locate the existing article(s) that should cover it using
+   query_documents / get_document, and read enough of each article to know
+   exactly where the fix belongs and what the surrounding content looks like.
+   Strongly prefer improving existing articles over proposing new ones; if a
+   gap has no sensible home, mark it "needs a new article".
+4. Compose the fixes and output the proposal. Then stop.
+
+## Composing the fixes
+
+- Make the smallest edit that closes the gap: add the missing signature,
+  return shape, option name, or a short corrective example. Do not rewrite
+  articles wholesale.
+- Match the structure, tone, and formatting conventions of the surrounding
+  content in each article. Mirror how existing code examples in the dataset
+  are marked up.
+- Never document an API surface you are not sure exists — when uncertain,
+  leave it out and flag it under "Not addressed".
+
+## Output format
+
+Reply ONLY with the proposal document, no preamble. It is printed to stdout
+and saved as a report, so it must be self-contained markdown:
+
+    # Proposed docs improvements — AILF report ${REPORT_ID}
+
+    ## Gaps identified
+    (numbered list; one line each, referencing the judgments they come from)
+
+    ## Proposed changes
+
+    ### Change 1: <short title>
+    - **Document:** <_id> — "<article title>"
+    - **Field/path:** <where in the document, e.g. body block index / section heading>
+    - **Addresses:** gap(s) #n
+    - **Location context:** quote the 1-3 existing sentences or the heading
+      the change anchors to, so a human can find the spot instantly.
+
+    **Current** (omit if purely an addition):
+    > quoted existing text
+
+    **Proposed:**
+    (the exact new/replacement content, ready to paste — prose and/or code)
+
+    **Why:** one or two sentences tying it back to the judgments.
+
+    ## Not addressed
+    (gaps you could not place or were unsure about, and why)
+
+---
+
+## AILF report
+
+${report}
+`
+
+const PROPOSAL_FILE = path.join(OUT_DIR, 'docs-improvement.md')
+
+const result = query({
+  prompt,
+  options: {
+    mcpServers: {
+      // renamed because we want to avoid conflicts with the "sanity" server that many Sanity devs already have cached
+      'sanity-docs': {
+        type: 'http',
+        url: 'https://mcp.sanity.io',
+        headers: {Authorization: `Bearer ${SANITY_DOCS_READ_TOKEN}`},
+        // required: we want to block the agent until the MCP server is ready, since we've disabled built-in tools
+        alwaysLoad: true,
+      },
+    },
+    strictMcpConfig: true,
+    tools: [], // no built-in tools (Bash, Write, …) — MCP read tools only
+    allowedTools: ALLOWED_TOOLS,
+    disallowedTools: DISALLOWED_TOOLS,
+    permissionMode: 'dontAsk', // headless: anything not allowlisted is denied
+    maxTurns: 60,
+  },
+})
+
+// Stream the agent's activity (tool calls, text) to stderr as it happens;
+// devs can see what the agent is trying to do and iterate on the prompt as needed.
+const streamFile = VERBOSE
+  ? createWriteStream(path.join(OUT_DIR, 'docs-improvement.stream.jsonl'))
+  : null
+
+let proposal: string | null = null
+for await (const message of result) {
+  streamFile?.write(`${JSON.stringify(message)}\n`)
+  if (message.type === 'assistant') {
+    if (!VERBOSE) continue
+    for (const block of message.message.content) {
+      if (block.type === 'tool_use') {
+        const input = JSON.stringify(block.input ?? {})
+        progress(`→ ${block.name} ${input.length > 120 ? `${input.slice(0, 120)}…` : input}`)
+      } else if (block.type === 'text' && block.text.trim()) {
+        progress(`· ${block.text.trim().split('\n')[0].slice(0, 120)}`)
+      }
+    }
+  } else if (message.type === 'result') {
+    if (VERBOSE) {
+      const cost = message.total_cost_usd?.toFixed(2) ?? '?'
+      const secs = Math.round((message.duration_ms ?? 0) / 1000)
+      progress(`✓ done (${message.num_turns} turns, $${cost}, ${secs}s)`)
+    }
+    if (message.subtype !== 'success' || message.is_error) {
+      const detail = 'errors' in message ? message.errors.join('; ') : message.subtype
+      fail(`agent run failed: ${detail || message.subtype}`)
+    }
+    proposal = message.result
+  }
+}
+streamFile?.end()
+
+if (proposal === null) fail('no result message received from the agent')
+
+process.stdout.write(proposal)
+await writeFile(PROPOSAL_FILE, proposal)
+
+progress()
+progress(`Proposal also saved to ${PROPOSAL_FILE}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,9 +343,12 @@ importers:
 
   packages/@repo/ailf-eval:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.168
+        version: 0.3.168(@anthropic-ai/sdk@0.93.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@sanity/ailf':
         specifier: ^7.6.0
-        version: 7.6.0(@noble/hashes@2.0.1)(@types/json-schema@7.0.15)(@types/node@24.12.4)(@types/react@19.2.17)(pg@8.21.0)(playwright-core@1.60.0)(socks@2.8.9)
+        version: 7.9.0(@noble/hashes@2.0.1)(@types/json-schema@7.0.15)(@types/node@24.12.4)(@types/react@19.2.17)(pg@8.21.0)(playwright-core@1.60.0)(socks@2.8.9)
     devDependencies:
       '@repo/config-eslint':
         specifier: workspace:*
@@ -779,13 +782,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.168':
+    resolution: {integrity: sha512-tvFGCGVX9tesGBzfpK008nRmv91pd3ToapDpJbjdwiFSLGWT9n+dc/qurwgxgv9VwWRvV8nWTc3zLRSFI8Lf2g==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141':
     resolution: {integrity: sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ==}
     cpu: [x64]
     os: [darwin]
 
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.168':
+    resolution: {integrity: sha512-J5dZUCrwjz4+gY2dAds2rMDWWSdcMl9jEDpZIzKNCx0f0KlJfE1C7/+stOJaBv6tGj8d/mmzcfBCeNBS1KScgA==}
+    cpu: [x64]
+    os: [darwin]
+
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141':
     resolution: {integrity: sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.168':
+    resolution: {integrity: sha512-uOFtBJjntrYkXlHPRK+cTx1pCc37XxGQ/kN3KBK/KoIDcIrmU8DcX2WUw5IJHJqpG2Qjb7gZ5xAbcw3WTmduwQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -796,8 +815,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.168':
+    resolution: {integrity: sha512-K9fltcI0VJBr21z4t0iJ4aArFtiS9UwhmMGkxl1jAIM0jatGqiHHbbk+qaCB04va3U6vaflukgtmbpogSB36yQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141':
     resolution: {integrity: sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.168':
+    resolution: {integrity: sha512-JwYD7oxYlIVYDFhgj+QVHgWbJUVGMXsiecB6WQ5VS5u4OqUorivJPFYPaP469otMj4HFtkDupESB+7Zp4jMmUw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -808,8 +839,19 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.168':
+    resolution: {integrity: sha512-0Fw4ICZopwKbqNQo64HqkpJw5cqxOxFOV/w8GCS2hDsJ+0aogmK/B78t4iV6rFHIkC076Nm5UH14FP1eOIJ3OA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141':
     resolution: {integrity: sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.168':
+    resolution: {integrity: sha512-NREaLXAxl23pEzoU7bmX6u8MibAYEY2t8XP5xtj/vMO6UwxFjT3YgGsTuQcnFP+1qsjWaOBCia2ZQnqI68Y0Ng==}
     cpu: [arm64]
     os: [win32]
 
@@ -818,10 +860,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.168':
+    resolution: {integrity: sha512-Ha3eivz2Wm4y3BR+Xpn/r+CBM8ARC6knYDLbjLqH/DxjKahr6WB60xQkBD1U6wchT6w7zfIQqQGbucuUOTTuew==}
+    cpu: [x64]
+    os: [win32]
+
   '@anthropic-ai/claude-agent-sdk@0.2.141':
     resolution: {integrity: sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      zod: ^4.0.0
+
+  '@anthropic-ai/claude-agent-sdk@0.3.168':
+    resolution: {integrity: sha512-C7n9uS1fsAt9lFKw/ovsFNAlPI7UXE2uPQbOzzKLpDNjfFR5spthALhV49b01PtYWEzTo3W3OJfgCv6wooXtYg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.78.0':
@@ -4249,8 +4304,8 @@ packages:
     resolution: {integrity: sha512-+i7GXix4Akt34VDWgSM1Lpq8Hxf8SH8022uNsDRXSNuAqQMjKVGWLItAyc2TyfWVwWZLhsCF3lj5tdW7cecDxQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
-  '@sanity/ailf@7.6.0':
-    resolution: {integrity: sha512-aJUyvmiUiTD9mCgcBY1r6uAjaZcLCVHwKgpIeuNSZQ7wepoyJnTVUuVrxpCnRT/m/3MWdi2/YB6F9MaspugVoQ==}
+  '@sanity/ailf@7.9.0':
+    resolution: {integrity: sha512-wwY8UXSFsEpX/kLZlQ+UCHg89FRuKOK5bT9Ih0T/fxQ2htPCfSzXUqgqUgEGwZzEgvrzFc5f2ClwV8MwL5rA+Q==}
     hasBin: true
 
   '@sanity/asset-utils@2.3.0':
@@ -11101,25 +11156,49 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.168':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.168':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.168':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.168':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.168':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.168':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.168':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.168':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk@0.2.141(zod@4.4.3)':
@@ -11141,6 +11220,21 @@ snapshots:
       - supports-color
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk@0.3.168(@anthropic-ai/sdk@0.93.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.93.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.168
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.168
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.168
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.168
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.168
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.168
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.168
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.168
+
   '@anthropic-ai/sdk@0.78.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -11152,7 +11246,6 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
-    optional: true
 
   '@apidevtools/json-schema-ref-parser@15.3.5(@types/json-schema@7.0.15)':
     dependencies:
@@ -12687,7 +12780,7 @@ snapshots:
   '@commitlint/is-ignored@21.0.2':
     dependencies:
       '@commitlint/types': 21.0.1
-      semver: 7.8.0
+      semver: 7.8.3
 
   '@commitlint/lint@21.0.2':
     dependencies:
@@ -12759,7 +12852,7 @@ snapshots:
     dependencies:
       '@simple-libs/child-process-utils': 1.0.2
       '@simple-libs/stream-utils': 1.2.0
-      semver: 7.8.0
+      semver: 7.8.3
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
@@ -14741,7 +14834,7 @@ snapshots:
 
   '@sanity-labs/design-tokens@0.0.2-alpha.4': {}
 
-  '@sanity/ailf@7.6.0(@noble/hashes@2.0.1)(@types/json-schema@7.0.15)(@types/node@24.12.4)(@types/react@19.2.17)(pg@8.21.0)(playwright-core@1.60.0)(socks@2.8.9)':
+  '@sanity/ailf@7.9.0(@noble/hashes@2.0.1)(@types/json-schema@7.0.15)(@types/node@24.12.4)(@types/react@19.2.17)(pg@8.21.0)(playwright-core@1.60.0)(socks@2.8.9)':
     dependencies:
       '@google-cloud/bigquery': 8.3.1
       '@google-cloud/storage': 7.19.0
@@ -14841,7 +14934,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       read-package-up: 12.0.0
-      semver: 7.8.0
+      semver: 7.8.3
       vite: 7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)
       zod: 4.4.3
     optionalDependencies:
@@ -16078,7 +16171,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
-      semver: 7.8.0
+      semver: 7.8.3
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -18439,7 +18532,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.8.0
+      semver: 7.8.3
       serialize-error: 7.0.1
     optional: true
 
@@ -18715,7 +18808,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.16.1)
+      retry-axios: 2.6.0(axios@1.16.1(debug@4.3.4))
       tough-cookie: 4.1.3
     transitivePeerDependencies:
       - supports-color
@@ -19285,7 +19378,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.8.0
+      semver: 7.8.3
     optional: true
 
   jsx-ast-utils@3.3.5:
@@ -19562,7 +19655,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.0
+      semver: 7.8.3
 
   markdown-it@14.1.1:
     dependencies:
@@ -19863,7 +19956,7 @@ snapshots:
 
   node-abi@3.92.0:
     dependencies:
-      semver: 7.8.0
+      semver: 7.8.3
 
   node-domexception@1.0.0: {}
 
@@ -19901,7 +19994,7 @@ snapshots:
   normalize-package-data@8.0.0:
     dependencies:
       hosted-git-info: 9.0.3
-      semver: 7.8.0
+      semver: 7.8.3
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -20648,7 +20741,7 @@ snapshots:
       react: 19.2.7
       rfdc: 1.4.1
       rxjs: 7.8.2
-      semver: 7.8.0
+      semver: 7.8.3
       simple-git: 3.36.0
       socket.io: 4.8.3
       socket.io-client: 4.8.3
@@ -21197,7 +21290,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.16.1):
+  retry-axios@2.6.0(axios@1.16.1(debug@4.3.4)):
     dependencies:
       axios: 1.16.1(debug@4.3.4)
     optional: true
@@ -21633,7 +21726,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.0
+      semver: 7.8.3
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,10 @@
     "SANITY_INTERNAL_ENV"
   ],
   "tasks": {
+    "@repo/ailf-eval#improve-docs": {
+      "cache": false,
+      "env": ["ANTHROPIC_API_KEY", "SANITY_DOCS_READ_TOKEN"]
+    },
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]


### PR DESCRIPTION
### Description
This PR adds a script that uses Claude and the Sanity MCP to respond to AILF feedback. This is mostly intended to be used in CI; you'll see the AILF Github workflow updated so that we can get feedback during AILF runs. This is only the first part of the full workflow -- we can follow this up with using an agent to write a content release that actually reflects this feedback.

While I was here I also removed some things that led to constant AILF report noise. We (purposely) don't encourage `useDocumentPreview` and adding the `best-practices` document also meant that the report focused on things that aren't actually in our docs (we kept getting false dings on not documenting `Suspense` for example).

I also removed llm-ese from places, just to keep things a bit terser.

### What to review
The script itself is hopefully rather defensive; we've excluded most paths to writing anything. Let me know if there are places I can harden up.

### Testing
You can see the results of the output in the AILF CI job on this PR!

### Fun gif
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjFuenh6ODI5em9qdDlvMWF3N3BpYXR2bWdwNW1wMGNtemZxcm8yNiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/PAN5H1rXUmrEQ/giphy.gif)
