### PR TITLE
chore(renovate): update renovate grouping

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -29,6 +29,7 @@ Focus on:
 - Ensure any new dependency installed is truly necessary or could be accomplished with existing dependencies
 - Breaking changes to publicly exported APIs — this is a published SDK and semver must be respected
 - Cross-package impact — changes in `packages/core` can have downstream effects on `packages/react` consumers; flag if related packages need corresponding updates
+- Renovate config sync — when a dependency is added/removed/moved in `packages/core` or `packages/react`, verify `.github/renovate.json` stays in sync: a new **runtime** dep must appear in all three runtime rules' `matchPackageNames` (the fix-list) or it ships as `chore` and silently misses its patch release; a new dep belonging to an existing group (eslint/vitest/react-types/apps) should be matched by that group. There is no CI guard for this, so it must be checked here
 - React leakage into `packages/core` — core is framework-agnostic; flag any React imports, hooks, or JSX introduced there
 
 If there is no actionable feedback, do not post a comment. If you have already posted a review comment on this PR, update it to indicate there are no further issues.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -29,7 +29,7 @@ Focus on:
 - Ensure any new dependency installed is truly necessary or could be accomplished with existing dependencies
 - Breaking changes to publicly exported APIs — this is a published SDK and semver must be respected
 - Cross-package impact — changes in `packages/core` can have downstream effects on `packages/react` consumers; flag if related packages need corresponding updates
-- Renovate config sync — when a dependency is added/removed/moved in `packages/core` or `packages/react`, verify `.github/renovate.json` stays in sync: a new **runtime** dep must appear in all three runtime rules' `matchPackageNames` (the fix-list) or it ships as `chore` and silently misses its patch release; a new dep belonging to an existing group (eslint/vitest/react-types/apps) should be matched by that group. There is no CI guard for this, so it must be checked here
+- Renovate release coverage — when a runtime dependency is added to `packages/core` or `packages/react`, confirm it will trigger a release. `@sanity/*` deps and inline (non-catalog) `dependencies` are covered automatically by `.github/renovate.json`. The gap is a **catalog, non-`@sanity`** runtime dep (its catalog depType hides it from the catch-all) — that ships as `chore` and silently misses its patch release, so flag it (it needs a name-matched `fix` rule). There is no CI guard for this
 - React leakage into `packages/core` — core is framework-agnostic; flag any React imports, hooks, or JSX introduced there
 
 If there is no actionable feedback, do not post a comment. If you have already posted a review comment on this PR, update it to indicate there are no further issues.

--- a/.github/RENOVATE_STRATEGY.md
+++ b/.github/RENOVATE_STRATEGY.md
@@ -51,17 +51,22 @@ Neither usually appears. If one does, check the Renovate run logs linked from th
 
 ## Automerge policy
 
-| Dependency type                                                                                                                                                              | Update type    | Auto/Manual | Release age | Commit type        | Triggers release?                                                   |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ----------- | ----------- | ------------------ | ------------------------------------------------------------------- |
-| devDependencies                                                                                                                                                              | patch/minor    | Auto        | 3 days      | `chore(dev-deps)`  | No                                                                  |
-| devDependencies (except TypeScript)                                                                                                                                          | major          | Auto        | 3 days      | `chore(dev-deps)`  | No                                                                  |
-| TypeScript                                                                                                                                                                   | major          | Manual      | 3 days      | `chore(tooling)`   | No                                                                  |
-| Production deps (in `packages/core`, `packages/react`)                                                                                                                       | patch/minor    | Auto        | 3 days      | `fix(deps)`        | **Yes, patch**                                                      |
-| Production deps (in `packages/core`, `packages/react`)                                                                                                                       | major          | Manual      | 3 days      | `fix(deps)`        | **Yes, patch** (override to `feat!` at squash for breaking changes) |
-| Peer deps                                                                                                                                                                    | any            | Manual      | 3 days      | `chore(peer-deps)` | No                                                                  |
-| App deps (`apps/**`)                                                                                                                                                         | any            | Auto        | 3 days      | `chore(apps)`      | No                                                                  |
-| **Trusted upstream packages** (Sanity-maintained, React, Next, `@types/*`, full list in [preset](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json)) | inherits above | inherits    | **0 days**  | inherits           | inherits                                                            |
-| High-severity security (any)                                                                                                                                                 | any            | Manual      | 0 days      | varies             | varies                                                              |
+Rules are scoped by **package name**, not file path (see below for why). "Auto" means the PR inherits the global `automerge: true`; "Manual" means the rule sets `dependencyDashboardApproval: true` (the PR won't open until ticked) and carries a `needs-review`/`major-update`/`breaking-change` label the auto-approve workflow skips.
+
+| Dependency type                                                                                                                                                              | Update type    | Auto/Manual | Release age | Commit type                          | Triggers release?                                                   |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ----------- | ----------- | ------------------------------------ | ------------------------------------------------------------------- |
+| devDependencies                                                                                                                                                              | patch/minor    | Auto        | 3 days      | `chore(dev-deps)`                    | No                                                                  |
+| devDependencies (except TypeScript)                                                                                                                                          | major          | Auto        | 3 days      | `chore(dev-deps)`                    | No                                                                  |
+| TypeScript                                                                                                                                                                   | major          | Manual      | 3 days      | `chore(tooling)`                     | No                                                                  |
+| Runtime deps of core/react (the `matchPackageNames` fix-list)                                                                                                                | patch/minor    | Auto        | 3 days      | `fix(deps)`                          | **Yes, patch**                                                      |
+| Runtime deps of core/react (fix-list)                                                                                                                                        | major          | Manual      | 3 days      | `fix(deps)`                          | **Yes, patch** (override to `feat!` at squash for breaking changes) |
+| `react` / `react-dom` peers                                                                                                                                                  | any            | Manual      | 3 days      | `chore(peer-deps)`                   | No                                                                  |
+| eslint-tooling / vitest-tooling / react-types groups                                                                                                                         | patch/minor    | Auto        | varies      | `chore(tooling)` / `chore(dev-deps)` | No                                                                  |
+| App-only deps (the `app dependencies` group)                                                                                                                                 | patch/minor    | Auto        | 3 days      | `chore(apps)`                        | No                                                                  |
+| **Trusted upstream packages** (Sanity-maintained, React, Next, `@types/*`, full list in [preset](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json)) | inherits above | inherits    | **0 days**  | inherits                             | inherits                                                            |
+| High-severity security (any)                                                                                                                                                 | any            | Manual      | 0 days      | varies                               | varies                                                              |
+
+Majors are never grouped — each opens its own PR (groups are scoped to `patch`/`minor`), so a breaking bump is reviewed in isolation.
 
 ### Why 3 days for external packages
 
@@ -79,10 +84,16 @@ The Sanity preset exempts packages we trust from the minimum-age delay: our own 
 
 Our rules align Renovate's commit types with [release-please](../release-please-config.json):
 
-- `fix(deps)`: triggers a patch release. Used for any production dep update in `packages/core` or `packages/react`.
+- `fix(deps)`: triggers a patch release. Used for the runtime deps of `packages/core` / `packages/react` (the `matchPackageNames` fix-list).
 - `chore(*)`: hidden from the changelog. Used for dev deps, tooling, peer deps, apps.
 
 If a production major dep actually breaks our public API, override the commit type at squash time from `fix(deps)` to `feat(deps)!` or add a `BREAKING CHANGE:` footer so release-please produces a minor/major release.
+
+### Why rules are scoped by package name, not file path
+
+pnpm catalog deps live in `pnpm-workspace.yaml`; Renovate reports their `packageFile` as that file and their `depType` as `pnpm.catalog.<name>` — never the consuming package's `dependencies` type. So `matchFileNames`/`matchDepTypes` cannot identify a catalog'd runtime dep, and a flat catalog erases the usage signal. (This is why catalog'd runtime deps like `@sanity/client` historically shipped as silent `chore` instead of `fix`.) We therefore list the published runtime deps of core/react explicitly in `matchPackageNames` (the "fix-list"), duplicated across the patch/minor rule, the major rule, and the `rangeStrategy: bump` rule.
+
+**Keep the fix-list in sync (manual).** The list mirrors core+react `dependencies`. When you add or remove a runtime dependency in `packages/core` or `packages/react`, update all three runtime rules in `renovate.json` to match. If you forget, the dep will bump as `chore` and miss its patch release — recoverable, but silent. (`groq` and `@sanity/codegen` are intentionally excluded; the disable rule freezes them on the `typegen-experimental` tag. `@sanity/sdk` is `workspace:*` and not Renovate-managed.) There is no CI guard for this today; the `/review` command flags dep changes that aren't reflected here, and a CI check can be added if drift becomes a recurring problem.
 
 ## Auto-approval workflow
 

--- a/.github/RENOVATE_STRATEGY.md
+++ b/.github/RENOVATE_STRATEGY.md
@@ -6,9 +6,9 @@ For Renovate's own docs, see [Dependency Dashboard](https://docs.renovatebot.com
 
 ## Key principles
 
-1. **Automerge by default**, with CI as the safety net.
+1. **Automerge by default**, with CI as the safety net. Nothing is gated behind manual dashboard approval (except security alerts, which we review).
 2. **Production dep updates trigger a patch release** via `fix(deps)` commits, aligning with release-please.
-3. **Manual review for high-risk changes**: production majors, peer deps, TypeScript majors.
+3. **Scope rules by package name, not file path** — pnpm catalogs make file paths unreliable for deciding what releases (see below).
 4. **3-day release age for external deps, 0 days for trusted upstream packages** (Sanity-maintained, React, Next, `@types/*`, and the rest of the [preset exemption list](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json)), to balance supply-chain safety against keeping current. Both values come from the upstream [`sanity-io/renovate-config`](https://github.com/sanity-io/renovate-config) preset; we don't override.
 
 ## Where to look
@@ -19,143 +19,120 @@ For Renovate's own docs, see [Dependency Dashboard](https://docs.renovatebot.com
 
 ## Reading the dashboard
 
-The dashboard groups pending work into sections. Only a couple of them need regular human input.
+The dashboard groups pending work into sections. With approval gating removed, most are automatic.
 
-### Pending Approval (needs you)
+### Pending Approval (should stay empty)
 
-Renovate won't create these PRs until you tick a checkbox. Matches rules with `dependencyDashboardApproval: true`: production major deps, peer deps, and TypeScript majors. Ticking the box only opens the PR; you can still review, reject, or ask for changes.
+We no longer set `dependencyDashboardApproval` on any rule, so nothing should land here. If something does, it came from the upstream preset — worth a look.
 
 ### Awaiting Schedule (automatic)
 
-Renovate will create these PRs at its next scheduled run (currently `before 5am` UTC daily) or once `minimumReleaseAge` has elapsed. No action required.
+Renovate creates these PRs at its next scheduled run (`before 5am` UTC daily) or once `minimumReleaseAge` has elapsed. No action required.
 
 ### Rate-Limited (automatic, but capped)
 
-We set `prConcurrentLimit: 20` (max open PRs at once) and `prHourlyLimit: 5` (max PRs created per hour). New updates queue here when either ceiling is hit. The hourly cap is usually the bottleneck during a backlog; drain it by merging open Renovate PRs, or temporarily raise either limit in `.github/renovate.json`.
+`prConcurrentLimit: 20` (max open PRs) and `prHourlyLimit: 5` (max PRs created per hour). New updates queue here when either ceiling is hit. Drain by merging open Renovate PRs, or raise a limit temporarily.
 
 ### Pending Status Checks (should stay empty)
 
-We use `prCreation: "immediate"` so Renovate opens PRs right away rather than waiting for branch-level CI. Our CI workflows only fire on `pull_request:` events, so waiting for branch status checks would deadlock. If items do land here, it means Renovate observed an external pending check on the branch — worth investigating.
+We use `prCreation: "immediate"` so Renovate opens PRs right away rather than waiting for branch-level CI. Our CI fires on `pull_request:` events, so waiting for branch status would deadlock.
 
 ### PR Closed (Blocked) (needs you)
 
-A previous PR was closed without merging, and Renovate won't try again unless you tick the box. Only re-tick if you actually want to retry the upgrade.
+A previous PR was closed without merging; Renovate won't retry unless you tick the box.
 
 ### Detected Dependencies (reference only)
 
 Inventory of everything Renovate tracks. No action required.
 
-### Repository problems / Errored (investigate)
-
-Neither usually appears. If one does, check the Renovate run logs linked from the top of the dashboard issue.
-
 ## Automerge policy
 
-Rules are scoped by **package name**, not file path (see below for why). "Auto" means the PR inherits the global `automerge: true`; "Manual" means the rule sets `dependencyDashboardApproval: true` (the PR won't open until ticked) and carries a `needs-review`/`major-update`/`breaking-change` label the auto-approve workflow skips.
+Rules are scoped by **package name** (or, for apps, by file path) — never by `matchFileNames` on the published packages. Everything automerges after CI passes and the release age elapses; the auto-approve workflow supplies the required approval.
 
-| Dependency type                                                                                                                                                              | Update type    | Auto/Manual | Release age | Commit type                          | Triggers release?                                                   |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ----------- | ----------- | ------------------------------------ | ------------------------------------------------------------------- |
-| devDependencies                                                                                                                                                              | patch/minor    | Auto        | 3 days      | `chore(dev-deps)`                    | No                                                                  |
-| devDependencies (except TypeScript)                                                                                                                                          | major          | Auto        | 3 days      | `chore(dev-deps)`                    | No                                                                  |
-| TypeScript                                                                                                                                                                   | major          | Manual      | 3 days      | `chore(tooling)`                     | No                                                                  |
-| Runtime deps of core/react (the `matchPackageNames` fix-list)                                                                                                                | patch/minor    | Auto        | 3 days      | `fix(deps)`                          | **Yes, patch**                                                      |
-| Runtime deps of core/react (fix-list)                                                                                                                                        | major          | Manual      | 3 days      | `fix(deps)`                          | **Yes, patch** (override to `feat!` at squash for breaking changes) |
-| `react` / `react-dom` peers                                                                                                                                                  | any            | Manual      | 3 days      | `chore(peer-deps)`                   | No                                                                  |
-| eslint-tooling / vitest-tooling / react-types groups                                                                                                                         | patch/minor    | Auto        | varies      | `chore(tooling)` / `chore(dev-deps)` | No                                                                  |
-| App-only deps (the `app dependencies` group)                                                                                                                                 | patch/minor    | Auto        | 3 days      | `chore(apps)`                        | No                                                                  |
-| **Trusted upstream packages** (Sanity-maintained, React, Next, `@types/*`, full list in [preset](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json)) | inherits above | inherits    | **0 days**  | inherits                             | inherits                                                            |
-| High-severity security (any)                                                                                                                                                 | any            | Manual      | 0 days      | varies                               | varies                                                              |
+| Dependency type                                                                                          | Update type | Commit type                                 | Triggers release?     |
+| -------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------- | --------------------- |
+| `@sanity/*` (grouped as `sanity`)                                                                        | any         | `fix(deps)`                                 | **Yes, patch**        |
+| Other production `dependencies` (catch-all)                                                              | any         | `fix(deps)`                                 | **Yes, patch**        |
+| Catalog non-`@sanity` runtime deps (`rxjs`, `groq-js`, `react-compiler-runtime`, `react-error-boundary`) | any         | `chore`                                     | No — see caveat below |
+| eslint / vitest / commitlint / react groups                                                              | any         | `chore(tooling)` / `chore(dev-deps)`        | No                    |
+| `devDependencies`                                                                                        | any         | `chore(dev-deps)`                           | No                    |
+| Anything under `apps/**`                                                                                 | any         | `chore(apps)`                               | No                    |
+| `groq`, `@sanity/codegen`                                                                                | —           | disabled (pinned to `typegen-experimental`) | —                     |
+| High-severity security                                                                                   | any         | varies                                      | varies                |
+| Trusted upstream (Sanity-maintained, React, Next, `@types/*`, etc.)                                      | inherits    | inherits                                    | inherits              |
 
-Majors are never grouped — each opens its own PR (groups are scoped to `patch`/`minor`), so a breaking bump is reviewed in isolation.
+Majors are never grouped — each opens its own PR (`separateMajorMinor` is on by default), so a breaking bump is reviewed in isolation before it automerges.
+
+### Why rules are scoped by package name
+
+pnpm catalog deps live in `pnpm-workspace.yaml`; Renovate reports their `packageFile` as that file and their `depType` as `pnpm.catalog.<name>` — never `dependencies`. So `matchFileNames` on the published packages and a `matchDepTypes: ["dependencies"]` catch-all both **miss catalog deps**. Matching `@sanity/*` by name catches the bulk of our runtime deps (catalog or not) and auto-covers new ones, and the production `dependencies` catch-all covers the inline (non-catalog) deps.
+
+**Caveat — catalog non-`@sanity` runtime deps.** A few runtime deps of core/react live in the catalog but aren't `@sanity`-scoped: `rxjs`, `groq-js`, `react-compiler-runtime`, `react-error-boundary`. The catch-all can't see them (catalog depType) and the `@sanity/*` rule doesn't match them, so they bump as `chore` and **don't trigger a release** on their own. If a fix in one of them needs to ship, either trigger a release another way or add it to a name-matched `fix` rule. The `/review` command flags dep changes that should be reconsidered here.
 
 ### Why 3 days for external packages
 
-We inherit a 3-day [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) from the [`min-age-3days`](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json) preset. We don't override it. Three days aligns with npm's 72-hour unpublish window: if a malicious release gets pulled within that grace period, we never installed it. It also matches where industry guidance is converging, including [Datadog Security Labs](https://securitylabs.datadoghq.com/articles/dependency-cooldowns/), the [npm `min-release-age` proposals](https://github.com/npm/cli/pull/9173), and the pnpm/Yarn defaults, which all cluster in the 3-7 day range.
+We inherit a 3-day [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) from the [`min-age-3days`](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json) preset. Three days aligns with npm's 72-hour unpublish window: if a malicious release is pulled within that grace period, we never installed it. It also matches converging industry guidance ([Datadog Security Labs](https://securitylabs.datadoghq.com/articles/dependency-cooldowns/), the [npm `min-release-age` proposals](https://github.com/npm/cli/pull/9173), pnpm/Yarn defaults).
 
-The wait only protects automerged paths. On manual-review tracks (production majors, peer deps, TypeScript major) the human review is the actual safety net.
-
-Vulnerability alerts bypass the delay entirely (`vulnerabilityAlerts.minimumReleaseAge: null`), so security advisories from the GitHub Advisory Database land immediately.
+Vulnerability alerts bypass the delay (`vulnerabilityAlerts.minimumReleaseAge: null`), so security advisories land immediately.
 
 ### Why 0 days for trusted upstream packages
 
-The Sanity preset exempts packages we trust from the minimum-age delay: our own (`@sanity/*`, `sanity`, `groq`, `groq-js`) and framework deps we use heavily (`react*`, `next*`, `@types/*`, `pnpm`, `@portabletext/*`, etc.). We have direct relationships or strong visibility into these release processes, so the wait would slow our work without meaningful safety benefit. Full list lives in [`min-age-3days.json`](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json).
+The Sanity preset exempts packages we trust from the minimum-age delay: our own (`@sanity/*`, `sanity`, `groq`, `groq-js`) and framework deps we use heavily (`react*`, `next*`, `@types/*`, `pnpm`, `@portabletext/*`, etc.). Full list in [`min-age-3days.json`](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json).
 
 ## Commit messages and releases
 
 Our rules align Renovate's commit types with [release-please](../release-please-config.json):
 
-- `fix(deps)`: triggers a patch release. Used for the runtime deps of `packages/core` / `packages/react` (the `matchPackageNames` fix-list).
-- `chore(*)`: hidden from the changelog. Used for dev deps, tooling, peer deps, apps.
+- `fix(deps)`: triggers a patch release. Used for `@sanity/*` and other production `dependencies`.
+- `chore(*)`: hidden from the changelog. Used for dev deps, tooling groups, and apps.
 
-If a production major dep actually breaks our public API, override the commit type at squash time from `fix(deps)` to `feat(deps)!` or add a `BREAKING CHANGE:` footer so release-please produces a minor/major release.
+If a production major dep breaks our public API, override the commit type at squash time from `fix(deps)` to `feat(deps)!` or add a `BREAKING CHANGE:` footer so release-please produces a minor/major release.
 
-### Why rules are scoped by package name, not file path
+## pnpm version
 
-pnpm catalog deps live in `pnpm-workspace.yaml`; Renovate reports their `packageFile` as that file and their `depType` as `pnpm.catalog.<name>` — never the consuming package's `dependencies` type. So `matchFileNames`/`matchDepTypes` cannot identify a catalog'd runtime dep, and a flat catalog erases the usage signal. (This is why catalog'd runtime deps like `@sanity/client` historically shipped as silent `chore` instead of `fix`.) We therefore list the published runtime deps of core/react explicitly in `matchPackageNames` (the "fix-list"), duplicated across the patch/minor rule, the major rule, and the `rangeStrategy: bump` rule.
-
-**Keep the fix-list in sync (manual).** The list mirrors core+react `dependencies`. When you add or remove a runtime dependency in `packages/core` or `packages/react`, update all three runtime rules in `renovate.json` to match. If you forget, the dep will bump as `chore` and miss its patch release — recoverable, but silent. (`groq` and `@sanity/codegen` are intentionally excluded; the disable rule freezes them on the `typegen-experimental` tag. `@sanity/sdk` is `workspace:*` and not Renovate-managed.) There is no CI guard for this today; the `/review` command flags dep changes that aren't reflected here, and a CI check can be added if drift becomes a recurring problem.
+Renovate reads the pnpm version from the root `package.json` `packageManager` field automatically. We do **not** set a `constraints.pnpm` override (it only drifts out of sync).
 
 ## Auto-approval workflow
 
-Our branch protection requires at least 1 approval before merging. The auto-approve workflow (`.github/workflows/renovate-auto-approve.yml`):
+Branch protection requires at least 1 approval before merging. The auto-approve workflow (`.github/workflows/renovate-auto-approve.yml`) waits for CI (build, test, lint, typecheck) and then approves so Renovate's automerge can proceed.
 
-1. Waits for CI checks (build, test, lint, typecheck).
-2. Skips auto-approval for PRs labeled `needs-review`, `major-update`, or `breaking-change`.
-3. Auto-approves the rest so Renovate's automerge can proceed.
-
-**Known gap**: the workflow uses `GITHUB_TOKEN`, whose approvals don't count toward CODEOWNERS or team-approval rules. Tracked in [SDK-1272](https://linear.app/sanity/issue/SDK-1272), where we plan to switch to `squiggler-app` so approvals come from a trusted team-identity bot.
+**Known gap**: the workflow uses `GITHUB_TOKEN`, whose approvals don't count toward CODEOWNERS or team-approval rules. Tracked in [SDK-1272](https://linear.app/sanity/issue/SDK-1272).
 
 ## Expected weekly flow
 
-**Monday-Thursday**: Renovate opens PRs in the early morning (before 5am UTC). CI runs. PRs automerge as release age elapses and CI goes green.
+**Mon–Thu**: Renovate opens PRs before 5am UTC. CI runs. PRs automerge as release age elapses and CI goes green.
 
-**Friday**: Most PRs from early in the week have merged. Review pending approvals on the Dependency Dashboard. Check for failed automerges.
-
-**Release cadence**: 1-2 releases per week via release-please, driven by `fix(deps)` commits merging in.
+**Release cadence**: 1–2 releases per week via release-please, driven by `fix(deps)` commits merging in.
 
 ## Monitoring & maintenance
 
 ### Weekly checklist
 
-- Check the [Dependency Dashboard](../../issues/9) for pending approvals.
-- Review any failed automerge PRs.
+- Skim the [Dependency Dashboard](../../issues/9) for anything stuck (errored, or repeatedly failing automerge).
 - Merge the release-please PR if ready.
 - Note any major updates that need planning.
 
 ### Pre-release checklist
 
-Before merging a release-please PR:
-
 ```bash
-# Review dependency changes since last release
-git log v2.4.0..HEAD --oneline --grep="fix(deps)"
-
-# Run full test suite
-pnpm run all
-
-# Run E2E tests
-pnpm run test:e2e
-
-# Test in kitchensink app
-pnpm run dev:kitchensink
-
-# Check bundle size
-pnpm run build:bundle
+git log v2.4.0..HEAD --oneline --grep="fix(deps)"   # dependency changes since last release
+pnpm run all                                          # full suite
+pnpm run test:e2e                                     # E2E
+pnpm run dev:kitchensink                              # smoke-test in the app
+pnpm run build:bundle                                 # bundle size
 ```
 
 ## Troubleshooting
 
 ### A Renovate PR's lockfile looks broken
 
-Our config uses `postUpdateOptions: ["pnpmDedupe"]` and pins `constraints.pnpm` to match the repo's `packageManager` field, which should prevent most lockfile issues. If one slips through, run `pnpm install` locally, commit the result, and push to the Renovate branch. Renovate won't overwrite manual commits.
+We use `postUpdateOptions: ["pnpmDedupe"]`. If a lockfile slips through broken, run `pnpm install` locally, commit, and push to the Renovate branch — Renovate won't overwrite manual commits.
 
 ### A PR won't automerge
 
 1. Check CI status: all checks must pass.
-2. Check the release-age label: might still be waiting.
-3. Check the PR has been approved: branch protection requires 1 approval.
-4. Check it's not labeled `needs-review`, `major-update`, or `breaking-change`.
-5. Check `renovate.json` confirms automerge is enabled for that PR type.
+2. Check the release-age: it might still be waiting.
+3. Check the PR is approved: branch protection requires 1 approval (the auto-approve workflow supplies it once checks pass).
 
 ### I want to retry a closed Renovate PR
 
@@ -163,21 +140,15 @@ Find it in "PR Closed (Blocked)" on the dashboard and tick the box.
 
 ### The rate-limited queue is huge
 
-Either merge/close open Renovate PRs to drain the queue, or temporarily bump `prHourlyLimit` (the creation throttle) and/or `prConcurrentLimit` (the open-PR ceiling) in `renovate.json`, then revert once drained. The hourly cap is usually the bottleneck.
-
-### I'm bumping the repo's pnpm version
-
-When `packageManager` in `package.json` changes, update `constraints.pnpm` in `.github/renovate.json` to match. Otherwise Renovate's lockfile output will drift from local and CI.
+Merge/close open Renovate PRs to drain it, or temporarily bump `prHourlyLimit` / `prConcurrentLimit` in `renovate.json`.
 
 ## Making changes
 
-1. Edit `.github/renovate.json` (the `$schema` key provides editor validation).
-2. Open a PR and monitor the Dependency Dashboard over the next week to confirm behavior matches expectations.
-3. Adjust based on actual PR volume and team capacity.
+1. Edit `.github/renovate.json` (the `$schema` key provides editor validation; validate with `renovate-config-validator`).
+2. Open a PR and watch the Dependency Dashboard over the next week to confirm behavior.
 
 ## Related docs
 
 - [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/)
 - [Upgrade best practices](https://docs.renovatebot.com/upgrade-best-practices/)
-- [Noise reduction](https://docs.renovatebot.com/noise-reduction/)
 - [Configuration options](https://docs.renovatebot.com/configuration-options/)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,65 +35,88 @@
       "enabled": false
     },
     {
-      "description": "Automerge all devDependencies (non-major)",
-      "matchDepTypes": ["devDependencies"],
+      "description": "Runtime deps of core/react (patch/minor) - trigger patch release (automerge inherited from global). KEEP IN SYNC with core+react dependencies (manual; see RENOVATE_STRATEGY.md).",
+      "matchPackageNames": [
+        "@sanity/bifur-client",
+        "@sanity/client",
+        "@sanity/comlink",
+        "@sanity/diff-match-patch",
+        "@sanity/diff-patch",
+        "@sanity/id-utils",
+        "@sanity/image-url",
+        "@sanity/json-match",
+        "@sanity/message-protocol",
+        "@sanity/mutate",
+        "@sanity/telemetry",
+        "@sanity/types",
+        "groq-js",
+        "reselect",
+        "rxjs",
+        "zustand",
+        "react-compiler-runtime",
+        "react-error-boundary"
+      ],
       "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "devDependencies (non-major)",
-      "automerge": true,
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "dev-deps"
-    },
-    {
-      "description": "Automerge devDependencies (major) after longer stability period",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["major"],
-      "automerge": true,
-      "labels": ["major-update"],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "dev-deps",
-      "matchPackageNames": ["!typescript"]
-    },
-    {
-      "description": "TypeScript major versions - require approval due to breaking changes",
-      "matchPackageNames": ["typescript"],
-      "matchUpdateTypes": ["major"],
-      "automerge": false,
-      "dependencyDashboardApproval": true,
-      "labels": ["typescript", "major-update", "breaking-change"],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "tooling"
-    },
-    {
-      "description": "Production dependencies (patch/minor) - automerge and trigger patch release",
-      "matchDepTypes": ["dependencies"],
-      "matchFileNames": ["packages/core/package.json", "packages/react/package.json"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "labels": ["dependencies", "automerge"],
+      "groupName": "sanity-runtime",
+      "labels": ["dependencies"],
       "semanticCommitType": "fix",
       "semanticCommitScope": "deps"
     },
     {
-      "description": "Production dependencies (major) - require manual approval. Defaults to fix(deps) for a patch release; override to feat! or BREAKING CHANGE at squash time if the upgrade affects the SDK's public API",
-      "matchDepTypes": ["dependencies"],
-      "matchFileNames": ["packages/core/package.json", "packages/react/package.json"],
+      "description": "Runtime deps of core/react (major) - manual review (dependencyDashboardApproval + needs-review label gate it), still patch release by default (override to feat! at squash if breaking). KEEP IN SYNC with core+react dependencies (manual; see RENOVATE_STRATEGY.md).",
+      "matchPackageNames": [
+        "@sanity/bifur-client",
+        "@sanity/client",
+        "@sanity/comlink",
+        "@sanity/diff-match-patch",
+        "@sanity/diff-patch",
+        "@sanity/id-utils",
+        "@sanity/image-url",
+        "@sanity/json-match",
+        "@sanity/message-protocol",
+        "@sanity/mutate",
+        "@sanity/telemetry",
+        "@sanity/types",
+        "groq-js",
+        "reselect",
+        "rxjs",
+        "zustand",
+        "react-compiler-runtime",
+        "react-error-boundary"
+      ],
       "matchUpdateTypes": ["major"],
-      "automerge": false,
       "dependencyDashboardApproval": true,
       "labels": ["dependencies", "major-update", "breaking-change", "needs-review"],
       "semanticCommitType": "fix",
       "semanticCommitScope": "deps"
     },
     {
-      "description": "Use bump strategy for all production dependencies in public packages",
-      "matchDepTypes": ["dependencies"],
-      "matchFileNames": ["packages/core/package.json", "packages/react/package.json"],
+      "description": "Use bump strategy for the core/react runtime deps so release-please sees the version change. KEEP IN SYNC with the runtime fix-list above.",
+      "matchPackageNames": [
+        "@sanity/bifur-client",
+        "@sanity/client",
+        "@sanity/comlink",
+        "@sanity/diff-match-patch",
+        "@sanity/diff-patch",
+        "@sanity/id-utils",
+        "@sanity/image-url",
+        "@sanity/json-match",
+        "@sanity/message-protocol",
+        "@sanity/mutate",
+        "@sanity/telemetry",
+        "@sanity/types",
+        "groq-js",
+        "reselect",
+        "rxjs",
+        "zustand",
+        "react-compiler-runtime",
+        "react-error-boundary"
+      ],
       "rangeStrategy": "bump"
     },
     {
-      "description": "PeerDependencies - require approval as they affect consumer compatibility",
-      "matchDepTypes": ["peerDependencies"],
-      "automerge": false,
+      "description": "React peer dependencies - manual review (dependencyDashboardApproval + needs-review label gate it). Matched by name because catalog-flattened depType won't match peerDependencies.",
+      "matchPackageNames": ["react", "react-dom"],
       "dependencyDashboardApproval": true,
       "labels": ["peer-dependencies", "needs-review"],
       "rangeStrategy": "widen",
@@ -101,15 +124,7 @@
       "semanticCommitScope": "peer-deps"
     },
     {
-      "description": "Group TypeScript tooling deps (excluding typescript itself)",
-      "groupName": "typescript-tooling",
-      "matchPackageNames": ["@sanity/pkg-utils", "@sanity/tsdoc"],
-      "automerge": true,
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "tooling"
-    },
-    {
-      "description": "Group eslint related deps for easier review",
+      "description": "Group eslint related deps",
       "groupName": "eslint-tooling",
       "matchPackageNames": [
         "@eslint/*",
@@ -118,25 +133,69 @@
         "eslint-config-*",
         "typescript-eslint"
       ],
-      "automerge": true,
+      "matchUpdateTypes": ["patch", "minor"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "tooling"
     },
     {
-      "description": "App dependencies - aggressive automerge since apps aren't published",
-      "matchDepTypes": [
-        "dependencies",
-        "devDependencies",
-        "engines",
-        "optionalDependencies",
-        "peerDependencies"
-      ],
-      "matchManagers": ["npm"],
-      "matchFileNames": ["apps/**/package.json"],
+      "description": "Group vitest related deps",
+      "groupName": "vitest-tooling",
+      "matchPackageNames": ["vitest", "@vitest/*"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "tooling"
+    },
+    {
+      "description": "Group React type packages",
+      "groupName": "react-types",
+      "matchPackageNames": ["@types/react", "@types/react-dom"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "dev-deps"
+    },
+    {
+      "description": "App-only dependencies (not consumed by published packages) - never trigger a release.",
       "groupName": "app dependencies",
-      "automerge": true,
+      "matchPackageNames": [
+        "@paramour/css",
+        "@sanity/icons",
+        "@sanity/ui",
+        "inter-ui",
+        "json-edit-react",
+        "react-router",
+        "sanity",
+        "styled-components",
+        "rimraf"
+      ],
+      "matchUpdateTypes": ["patch", "minor"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "apps"
+    },
+    {
+      "description": "TypeScript major versions - require approval due to breaking changes",
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "labels": ["typescript", "major-update", "breaking-change"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "tooling"
+    },
+    {
+      "description": "Group all devDependencies (non-major)",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "dev-deps"
+    },
+    {
+      "description": "devDependencies (major) after longer stability period",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["major"],
+      "labels": ["major-update"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "dev-deps",
+      "matchPackageNames": ["!typescript"]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,9 +7,6 @@
     "abandonments:recommended"
   ],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
-  "constraints": {
-    "pnpm": "10.34.1"
-  },
   "postUpdateOptions": ["pnpmDedupe"],
   "schedule": ["before 5am"],
   "prConcurrentLimit": 20,
@@ -20,7 +17,7 @@
   "automergeStrategy": "squash",
   "dependencyDashboard": true,
   "dependencyDashboardApproval": false,
-  "dependencyDashboardHeader": "## How to use this dashboard\n\nFull playbook: [RENOVATE_STRATEGY.md](../blob/main/.github/RENOVATE_STRATEGY.md)\n\n**Quick section reference**\n\n- **Pending Approval**: tick a checkbox to open the PR. Only tick items worth trying.\n- **Awaiting Schedule** / **Rate-Limited**: automatic, no action needed.\n- **Pending Status Checks**: should stay empty. Renovate PRs open immediately so CI runs on the PR itself.\n- **PR Closed (Blocked)**: previously closed. Only tick to retry.\n- **Detected Dependencies**: reference only.\n\n<details>\n<summary><b>Automerge policy</b></summary>\n\n| Dependency type | Auto/Manual | Release age | Commit type | Triggers release? |\n| --- | --- | --- | --- | --- |\n| devDependencies (patch/minor/major) | Auto | 3 days | `chore(dev-deps)` | No |\n| TypeScript (major) | Manual | 3 days | `chore(tooling)` | No |\n| Production deps patch/minor (`packages/core`, `packages/react`) | Auto | 3 days | `fix(deps)` | **Yes, patch** |\n| Production deps major (`packages/core`, `packages/react`) | Manual | 3 days | `fix(deps)` | **Yes, patch**<br/>(override to `feat!` at squash if breaking) |\n| Peer deps | Manual | 3 days | `chore(peer-deps)` | No |\n| App deps (`apps/**`) | Auto | 3 days | `chore(apps)` | No |\n| High-severity security | Manual | 0 days | varies | varies |\n| Trusted upstream (Sanity-maintained, React, Next, `@types/*`, etc.; full list in [preset](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json)) | inherits | **0 days** | inherits | inherits |\n\n</details>\n\n<details>\n<summary><b>Common actions</b></summary>\n\n**Retry a closed PR**: find it under \"PR Closed (Blocked)\" and tick the box.\n\n**Approve a major dep update**: tick its checkbox under \"Pending Approval\". This only opens the PR; you still review and squash-merge manually. If the upgrade is a breaking change for our consumers, change the commit type from `fix(deps)` to `feat(deps)!` at squash time so release-please produces a major/minor bump.\n\n**A PR won't automerge**: check CI status, that the PR is approved, and that it's not labeled `needs-review`, `major-update`, or `breaking-change`.\n\n**A lockfile looks broken**: run `pnpm install` locally, commit, and push to the Renovate branch. Renovate won't overwrite manual commits.\n\n**Rate-limited queue is huge**: drain it by merging open Renovate PRs. The throttles are `prHourlyLimit` (currently 5, the creation rate) and `prConcurrentLimit` (currently 20, the open-PR ceiling) in `.github/renovate.json`; raise either temporarily if needed.\n\n**Bumping the repo's pnpm version**: also update `constraints.pnpm` in `.github/renovate.json` to match.\n\n</details>\n\n<details>\n<summary><b>Weekly checklist</b></summary>\n\n- Check this dashboard for pending approvals.\n- Review any failed automerge PRs.\n- Merge the release-please PR if ready.\n- Note any major updates that need planning.\n\n</details>",
+  "dependencyDashboardHeader": "## How to use this dashboard\n\nFull playbook: [RENOVATE_STRATEGY.md](../blob/main/.github/RENOVATE_STRATEGY.md)\n\n**Quick section reference**\n\n- **Pending Approval**: should stay empty — we no longer gate any update behind dashboard approval.\n- **Awaiting Schedule** / **Rate-Limited**: automatic, no action needed.\n- **Pending Status Checks**: should stay empty. Renovate PRs open immediately so CI runs on the PR itself.\n- **PR Closed (Blocked)**: previously closed. Only tick to retry.\n- **Detected Dependencies**: reference only.\n\n<details>\n<summary><b>Automerge policy</b></summary>\n\n| Dependency type | Auto/Manual | Release age | Commit type | Triggers release? |\n| --- | --- | --- | --- | --- |\n| `@sanity/*` and other production `dependencies` | Auto | 3 days | `fix(deps)` | **Yes, patch** |\n| Catalog non-`@sanity` deps (rxjs, groq-js, react-compiler-runtime, react-error-boundary) | Auto | 3 days | `chore` | No — catalog hides depType, see RENOVATE_STRATEGY.md |\n| eslint / vitest / commitlint / react groups, app deps, devDependencies | Auto | 3 days | `chore(*)` | No |\n| High-severity security | Manual | 0 days | varies | varies |\n| Trusted upstream (Sanity-maintained, React, Next, `@types/*`, etc.; full list in [preset](https://github.com/sanity-io/renovate-config/blob/main/min-age-3days.json)) | inherits | **0 days** | inherits | inherits |\n\n</details>\n\n<details>\n<summary><b>Common actions</b></summary>\n\n**Retry a closed PR**: find it under \"PR Closed (Blocked)\" and tick the box.\n\n**A breaking major landed**: majors automerge after CI + release age like everything else. If a major is a breaking change for our consumers, change its commit type from `fix(deps)` to `feat(deps)!` (or add a `BREAKING CHANGE:` footer) when squashing so release-please produces a major/minor bump.\n\n**A PR won't automerge**: check CI status and that the PR is approved (the auto-approve workflow approves once checks pass).\n\n**A lockfile looks broken**: run `pnpm install` locally, commit, and push to the Renovate branch. Renovate won't overwrite manual commits.\n\n**Rate-limited queue is huge**: drain it by merging open Renovate PRs. The throttles are `prHourlyLimit` (currently 5, the creation rate) and `prConcurrentLimit` (currently 20, the open-PR ceiling) in `.github/renovate.json`; raise either temporarily if needed.\n\n**The pnpm version** comes from the root `package.json` `packageManager` field — Renovate reads it automatically (no `constraints` override).\n\n</details>\n\n<details>\n<summary><b>Weekly checklist</b></summary>\n\n- Skim the dashboard for anything stuck (errored, or repeatedly failing automerge).\n- Merge the release-please PR if ready.\n- Note any major updates that need planning.\n\n</details>",
   "prCreation": "immediate",
   "vulnerabilityAlerts": {
     "enabled": true,
@@ -30,102 +27,29 @@
   },
   "packageRules": [
     {
-      "description": "Pin groq and @sanity/codegen to the typegen-experimental prerelease tag. The kitchensink's typegen depends on APIs (defineProjection / defineQuery, multi-schema/projections) that only exist on this prerelease; do not let Renovate move them to a stable release, which would drop the experimental typegen the SDK relies on. Revisit once typegen lands in a regular release.",
-      "matchDepNames": ["groq", "@sanity/codegen"],
-      "enabled": false
-    },
-    {
-      "description": "Runtime deps of core/react (patch/minor) - trigger patch release (automerge inherited from global). KEEP IN SYNC with core+react dependencies (manual; see RENOVATE_STRATEGY.md).",
-      "matchPackageNames": [
-        "@sanity/bifur-client",
-        "@sanity/client",
-        "@sanity/comlink",
-        "@sanity/diff-match-patch",
-        "@sanity/diff-patch",
-        "@sanity/id-utils",
-        "@sanity/image-url",
-        "@sanity/json-match",
-        "@sanity/message-protocol",
-        "@sanity/mutate",
-        "@sanity/telemetry",
-        "@sanity/types",
-        "groq-js",
-        "reselect",
-        "rxjs",
-        "zustand",
-        "react-compiler-runtime",
-        "react-error-boundary"
-      ],
-      "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "sanity-runtime",
-      "labels": ["dependencies"],
+      "description": "Group @sanity/* deps; production, triggers a patch release",
+      "matchPackageNames": ["@sanity/*"],
+      "groupName": "sanity",
+      "rangeStrategy": "bump",
       "semanticCommitType": "fix",
       "semanticCommitScope": "deps"
     },
     {
-      "description": "Runtime deps of core/react (major) - manual review (dependencyDashboardApproval + needs-review label gate it), still patch release by default (override to feat! at squash if breaking). KEEP IN SYNC with core+react dependencies (manual; see RENOVATE_STRATEGY.md).",
-      "matchPackageNames": [
-        "@sanity/bifur-client",
-        "@sanity/client",
-        "@sanity/comlink",
-        "@sanity/diff-match-patch",
-        "@sanity/diff-patch",
-        "@sanity/id-utils",
-        "@sanity/image-url",
-        "@sanity/json-match",
-        "@sanity/message-protocol",
-        "@sanity/mutate",
-        "@sanity/telemetry",
-        "@sanity/types",
-        "groq-js",
-        "reselect",
-        "rxjs",
-        "zustand",
-        "react-compiler-runtime",
-        "react-error-boundary"
-      ],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true,
-      "labels": ["dependencies", "major-update", "breaking-change", "needs-review"],
+      "description": "All other production deps; triggers a patch release",
+      "matchDepTypes": ["dependencies"],
+      "rangeStrategy": "bump",
       "semanticCommitType": "fix",
       "semanticCommitScope": "deps"
     },
     {
-      "description": "Use bump strategy for the core/react runtime deps so release-please sees the version change. KEEP IN SYNC with the runtime fix-list above.",
-      "matchPackageNames": [
-        "@sanity/bifur-client",
-        "@sanity/client",
-        "@sanity/comlink",
-        "@sanity/diff-match-patch",
-        "@sanity/diff-patch",
-        "@sanity/id-utils",
-        "@sanity/image-url",
-        "@sanity/json-match",
-        "@sanity/message-protocol",
-        "@sanity/mutate",
-        "@sanity/telemetry",
-        "@sanity/types",
-        "groq-js",
-        "reselect",
-        "rxjs",
-        "zustand",
-        "react-compiler-runtime",
-        "react-error-boundary"
-      ],
-      "rangeStrategy": "bump"
-    },
-    {
-      "description": "React peer dependencies - manual review (dependencyDashboardApproval + needs-review label gate it). Matched by name because catalog-flattened depType won't match peerDependencies.",
-      "matchPackageNames": ["react", "react-dom"],
-      "dependencyDashboardApproval": true,
-      "labels": ["peer-dependencies", "needs-review"],
-      "rangeStrategy": "widen",
+      "description": "devDependencies; no release",
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "devDependencies (non-major)",
       "semanticCommitType": "chore",
-      "semanticCommitScope": "peer-deps"
+      "semanticCommitScope": "dev-deps"
     },
     {
-      "description": "Group eslint related deps",
-      "groupName": "eslint-tooling",
+      "description": "Group eslint deps",
       "matchPackageNames": [
         "@eslint/*",
         "eslint",
@@ -133,69 +57,42 @@
         "eslint-config-*",
         "typescript-eslint"
       ],
-      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "eslint-tooling",
       "semanticCommitType": "chore",
       "semanticCommitScope": "tooling"
     },
     {
-      "description": "Group vitest related deps",
-      "groupName": "vitest-tooling",
+      "description": "Group vitest deps",
       "matchPackageNames": ["vitest", "@vitest/*"],
-      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "vitest-tooling",
       "semanticCommitType": "chore",
       "semanticCommitScope": "tooling"
     },
     {
-      "description": "Group React type packages",
-      "groupName": "react-types",
-      "matchPackageNames": ["@types/react", "@types/react-dom"],
-      "matchUpdateTypes": ["patch", "minor"],
+      "description": "Group commitlint deps",
+      "matchPackageNames": ["@commitlint/*", "commitlint"],
+      "groupName": "commitlint-tooling",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "tooling"
+    },
+    {
+      "description": "Group react deps",
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+      "groupName": "react",
       "semanticCommitType": "chore",
       "semanticCommitScope": "dev-deps"
     },
     {
-      "description": "App-only dependencies (not consumed by published packages) - never trigger a release.",
+      "description": "App deps; no release",
+      "matchFileNames": ["apps/**/package.json"],
       "groupName": "app dependencies",
-      "matchPackageNames": [
-        "@paramour/css",
-        "@sanity/icons",
-        "@sanity/ui",
-        "inter-ui",
-        "json-edit-react",
-        "react-router",
-        "sanity",
-        "styled-components",
-        "rimraf"
-      ],
-      "matchUpdateTypes": ["patch", "minor"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "apps"
     },
     {
-      "description": "TypeScript major versions - require approval due to breaking changes",
-      "matchPackageNames": ["typescript"],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true,
-      "labels": ["typescript", "major-update", "breaking-change"],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "tooling"
-    },
-    {
-      "description": "Group all devDependencies (non-major)",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "devDependencies (non-major)",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "dev-deps"
-    },
-    {
-      "description": "devDependencies (major) after longer stability period",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["major"],
-      "labels": ["major-update"],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "dev-deps",
-      "matchPackageNames": ["!typescript"]
+      "description": "Pin groq and @sanity/codegen to the typegen-experimental prerelease; don't bump to stable",
+      "matchDepNames": ["groq", "@sanity/codegen"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
### Description

Renovate decided whether a dependency bump triggered a release (`fix(deps)`) vs. a silent `chore` using `matchFileNames` on `packages/core` / `packages/react`. That's broken for **pnpm catalog deps**: a catalog entry lives in `pnpm-workspace.yaml`, so Renovate reports its `packageFile` as that file and its `depType` as `pnpm.catalog.<name>` — neither file-path nor depType matchers can see it. So catalog'd runtime deps (`@sanity/client`, `@sanity/types`, …) shipped as silent `chore` and missed their patch release.

This reworks `.github/renovate.json` to be name/ecosystem-scoped and much simpler — modelled on `sanity-io/cli`:

- **`@sanity/*`** → `fix(deps)`, grouped as `sanity`. Wildcard auto-covers new sanity runtime deps.
- **Catch-all** `matchDepTypes: ["dependencies"]` → `fix(deps)` for all other (inline) production deps.
- **Ecosystem groups** so each bumps together: `eslint-tooling`, `vitest-tooling`, `commitlint-tooling`, `react`.
- **`devDependencies`** → `chore(dev-deps)`; **`apps/**`** (file path) → `chore(apps)`.
- **Automerge is fully global**; no per-rule `automerge`, no `dependencyDashboardApproval`. Majors automerge after CI + release age, each in its own PR. CI is the safety net.
- Removed the `constraints.pnpm` override (Renovate reads the version from root `package.json` `packageManager`; it had also drifted out of sync).
- `groq` / `@sanity/codegen` stay pinned/disabled on the `typegen-experimental` tag.

**Known caveat (documented):** the catch-all can't see catalog deps, so the few catalog'd non-`@sanity` runtime deps (`rxjs`, `groq-js`, `react-compiler-runtime`, `react-error-boundary`) ship as `chore` and won't trigger a release on their own. `RENOVATE_STRATEGY.md` and the `/review` command both call this out.

### What to review

- `.github/renovate.json` — the 9 rules + the dashboard-header policy table.
- `.github/RENOVATE_STRATEGY.md` — rewritten for the name-based / catch-all model.
- `.claude/commands/review.md` — added a release-coverage check for new runtime deps.

### Testing

- `renovate-config-validator .github/renovate.json` → **Config validated successfully**.
- Simulated rule precedence (catalog-aware, last-match-wins) over the real dependency graph to confirm each package lands on the intended commit type / group.

### Fun gif

![dependencies in order](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
