### PR TITLE
fix(core): recover queries after fetch, live-connection, and suspense errors

### DIFF
--- a/packages/core/src/query/queryStore.test.ts
+++ b/packages/core/src/query/queryStore.test.ts
@@ -7,12 +7,7 @@ import {isCanvasResource} from '../config/sanityConfig'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
 import {getQueryState, resolveQuery} from './queryStore'
-
-vi.mock('./queryStoreConstants', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('./queryStoreConstants')>()),
-  QUERY_STATE_CLEAR_DELAY: 10,
-  LIVE_EVENTS_RETRY_DELAY: 10,
-}))
+import {LIVE_EVENTS_RETRY_DELAY, QUERY_STATE_CLEAR_DELAY} from './queryStoreConstants'
 
 vi.mock('../client/clientStore', () => ({
   getClientState: vi.fn(),
@@ -35,6 +30,14 @@ vi.mock('../releases/getPerspectiveState', async () => {
   }
 })
 
+// With fake timers, an emission gated on a pending rxjs delay or cleanup
+// timeout never arrives on its own: create the promise first, advance the
+// clock, then await it.
+async function advanceAndAwait<T>(promise: Promise<T>, ms = 0): Promise<T> {
+  await vi.advanceTimersByTimeAsync(ms)
+  return promise
+}
+
 describe('queryStore', () => {
   let instance: SanityInstance
   let liveEvents: Subject<LiveEvent>
@@ -49,6 +52,7 @@ describe('queryStore', () => {
   }
 
   beforeEach(() => {
+    vi.useFakeTimers()
     instance = createSanityInstance({projectId: 'test', dataset: 'test'})
 
     fetch = vi
@@ -77,6 +81,7 @@ describe('queryStore', () => {
   afterEach(() => {
     vi.mocked(getClientState).mockClear()
     instance.dispose()
+    vi.useRealTimers()
   })
 
   it('initializes query state and cleans up after unsubscribe', async () => {
@@ -90,7 +95,7 @@ describe('queryStore', () => {
     const unsubscribe = state.subscribe()
 
     // Wait for data to be fetched
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
 
     // Verify data is present
     expect(state.getCurrent()).toEqual([
@@ -102,7 +107,7 @@ describe('queryStore', () => {
     unsubscribe()
 
     // Wait for the cleanup delay
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await vi.advanceTimersByTimeAsync(QUERY_STATE_CLEAR_DELAY)
 
     // Verify state is cleared
     expect(state.getCurrent()).toBeUndefined()
@@ -117,7 +122,7 @@ describe('queryStore', () => {
     const unsubscribe2 = state.subscribe()
 
     // Wait for data to be fetched
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
 
     // Verify data is present
     expect(state.getCurrent()).toEqual([
@@ -138,7 +143,7 @@ describe('queryStore', () => {
     unsubscribe2()
 
     // Wait for cleanup delay
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await vi.advanceTimersByTimeAsync(QUERY_STATE_CLEAR_DELAY)
 
     // Verify state is cleared after all subscribers are gone
     expect(state.getCurrent()).toBeUndefined()
@@ -154,7 +159,7 @@ describe('queryStore', () => {
 
     // resolveQuery holds only a temporary subscriber (released after the
     // clear delay once the promise settles)
-    const result = await resolveQuery(instance, {query})
+    const result = await advanceAndAwait(resolveQuery(instance, {query}))
     expect(result).toEqual([
       {_id: 'movie1', _type: 'movie', title: 'Movie 1'},
       {_id: 'movie2', _type: 'movie', title: 'Movie 2'},
@@ -171,7 +176,7 @@ describe('queryStore', () => {
     // Subscribing and unsubscribing should nuke the state now
     const unsubscribe = state.subscribe()
     unsubscribe()
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await vi.advanceTimersByTimeAsync(QUERY_STATE_CLEAR_DELAY)
     expect(state.getCurrent()).toBeUndefined()
   })
 
@@ -195,7 +200,7 @@ describe('queryStore', () => {
     // resolveQuery re-adds it, which only triggers a fresh fetch if the abort
     // actually released the previous temporary subscriber
     const callsBefore = vi.mocked(fetch).mock.calls.length
-    await expect(resolveQuery(instance, {query})).resolves.toEqual(mockData.movies)
+    await expect(advanceAndAwait(resolveQuery(instance, {query}))).resolves.toEqual(mockData.movies)
     expect(vi.mocked(fetch).mock.calls.length).toBe(callsBefore + 1)
   })
 
@@ -218,7 +223,7 @@ describe('queryStore', () => {
     const state = getQueryState<{_id: string; _type: string; title: string}[]>(instance, {query})
 
     const unsubscribe = state.subscribe()
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
 
     // Emit live event with matching sync tag
     liveEvents.next({
@@ -230,7 +235,9 @@ describe('queryStore', () => {
     } as LiveEvent)
 
     // Wait for updated data
-    const result = await firstValueFrom(state.observable.pipe(filter((data) => data?.length === 3)))
+    const result = await advanceAndAwait(
+      firstValueFrom(state.observable.pipe(filter((data) => data?.length === 3))),
+    )
 
     expect(fetch).toHaveBeenCalledTimes(2)
     expect(vi.mocked(fetch).mock.calls[1][2]?.lastLiveEventId).toBe('event1')
@@ -249,7 +256,7 @@ describe('queryStore', () => {
     const state = getQueryState(instance, {query})
 
     const unsubscribe = state.subscribe()
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
 
     // Emit event with different tag
     liveEvents.next({
@@ -260,7 +267,7 @@ describe('queryStore', () => {
       event: 'created',
     } as LiveEvent)
 
-    await new Promise((resolve) => setTimeout(resolve, 50)) // Allow time for potential refetch
+    await vi.advanceTimersByTimeAsync(50) // Allow time for potential refetch
     expect(fetch).toHaveBeenCalledTimes(1)
 
     unsubscribe()
@@ -282,7 +289,7 @@ describe('queryStore', () => {
     const state = getQueryState(instance, {query})
 
     const unsubscribe = state.subscribe()
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
 
     // Emit two events with same tag
     liveEvents.next({
@@ -297,7 +304,7 @@ describe('queryStore', () => {
       tags: mockSyncTags,
     })
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await vi.advanceTimersByTimeAsync(0)
     expect(fetch).toHaveBeenCalledTimes(3)
     expect(vi.mocked(fetch).mock.calls[1][2]?.lastLiveEventId).toBe('event1')
     expect(vi.mocked(fetch).mock.calls[2][2]?.lastLiveEventId).toBe('event2')
@@ -340,16 +347,18 @@ describe('queryStore', () => {
     unsub1()
 
     // Wait for the clear delay so the key is fully removed from state
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await vi.advanceTimersByTimeAsync(QUERY_STATE_CLEAR_DELAY)
 
     // Retry with the same key — must trigger a fresh fetch
     const state2 = getQueryState(instance, {query})
     const unsub2 = state2.subscribe()
 
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await vi.advanceTimersByTimeAsync(0)
     expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2)
 
-    const result = await firstValueFrom(state2.observable.pipe(filter((i) => i !== undefined)))
+    const result = await advanceAndAwait(
+      firstValueFrom(state2.observable.pipe(filter((i) => i !== undefined))),
+    )
     expect(result).toEqual(mockData.movies)
     unsub2()
   })
@@ -373,18 +382,18 @@ describe('queryStore', () => {
     // After the clear delay, the errored key must be released — otherwise it
     // has no subscribers, nothing ever removes it, and every future mount
     // rethrows the stored error without ever fetching
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await vi.advanceTimersByTimeAsync(QUERY_STATE_CLEAR_DELAY)
     expect(state.getCurrent()).toBeUndefined()
 
     // A retry now creates a fresh key and fetches
-    await expect(resolveQuery(instance, {query})).resolves.toEqual(mockData.movies)
+    await expect(advanceAndAwait(resolveQuery(instance, {query}))).resolves.toEqual(mockData.movies)
   })
 
   it('stops live updates without retrying or erroring on DisconnectError', async () => {
     const query = '*[_type == "movie"]'
     const state = getQueryState(instance, {query})
     const unsub = state.subscribe()
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
 
     // Grab the live events factory from the client the store is subscribed to
     const clientState = vi.mocked(getClientState).mock.results[0]
@@ -395,8 +404,8 @@ describe('queryStore', () => {
 
     // The server instructed the client to stop reconnecting
     liveEvents.error(new DisconnectError('Server disconnected client'))
-    // Wait past several (mocked, 10ms) retry delays
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    // Advance past several retry delays
+    await vi.advanceTimersByTimeAsync(LIVE_EVENTS_RETRY_DELAY * 5)
 
     // No store-wide error, and no reconnect attempts (a retry would call
     // live.events again)
@@ -409,11 +418,11 @@ describe('queryStore', () => {
     const query = '*[_type == "movie"]'
     const state = getQueryState(instance, {query})
     const unsub = state.subscribe()
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
 
     // The live connection drops (e.g. network goes offline)
     liveEvents.error(new Error('live connection lost'))
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await vi.advanceTimersByTimeAsync(0)
 
     // Existing query state must remain readable — a lost live connection must
     // not poison the whole store
@@ -423,10 +432,12 @@ describe('queryStore', () => {
 
     // Wait for the clear delay so the key is fully removed, then re-add it —
     // fetching must still work
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await vi.advanceTimersByTimeAsync(QUERY_STATE_CLEAR_DELAY)
     const state2 = getQueryState(instance, {query})
     const unsub2 = state2.subscribe()
-    const result = await firstValueFrom(state2.observable.pipe(filter((i) => i !== undefined)))
+    const result = await advanceAndAwait(
+      firstValueFrom(state2.observable.pipe(filter((i) => i !== undefined))),
+    )
     expect(result).toEqual(mockData.movies)
     unsub2()
   })
@@ -436,14 +447,14 @@ describe('queryStore', () => {
     const state = getQueryState(instance, {query})
     const unsubscribe = state.subscribe()
 
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
 
     unsubscribe()
     // Immediately after unsubscription, state should still be present due to delay
     expect(state.getCurrent()).not.toBeUndefined()
 
     // Wait for the cleanup delay and then state should be removed
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await vi.advanceTimersByTimeAsync(QUERY_STATE_CLEAR_DELAY)
     expect(state.getCurrent()).toBeUndefined()
   })
 
@@ -452,7 +463,7 @@ describe('queryStore', () => {
     const state = getQueryState(instance, {query})
     const unsubscribe1 = state.subscribe()
 
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
     expect(state.getCurrent()).toEqual([
       {_id: 'movie1', _type: 'movie', title: 'Movie 1'},
       {_id: 'movie2', _type: 'movie', title: 'Movie 2'},
@@ -460,13 +471,13 @@ describe('queryStore', () => {
 
     unsubscribe1()
     // Wait less than the cleanup delay
-    await new Promise((resolve) => setTimeout(resolve, 5))
+    await vi.advanceTimersByTimeAsync(QUERY_STATE_CLEAR_DELAY / 2)
 
     // Subscribe again before cleanup occurs
     const unsubscribe2 = state.subscribe()
 
     // Wait for cleanup delay to pass
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await vi.advanceTimersByTimeAsync(QUERY_STATE_CLEAR_DELAY)
 
     // Since a subscriber now exists, state should still be present
     expect(state.getCurrent()).toEqual([
@@ -506,11 +517,11 @@ describe('queryStore', () => {
     const unsubDrafts = sDrafts.subscribe()
     const unsubPublished = sPublished.subscribe()
 
-    const draftsResult = await firstValueFrom(
-      sDrafts.observable.pipe(filter((i) => i !== undefined)),
+    const draftsResult = await advanceAndAwait(
+      firstValueFrom(sDrafts.observable.pipe(filter((i) => i !== undefined))),
     )
-    const publishedResult = await firstValueFrom(
-      sPublished.observable.pipe(filter((i) => i !== undefined)),
+    const publishedResult = await advanceAndAwait(
+      firstValueFrom(sPublished.observable.pipe(filter((i) => i !== undefined))),
     )
 
     expect(draftsResult).toEqual([{_id: 'drafts'}])
@@ -546,11 +557,11 @@ describe('queryStore', () => {
     const unsubDrafts = sDrafts.subscribe()
     const unsubPublished = sPublished.subscribe()
 
-    const draftsResult = await firstValueFrom(
-      sDrafts.observable.pipe(filter((i) => i !== undefined)),
+    const draftsResult = await advanceAndAwait(
+      firstValueFrom(sDrafts.observable.pipe(filter((i) => i !== undefined))),
     )
-    const publishedResult = await firstValueFrom(
-      sPublished.observable.pipe(filter((i) => i !== undefined)),
+    const publishedResult = await advanceAndAwait(
+      firstValueFrom(sPublished.observable.pipe(filter((i) => i !== undefined))),
     )
 
     expect(draftsResult).toEqual([{_id: 'drafts'}])
@@ -569,7 +580,7 @@ describe('queryStore', () => {
     const state = getQueryState(instance, {query, resource: mediaLibrarySource})
     const unsubscribe = state.subscribe()
 
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
 
     // Verify getClientState was called with the resource from params in listenForNewSubscribersAndFetch
     // This call includes projectId, dataset, and resource
@@ -592,7 +603,7 @@ describe('queryStore', () => {
     const state = getQueryState(instance, {query, resource: canvasSource})
     const unsubscribe = state.subscribe()
 
-    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
 
     // Verify getClientState was called with the canvas resource for live events
     // The resource is extracted from the store key and passed when it's not a dataset resource

--- a/packages/core/src/query/queryStore.test.ts
+++ b/packages/core/src/query/queryStore.test.ts
@@ -317,6 +317,35 @@ describe('queryStore', () => {
     unsubscribe()
   })
 
+  it('refetches when a query key is re-added after an error', async () => {
+    // First fetch fails (e.g. transient network failure)
+    vi.mocked(fetch).mockReturnValueOnce(
+      new Observable((observer) => {
+        observer.error(new Error('transient network failure'))
+      }),
+    )
+
+    const query = '*[_type == "movie"]'
+    const state1 = getQueryState(instance, {query})
+    const unsub1 = state1.subscribe()
+    expect(() => state1.getCurrent()).toThrow('transient network failure')
+    unsub1()
+
+    // Wait for the clear delay so the key is fully removed from state
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    // Retry with the same key — must trigger a fresh fetch
+    const state2 = getQueryState(instance, {query})
+    const unsub2 = state2.subscribe()
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2)
+
+    const result = await firstValueFrom(state2.observable.pipe(filter((i) => i !== undefined)))
+    expect(result).toEqual(mockData.movies)
+    unsub2()
+  })
+
   it('delays query state removal after unsubscribe', async () => {
     const query = '*[_type == "movie"]'
     const state = getQueryState(instance, {query})

--- a/packages/core/src/query/queryStore.test.ts
+++ b/packages/core/src/query/queryStore.test.ts
@@ -1,4 +1,4 @@
-import {type LiveEvent, type SanityClient, type SyncTag} from '@sanity/client'
+import {DisconnectError, type LiveEvent, type SanityClient, type SyncTag} from '@sanity/client'
 import {delay, filter, firstValueFrom, Observable, of, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -11,6 +11,7 @@ import {getQueryState, resolveQuery} from './queryStore'
 vi.mock('./queryStoreConstants', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./queryStoreConstants')>()),
   QUERY_STATE_CLEAR_DELAY: 10,
+  LIVE_EVENTS_RETRY_DELAY: 10,
 }))
 
 vi.mock('../client/clientStore', () => ({
@@ -151,17 +152,17 @@ describe('queryStore', () => {
     // Check that getQueryState starts undefined
     expect(state.getCurrent()).toBeUndefined()
 
-    // Use resolveQuery which should not add a subscriber
+    // resolveQuery holds only a temporary subscriber (released after the
+    // clear delay once the promise settles)
     const result = await resolveQuery(instance, {query})
     expect(result).toEqual([
       {_id: 'movie1', _type: 'movie', title: 'Movie 1'},
       {_id: 'movie2', _type: 'movie', title: 'Movie 2'},
     ])
 
-    // Check that getQueryState starts resolved now.
-    // Note that this behavior is important for supporting suspense.
-    // `resolveQuery` is the only way to resolve state without adding a
-    // subscriber that can trigger a clean up
+    // Check that getQueryState is resolved now. This behavior is important
+    // for supporting suspense: the resolved state must remain readable while
+    // React re-renders and attaches a lasting subscriber
     expect(state.getCurrent()).toEqual([
       {_id: 'movie1', _type: 'movie', title: 'Movie 1'},
       {_id: 'movie2', _type: 'movie', title: 'Movie 2'},
@@ -189,6 +190,13 @@ describe('queryStore', () => {
 
     // Verify state is cleared after abort
     expect(getQueryState(instance, {query}).getCurrent()).toBeUndefined()
+
+    // The key must be removed immediately (not after the clear delay): a new
+    // resolveQuery re-adds it, which only triggers a fresh fetch if the abort
+    // actually released the previous temporary subscriber
+    const callsBefore = vi.mocked(fetch).mock.calls.length
+    await expect(resolveQuery(instance, {query})).resolves.toEqual(mockData.movies)
+    expect(vi.mocked(fetch).mock.calls.length).toBe(callsBefore + 1)
   })
 
   it('refetches query when receiving live event with matching sync tag', async () => {
@@ -341,6 +349,83 @@ describe('queryStore', () => {
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2)
 
+    const result = await firstValueFrom(state2.observable.pipe(filter((i) => i !== undefined)))
+    expect(result).toEqual(mockData.movies)
+    unsub2()
+  })
+
+  it('releases an errored key created by resolveQuery so a retry can refetch', async () => {
+    vi.mocked(fetch).mockReturnValueOnce(
+      new Observable((observer) => {
+        observer.error(new Error('network down'))
+      }),
+    )
+
+    const query = '*[_type == "movie"]'
+    // This is how React drives a suspended query: resolveQuery creates the
+    // key without any subscriber (the component never commits when it throws)
+    await expect(resolveQuery(instance, {query})).rejects.toThrow('network down')
+
+    // While the errored key exists, the error surfaces to error boundaries
+    const state = getQueryState(instance, {query})
+    expect(() => state.getCurrent()).toThrow('network down')
+
+    // After the clear delay, the errored key must be released — otherwise it
+    // has no subscribers, nothing ever removes it, and every future mount
+    // rethrows the stored error without ever fetching
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(state.getCurrent()).toBeUndefined()
+
+    // A retry now creates a fresh key and fetches
+    await expect(resolveQuery(instance, {query})).resolves.toEqual(mockData.movies)
+  })
+
+  it('stops live updates without retrying or erroring on DisconnectError', async () => {
+    const query = '*[_type == "movie"]'
+    const state = getQueryState(instance, {query})
+    const unsub = state.subscribe()
+    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+
+    // Grab the live events factory from the client the store is subscribed to
+    const clientState = vi.mocked(getClientState).mock.results[0]
+      ?.value as StateSource<SanityClient>
+    const client = await firstValueFrom(clientState.observable)
+    const eventsMock = vi.mocked(client.live.events)
+    const callsBefore = eventsMock.mock.calls.length
+
+    // The server instructed the client to stop reconnecting
+    liveEvents.error(new DisconnectError('Server disconnected client'))
+    // Wait past several (mocked, 10ms) retry delays
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // No store-wide error, and no reconnect attempts (a retry would call
+    // live.events again)
+    expect(() => state.getCurrent()).not.toThrow()
+    expect(eventsMock.mock.calls.length).toBe(callsBefore)
+    unsub()
+  })
+
+  it('keeps queries working after the live events connection errors', async () => {
+    const query = '*[_type == "movie"]'
+    const state = getQueryState(instance, {query})
+    const unsub = state.subscribe()
+    await firstValueFrom(state.observable.pipe(filter((i) => i !== undefined)))
+
+    // The live connection drops (e.g. network goes offline)
+    liveEvents.error(new Error('live connection lost'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Existing query state must remain readable — a lost live connection must
+    // not poison the whole store
+    expect(() => state.getCurrent()).not.toThrow()
+    expect(state.getCurrent()).toEqual(mockData.movies)
+    unsub()
+
+    // Wait for the clear delay so the key is fully removed, then re-add it —
+    // fetching must still work
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    const state2 = getQueryState(instance, {query})
+    const unsub2 = state2.subscribe()
     const result = await firstValueFrom(state2.observable.pipe(filter((i) => i !== undefined)))
     expect(result).toEqual(mockData.movies)
     unsub2()

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -208,14 +208,18 @@ const listenForNewSubscribersAndFetch = ({state, instance}: StoreContext<QuerySt
                   tag,
                 }),
               ),
+              tap(({result, syncTags}) => {
+                state.set('setQueryData', setQueryData(group$.key, result, syncTags))
+              }),
+              // Catch inside the per-event stream: erroring the group pipe would
+              // complete the group's subscription, and since `groupBy` above never
+              // removes its group subjects, re-adding the key would emit into a
+              // subject with no subscribers — the key could never be fetched again.
+              catchError((error) => {
+                state.set('setQueryError', setQueryError(group$.key, error))
+                return EMPTY
+              }),
             )
-          }),
-          catchError((error) => {
-            state.set('setQueryError', setQueryError(group$.key, error))
-            return EMPTY
-          }),
-          tap(({result, syncTags}) => {
-            state.set('setQueryData', setQueryData(group$.key, result, syncTags))
           }),
         ),
       ),

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -1,4 +1,4 @@
-import {CorsOriginError, type ResponseQueryOptions} from '@sanity/client'
+import {CorsOriginError, DisconnectError, type ResponseQueryOptions} from '@sanity/client'
 import {type SanityQueryResult} from 'groq'
 import {
   catchError,
@@ -17,6 +17,7 @@ import {
   of,
   pairwise,
   race,
+  retry,
   share,
   startWith,
   switchMap,
@@ -47,14 +48,13 @@ import {defineStore, type StoreContext} from '../store/defineStore'
 import {insecureRandomId} from '../utils/ids'
 import {setCleanupTimeout} from '../utils/setCleanupTimeout'
 import {
+  LIVE_EVENTS_RETRY_DELAY,
   QUERY_STATE_CLEAR_DELAY,
   QUERY_STORE_API_VERSION,
   QUERY_STORE_DEFAULT_PERSPECTIVE,
 } from './queryStoreConstants'
 import {
   addSubscriber,
-  cancelQuery,
-  initializeQuery,
   type QueryStoreState,
   removeSubscriber,
   setLastLiveEventId,
@@ -246,8 +246,20 @@ const listenToLiveClientAndSetLastLiveEventIds = ({
             state.set('setError', {error})
             return EMPTY
           }
+          if (error instanceof DisconnectError) {
+            // The server explicitly told this client to stop reconnecting —
+            // end live updates without erroring the store (queries keep
+            // serving, they just stop receiving live invalidation)
+            return EMPTY
+          }
           throw error
         }),
+        // Server-initiated live errors (e.g. ChannelError, MessageError) are
+        // retried, not surfaced: an error here would reach the outer
+        // subscription's errorHandler, set the store-wide `state.error`, and
+        // permanently brick every query selector (nothing ever clears it).
+        // Dropped connections are already reconnected inside @sanity/client.
+        retry({delay: LIVE_EVENTS_RETRY_DELAY}),
       ),
     ),
     share(),
@@ -350,13 +362,14 @@ const _getQueryState = bindActionByResource(
  * Resolves the result of a query without registering a lasting subscriber.
  *
  * This function fetches the result of a GROQ query and returns a promise that resolves with the query result.
- * Unlike `getQueryState`, which registers subscribers to keep the query live and performs automatic cleanup,
- * `resolveQuery` does not track subscribers. This makes it ideal for use with React Suspense, where the returned
- * promise is thrown to delay rendering until the query result becomes available.
+ * It registers a temporary subscriber for the lifetime of the resolution (released shortly after the promise
+ * settles), so the query state participates in normal cleanup even when no lasting subscriber ever attaches —
+ * e.g. when a suspended component errors before committing. This makes it ideal for use with React Suspense,
+ * where the returned promise is thrown to delay rendering until the query result becomes available.
  * Once the promise resolves, it is expected that a real subscriber will be added via `getQueryState` to manage ongoing updates.
  *
  * Additionally, an optional AbortSignal can be provided to cancel the query and immediately clear the associated state
- * if there are no active subscribers.
+ * if there are no other active subscribers.
  *
  * @beta
  */
@@ -385,6 +398,14 @@ const _resolveQuery = bindActionByResource(
     const {getCurrent} = getQueryState(instance, normalized)
     const key = getQueryKey(normalized)
 
+    // Hold a temporary subscription for the lifetime of this resolution so the
+    // key participates in normal cleanup. Without one, a fetch that errors
+    // while a component is suspended leaves a subscriber-less key behind — the
+    // component never commits, so no other subscriber exists — and its stored
+    // error would be rethrown on every future mount without ever refetching.
+    const subscriptionId = insecureRandomId()
+    state.set('addSubscriber', addSubscriber(key, subscriptionId))
+
     const aborted$ = signal
       ? new Observable<void>((observer) => {
           const cleanup = () => {
@@ -402,20 +423,29 @@ const _resolveQuery = bindActionByResource(
         }).pipe(
           catchError((error) => {
             if (error instanceof Error && error.name === 'AbortError') {
-              state.set('cancelQuery', cancelQuery(key))
+              // Release immediately (not after the clear delay) so that when
+              // this was the only subscriber, the key removal tears down the
+              // in-flight request right away — e.g. when useQuery switches
+              // to a different query
+              state.set('removeSubscriber', removeSubscriber(key, subscriptionId))
             }
             throw error
           }),
         )
       : NEVER
 
-    state.set('initializeQuery', initializeQuery(key))
-
     const resolved$ = state.observable.pipe(
       map(getCurrent),
       first((i) => i !== undefined),
     )
 
-    return firstValueFrom(race([resolved$, aborted$]))
+    const promise = firstValueFrom(race([resolved$, aborted$]))
+    const releaseSubscriber = () => {
+      setCleanupTimeout(() => {
+        state.set('removeSubscriber', removeSubscriber(key, subscriptionId))
+      }, QUERY_STATE_CLEAR_DELAY)
+    }
+    promise.then(releaseSubscriber, releaseSubscriber)
+    return promise
   },
 )

--- a/packages/core/src/query/queryStoreConstants.ts
+++ b/packages/core/src/query/queryStoreConstants.ts
@@ -8,3 +8,12 @@
 export const QUERY_STATE_CLEAR_DELAY = 1000
 export const QUERY_STORE_API_VERSION = 'v2025-05-06'
 export const QUERY_STORE_DEFAULT_PERSPECTIVE = 'drafts'
+
+/**
+ * Delay before re-establishing the live events connection after a
+ * server-initiated error (e.g. ChannelError, MessageError). Live errors are
+ * retried rather than surfaced because an errored live connection would
+ * otherwise poison the whole store. Plain connection drops never reach this —
+ * they are reconnected inside `@sanity/client`.
+ */
+export const LIVE_EVENTS_RETRY_DELAY = 1000

--- a/packages/core/src/query/reducers.test.ts
+++ b/packages/core/src/query/reducers.test.ts
@@ -2,8 +2,6 @@ import {describe, expect, it} from 'vitest'
 
 import {
   addSubscriber,
-  cancelQuery,
-  initializeQuery,
   type QueryStoreState,
   removeSubscriber,
   setLastLiveEventId,
@@ -107,46 +105,6 @@ describe('Query Reducers', () => {
       const reducer = removeSubscriber('q8', 'onlySub')
       const newState = reducer(state)
       expect(newState.queries).not.toHaveProperty('q8')
-    })
-  })
-
-  describe('cancelQuery', () => {
-    it('should return state unchanged if key does not exist', () => {
-      const state: QueryStoreState = {queries: {}}
-      const reducer = cancelQuery('nonexistent')
-      const newState = reducer(state)
-      expect(newState).toBe(state)
-    })
-
-    it('should return state unchanged if query has subscribers', () => {
-      const state: QueryStoreState = {queries: {q9: {subscribers: ['sub1']}}}
-      const reducer = cancelQuery('q9')
-      const newState = reducer(state)
-      expect(newState).toBe(state)
-    })
-
-    it('should remove the query if no subscribers exist', () => {
-      const state: QueryStoreState = {queries: {q10: {subscribers: []}}}
-      const reducer = cancelQuery('q10')
-      const newState = reducer(state)
-      expect(newState.queries).not.toHaveProperty('q10')
-    })
-  })
-
-  describe('initializeQuery', () => {
-    it('should return state unchanged if query already exists', () => {
-      const existing = {subscribers: ['sub1']}
-      const state: QueryStoreState = {queries: {q11: existing}}
-      const reducer = initializeQuery('q11')
-      const newState = reducer(state)
-      expect(newState).toBe(state)
-    })
-
-    it('should add the query with empty subscribers if it does not exist', () => {
-      const state: QueryStoreState = {queries: {}}
-      const reducer = initializeQuery('q12')
-      const newState = reducer(state)
-      expect(newState.queries['q12']).toEqual({subscribers: []})
     })
   })
 })

--- a/packages/core/src/query/reducers.ts
+++ b/packages/core/src/query/reducers.ts
@@ -57,19 +57,3 @@ export const removeSubscriber =
     if (!subscribers.length) return {...prev, queries: omitProperty(prev.queries, key)}
     return {...prev, queries: {...prev.queries, [key]: {...prevQuery, subscribers}}}
   }
-
-export const cancelQuery =
-  (key: string) =>
-  (prev: QueryStoreState): QueryStoreState => {
-    const prevQuery = prev.queries[key]
-    if (!prevQuery) return prev
-    if (prevQuery.subscribers.length) return prev
-    return {...prev, queries: omitProperty(prev.queries, key)}
-  }
-
-export const initializeQuery =
-  (key: string) =>
-  (prev: QueryStoreState): QueryStoreState => {
-    if (prev.queries[key]) return prev
-    return {...prev, queries: {...prev.queries, [key]: {subscribers: []}}}
-  }


### PR DESCRIPTION
### Description

A query that errored once could get permanently stuck until page reload. Three distinct defects, each fixed with a regression test:

1. **Errored query keys never refetched.** `catchError(() => EMPTY)` on the per-key `groupBy` group pipe completed the group's subscription; re-added keys emitted into a dead Subject. Moved `tap`/`catchError` inside the per-event fetch stream so an error only ends that fetch.
2. **One live-events error bricked the whole store.** Non-CORS errors from `client.live.events()` set the store-global `state.error`, which every selector throws and nothing clears. Now retried with a delay; `DisconnectError` ends live updates quietly instead of reconnecting against the server's instruction.
3. **A query that errored while suspended left an immortal key.** The component never commits, so no subscriber exists and nothing could remove the errored key — every retry rethrew the stored error. `resolveQuery` now holds a temporary subscriber, released after the clear delay when its promise settles (immediately on abort).

Fixes 1 and 3 depend on each other; 2 is independent. Dead `initializeQuery`/`cancelQuery` reducers removed.

FIXES SDK-1872

### What to review

`packages/core/src/query/queryStore.ts` — the three changes above. Behavior notes: abort removes the key immediately via `removeSubscriber` (was `cancelQuery`); resolved-but-never-subscribed query state now expires after the clear delay instead of persisting forever.

### Testing

Five regression tests in `queryStore.test.ts`, one per behavior (each fails without its fix). Full core suite passes (83 files / 1000 tests). Verified manually: force one fetch failure via DevTools offline, go back online, retry — previously no request ever fired again; now it refetches.

### Fun gif

![Try again](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2ZoZmVmd2xrYmxuZ3Q2aXQxc2M2c2Q3aWl4dWt3d2J4Z2ZqeHd0ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JycbitpNwZJDq/giphy.gif)
