### PR TITLE
fix(react): auto-recover auth error screen when the session is restored

### DIFF
--- a/packages/react/src/components/auth/AuthBoundary.recovery.test.tsx
+++ b/packages/react/src/components/auth/AuthBoundary.recovery.test.tsx
@@ -1,0 +1,86 @@
+import {AuthStateType, getIsInDashboardState} from '@sanity/sdk'
+import {render, screen, waitFor} from '@testing-library/react'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {ResourceProvider} from '../../context/ResourceProvider'
+import {useAuthState} from '../../hooks/auth/useAuthState'
+import {AuthBoundary} from './AuthBoundary'
+
+// NOTE: unlike AuthBoundary.test.tsx this file does NOT mock react-error-boundary
+// — we want the REAL ErrorBoundary so we can observe whether it recovers when the
+// auth store transitions back to LOGGED_IN (e.g. after a successful silent token
+// refresh via ComlinkTokenRefresh -> setAuthToken).
+
+vi.mock('@sanity/sdk', async () => {
+  const actual = await vi.importActual('@sanity/sdk')
+  return {
+    ...actual,
+    getIsInDashboardState: vi.fn(() => ({getCurrent: () => true})),
+  }
+})
+
+vi.mock('../../hooks/auth/useAuthState', () => ({useAuthState: vi.fn()}))
+vi.mock('../../hooks/auth/useLoginUrl', () => ({
+  useLoginUrl: vi.fn(() => 'https://example.com/login'),
+}))
+vi.mock('../../hooks/auth/useVerifyOrgProjects', () => ({useVerifyOrgProjects: vi.fn(() => null)}))
+vi.mock('../../hooks/auth/useLogOut', () => ({useLogOut: vi.fn(() => async () => {})}))
+vi.mock('../../hooks/auth/useHandleAuthCallback', () => ({
+  useHandleAuthCallback: vi.fn(() => async () => {}),
+}))
+vi.mock('../../hooks/comlink/useWindowConnection', () => ({
+  useWindowConnection: vi.fn(() => ({fetch: vi.fn().mockResolvedValue({token: 'fresh-token'})})),
+}))
+// Avoid injecting the SanityOS bridge.js <script> during import.
+vi.mock('../utils', () => ({isInIframe: vi.fn(() => false)}))
+
+const mockUseAuthState = useAuthState as Mock
+
+describe('AuthBoundary — recovery after silent token refresh (dashboard)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(getIsInDashboardState as Mock).mockReturnValue({getCurrent: () => true})
+  })
+
+  it('renders the app again once the session is re-established (LOGGED_IN)', async () => {
+    // 1. Session expires: a request 401s and the auth store goes to ERROR.
+    mockUseAuthState.mockReturnValue({
+      type: AuthStateType.ERROR,
+      error: Object.assign(new Error('Unauthorized'), {statusCode: 401}),
+    })
+
+    const {rerender} = render(
+      <ResourceProvider projectId="p" dataset="d" fallback={null}>
+        <AuthBoundary projectIds={['p']}>
+          <div>Protected Content</div>
+        </AuthBoundary>
+      </ResourceProvider>,
+    )
+
+    // The error boundary catches the AuthError and shows the auth-error screen.
+    await waitFor(() => {
+      expect(screen.getByText('Authentication Error')).toBeInTheDocument()
+    })
+
+    // 2. ComlinkTokenRefresh fetches a fresh token from the Dashboard, setAuthToken
+    //    lands it, /users/me re-fetches and the store returns to LOGGED_IN.
+    mockUseAuthState.mockReturnValue({
+      type: AuthStateType.LOGGED_IN,
+      currentUser: null,
+      token: 'fresh-token',
+    })
+    rerender(
+      <ResourceProvider projectId="p" dataset="d" fallback={null}>
+        <AuthBoundary projectIds={['p']}>
+          <div>Protected Content</div>
+        </AuthBoundary>
+      </ResourceProvider>,
+    )
+
+    // EXPECTED (desired) behaviour: the app recovers automatically, no Retry click.
+    await waitFor(() => {
+      expect(screen.getByText('Protected Content')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Authentication Error')).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/auth/AuthBoundary.tsx
+++ b/packages/react/src/components/auth/AuthBoundary.tsx
@@ -109,6 +109,16 @@ export function AuthBoundary({
   LoginErrorComponent = LoginError,
   ...props
 }: AuthBoundaryProps): React.ReactNode {
+  /**
+   * When the session is re-established (e.g. ComlinkTokenRefresh silently mints a
+   * fresh token via setAuthToken), the auth store returns to LOGGED_IN but the
+   * ErrorBoundary stays latched on its fallback until reset. Keying it on the
+   * recovered session lets it clear automatically
+   */
+  const authState = useAuthState()
+  const sessionResetKey =
+    authState.type === AuthStateType.LOGGED_IN ? authState.token : authState.type
+
   const FallbackComponent = useMemo(() => {
     return function LoginComponentWithLayoutProps(fallbackProps: FallbackProps) {
       // Chunk-load errors from any lazy-loaded code beneath this boundary
@@ -131,7 +141,7 @@ export function AuthBoundary({
 
   return (
     <ComlinkTokenRefreshProvider>
-      <ErrorBoundary FallbackComponent={FallbackComponent}>
+      <ErrorBoundary FallbackComponent={FallbackComponent} resetKeys={[sessionResetKey]}>
         <AuthSwitch {...props} />
       </ErrorBoundary>
     </ComlinkTokenRefreshProvider>


### PR DESCRIPTION
When a Sanity app in the Dashboard loses its session (often after an inactive tab), it shows an "Authentication Error" screen — and that screen stays up even once the SDK has quietly obtained a fresh session in the background, forcing the user to click Retry or reload.

This PR makes the auth error screen clear itself automatically as soon as the session is restored, so the app recovers with no user action.