### PR TITLE
chore(renovate): cap branchConcurrentLimit at 5

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
   "postUpdateOptions": ["pnpmDedupe"],
   "schedule": ["before 5am"],
   "prConcurrentLimit": 20,
+  "branchConcurrentLimit": 5,
   "prHourlyLimit": 5,
   "automerge": true,
   "platformAutomerge": true,


### PR DESCRIPTION
### Description

Caps `branchConcurrentLimit` at 5 in `.github/renovate.json`.

Previously this was unset, so Renovate fell back to `prConcurrentLimit` (20) — meaning up to 20 update branches could be resolved/deduped concurrently, each running a `pnpm install` + `pnpm dedupe` lockfile pass. That parallelism is the most likely driver behind a recent Renovate run OOMing (`Ineffective mark-compacts near heap limit`, ~1.5 GB heap). Limiting branch concurrency to 5 caps the parallel lockfile/dedupe work into smaller waves.

`prConcurrentLimit` is intentionally left at 20: it only governs how many PRs stay *open* (no run-time memory cost), so throughput under automerge is unaffected.

### What to review

- The single-line addition in `.github/renovate.json`.
- Confirm 5 is an acceptable branch-processing wave size for our queue depth.

### Testing

Config-only change; no automated test. Effect will be observable on the next scheduled Renovate run (fewer concurrent branch updates, lower peak memory).

### Fun gif

![slow down](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
