### PR TITLE
feat(react): add useCreateDocument hook

### DIFF
--- a/apps/kitchensink-react/e2e/document-editor.spec.ts
+++ b/apps/kitchensink-react/e2e/document-editor.spec.ts
@@ -49,4 +49,54 @@ test.describe('Document Editor', () => {
     // we should play with the other actions here (delete, discard, publish, etc)
     // and also see what happens in the browser if we update the value via the client (does it sync? race conditions?)
   })
+
+  test('creates a new document with useCreateDocument and navigates to it', async ({
+    page,
+    createDocuments,
+    trackDocumentsForCleanup,
+    getPageContext,
+  }) => {
+    // Seed a document so the editor has something loaded to start from.
+    const {
+      documentIds: [id],
+    } = await createDocuments([
+      {
+        _type: 'author',
+        name: 'Original Author',
+      },
+    ])
+    const originalId = id.replace('drafts.', '')
+
+    await page.goto('./document-editor')
+    const pageContext = await getPageContext(page)
+
+    const documentIdInput = pageContext.getByTestId('document-id-input')
+    await expect(documentIdInput).toBeVisible()
+    await documentIdInput.fill(originalId)
+    await pageContext.getByTestId('load-document-button').click()
+
+    await expect(async () => {
+      const content = await pageContext.getByTestId('document-content').textContent()
+      expect(JSON.parse(content || '{}').name).toBe('Original Author')
+    }).toPass({timeout: 10000})
+
+    // Create a brand-new document via the hook; it generates the id and the UI
+    // navigates to the returned handle.
+    await pageContext.getByTestId('document-editor-action-create-hook').click()
+
+    // The hook mints the id in the browser, so register it for teardown to
+    // avoid leaking a document into the dataset on every run.
+    let createdId: string | undefined
+    await expect(async () => {
+      const content = await pageContext.getByTestId('document-content').textContent()
+      const document = JSON.parse(content || '{}')
+      // AUTHOR_INITIAL_VALUES.name from DocumentEditorRoute
+      expect(document.name).toBe('New Author')
+      const newId = document._id.replace('drafts.', '')
+      expect(newId).not.toBe(originalId)
+      createdId = newId
+    }).toPass({timeout: 10000})
+
+    if (createdId) trackDocumentsForCleanup(createdId)
+  })
 })

--- a/apps/kitchensink-react/e2e/version-document-editor.spec.ts
+++ b/apps/kitchensink-react/e2e/version-document-editor.spec.ts
@@ -54,8 +54,10 @@ test.describe('Version Document Editor', () => {
     await expect(dialog).toBeVisible()
 
     // The document doesn't exist in the release yet — wait for permissions to
-    // resolve, then click Create to create the version document
-    const createButton = dialog.getByRole('button', {name: 'Create'})
+    // resolve, then click Create to create the version document. Target the
+    // testid directly: a substring match on "Create" is ambiguous now that the
+    // panel also has a "Create New (useCreateDocument)" button.
+    const createButton = dialog.getByTestId('document-editor-action-create')
     await expect(createButton).toBeEnabled({timeout: 10000})
     await createButton.click()
 

--- a/apps/kitchensink-react/src/components/DocumentEditorPanel.tsx
+++ b/apps/kitchensink-react/src/components/DocumentEditorPanel.tsx
@@ -7,6 +7,7 @@ import {
   publishDocument,
   unpublishDocument,
   useApplyDocumentActions,
+  useCreateDocument,
   useDocument,
   useDocumentPermissions,
   useEditDocument,
@@ -58,6 +59,14 @@ export function DocumentEditorPanel({
     projectId: instance.config.projectId,
     dataset: instance.config.dataset,
   }
+
+  // useCreateDocument mints a brand-new document (generating its id) and
+  // returns the handle, so we can navigate to it via onDocumentIdChange.
+  const createDocumentFromHook = useCreateDocument({
+    documentType: docHandle.documentType,
+    projectId: instance.config.projectId,
+    dataset: instance.config.dataset,
+  })
 
   const canEdit = useDocumentPermissions(editDocument(strictHandle))
   const canCreate = useDocumentPermissions(createDocument(strictHandle))
@@ -150,6 +159,22 @@ export function DocumentEditorPanel({
                 </Box>
               </Tooltip>
             )}
+
+            <Tooltip content={canCreate.message}>
+              <Box>
+                <Button
+                  disabled={!canCreate.allowed}
+                  onClick={async () => {
+                    const newHandle = await createDocumentFromHook(createInitialValues)
+                    onDocumentIdChange?.(newHandle.documentId)
+                  }}
+                  text="Create New (useCreateDocument)"
+                  tone="positive"
+                  fontSize={1}
+                  data-testid="document-editor-action-create-hook"
+                />
+              </Box>
+            </Tooltip>
 
             {!docHandle.liveEdit && (
               <>

--- a/apps/kitchensink-react/src/components/DocumentEditorPanel.tsx
+++ b/apps/kitchensink-react/src/components/DocumentEditorPanel.tsx
@@ -160,21 +160,20 @@ export function DocumentEditorPanel({
               </Tooltip>
             )}
 
-            <Tooltip content={canCreate.message}>
-              <Box>
-                <Button
-                  disabled={!canCreate.allowed}
-                  onClick={async () => {
-                    const newHandle = await createDocumentFromHook(createInitialValues)
-                    onDocumentIdChange?.(newHandle.documentId)
-                  }}
-                  text="Create New (useCreateDocument)"
-                  tone="positive"
-                  fontSize={1}
-                  data-testid="document-editor-action-create-hook"
-                />
-              </Box>
-            </Tooltip>
+            {/* useCreateDocument always targets a brand-new id, so it isn't
+                gated on the loaded document's create permission. */}
+            <Box>
+              <Button
+                onClick={async () => {
+                  const newHandle = await createDocumentFromHook(createInitialValues)
+                  onDocumentIdChange?.(newHandle.documentId)
+                }}
+                text="Create New (useCreateDocument)"
+                tone="positive"
+                fontSize={1}
+                data-testid="document-editor-action-create-hook"
+              />
+            </Box>
 
             {!docHandle.liveEdit && (
               <>

--- a/packages/@repo/e2e/src/fixtures.ts
+++ b/packages/@repo/e2e/src/fixtures.ts
@@ -2,7 +2,12 @@ import {type BrowserContext, type Page, test as base} from '@playwright/test'
 import {type MultipleMutationResult, SanityClient} from '@sanity/client'
 
 import {getCanvasClient, getClient, getMediaLibraryClient} from './helpers/clients'
-import {cleanupDocuments, createDocuments, type DocumentStub} from './helpers/documents'
+import {
+  cleanupDocuments,
+  createDocuments,
+  type DocumentStub,
+  trackDocumentsForCleanup,
+} from './helpers/documents'
 import {createPageContext, type PageContext} from './helpers/pageContext'
 
 interface SanityFixtures {
@@ -11,6 +16,7 @@ interface SanityFixtures {
     options?: {asDraft?: boolean},
     dataset?: string,
   ) => Promise<MultipleMutationResult>
+  trackDocumentsForCleanup: (...ids: string[]) => void
   getClient: (dataset?: string) => SanityClient
   getMediaLibraryClient: () => SanityClient
   getCanvasClient: () => SanityClient
@@ -37,6 +43,15 @@ export const test = base.extend<SanityFixtures>({
     await use(createDocuments)
 
     // cleanup documents after each test
+    await cleanupDocuments()
+  },
+  // Lets tests register IDs minted by the app under test (e.g. via
+  // useCreateDocument) so they're deleted during teardown.
+  // eslint-disable-next-line no-empty-pattern
+  trackDocumentsForCleanup: async ({}, use) => {
+    await use(trackDocumentsForCleanup)
+
+    // cleanup documents after each test (no-op if createDocuments already ran it)
     await cleanupDocuments()
   },
   // eslint-disable-next-line no-empty-pattern

--- a/packages/@repo/e2e/src/helpers/documents.ts
+++ b/packages/@repo/e2e/src/helpers/documents.ts
@@ -17,6 +17,18 @@ function getUniqueDocumentId(): string {
   return documentId
 }
 
+/**
+ * Registers document IDs that were created outside of {@link createDocuments}
+ * (e.g. minted by the app under test) so they are removed during teardown.
+ * Any `drafts.` prefix is stripped, since cleanup deletes both the draft and
+ * published forms.
+ */
+export function trackDocumentsForCleanup(...ids: string[]): void {
+  for (const id of ids) {
+    documentIds.add(id.replace(/^drafts\./, ''))
+  }
+}
+
 export async function createDocuments<T extends DocumentStub>(
   data: T[],
   options?: {asDraft?: boolean},

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -108,6 +108,10 @@ const {data} = useQuery({
 #### Document Manipulation
 
 ```tsx
+// Create a new document and get back its handle
+const createArticle = useCreateDocument({documentType: 'article'})
+const newHandle = await createArticle({title: 'Untitled', status: 'draft'})
+
 // Edit field (emits optimistic updates to useEditDocument listeners, creates a draft automatically)
 const editTitle = useEditDocument({...handle, path: 'title'})
 editTitle('New Title') // fires on every keystroke, debounced internally
@@ -133,13 +137,6 @@ await apply(publishDocument(handle))
 
 // Batch actions
 await apply([publishDocument(handle1), publishDocument(handle2), deleteDocument(handle3)])
-
-// Create new document with an optional initial content
-const newHandle = createDocumentHandle({
-  documentId: crypto.randomUUID(),
-  documentType: 'article',
-})
-await apply(createDocument(newHandle, {title: 'Untitled', status: 'draft'}))
 ```
 
 #### Events & Permissions
@@ -183,40 +180,32 @@ The `useApplyDocumentActions` hook is used to perform document lifecycle operati
 
 #### Creating Documents
 
-To create a document, you must:
-
-1. Generate your own document ID (using `crypto.randomUUID()`)
-2. Create a document handle with `createDocumentHandle`
-3. Apply the `createDocument` action using the document handle, along with optional initial content
+`useCreateDocument` handles the common case: it generates the document ID for you and returns the new document's handle, ready to pass to `useDocument`, `useEditDocument`, or your router.
 
 ```tsx
-import {useApplyDocumentActions, createDocumentHandle, createDocument} from '@sanity/sdk-react'
+import {useCreateDocument} from '@sanity/sdk-react'
 
 function CreateArticleButton() {
-  const apply = useApplyDocumentActions()
+  const createArticle = useCreateDocument({documentType: 'article'})
 
-  const handleCreateArticle = () => {
-    const newId = crypto.randomUUID()
-    const handle = createDocumentHandle({
-      documentId: newId,
-      documentType: 'article',
+  const handleCreateArticle = async () => {
+    const handle = await createArticle({
+      title: 'New Article',
+      status: 'draft',
+      author: {_type: 'reference', _ref: 'author-123'},
     })
 
-    apply(
-      createDocument(handle, {
-        title: 'New Article',
-        status: 'draft',
-        author: {_type: 'reference', _ref: 'author-123'},
-      }),
-    )
-
-    // Navigate to the new document
-    navigate(`/articles/${newId}`)
+    // Navigate to the new document using the returned handle
+    navigate(`/articles/${handle.documentId}`)
   }
 
   return <button onClick={handleCreateArticle}>Create Article</button>
 }
 ```
+
+To use a specific ID instead of a generated one, pass it on the handle (`useCreateDocument({documentType: 'article', documentId})`) or per call (`createArticle(initialValue, {documentId})`).
+
+For atomic create-and-publish, or to create several documents in a single transaction, drop down to `useApplyDocumentActions` with the `createDocument` and `publishDocument` action creators (see [Batch Operations](#batch-operations) below).
 
 #### Publishing Documents
 

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -59,6 +59,7 @@ export {useStudioWorkspacesByProjectIdDataset} from '../hooks/dashboard/useStudi
 export {useWindowTitle} from '../hooks/dashboard/useWindowTitle'
 export {useDatasets} from '../hooks/datasets/useDatasets'
 export {useApplyDocumentActions} from '../hooks/document/useApplyDocumentActions'
+export {type CreateDocumentOverrides, useCreateDocument} from '../hooks/document/useCreateDocument'
 export {useDocument} from '../hooks/document/useDocument'
 export {useDocumentEvent} from '../hooks/document/useDocumentEvent'
 export {useDocumentPermissions} from '../hooks/document/useDocumentPermissions'

--- a/packages/react/src/hooks/document/useCreateDocument.test.tsx
+++ b/packages/react/src/hooks/document/useCreateDocument.test.tsx
@@ -1,0 +1,83 @@
+import {createDocument} from '@sanity/sdk'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {renderHook} from '../../../test/test-utils'
+import {useApplyDocumentActions} from './useApplyDocumentActions'
+import {useCreateDocument} from './useCreateDocument'
+
+vi.mock('./useApplyDocumentActions', () => ({
+  useApplyDocumentActions: vi.fn(),
+}))
+
+const typeHandle = {
+  documentType: 'book',
+  projectId: 'test',
+  dataset: 'test',
+} as const
+
+describe('useCreateDocument hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('applies a createDocument action with a generated id and initial values', async () => {
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-0000-0000-000000000000')
+    const apply = vi.fn().mockResolvedValue({transactionId: 'tx1'})
+    vi.mocked(useApplyDocumentActions).mockReturnValue(apply)
+
+    const {result} = renderHook(() => useCreateDocument(typeHandle))
+    const handle = await result.current({title: 'New Book'})
+
+    expect(apply).toHaveBeenCalledWith(
+      createDocument(
+        {...typeHandle, documentId: '00000000-0000-0000-0000-000000000000'},
+        {
+          title: 'New Book',
+        },
+      ),
+    )
+    expect(handle).toEqual({...typeHandle, documentId: '00000000-0000-0000-0000-000000000000'})
+  })
+
+  it('returns a handle carrying the generated id', async () => {
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('11111111-1111-1111-1111-111111111111')
+    const apply = vi.fn().mockResolvedValue({transactionId: 'tx2'})
+    vi.mocked(useApplyDocumentActions).mockReturnValue(apply)
+
+    const {result} = renderHook(() => useCreateDocument(typeHandle))
+    const handle = await result.current()
+
+    expect(handle.documentId).toBe('11111111-1111-1111-1111-111111111111')
+    expect(handle.documentType).toBe('book')
+  })
+
+  it('uses the documentId supplied on the handle instead of generating one', async () => {
+    const apply = vi.fn().mockResolvedValue({transactionId: 'tx3'})
+    vi.mocked(useApplyDocumentActions).mockReturnValue(apply)
+
+    const {result} = renderHook(() => useCreateDocument({...typeHandle, documentId: 'fixed-id'}))
+    const handle = await result.current()
+
+    expect(handle.documentId).toBe('fixed-id')
+    expect(apply).toHaveBeenCalledWith(
+      createDocument({...typeHandle, documentId: 'fixed-id'}, undefined),
+    )
+  })
+
+  it('uses a per-call documentId override over the handle id', async () => {
+    const apply = vi.fn().mockResolvedValue({transactionId: 'tx4'})
+    vi.mocked(useApplyDocumentActions).mockReturnValue(apply)
+
+    const {result} = renderHook(() => useCreateDocument({...typeHandle, documentId: 'handle-id'}))
+    const handle = await result.current({title: 'Override'}, {documentId: 'override-id'})
+
+    expect(handle.documentId).toBe('override-id')
+    expect(apply).toHaveBeenCalledWith(
+      createDocument({...typeHandle, documentId: 'override-id'}, {title: 'Override'}),
+    )
+  })
+})

--- a/packages/react/src/hooks/document/useCreateDocument.ts
+++ b/packages/react/src/hooks/document/useCreateDocument.ts
@@ -1,0 +1,117 @@
+import {createDocument} from '@sanity/sdk'
+import {type SanityDocument} from 'groq'
+
+import {type DocumentHandle, type DocumentTypeHandle} from '../../config/handles'
+import {useSanityInstance} from '../context/useSanityInstance'
+import {trackHookUsage} from '../helpers/useTrackHookUsage'
+import {useApplyDocumentActions} from './useApplyDocumentActions'
+
+type IgnoredKey = '_id' | '_type' | '_rev' | '_createdAt' | '_updatedAt'
+
+/**
+ * Optional per-call overrides for {@link useCreateDocument}'s create function.
+ * @public
+ */
+export interface CreateDocumentOverrides {
+  /**
+   * Use this document ID instead of generating one. Overrides any `documentId`
+   * supplied on the handle passed to `useCreateDocument`.
+   */
+  documentId?: string
+}
+
+// Overload 1: Typegen — infers the document shape from your schema.
+/**
+ * @public
+ * Create a new document, relying on Typegen for the initial-value type.
+ *
+ * @param options - A document-type handle including `documentType`, an optional `documentId`, and optionally `projectId`/`dataset`/`perspective`.
+ * @returns A function that creates the document. It accepts optional initial field values and an optional `{documentId}` override,
+ *          and resolves to the {@link DocumentHandle} of the created document (carrying the generated or supplied id).
+ */
+export function useCreateDocument<
+  TDocumentType extends string = string,
+  TDataset extends string = string,
+  TProjectId extends string = string,
+>(
+  options: DocumentTypeHandle<TDocumentType, TDataset, TProjectId>,
+): (
+  initialValue?: Partial<
+    Omit<SanityDocument<TDocumentType, `${TProjectId}.${TDataset}`>, IgnoredKey>
+  >,
+  overrides?: CreateDocumentOverrides,
+) => Promise<DocumentHandle<TDocumentType, TDataset, TProjectId>>
+
+// Overload 2: Explicit type `TData`.
+/**
+ * @public
+ * Create a new document with an explicit type `TData`.
+ *
+ * @param options - A document-type handle including `documentType` and optionally `projectId`/`dataset`/`perspective`.
+ * @returns A function that creates the document. It accepts optional initial field values (typed against `TData`) and an
+ *          optional `{documentId}` override, and resolves to the {@link DocumentHandle} of the created document.
+ */
+export function useCreateDocument<TData extends Record<string, unknown>>(
+  options: DocumentTypeHandle,
+): (
+  initialValue?: Partial<Omit<TData, IgnoredKey>>,
+  overrides?: CreateDocumentOverrides,
+) => Promise<DocumentHandle>
+
+/**
+ * @public
+ * Provides a function to create a new document and returns its handle.
+ *
+ * @category Documents
+ * @remarks
+ * This is the create counterpart to {@link useEditDocument}. It wraps
+ * {@link useApplyDocumentActions} and the `createDocument` action for the common
+ * single-document case, so you don't have to assemble the action by hand.
+ *
+ * It handles the document ID for you: if you don't supply one (on the handle or
+ * via the per-call `{documentId}` override), a UUID is generated. Either way the
+ * returned {@link DocumentHandle} carries that id, ready to pass to
+ * {@link useDocument}, {@link useEditDocument}, or your router.
+ *
+ * Unlike {@link useEditDocument}, this hook does not read existing document state,
+ * so it never suspends.
+ *
+ * For atomic create-and-publish, or for creating several documents in a single
+ * transaction, use {@link useApplyDocumentActions} with the `createDocument` and
+ * `publishDocument` action creators directly.
+ *
+ * @example Create a document and navigate to it
+ * ```tsx
+ * import {useCreateDocument} from '@sanity/sdk-react'
+ * import {useNavigate} from 'react-router-dom'
+ *
+ * function CreateArticleButton() {
+ *   const createArticle = useCreateDocument({documentType: 'article'})
+ *   const navigate = useNavigate()
+ *
+ *   const handleClick = async () => {
+ *     const handle = await createArticle({title: 'New Article'})
+ *     navigate(`/articles/${handle.documentId}`)
+ *   }
+ *
+ *   return <button onClick={handleClick}>Create Article</button>
+ * }
+ * ```
+ */
+export function useCreateDocument(
+  options: DocumentTypeHandle,
+): (
+  initialValue?: Record<string, unknown>,
+  overrides?: CreateDocumentOverrides,
+) => Promise<DocumentHandle> {
+  const instance = useSanityInstance()
+  trackHookUsage(instance, 'useCreateDocument')
+  const apply = useApplyDocumentActions()
+
+  return async (initialValue, overrides) => {
+    const documentId = overrides?.documentId ?? options.documentId ?? crypto.randomUUID()
+    const handle: DocumentHandle = {...options, documentId}
+    await apply(createDocument(handle, initialValue))
+    return handle
+  }
+}


### PR DESCRIPTION
### Description

Adds a `useCreateDocument` hook to `@sanity/sdk-react`.

Document creation previously had no dedicated hook, even though reading and editing do (`useDocument`, `useDocumentProjection`, `useEditDocument`). To create a document you had to generate an ID yourself, build a handle, and call `useApplyDocumentActions` with the `createDocument` action. This asymmetry trips people up: both humans and LLMs reaching for the SDK consistently expect a `useCreateDocument` to exist and guess at it.

`useCreateDocument` is the create counterpart to `useEditDocument`. It wraps `useApplyDocumentActions` + the `createDocument` action for the common single-document case:

- Generates the document ID for you (override via the handle or a per-call `{documentId}`).
- Returns the new document's `DocumentHandle`, ready to pass to `useDocument`, `useEditDocument`, or your router.
- Does not read existing state, so it never suspends.

The lower-level `useApplyDocumentActions` path remains for atomic create-and-publish or multi-document transactions, and the docs point there.

### What to review

- `packages/react/src/hooks/document/useCreateDocument.ts` — the hook, with Typegen and explicit-type overloads and an exported `CreateDocumentOverrides` type. Note that the returned handle carries the plain logical ID (not the effective/published ID).
- `packages/react/src/_exports/sdk-react.ts` — public export.
- `packages/react/README.md` — the "Creating Documents" section now leads with `useCreateDocument` and keeps the action-based path for transactions.
- `apps/kitchensink-react` — a "Create New (useCreateDocument)" button in `DocumentEditorPanel` that mints a new document and navigates to the returned handle, plus an e2e case in `document-editor.spec.ts`.
- `packages/@repo/e2e` — additive `trackDocumentsForCleanup` helper/fixture so app-minted document IDs (created in the browser) get deleted during teardown rather than leaking into the dataset.

### Testing

- Unit tests in `useCreateDocument.test.tsx` cover generated ID, returned handle, handle-supplied ID, and per-call override. All react document-hook tests pass (`pnpm test`).
- `ts:check` passes for `@sanity/sdk-react`; lint is clean across changed files.
- Added an e2e test exercising the hook end-to-end through the kitchensink UI, with cleanup wired up. The Playwright suite was not run locally as it needs live project credentials; please run `pnpm test:e2e` in `apps/kitchensink-react` before merge to confirm create permissions in the e2e project.

### Fun gif
![another way](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWI5Y21vbjRsc3lmYXVhNjB0ZHN0MXJ0b2lqZ3ZsZDViaHp2ZW1xdiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xUPOqFurYbuMrvN0Nq/giphy.gif)
