### PR TITLE
fix(releases): handle missing metadata

### DIFF
--- a/apps/kitchensink-react/src/routes/releases/ReleasesAutocomplete.tsx
+++ b/apps/kitchensink-react/src/routes/releases/ReleasesAutocomplete.tsx
@@ -22,7 +22,9 @@ export function ReleasesAutocomplete({
       <Autocomplete
         id="release-autocomplete"
         filterOption={(query, option) =>
-          (option.payload.metadata.title ?? '').toLowerCase().indexOf(query.toLowerCase()) > -1
+          (option.payload.metadata?.title ?? option.payload.name ?? '')
+            .toLowerCase()
+            .indexOf(query.toLowerCase()) > -1
         }
         fontSize={[2, 2, 3]}
         icon={<SearchIcon style={{width: '1.5em', height: '1.5em'}} />}
@@ -41,13 +43,13 @@ export function ReleasesAutocomplete({
             <Card as="button" padding={2}>
               <Stack space={2}>
                 <Text size={[2, 2, 3]} weight="semibold">
-                  {release.metadata.title}
+                  {release.metadata?.title || release.name}
                 </Text>
                 <Text size={1} muted>
                   Release ID: {release.name}
                 </Text>
                 <Text size={1}>
-                  Type: {release.metadata.releaseType} | State: {release.state}
+                  Type: {release.metadata?.releaseType ?? 'unknown'} | State: {release.state}
                 </Text>
                 {formattedDate && (
                   <Text size={1} muted>
@@ -58,7 +60,7 @@ export function ReleasesAutocomplete({
             </Card>
           )
         }}
-        renderValue={(value, option) => option?.payload.metadata.title || value}
+        renderValue={(value, option) => option?.payload.metadata?.title || value}
         value={
           isReleasePerspective(selectedPerspective.perspective)
             ? selectedPerspective.perspective.releaseName

--- a/packages/core/src/releases/releasesStore.test.ts
+++ b/packages/core/src/releases/releasesStore.test.ts
@@ -1,5 +1,5 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {NEVER, Observable, type Observer, of, Subject} from 'rxjs'
+import {defer, NEVER, Observable, type Observer, of, Subject, throwError} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {getQueryState, resolveQuery} from '../query/queryStore'
@@ -216,20 +216,75 @@ describe('releasesStore', () => {
     expect(allNames).toHaveLength(3)
   })
 
-  it('should not crash when the releases query errors', async () => {
-    const subject = new Subject<ReleaseDocument[]>()
-    vi.mocked(getQueryState).mockReturnValue({
-      subscribe: () => () => {},
-      getCurrent: () => undefined,
-      observable: subject.asObservable(),
-    } as StateSource<ReleaseDocument[] | undefined>)
+  it('recovers via retry when a transient query error is followed by success', async () => {
+    vi.useFakeTimers()
+    try {
+      const release = {
+        _id: '_.releases.r-active',
+        _type: 'system.release',
+        name: 'r-active',
+        state: 'active',
+        metadata: {releaseType: 'asap'},
+      } as ReleaseDocument
 
-    const state = getActiveReleasesState(instance, {resource: {projectId: 'test', dataset: 'test'}})
+      let attempts = 0
+      const source = defer(() => {
+        attempts += 1
+        return attempts === 1 ? throwError(() => new Error('transient blip')) : of([release])
+      })
+      vi.mocked(getQueryState).mockReturnValue({
+        subscribe: () => () => {},
+        getCurrent: () => undefined,
+        observable: source,
+      } as StateSource<ReleaseDocument[] | undefined>)
 
-    subject.error(new Error('Query failed'))
+      const active = getActiveReleasesState(instance, {
+        resource: {projectId: 'test', dataset: 'test'},
+      })
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
+      // First attempt errors; after the backoff delay the retry re-subscribes
+      // and the second attempt succeeds — no error should surface.
+      await vi.advanceTimersByTimeAsync(600)
 
-    expect(state.getCurrent()).toEqual(undefined)
+      expect(attempts).toBe(2)
+      expect(() => active.getCurrent()).not.toThrow()
+      expect(active.getCurrent()?.map((r) => r.name)).toEqual(['r-active'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('surfaces the error only after retries are exhausted', async () => {
+    vi.useFakeTimers()
+    try {
+      // A permanently-errored subject re-errors every re-subscription, so the
+      // retry budget is exhausted and the error is ultimately surfaced.
+      const subject = new Subject<ReleaseDocument[]>()
+      vi.mocked(getQueryState).mockReturnValue({
+        subscribe: () => () => {},
+        getCurrent: () => undefined,
+        observable: subject.asObservable(),
+      } as StateSource<ReleaseDocument[] | undefined>)
+
+      const active = getActiveReleasesState(instance, {
+        resource: {projectId: 'test', dataset: 'test'},
+      })
+      const all = getAllReleasesState(instance, {resource: {projectId: 'test', dataset: 'test'}})
+
+      const error = new Error('Query failed')
+      subject.error(error)
+
+      // While retries are still pending, the error is not yet surfaced.
+      await vi.advanceTimersByTimeAsync(0)
+      expect(() => active.getCurrent()).not.toThrow()
+
+      // After all backoff delays elapse (500+1000+2000+4000+8000ms), the error
+      // is surfaced rather than silently swallowed.
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(() => active.getCurrent()).toThrow(error)
+      expect(() => all.getCurrent()).toThrow(error)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/core/src/releases/releasesStore.test.ts
+++ b/packages/core/src/releases/releasesStore.test.ts
@@ -1,5 +1,5 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {defer, NEVER, Observable, type Observer, of, Subject, throwError} from 'rxjs'
+import {NEVER, Observable, type Observer, of, Subject} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {getQueryState, resolveQuery} from '../query/queryStore'
@@ -216,75 +216,27 @@ describe('releasesStore', () => {
     expect(allNames).toHaveLength(3)
   })
 
-  it('recovers via retry when a transient query error is followed by success', async () => {
-    vi.useFakeTimers()
-    try {
-      const release = {
-        _id: '_.releases.r-active',
-        _type: 'system.release',
-        name: 'r-active',
-        state: 'active',
-        metadata: {releaseType: 'asap'},
-      } as ReleaseDocument
+  it('should surface the error when the releases query errors', async () => {
+    const subject = new Subject<ReleaseDocument[]>()
+    vi.mocked(getQueryState).mockReturnValue({
+      subscribe: () => () => {},
+      getCurrent: () => undefined,
+      observable: subject.asObservable(),
+    } as StateSource<ReleaseDocument[] | undefined>)
 
-      let attempts = 0
-      const source = defer(() => {
-        attempts += 1
-        return attempts === 1 ? throwError(() => new Error('transient blip')) : of([release])
-      })
-      vi.mocked(getQueryState).mockReturnValue({
-        subscribe: () => () => {},
-        getCurrent: () => undefined,
-        observable: source,
-      } as StateSource<ReleaseDocument[] | undefined>)
+    const active = getActiveReleasesState(instance, {
+      resource: {projectId: 'test', dataset: 'test'},
+    })
+    const all = getAllReleasesState(instance, {resource: {projectId: 'test', dataset: 'test'}})
 
-      const active = getActiveReleasesState(instance, {
-        resource: {projectId: 'test', dataset: 'test'},
-      })
+    const error = new Error('Query failed')
+    subject.error(error)
 
-      // First attempt errors; after the backoff delay the retry re-subscribes
-      // and the second attempt succeeds — no error should surface.
-      await vi.advanceTimersByTimeAsync(600)
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
-      expect(attempts).toBe(2)
-      expect(() => active.getCurrent()).not.toThrow()
-      expect(active.getCurrent()?.map((r) => r.name)).toEqual(['r-active'])
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it('surfaces the error only after retries are exhausted', async () => {
-    vi.useFakeTimers()
-    try {
-      // A permanently-errored subject re-errors every re-subscription, so the
-      // retry budget is exhausted and the error is ultimately surfaced.
-      const subject = new Subject<ReleaseDocument[]>()
-      vi.mocked(getQueryState).mockReturnValue({
-        subscribe: () => () => {},
-        getCurrent: () => undefined,
-        observable: subject.asObservable(),
-      } as StateSource<ReleaseDocument[] | undefined>)
-
-      const active = getActiveReleasesState(instance, {
-        resource: {projectId: 'test', dataset: 'test'},
-      })
-      const all = getAllReleasesState(instance, {resource: {projectId: 'test', dataset: 'test'}})
-
-      const error = new Error('Query failed')
-      subject.error(error)
-
-      // While retries are still pending, the error is not yet surfaced.
-      await vi.advanceTimersByTimeAsync(0)
-      expect(() => active.getCurrent()).not.toThrow()
-
-      // After all backoff delays elapse (500+1000+2000+4000+8000ms), the error
-      // is surfaced rather than silently swallowed.
-      await vi.advanceTimersByTimeAsync(20_000)
-      expect(() => active.getCurrent()).toThrow(error)
-      expect(() => all.getCurrent()).toThrow(error)
-    } finally {
-      vi.useRealTimers()
-    }
+    // The error must be surfaced (thrown) rather than silently swallowed,
+    // otherwise consumers just see an empty list with no signal.
+    expect(() => active.getCurrent()).toThrow(error)
+    expect(() => all.getCurrent()).toThrow(error)
   })
 })

--- a/packages/core/src/releases/releasesStore.ts
+++ b/packages/core/src/releases/releasesStore.ts
@@ -1,5 +1,5 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {map} from 'rxjs'
+import {map, retry, timer} from 'rxjs'
 
 import {type DocumentResource} from '../config/sanityConfig'
 /*
@@ -19,6 +19,10 @@ import {sortReleases} from './utils/sortReleases'
 
 const ARCHIVED_RELEASE_STATES = ['archived', 'published']
 const STABLE_EMPTY_RELEASES: ReleaseDocument[] = []
+
+const RELEASES_RETRY_BASE_DELAY = 500
+const RELEASES_RETRY_MAX_DELAY = 10_000
+const RELEASES_MAX_RETRIES = 5
 
 /**
  * Lifecycle states a release document can be in. Mirrors the server's
@@ -60,7 +64,10 @@ export const releasesStore = defineStore<ReleasesStoreState, BoundResourceKey>({
 const _getActiveReleasesState = bindActionByResource(
   releasesStore,
   createStateSourceAction({
-    selector: ({state}, _?) => state.activeReleases,
+    selector: ({state}) => {
+      if (state.error) throw state.error
+      return state.activeReleases
+    },
   }),
 )
 
@@ -82,7 +89,10 @@ export const getActiveReleasesState = (
 const _getAllReleasesState = bindActionByResource(
   releasesStore,
   createStateSourceAction({
-    selector: ({state}, _?) => state.allReleases,
+    selector: ({state}) => {
+      if (state.error) throw state.error
+      return state.allReleases
+    },
   }),
 )
 
@@ -120,6 +130,14 @@ const subscribeToReleases = ({
             (release) => !ARCHIVED_RELEASE_STATES.includes(release.state),
           ),
         })
+      }),
+      retry({
+        count: RELEASES_MAX_RETRIES,
+        delay: (_error, retryCount) =>
+          timer(
+            Math.min(RELEASES_RETRY_BASE_DELAY * 2 ** (retryCount - 1), RELEASES_RETRY_MAX_DELAY),
+          ),
+        resetOnSuccess: true,
       }),
     )
     .subscribe({error: (error) => state.set('setError', {error})})

--- a/packages/core/src/releases/releasesStore.ts
+++ b/packages/core/src/releases/releasesStore.ts
@@ -1,5 +1,5 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {map, retry, timer} from 'rxjs'
+import {map} from 'rxjs'
 
 import {type DocumentResource} from '../config/sanityConfig'
 /*
@@ -19,10 +19,6 @@ import {sortReleases} from './utils/sortReleases'
 
 const ARCHIVED_RELEASE_STATES = ['archived', 'published']
 const STABLE_EMPTY_RELEASES: ReleaseDocument[] = []
-
-const RELEASES_RETRY_BASE_DELAY = 500
-const RELEASES_RETRY_MAX_DELAY = 10_000
-const RELEASES_MAX_RETRIES = 5
 
 /**
  * Lifecycle states a release document can be in. Mirrors the server's
@@ -118,27 +114,22 @@ const subscribeToReleases = ({
     resource,
     tag: 'releases',
   })
-  return releases$
-    .pipe(
-      map((releases) => {
-        // logic here mirrors that of studio:
-        // https://github.com/sanity-io/sanity/blob/156e8fa482703d99219f08da7bacb384517f1513/packages/sanity/src/core/releases/store/useActiveReleases.ts#L29
-        const sorted = sortReleases(releases ?? STABLE_EMPTY_RELEASES).reverse()
-        state.set('setReleases', {
-          allReleases: sorted,
-          activeReleases: sorted.filter(
-            (release) => !ARCHIVED_RELEASE_STATES.includes(release.state),
-          ),
-        })
-      }),
-      retry({
-        count: RELEASES_MAX_RETRIES,
-        delay: (_error, retryCount) =>
-          timer(
-            Math.min(RELEASES_RETRY_BASE_DELAY * 2 ** (retryCount - 1), RELEASES_RETRY_MAX_DELAY),
-          ),
-        resetOnSuccess: true,
-      }),
-    )
-    .subscribe({error: (error) => state.set('setError', {error})})
+  return (
+    releases$
+      .pipe(
+        map((releases) => {
+          // logic here mirrors that of studio:
+          // https://github.com/sanity-io/sanity/blob/156e8fa482703d99219f08da7bacb384517f1513/packages/sanity/src/core/releases/store/useActiveReleases.ts#L29
+          const sorted = sortReleases(releases ?? STABLE_EMPTY_RELEASES).reverse()
+          state.set('setReleases', {
+            allReleases: sorted,
+            activeReleases: sorted.filter(
+              (release) => !ARCHIVED_RELEASE_STATES.includes(release.state),
+            ),
+          })
+        }),
+      )
+      // the query is retried by the queryStore, so we don't need to retry here
+      .subscribe({error: (error) => state.set('setError', {error})})
+  )
 }

--- a/packages/core/src/releases/utils/sortReleases.test.ts
+++ b/packages/core/src/releases/utils/sortReleases.test.ts
@@ -333,4 +333,40 @@ describe('sortReleases()', () => {
       expect(sorted[idx]['_id']).toContain(expectedName)
     })
   })
+
+  it('should not throw when a release has no metadata', () => {
+    // Releases created without a title/type can come back from the API with no
+    // `metadata` object at all. Sorting must not throw on these, otherwise the
+    // whole releases subscription errors and the list comes back empty.
+    const releaseWithoutMetadata = {
+      _id: '_.releases.rnometa',
+      _rev: 'rev',
+      _type: 'system.release',
+      _createdAt: '2024-10-24T00:00:00Z',
+      _updatedAt: '2024-10-24T00:00:00Z',
+      state: 'active',
+      name: 'rnometa',
+    } as unknown as ReleaseDocument
+
+    const releases: ReleaseDocument[] = [
+      createReleaseMock({
+        _id: '_.releases.rasap1',
+        _createdAt: '2024-10-25T00:00:00Z',
+        metadata: {releaseType: 'asap'},
+      }),
+      releaseWithoutMetadata,
+      createReleaseMock({
+        _id: '_.releases.rundecided1',
+        _createdAt: '2024-10-26T00:00:00Z',
+        metadata: {releaseType: 'undecided'},
+      }),
+    ]
+
+    let sorted: ReleaseDocument[] = []
+    expect(() => {
+      sorted = sortReleases(releases)
+    }).not.toThrow()
+    expect(sorted).toHaveLength(3)
+    expect(sorted.map((r) => r._id)).toContain('_.releases.rnometa')
+  })
 })

--- a/packages/core/src/releases/utils/sortReleases.ts
+++ b/packages/core/src/releases/utils/sortReleases.ts
@@ -6,25 +6,30 @@ export function sortReleases(releases: ReleaseDocument[] = []): ReleaseDocument[
   // The order should always be:
   // [undecided (sortByCreatedAt), scheduled(sortBy publishAt || metadata.intendedPublishAt), asap(sortByCreatedAt)]
   return [...releases].sort((a, b) => {
+    // metadata is optional on a release document; guard against releases that
+    // have no metadata at all so sorting can't throw and wipe out the list.
+    const aType = a.metadata?.releaseType
+    const bType = b.metadata?.releaseType
+
     // undecided are always first, then by createdAt descending
-    if (a.metadata.releaseType === 'undecided' && b.metadata.releaseType !== 'undecided') {
+    if (aType === 'undecided' && bType !== 'undecided') {
       return -1
     }
-    if (a.metadata.releaseType !== 'undecided' && b.metadata.releaseType === 'undecided') {
+    if (aType !== 'undecided' && bType === 'undecided') {
       return 1
     }
-    if (a.metadata.releaseType === 'undecided' && b.metadata.releaseType === 'undecided') {
+    if (aType === 'undecided' && bType === 'undecided') {
       // Sort by createdAt
       return new Date(b._createdAt).getTime() - new Date(a._createdAt).getTime()
     }
 
     // Scheduled are always at the middle, then by publishAt descending
-    if (a.metadata.releaseType === 'scheduled' && b.metadata.releaseType === 'scheduled') {
-      const aPublishAt = a['publishAt'] || a.metadata['intendedPublishAt']
+    if (aType === 'scheduled' && bType === 'scheduled') {
+      const aPublishAt = a['publishAt'] || a.metadata?.['intendedPublishAt']
       if (!aPublishAt) {
         return 1
       }
-      const bPublishAt = b['publishAt'] || b.metadata['intendedPublishAt']
+      const bPublishAt = b['publishAt'] || b.metadata?.['intendedPublishAt']
       if (!bPublishAt) {
         return -1
       }
@@ -32,13 +37,13 @@ export function sortReleases(releases: ReleaseDocument[] = []): ReleaseDocument[
     }
 
     // ASAP are always last, then by createdAt descending
-    if (a.metadata.releaseType === 'asap' && b.metadata.releaseType !== 'asap') {
+    if (aType === 'asap' && bType !== 'asap') {
       return 1
     }
-    if (a.metadata.releaseType !== 'asap' && b.metadata.releaseType === 'asap') {
+    if (aType !== 'asap' && bType === 'asap') {
       return -1
     }
-    if (a.metadata.releaseType === 'asap' && b.metadata.releaseType === 'asap') {
+    if (aType === 'asap' && bType === 'asap') {
       // Sort by createdAt
       return new Date(b._createdAt).getTime() - new Date(a._createdAt).getTime()
     }


### PR DESCRIPTION
### Description
The `sortReleases` logic was a bit more fragile than I realized; although we have type guards across the client et al that prevent releases being made without metadata, it's [possible to create a release document without metadata](https://ppsg7ml5.api.sanity.io/v2026-07-08/data/query/test?query=*%5B_id+%3D%3D+%27_.releases.carolina-test-1%27%5D&perspective=drafts). This ended up bricking the whole store and resulted in releases hooks silently returning nothing.

This PR accounts for the possibility of missing metadata and improves error handling.

### What to review
Are the guards still fragile in any way?

### Testing
Tests added and updated. I don't know why Fallow thinks that file is not being used. It is being used.

### Fun gif
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExdW52NHMzM2cxZnJha21veDZ1NThuNDR2czQwN2UzeHY3Nnk0a2xmNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tIeCLkB8geYtW/giphy.gif)