### PR TITLE
[debug] instrument firefox e2e live SSE lifecycle

### DIFF
--- a/apps/kitchensink-react/e2e/multi-resource.spec.ts
+++ b/apps/kitchensink-react/e2e/multi-resource.spec.ts
@@ -7,68 +7,6 @@ test.describe('Multi Resource Route', () => {
     createDocuments,
     getPageContext,
   }) => {
-    // --- TEMP DIAGNOSTICS (debug/firefox-e2e-sse): capture live SSE lifecycle ---
-    // eslint-disable-next-line no-console
-    const diag = (m: string) => console.log(`[DIAG] ${m}`)
-    page.on('console', (msg) => {
-      const t = msg.text()
-      if (/\[ES\]|EventSource|listen|live|sse|abort|subscript|reconnect|error/i.test(t)) {
-        diag(`browser:${msg.type()} ${t}`)
-      }
-    })
-    page.on('pageerror', (err) => diag(`pageerror ${err.message}`))
-    page.on('requestfailed', (req) => {
-      const u = req.url()
-      if (/live|listen|query|\/data\//.test(u)) {
-        diag(`requestfailed ${req.failure()?.errorText} ${u.slice(-80)}`)
-      }
-    })
-    page.on('response', (res) => {
-      const u = res.url()
-      if (/live\/events|data\/listen/.test(u)) {
-        diag(`response ${res.status()} ${u.slice(-80)}`)
-      }
-    })
-    await page.addInitScript(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const w = window as any
-      if (w.__esWrapped) return
-      w.__esWrapped = true
-      const Orig = w.EventSource
-      if (!Orig) return
-      w.EventSource = function (url: string, cfg: unknown) {
-        const es = new Orig(url, cfg)
-        const t0 = Date.now()
-        const tag = `[ES] ${String(url).slice(-70)}`
-        // eslint-disable-next-line no-console
-        console.log(`${tag} :: created`)
-        es.addEventListener('open', () =>
-          // eslint-disable-next-line no-console
-          console.log(`${tag} :: open @${Date.now() - t0}ms`),
-        )
-        es.addEventListener('error', () =>
-          // eslint-disable-next-line no-console
-          console.log(`${tag} :: ERROR @${Date.now() - t0}ms readyState=${es.readyState}`),
-        )
-        const origClose = es.close.bind(es)
-        es.close = function () {
-          // eslint-disable-next-line no-console
-          console.log(`${tag} :: close() @${Date.now() - t0}ms :: ${new Error().stack}`)
-          return origClose()
-        }
-        return es
-      }
-      w.EventSource.prototype = Orig.prototype
-      Object.keys(Orig).forEach((k) => {
-        try {
-          w.EventSource[k] = Orig[k]
-        } catch {
-          /* noop */
-        }
-      })
-    })
-    // --- END TEMP DIAGNOSTICS ---
-
     // create an author document in dataset 0
     const {
       documentIds: [authorId],

--- a/apps/kitchensink-react/e2e/multi-resource.spec.ts
+++ b/apps/kitchensink-react/e2e/multi-resource.spec.ts
@@ -7,6 +7,68 @@ test.describe('Multi Resource Route', () => {
     createDocuments,
     getPageContext,
   }) => {
+    // --- TEMP DIAGNOSTICS (debug/firefox-e2e-sse): capture live SSE lifecycle ---
+    // eslint-disable-next-line no-console
+    const diag = (m: string) => console.log(`[DIAG] ${m}`)
+    page.on('console', (msg) => {
+      const t = msg.text()
+      if (/\[ES\]|EventSource|listen|live|sse|abort|subscript|reconnect|error/i.test(t)) {
+        diag(`browser:${msg.type()} ${t}`)
+      }
+    })
+    page.on('pageerror', (err) => diag(`pageerror ${err.message}`))
+    page.on('requestfailed', (req) => {
+      const u = req.url()
+      if (/live|listen|query|\/data\//.test(u)) {
+        diag(`requestfailed ${req.failure()?.errorText} ${u.slice(-80)}`)
+      }
+    })
+    page.on('response', (res) => {
+      const u = res.url()
+      if (/live\/events|data\/listen/.test(u)) {
+        diag(`response ${res.status()} ${u.slice(-80)}`)
+      }
+    })
+    await page.addInitScript(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const w = window as any
+      if (w.__esWrapped) return
+      w.__esWrapped = true
+      const Orig = w.EventSource
+      if (!Orig) return
+      w.EventSource = function (url: string, cfg: unknown) {
+        const es = new Orig(url, cfg)
+        const t0 = Date.now()
+        const tag = `[ES] ${String(url).slice(-70)}`
+        // eslint-disable-next-line no-console
+        console.log(`${tag} :: created`)
+        es.addEventListener('open', () =>
+          // eslint-disable-next-line no-console
+          console.log(`${tag} :: open @${Date.now() - t0}ms`),
+        )
+        es.addEventListener('error', () =>
+          // eslint-disable-next-line no-console
+          console.log(`${tag} :: ERROR @${Date.now() - t0}ms readyState=${es.readyState}`),
+        )
+        const origClose = es.close.bind(es)
+        es.close = function () {
+          // eslint-disable-next-line no-console
+          console.log(`${tag} :: close() @${Date.now() - t0}ms :: ${new Error().stack}`)
+          return origClose()
+        }
+        return es
+      }
+      w.EventSource.prototype = Orig.prototype
+      Object.keys(Orig).forEach((k) => {
+        try {
+          w.EventSource[k] = Orig[k]
+        } catch {
+          /* noop */
+        }
+      })
+    })
+    // --- END TEMP DIAGNOSTICS ---
+
     // create an author document in dataset 0
     const {
       documentIds: [authorId],

--- a/packages/@repo/e2e/src/fixtures.ts
+++ b/packages/@repo/e2e/src/fixtures.ts
@@ -31,6 +31,101 @@ export const test = base.extend<SanityFixtures>({
     }
     await use(context)
   },
+  // TEMP DIAGNOSTICS (debug/firefox-e2e-sse): instrument the live SSE / realtime
+  // channel on every test + browser to diagnose flaky projection propagation.
+  // Captures EventSource lifecycle + per-event delivery, failed/aborted realtime
+  // requests, and page/console errors. Remove once the flake is understood.
+  /* eslint-disable no-console */
+  page: async ({page}, use, testInfo) => {
+    const ctx = `${testInfo.project.name}/${testInfo.title.slice(0, 40)}`
+    const diag = (m: string) => console.log(`[DIAG ${ctx}] ${m}`)
+
+    page.on('console', (msg) => {
+      const text = msg.text()
+      if (
+        msg.type() === 'error' ||
+        /\[ES\]|EventSource|listen|live|sse|subscript|mutation|welcome|channel|disconnect|reconnect|abort/i.test(
+          text,
+        )
+      ) {
+        diag(`browser:${msg.type()} ${text}`)
+      }
+    })
+    page.on('pageerror', (err) => diag(`pageerror ${err.message}`))
+    page.on('requestfailed', (req) => {
+      const u = req.url()
+      if (/live|listen|query|\/data\/|api\.sanity/.test(u)) {
+        diag(`requestfailed ${req.failure()?.errorText} ${u.slice(-90)}`)
+      }
+    })
+    page.on('response', (res) => {
+      const u = res.url()
+      if (/live\/events|data\/listen/.test(u)) {
+        diag(`response ${res.status()} ${u.slice(-90)}`)
+      }
+    })
+
+    // Wrap EventSource in every frame (applies before app code runs) to log the
+    // stream lifecycle and EVERY delivered event, so we can tell "events never
+    // arrived" (transport/backend) from "events arrived but projection didn't
+    // update" (SDK). addInitScript runs in all frames incl. the dashboard iframe.
+    await page.addInitScript(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const w = window as any
+      if (w.__esWrapped) return
+      w.__esWrapped = true
+      const Orig = w.EventSource
+      if (!Orig) return
+      const Wrapped = function (url: string, cfg: unknown) {
+        const es = new Orig(url, cfg)
+        const t0 = Date.now()
+        const tag = `[ES] ${String(url).slice(-70)}`
+        const log = (m: string) => console.log(`${tag} :: ${m} @${Date.now() - t0}ms`)
+        log('created')
+        es.addEventListener('open', () => log('open'))
+        es.addEventListener('error', () => log(`ERROR readyState=${es.readyState}`))
+        // Tee every event the app subscribes to, so named events (mutation,
+        // welcome, channelError, disconnect, …) are logged with truncated data.
+        const origAdd = es.addEventListener.bind(es)
+        es.addEventListener = function (type: string, handler: unknown, opts: unknown) {
+          const wrapped = function (this: unknown, ev: {data?: unknown}) {
+            try {
+              const d = ev && ev.data ? String(ev.data).slice(0, 120) : ''
+              log(`event '${type}' ${d}`)
+            } catch {
+              /* noop */
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const h = handler as any
+            return typeof h === 'function'
+              ? // eslint-disable-next-line prefer-rest-params
+                h.apply(this, arguments)
+              : h?.handleEvent?.(ev)
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return origAdd(type, wrapped as any, opts as any)
+        }
+        const origClose = es.close.bind(es)
+        es.close = function () {
+          log(`close() ${new Error().stack}`)
+          return origClose()
+        }
+        return es
+      }
+      Wrapped.prototype = Orig.prototype
+      Object.keys(Orig).forEach((k) => {
+        try {
+          Wrapped[k] = Orig[k]
+        } catch {
+          /* noop */
+        }
+      })
+      w.EventSource = Wrapped
+    })
+
+    await use(page)
+  },
+  /* eslint-enable no-console */
   // Playwright will error if we don't pass an object to destructure
   // eslint-disable-next-line no-empty-pattern
   createDocuments: async ({}, use) => {

--- a/packages/@repo/e2e/src/fixtures.ts
+++ b/packages/@repo/e2e/src/fixtures.ts
@@ -76,7 +76,8 @@ export const test = base.extend<SanityFixtures>({
       w.__esWrapped = true
       const Orig = w.EventSource
       if (!Orig) return
-      const Wrapped = function (url: string, cfg: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const Wrapped: any = function (url: string, cfg: unknown) {
         const es = new Orig(url, cfg)
         const t0 = Date.now()
         const tag = `[ES] ${String(url).slice(-70)}`


### PR DESCRIPTION
Temporary debug branch to capture why the Firefox e2e `multi-resource` test fails in CI (live projection never updates).

Instruments `multi-resource.spec.ts` to log EventSource open/error/close lifecycle, failed/aborted live requests, and console/page errors across the chromium/firefox/webkit matrix.

**Not for merge** — diagnostics only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)