### PR TITLE
refactor(auth): remove unreachable lock-based stamped token refresh

### DIFF
--- a/packages/core/guides/AuthenticationGuide.md
+++ b/packages/core/guides/AuthenticationGuide.md
@@ -161,10 +161,10 @@ The primary interactive authentication flow involves redirecting the user to `sa
   - Runs periodically **only** for stamped tokens identified by containing a `-st` suffix.
 
   - Calls the `/auth/refresh-token` endpoint using the current stamped token to extend the token's validity or get a new one based on the active session, preventing the user from being logged out unexpectedly in long-lived browser sessions.
-    - Uses the Web Locks API (`navigator.locks`) for coordination when running
-      outside the dashboard context to prevent multiple tabs from attempting to
-      refresh simultaneously. Falls back to uncoordinated refresh if Locks API is
-      unavailable.
 
-  - When running inside the dashboard context, it uses a simpler timer mechanism
-    as coordination is not needed because each tab/host will have its own `sid` and therefore its own stamped token.
+  - Refreshes are triggered by a 12-hour timer (which only fires while the tab
+    is visible) and by the tab becoming visible again after the last refresh has
+    gone stale. Tabs do not coordinate refreshes with each other: in the
+    dashboard each tab/host has its own `sid` and therefore its own stamped
+    token, and in standalone mode tabs share the refreshed token through
+    localStorage storage events.

--- a/packages/core/src/auth/refreshStampedToken.test.ts
+++ b/packages/core/src/auth/refreshStampedToken.test.ts
@@ -1,18 +1,11 @@
-// NOTE: vi.mock REMOVED
-
 import {of, Subscription, throwError} from 'rxjs'
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest' // Removed Mock type
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createSanityInstance} from '../store/createSanityInstance'
 import {createStoreState} from '../store/createStoreState'
 import {AuthStateType} from './authStateType'
 import {type AuthState, authStore} from './authStore'
-import {
-  getLastRefreshTime,
-  getNextRefreshDelay,
-  refreshStampedToken,
-  setLastRefreshTime,
-} from './refreshStampedToken'
+import {refreshStampedToken} from './refreshStampedToken'
 import {createLoggedInAuthState} from './utils'
 
 // Mock logger to prevent actual logging during tests
@@ -30,22 +23,15 @@ vi.mock('../utils/logger', async (importOriginal) => {
   }
 })
 
-// Type definitions for Web Locks (can be kept if needed for context)
-// ... (Lock, LockOptions, LockGrantedCallback types)
-
 describe('refreshStampedToken', () => {
   let mockStorage: Storage
-  let originalNavigator: typeof navigator // Restored
   let originalDocument: Document
   let subscriptions: Subscription[]
-  // mockLocksRequest removed
 
   beforeEach(() => {
     subscriptions = []
     vi.clearAllMocks()
     vi.useFakeTimers()
-
-    originalNavigator = global.navigator // Restore original navigator setup
 
     // Mock document for visibility API
     originalDocument = global.document
@@ -67,49 +53,10 @@ describe('refreshStampedToken', () => {
       key: vi.fn(),
       length: 0,
     }
-    // Restore a basic, functional mock for navigator.locks
-    // This mock *will* run the callback, including the infinite loop
-    // if not handled carefully in tests.
-    const mockLocks = {
-      request: vi.fn(
-        async (
-          _name: string,
-          _options: LockOptions | LockGrantedCallback<unknown>,
-          callback?: LockGrantedCallback<unknown>,
-        ) => {
-          const actualCallback = typeof _options === 'function' ? _options : callback
-          if (!actualCallback) return false
-          const mockLock: Lock = {name: 'mock-lock', mode: 'exclusive'}
-          try {
-            await new Promise((resolve) => setTimeout(resolve, 0))
-            // CAUTION: This executes the callback provided by acquireTokenRefreshLock
-            // which contains the infinite loop. Tests need to avoid triggering
-            // timers indefinitely if this runs.
-            await actualCallback(mockLock)
-            // This return is unlikely to be hit if callback loops
-            return true
-          } catch (error) {
-            // eslint-disable-next-line no-console
-            console.error('Mock lock request failed:', error)
-            return false
-          }
-        },
-      ),
-      query: vi.fn(async () => ({held: [], pending: []})),
-    }
-    Object.defineProperty(global, 'navigator', {
-      value: {locks: mockLocks},
-      writable: true,
-    })
   })
 
   afterEach(async () => {
     subscriptions.forEach((sub) => sub.unsubscribe())
-    // Restore original navigator
-    Object.defineProperty(global, 'navigator', {
-      value: originalNavigator,
-      writable: true,
-    })
     // Restore original document
     Object.defineProperty(global, 'document', {
       value: originalDocument,
@@ -125,353 +72,222 @@ describe('refreshStampedToken', () => {
     vi.useRealTimers()
   })
 
-  describe('dashboard context', () => {
-    it('refreshes the token immediately without using locks', async () => {
-      // Test setup remains similar, using fake timers
-      const mockClient = {
-        observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
-      }
-      const mockClientFactory = vi.fn().mockReturnValue(mockClient)
-      const instance = createSanityInstance({
-        projectId: 'p',
-        dataset: 'd',
-        auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
-      })
-      const initialState = authStore.getInitialState(instance, null)
-      initialState.authState = {
-        type: AuthStateType.LOGGED_IN,
-        token: 'sk-initial-token-st123',
-        currentUser: null,
-      }
-      initialState.dashboardContext = {mode: 'test'}
-      const state = createStoreState(initialState)
-
-      const subscription = refreshStampedToken({state, instance, key: null})
-      subscriptions.push(subscription)
-
-      await vi.advanceTimersToNextTimerAsync()
-
-      const finalAuthStateDash = state.get().authState
-      expect(finalAuthStateDash.type).toBe(AuthStateType.LOGGED_IN)
-      // Ensure token was updated
-      if (finalAuthStateDash.type === AuthStateType.LOGGED_IN) {
-        expect(finalAuthStateDash.token).toBe('sk-refreshed-token-st123')
-      }
-      // Verify navigator.locks.request was NOT called
-      const locksRequest = navigator.locks.request as ReturnType<typeof vi.fn>
-      expect(locksRequest).not.toHaveBeenCalled()
+  it('refreshes the token when the interval timer fires', async () => {
+    const mockClient = {
+      observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
+    }
+    const mockClientFactory = vi.fn().mockReturnValue(mockClient)
+    const instance = createSanityInstance({
+      projectId: 'p',
+      dataset: 'd',
+      auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
     })
+    const initialState = authStore.getInitialState(instance, null)
+    initialState.authState = {
+      type: AuthStateType.LOGGED_IN,
+      token: 'sk-initial-token-st123',
+      currentUser: null,
+    }
+    const state = createStoreState(initialState)
 
-    it('does not refresh on visibility change when lastTokenRefresh is recent', async () => {
-      const mockClient = {
-        observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
-      }
-      const mockClientFactory = vi.fn().mockReturnValue(mockClient)
-      const instance = createSanityInstance({
-        auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
-      })
-      const initialState = authStore.getInitialState(instance, null)
-      initialState.authState = createLoggedInAuthState('sk-initial-token-st123', null)
-      initialState.dashboardContext = {mode: 'test'}
-      const state = createStoreState(initialState)
+    const subscription = refreshStampedToken({state, instance, key: null})
+    subscriptions.push(subscription)
 
-      const subscription = refreshStampedToken({state, instance, key: null})
-      subscriptions.push(subscription)
+    await vi.advanceTimersToNextTimerAsync()
 
-      const addEventListenerMock = global.document.addEventListener as ReturnType<typeof vi.fn>
-      expect(addEventListenerMock).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
-      const visibilityHandler = addEventListenerMock.mock.calls[0][1] as () => void
-
-      Object.defineProperty(global.document, 'visibilityState', {
-        value: 'visible',
-        writable: true,
-        configurable: true,
-      })
-
-      visibilityHandler()
-      await vi.advanceTimersByTimeAsync(100)
-
-      expect(mockClient.observable.request).not.toHaveBeenCalled()
-      const finalAuthState = state.get().authState
-      if (finalAuthState.type === AuthStateType.LOGGED_IN) {
-        expect(finalAuthState.token).toBe('sk-initial-token-st123')
-      }
-    })
-
-    it('refreshes on visibility change when lastTokenRefresh is stale', async () => {
-      const REFRESH_INTERVAL = 12 * 60 * 60 * 1000
-      const mockClient = {
-        observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
-      }
-      const mockClientFactory = vi.fn().mockReturnValue(mockClient)
-      const instance = createSanityInstance({
-        auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
-      })
-      const initialState = authStore.getInitialState(instance, null)
-      const staleTimestamp = Date.now() - REFRESH_INTERVAL - 1000
-      initialState.authState = {
-        type: AuthStateType.LOGGED_IN,
-        token: 'sk-initial-token-st123',
-        currentUser: null,
-        lastTokenRefresh: staleTimestamp,
-      }
-      initialState.dashboardContext = {mode: 'test'}
-      const state = createStoreState(initialState)
-
-      const subscription = refreshStampedToken({state, instance, key: null})
-      subscriptions.push(subscription)
-
-      const addEventListenerMock = global.document.addEventListener as ReturnType<typeof vi.fn>
-      expect(addEventListenerMock).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
-      const visibilityHandler = addEventListenerMock.mock.calls[0][1] as () => void
-
-      Object.defineProperty(global.document, 'visibilityState', {
-        value: 'visible',
-        writable: true,
-        configurable: true,
-      })
-
-      visibilityHandler()
-      await vi.advanceTimersToNextTimerAsync()
-
-      expect(mockClient.observable.request).toHaveBeenCalled()
-      const finalAuthState = state.get().authState
-      if (finalAuthState.type === AuthStateType.LOGGED_IN) {
-        expect(finalAuthState.token).toBe('sk-refreshed-token-st123')
-        expect(finalAuthState.lastTokenRefresh).toBeGreaterThan(staleTimestamp)
-      }
-    })
-
-    it('refreshes on visibility change when lastTokenRefresh is undefined (pre-fix behavior)', async () => {
-      const mockClient = {
-        observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
-      }
-      const mockClientFactory = vi.fn().mockReturnValue(mockClient)
-      const instance = createSanityInstance({
-        auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
-      })
-      const initialState = authStore.getInitialState(instance, null)
-      initialState.authState = {
-        type: AuthStateType.LOGGED_IN,
-        token: 'sk-initial-token-st123',
-        currentUser: null,
-        // lastTokenRefresh intentionally omitted to demonstrate the old bug
-      }
-      initialState.dashboardContext = {mode: 'test'}
-      const state = createStoreState(initialState)
-
-      const subscription = refreshStampedToken({state, instance, key: null})
-      subscriptions.push(subscription)
-
-      const addEventListenerMock = global.document.addEventListener as ReturnType<typeof vi.fn>
-      const visibilityHandler = addEventListenerMock.mock.calls[0][1] as () => void
-
-      Object.defineProperty(global.document, 'visibilityState', {
-        value: 'visible',
-        writable: true,
-        configurable: true,
-      })
-
-      visibilityHandler()
-      await vi.advanceTimersToNextTimerAsync()
-
-      // Without lastTokenRefresh, shouldRefreshToken returns true — this is the bug
-      expect(mockClient.observable.request).toHaveBeenCalled()
-    })
-
-    it('does not refresh when tab is not visible', async () => {
-      // Set visibility to hidden
-      Object.defineProperty(global, 'document', {
-        value: {
-          visibilityState: 'hidden',
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-        },
-        writable: true,
-        configurable: true,
-      })
-
-      const mockClient = {
-        observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
-      }
-      const mockClientFactory = vi.fn().mockReturnValue(mockClient)
-      const instance = createSanityInstance({
-        projectId: 'p',
-        dataset: 'd',
-        auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
-      })
-      const initialState = authStore.getInitialState(instance, null)
-      initialState.authState = {
-        type: AuthStateType.LOGGED_IN,
-        token: 'sk-initial-token-st123',
-        currentUser: null,
-      }
-      initialState.dashboardContext = {mode: 'test'}
-      const state = createStoreState(initialState)
-
-      const subscription = refreshStampedToken({state, instance, key: null})
-      subscriptions.push(subscription)
-
-      await vi.advanceTimersToNextTimerAsync()
-
-      // Verify that no refresh occurred
-      expect(mockClient.observable.request).not.toHaveBeenCalled()
-      const finalAuthState = state.get().authState
-      if (finalAuthState.type === AuthStateType.LOGGED_IN) {
-        expect(finalAuthState.token).toBe('sk-initial-token-st123')
-      }
-    })
+    const finalAuthState = state.get().authState
+    expect(finalAuthState.type).toBe(AuthStateType.LOGGED_IN)
+    if (finalAuthState.type === AuthStateType.LOGGED_IN) {
+      expect(finalAuthState.token).toBe('sk-refreshed-token-st123')
+    }
   })
 
-  describe('non-dashboard context', () => {
-    // Test is simplified: just ensure it runs without error
-    it('attempts token refresh coordination when not in dashboard context', async () => {
-      // Fake timers enabled via beforeEach
-      const mockClient = {observable: {request: vi.fn()}}
-      const mockClientFactory = vi.fn().mockReturnValue(mockClient)
-      const instance = createSanityInstance({
-        projectId: 'p',
-        dataset: 'd',
-        auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
-      })
-      const initialState = authStore.getInitialState(instance, null)
-      initialState.authState = {
-        type: AuthStateType.LOGGED_IN,
-        token: 'sk-initial-token-st123',
-        currentUser: null,
-      }
-      const state = createStoreState(initialState)
-
-      let subscription: Subscription | undefined
-      // We expect this NOT to throw, but accept we can't easily test the lock call or outcome
-      expect(() => {
-        subscription = refreshStampedToken({state, instance, key: null})
-        subscriptions.push(subscription!)
-      }).not.toThrow()
-
-      // DO NOT advance timers or yield here - focus on immediate observable logic
-      // We cannot reliably test that failingLocksRequest is called due to async/timer issues,
-      // but we *can* test the consequence of it resolving to false.
-
-      // VERIFY THE OUTCOME:
-      // Check client request was NOT made (because filter(hasLock => hasLock) receives false)
-      expect(mockClient.observable.request).not.toHaveBeenCalled()
-      // Check state remains unchanged
-      const finalAuthState = state.get().authState
-      expect(finalAuthState.type).toBe(AuthStateType.LOGGED_IN)
-      if (finalAuthState.type === AuthStateType.LOGGED_IN) {
-        expect(finalAuthState.token).toBe('sk-initial-token-st123')
-      }
+  it('writes the refreshed token to storage', async () => {
+    const mockClient = {
+      observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
+    }
+    const mockClientFactory = vi.fn().mockReturnValue(mockClient)
+    const instance = createSanityInstance({
+      projectId: 'p',
+      dataset: 'd',
+      auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
     })
+    const initialState = authStore.getInitialState(instance, null)
+    initialState.authState = {
+      type: AuthStateType.LOGGED_IN,
+      token: 'sk-initial-token-st123',
+      currentUser: null,
+    }
+    const state = createStoreState(initialState)
 
-    it('skips refresh if lock request returns false', async () => {
-      // Fake timers enabled via beforeEach
-      // Mock navigator.locks.request LOCALLY for this test to return false
-      const originalLocks = navigator.locks
-      // Use mockResolvedValue: the from(acquireTokenRefreshLock(...)) expects a Promise
-      const failingLocksRequest = vi.fn().mockResolvedValue(false)
-      Object.defineProperty(global, 'navigator', {
-        value: {locks: {...originalLocks, request: failingLocksRequest}},
-        writable: true,
-      })
+    const subscription = refreshStampedToken({state, instance, key: null})
+    subscriptions.push(subscription)
 
-      try {
-        const mockClient = {
-          observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
-        }
-        const mockClientFactory = vi.fn().mockReturnValue(mockClient)
-        const instance = createSanityInstance({
-          projectId: 'p',
-          dataset: 'd',
-          auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
-        })
-        const initialState = authStore.getInitialState(instance, null)
-        initialState.authState = {
-          type: AuthStateType.LOGGED_IN,
-          token: 'sk-initial-token-st123',
-          currentUser: null,
-        }
-        const state = createStoreState(initialState)
+    await vi.advanceTimersToNextTimerAsync()
 
-        const subscription = refreshStampedToken({state, instance, key: null})
-        subscriptions.push(subscription)
-
-        // DO NOT advance timers or yield here - focus on immediate observable logic
-        // We cannot reliably test that failingLocksRequest is called due to async/timer issues,
-        // but we *can* test the consequence of it resolving to false.
-
-        // VERIFY THE OUTCOME:
-        // Check client request was NOT made (because filter(hasLock => hasLock) receives false)
-        expect(mockClient.observable.request).not.toHaveBeenCalled()
-        // Check state remains unchanged
-        const finalAuthState = state.get().authState
-        expect(finalAuthState.type).toBe(AuthStateType.LOGGED_IN)
-        if (finalAuthState.type === AuthStateType.LOGGED_IN) {
-          expect(finalAuthState.token).toBe('sk-initial-token-st123')
-        }
-      } finally {
-        // Restore original navigator.locks
-        Object.defineProperty(global, 'navigator', {value: {locks: originalLocks}, writable: true})
-      }
-    })
+    expect(mockClient.observable.request).toHaveBeenCalled()
+    expect(mockStorage.setItem).toHaveBeenCalledWith(
+      initialState.options.storageKey,
+      JSON.stringify({token: 'sk-refreshed-token-st123'}),
+    )
   })
 
-  describe('unsupported environments', () => {
-    it('falls back to immediate refresh if Web Locks API is not supported', async () => {
-      // Temporarily remove navigator.locks for this test
-      const originalLocks = navigator.locks
-      Object.defineProperty(global.navigator, 'locks', {
-        value: undefined,
-        writable: true,
-      })
-
-      try {
-        const mockClient = {
-          observable: {request: vi.fn(() => of({token: 'sk-refreshed-immediately-st123'}))},
-        }
-        const mockClientFactory = vi.fn().mockReturnValue(mockClient)
-        const instance = createSanityInstance({
-          projectId: 'p',
-          dataset: 'd',
-          auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
-        })
-        const initialState = authStore.getInitialState(instance, null)
-        initialState.authState = {
-          type: AuthStateType.LOGGED_IN,
-          token: 'sk-initial-token-st123',
-          currentUser: null,
-        }
-        const state = createStoreState(initialState)
-
-        const subscription = refreshStampedToken({state, instance, key: null})
-        subscriptions.push(subscription)
-
-        // Advance timers to allow the async `performRefresh` to execute
-        await vi.advanceTimersToNextTimerAsync()
-
-        // Verify the refresh was performed and state was updated
-        expect(mockClient.observable.request).toHaveBeenCalled()
-        const finalAuthState = state.get().authState
-        expect(finalAuthState.type).toBe(AuthStateType.LOGGED_IN)
-        if (finalAuthState.type === AuthStateType.LOGGED_IN) {
-          expect(finalAuthState.token).toBe('sk-refreshed-immediately-st123')
-        }
-        // Verify token was set in storage
-        expect(mockStorage.setItem).toHaveBeenCalledWith(
-          initialState.options.storageKey,
-          JSON.stringify({token: 'sk-refreshed-immediately-st123'}),
-        )
-      } finally {
-        // Restore navigator.locks
-        Object.defineProperty(global.navigator, 'locks', {
-          value: originalLocks,
-          writable: true,
-        })
-      }
+  it('does not refresh on visibility change when lastTokenRefresh is recent', async () => {
+    const mockClient = {
+      observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
+    }
+    const mockClientFactory = vi.fn().mockReturnValue(mockClient)
+    const instance = createSanityInstance({
+      auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
     })
+    const initialState = authStore.getInitialState(instance, null)
+    initialState.authState = createLoggedInAuthState('sk-initial-token-st123', null)
+    const state = createStoreState(initialState)
+
+    const subscription = refreshStampedToken({state, instance, key: null})
+    subscriptions.push(subscription)
+
+    const addEventListenerMock = global.document.addEventListener as ReturnType<typeof vi.fn>
+    expect(addEventListenerMock).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    const visibilityHandler = addEventListenerMock.mock.calls[0][1] as () => void
+
+    Object.defineProperty(global.document, 'visibilityState', {
+      value: 'visible',
+      writable: true,
+      configurable: true,
+    })
+
+    visibilityHandler()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(mockClient.observable.request).not.toHaveBeenCalled()
+    const finalAuthState = state.get().authState
+    if (finalAuthState.type === AuthStateType.LOGGED_IN) {
+      expect(finalAuthState.token).toBe('sk-initial-token-st123')
+    }
   })
 
-  // Restore other tests to their simpler form
+  it('refreshes on visibility change when lastTokenRefresh is stale', async () => {
+    const REFRESH_INTERVAL = 12 * 60 * 60 * 1000
+    const mockClient = {
+      observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
+    }
+    const mockClientFactory = vi.fn().mockReturnValue(mockClient)
+    const instance = createSanityInstance({
+      auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
+    })
+    const initialState = authStore.getInitialState(instance, null)
+    const staleTimestamp = Date.now() - REFRESH_INTERVAL - 1000
+    initialState.authState = {
+      type: AuthStateType.LOGGED_IN,
+      token: 'sk-initial-token-st123',
+      currentUser: null,
+      lastTokenRefresh: staleTimestamp,
+    }
+    const state = createStoreState(initialState)
+
+    const subscription = refreshStampedToken({state, instance, key: null})
+    subscriptions.push(subscription)
+
+    const addEventListenerMock = global.document.addEventListener as ReturnType<typeof vi.fn>
+    expect(addEventListenerMock).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    const visibilityHandler = addEventListenerMock.mock.calls[0][1] as () => void
+
+    Object.defineProperty(global.document, 'visibilityState', {
+      value: 'visible',
+      writable: true,
+      configurable: true,
+    })
+
+    visibilityHandler()
+    await vi.advanceTimersToNextTimerAsync()
+
+    expect(mockClient.observable.request).toHaveBeenCalled()
+    const finalAuthState = state.get().authState
+    if (finalAuthState.type === AuthStateType.LOGGED_IN) {
+      expect(finalAuthState.token).toBe('sk-refreshed-token-st123')
+      expect(finalAuthState.lastTokenRefresh).toBeGreaterThan(staleTimestamp)
+    }
+  })
+
+  it('refreshes on visibility change when lastTokenRefresh is undefined (pre-fix behavior)', async () => {
+    const mockClient = {
+      observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
+    }
+    const mockClientFactory = vi.fn().mockReturnValue(mockClient)
+    const instance = createSanityInstance({
+      auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
+    })
+    const initialState = authStore.getInitialState(instance, null)
+    initialState.authState = {
+      type: AuthStateType.LOGGED_IN,
+      token: 'sk-initial-token-st123',
+      currentUser: null,
+      // lastTokenRefresh intentionally omitted to demonstrate the old bug
+    }
+    const state = createStoreState(initialState)
+
+    const subscription = refreshStampedToken({state, instance, key: null})
+    subscriptions.push(subscription)
+
+    const addEventListenerMock = global.document.addEventListener as ReturnType<typeof vi.fn>
+    const visibilityHandler = addEventListenerMock.mock.calls[0][1] as () => void
+
+    Object.defineProperty(global.document, 'visibilityState', {
+      value: 'visible',
+      writable: true,
+      configurable: true,
+    })
+
+    visibilityHandler()
+    await vi.advanceTimersToNextTimerAsync()
+
+    // Without lastTokenRefresh, shouldRefreshToken returns true — this is the bug
+    expect(mockClient.observable.request).toHaveBeenCalled()
+  })
+
+  it('does not refresh when tab is not visible', async () => {
+    // Set visibility to hidden
+    Object.defineProperty(global, 'document', {
+      value: {
+        visibilityState: 'hidden',
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    const mockClient = {
+      observable: {request: vi.fn(() => of({token: 'sk-refreshed-token-st123'}))},
+    }
+    const mockClientFactory = vi.fn().mockReturnValue(mockClient)
+    const instance = createSanityInstance({
+      projectId: 'p',
+      dataset: 'd',
+      auth: {clientFactory: mockClientFactory, storageArea: mockStorage},
+    })
+    const initialState = authStore.getInitialState(instance, null)
+    initialState.authState = {
+      type: AuthStateType.LOGGED_IN,
+      token: 'sk-initial-token-st123',
+      currentUser: null,
+    }
+    const state = createStoreState(initialState)
+
+    const subscription = refreshStampedToken({state, instance, key: null})
+    subscriptions.push(subscription)
+
+    await vi.advanceTimersToNextTimerAsync()
+
+    // Verify that no refresh occurred
+    expect(mockClient.observable.request).not.toHaveBeenCalled()
+    const finalAuthState = state.get().authState
+    if (finalAuthState.type === AuthStateType.LOGGED_IN) {
+      expect(finalAuthState.token).toBe('sk-initial-token-st123')
+    }
+  })
+
   it('sets an error state when token refresh fails', async () => {
     const error = new Error('Refresh failed')
     const mockClient = {observable: {request: vi.fn(() => throwError(() => error))}}
@@ -487,7 +303,6 @@ describe('refreshStampedToken', () => {
       token: 'sk-initial-token-st123',
       currentUser: null,
     }
-    initialState.dashboardContext = {mode: 'test'}
     const state = createStoreState(initialState)
 
     const subscription = refreshStampedToken({state, instance, key: null})
@@ -523,8 +338,6 @@ describe('refreshStampedToken', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(mockClientFactory).not.toHaveBeenCalled()
-    const locksRequest = navigator.locks.request as ReturnType<typeof vi.fn>
-    expect(locksRequest).not.toHaveBeenCalled()
     expect(state.get().authState.type).toBe(AuthStateType.LOGGED_OUT)
   })
 
@@ -550,102 +363,11 @@ describe('refreshStampedToken', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(mockClient.observable.request).not.toHaveBeenCalled()
-    const locksRequest = navigator.locks.request as ReturnType<typeof vi.fn>
-    expect(locksRequest).not.toHaveBeenCalled()
     // Add type guard before accessing token property
     const finalAuthState = state.get().authState
     expect(finalAuthState.type).toBe(AuthStateType.LOGGED_IN)
     if (finalAuthState.type === AuthStateType.LOGGED_IN) {
       expect(finalAuthState.token).toBe('sk-nonstamped-token')
     }
-  })
-})
-
-describe('time-based refresh helpers', () => {
-  let mockStorage: Storage
-  const storageKey = 'my-test-key'
-
-  beforeEach(() => {
-    mockStorage = {
-      getItem: vi.fn(),
-      setItem: vi.fn(),
-      removeItem: vi.fn(),
-      clear: vi.fn(),
-      key: vi.fn(),
-      length: 0,
-    }
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  describe('getLastRefreshTime', () => {
-    it('returns 0 if storage is undefined', () => {
-      expect(getLastRefreshTime(undefined, storageKey)).toBe(0)
-    })
-
-    it('returns 0 if item is not in storage', () => {
-      vi.spyOn(mockStorage, 'getItem').mockReturnValue(null)
-      expect(getLastRefreshTime(mockStorage, storageKey)).toBe(0)
-      expect(mockStorage.getItem).toHaveBeenCalledWith(`${storageKey}_last_refresh`)
-    })
-
-    it('returns the parsed timestamp from storage', () => {
-      const now = Date.now()
-      vi.spyOn(mockStorage, 'getItem').mockReturnValue(now.toString())
-      expect(getLastRefreshTime(mockStorage, storageKey)).toBe(now)
-    })
-
-    it('returns 0 if stored data is malformed', () => {
-      vi.spyOn(mockStorage, 'getItem').mockReturnValue('not a number')
-      expect(getLastRefreshTime(mockStorage, storageKey)).toBe(0)
-    })
-
-    it('returns 0 on storage access error', () => {
-      vi.spyOn(mockStorage, 'getItem').mockImplementation(() => {
-        throw new Error('Storage access failed')
-      })
-      expect(getLastRefreshTime(mockStorage, storageKey)).toBe(0)
-    })
-  })
-
-  describe('setLastRefreshTime', () => {
-    it('sets the current timestamp in storage', () => {
-      const now = Date.now()
-      setLastRefreshTime(mockStorage, storageKey)
-      expect(mockStorage.setItem).toHaveBeenCalledWith(`${storageKey}_last_refresh`, now.toString())
-    })
-
-    it('does not throw on storage access error', () => {
-      vi.spyOn(mockStorage, 'setItem').mockImplementation(() => {
-        throw new Error('Storage access failed')
-      })
-      expect(() => setLastRefreshTime(mockStorage, storageKey)).not.toThrow()
-    })
-  })
-
-  describe('getNextRefreshDelay', () => {
-    const REFRESH_INTERVAL = 12 * 60 * 60 * 1000
-
-    it('returns 0 if last refresh time is not available', () => {
-      vi.spyOn(mockStorage, 'getItem').mockReturnValue(null)
-      expect(getNextRefreshDelay(mockStorage, storageKey)).toBe(0)
-    })
-
-    it('returns the remaining time until the next refresh', () => {
-      const lastRefresh = Date.now() - 10000 // 10 seconds ago
-      vi.spyOn(mockStorage, 'getItem').mockReturnValue(lastRefresh.toString())
-
-      const delay = getNextRefreshDelay(mockStorage, storageKey)
-      expect(delay).toBeCloseTo(REFRESH_INTERVAL - 10000, -2)
-    })
-
-    it('returns 0 if the refresh interval has passed', () => {
-      const lastRefresh = Date.now() - REFRESH_INTERVAL - 5000 // 5 seconds past due
-      vi.spyOn(mockStorage, 'getItem').mockReturnValue(lastRefresh.toString())
-      expect(getNextRefreshDelay(mockStorage, storageKey)).toBe(0)
-    })
   })
 })

--- a/packages/core/src/auth/refreshStampedToken.ts
+++ b/packages/core/src/auth/refreshStampedToken.ts
@@ -2,8 +2,6 @@ import {
   distinctUntilChanged,
   exhaustMap,
   filter,
-  firstValueFrom,
-  from,
   map,
   Observable,
   type Subscription,
@@ -19,37 +17,6 @@ import {AuthStateType} from './authStateType'
 import {type AuthState, type AuthStoreState} from './authStore'
 
 const REFRESH_INTERVAL = 12 * 60 * 60 * 1000 // 12 hours in milliseconds
-const LOCK_NAME = 'sanity-token-refresh-lock'
-
-/** @internal */
-export function getLastRefreshTime(storageArea: Storage | undefined, storageKey: string): number {
-  try {
-    const data = storageArea?.getItem(`${storageKey}_last_refresh`)
-    const parsed = data ? parseInt(data, 10) : 0
-    return isNaN(parsed) ? 0 : parsed
-  } catch {
-    return 0
-  }
-}
-
-/** @internal */
-export function setLastRefreshTime(storageArea: Storage | undefined, storageKey: string): void {
-  try {
-    storageArea?.setItem(`${storageKey}_last_refresh`, Date.now().toString())
-  } catch {
-    // Ignore storage errors
-  }
-}
-
-/** @internal */
-export function getNextRefreshDelay(storageArea: Storage | undefined, storageKey: string): number {
-  const lastRefresh = getLastRefreshTime(storageArea, storageKey)
-  if (!lastRefresh) return 0
-
-  const now = Date.now()
-  const nextRefreshTime = lastRefresh + REFRESH_INTERVAL
-  return Math.max(0, nextRefreshTime - now)
-}
 
 function createTokenRefreshStream(
   token: string,
@@ -82,57 +49,6 @@ function createTokenRefreshStream(
   })
 }
 
-async function acquireTokenRefreshLock(
-  refreshFn: () => Promise<void>,
-  storageArea: Storage | undefined,
-  storageKey: string,
-): Promise<boolean> {
-  if (!navigator.locks) {
-    // If Web Locks API is not supported, perform an immediate, uncoordinated refresh.
-    // eslint-disable-next-line no-console
-    console.warn('Web Locks API not supported. Proceeding with uncoordinated refresh.')
-    await refreshFn()
-    setLastRefreshTime(storageArea, storageKey)
-    return true // Indicate success to allow stream processing, though it won't loop.
-  }
-
-  try {
-    // Attempt to acquire an exclusive lock for token refresh coordination.
-    // The callback handles the continuous refresh cycle while the lock is held.
-    const result = await navigator.locks.request(LOCK_NAME, {mode: 'exclusive'}, async (lock) => {
-      if (!lock) return false // Lock not granted
-
-      // Problematic infinite loop - needs redesign for graceful termination.
-      // This loop continuously refreshes the token at REFRESH_INTERVAL.
-      while (true) {
-        const delay = getNextRefreshDelay(storageArea, storageKey)
-        if (delay > 0) {
-          await new Promise((resolve) => setTimeout(resolve, delay))
-        }
-        try {
-          await refreshFn()
-          setLastRefreshTime(storageArea, storageKey)
-        } catch (error) {
-          // eslint-disable-next-line no-console
-          console.error('Token refresh failed within lock:', error)
-          // Decide how to handle errors - break, retry, etc.? Currently logs and continues.
-        }
-        // Wait for the next interval
-        await new Promise((resolve) => setTimeout(resolve, REFRESH_INTERVAL))
-      }
-      // Unreachable due to while(true)
-    })
-    // The promise from navigator.locks.request resolves with the callback's return value,
-    // but only if the callback finishes. The infinite loop prevents this.
-    return result === true
-  } catch (error) {
-    // Handle potential errors during the initial lock request itself.
-    // eslint-disable-next-line no-console
-    console.error('Failed to request token refresh lock:', error)
-    return false // Indicate lock acquisition failure.
-  }
-}
-
 function shouldRefreshToken(lastRefresh: number | undefined): boolean {
   if (!lastRefresh) return true
   const timeSinceLastRefresh = Date.now() - lastRefresh
@@ -140,6 +56,14 @@ function shouldRefreshToken(lastRefresh: number | undefined): boolean {
 }
 
 /**
+ * Periodically refreshes stamped auth tokens (those containing `-st`).
+ *
+ * Two triggers cause a refresh while the user stays logged in:
+ * - a 12-hour interval timer (only fires while the tab is visible)
+ * - the tab becoming visible again after `lastTokenRefresh` has gone stale
+ *
+ * Non-stamped tokens (e.g. personal access tokens) are never refreshed.
+ *
  * @internal
  */
 export const refreshStampedToken = ({
@@ -151,96 +75,27 @@ export const refreshStampedToken = ({
   const {clientFactory, apiHost, storageArea, storageKey} = state.get().options
 
   const refreshToken$ = state.observable.pipe(
-    map((storeState) => ({
-      authState: storeState.authState,
-      dashboardContext: storeState.dashboardContext,
-    })),
+    map((storeState) => storeState.authState),
     filter(
-      (
-        storeState,
-      ): storeState is {
-        authState: Extract<AuthState, {type: AuthStateType.LOGGED_IN}>
-        dashboardContext: AuthStoreState['dashboardContext']
-      } => storeState.authState.type === AuthStateType.LOGGED_IN,
+      (authState): authState is Extract<AuthState, {type: AuthStateType.LOGGED_IN}> =>
+        authState.type === AuthStateType.LOGGED_IN,
     ),
-    distinctUntilChanged(
-      (prev, curr) =>
-        prev.authState.type === curr.authState.type &&
-        prev.authState.token === curr.authState.token && // Only care about token for distinctness here
-        prev.dashboardContext === curr.dashboardContext,
-    ), // Make distinctness check explicit
-    filter((storeState) => storeState.authState.token.includes('-st')), // Ensure we only try to refresh stamped tokens
-    exhaustMap((storeState) => {
-      // USE exhaustMap instead of switchMap
-      // Create a function that performs a single refresh and updates state/storage
-      const performRefresh = async () => {
-        // Read the latest token directly from state inside refresh
-        const currentState = state.get()
-        if (currentState.authState.type !== AuthStateType.LOGGED_IN) {
-          logger.debug('Token refresh aborted - user logged out')
-          throw new Error('User logged out before refresh could complete') // Abort refresh
-        }
-        const currentToken = currentState.authState.token
-
-        logger.debug('Refreshing stamped token')
-        const response = await firstValueFrom(
-          createTokenRefreshStream(currentToken, clientFactory, apiHost),
-        )
-
-        logger.info('Token refreshed successfully')
-        state.set('setRefreshStampedToken', (prev) => ({
-          authState:
-            prev.authState.type === AuthStateType.LOGGED_IN
-              ? {...prev.authState, token: response.token}
-              : prev.authState,
-        }))
-        storageArea?.setItem(storageKey, JSON.stringify({token: response.token}))
-      }
-
-      if (storeState.dashboardContext) {
-        return new Observable<{token: string}>((subscriber) => {
-          const visibilityHandler = () => {
-            const currentState = state.get()
-            if (
-              document.visibilityState === 'visible' &&
-              currentState.authState.type === AuthStateType.LOGGED_IN &&
-              shouldRefreshToken(currentState.authState.lastTokenRefresh)
-            ) {
-              createTokenRefreshStream(
-                currentState.authState.token,
-                clientFactory,
-                apiHost,
-              ).subscribe({
-                next: (response) => {
-                  state.set('setRefreshStampedToken', (prev) => ({
-                    authState:
-                      prev.authState.type === AuthStateType.LOGGED_IN
-                        ? {
-                            ...prev.authState,
-                            token: response.token,
-                            lastTokenRefresh: Date.now(),
-                          }
-                        : prev.authState,
-                  }))
-                  subscriber.next(response)
-                },
-                error: (error) => subscriber.error(error),
-              })
-            }
-          }
-
-          const timerSubscription = timer(REFRESH_INTERVAL, REFRESH_INTERVAL)
-            .pipe(
-              filter(() => document.visibilityState === 'visible'),
-              switchMap(() => {
-                const currentState = state.get().authState
-                if (currentState.type !== AuthStateType.LOGGED_IN) {
-                  throw new Error('User logged out before refresh could complete')
-                }
-                return createTokenRefreshStream(currentState.token, clientFactory, apiHost)
-              }),
-            )
-            .subscribe({
+    distinctUntilChanged((prev, curr) => prev.token === curr.token),
+    filter((authState) => authState.token.includes('-st')), // Ensure we only try to refresh stamped tokens
+    exhaustMap(() =>
+      new Observable<{token: string}>((subscriber) => {
+        const visibilityHandler = () => {
+          const currentState = state.get()
+          if (
+            document.visibilityState === 'visible' &&
+            currentState.authState.type === AuthStateType.LOGGED_IN &&
+            shouldRefreshToken(currentState.authState.lastTokenRefresh)
+          ) {
+            createTokenRefreshStream(
+              currentState.authState.token,
+              clientFactory,
+              apiHost,
+            ).subscribe({
               next: (response) => {
                 state.set('setRefreshStampedToken', (prev) => ({
                   authState:
@@ -256,31 +111,48 @@ export const refreshStampedToken = ({
               },
               error: (error) => subscriber.error(error),
             })
-
-          document.addEventListener('visibilitychange', visibilityHandler)
-
-          return () => {
-            document.removeEventListener('visibilitychange', visibilityHandler)
-            timerSubscription.unsubscribe()
           }
-        }).pipe(
-          takeWhile(() => state.get().authState.type === AuthStateType.LOGGED_IN),
-          map((response: {token: string}) => ({token: response.token})),
-        )
-      }
+        }
 
-      // If not in dashboard context, use lock-based refresh
-      return from(acquireTokenRefreshLock(performRefresh, storageArea, storageKey)).pipe(
-        filter((hasLock) => hasLock),
-        map(() => {
-          const currentState = state.get().authState
-          if (currentState.type !== AuthStateType.LOGGED_IN) {
-            throw new Error('User logged out before refresh could complete')
-          }
-          return {token: currentState.token} as const
-        }),
-      )
-    }),
+        const timerSubscription = timer(REFRESH_INTERVAL, REFRESH_INTERVAL)
+          .pipe(
+            filter(() => document.visibilityState === 'visible'),
+            switchMap(() => {
+              const currentState = state.get().authState
+              if (currentState.type !== AuthStateType.LOGGED_IN) {
+                throw new Error('User logged out before refresh could complete')
+              }
+              return createTokenRefreshStream(currentState.token, clientFactory, apiHost)
+            }),
+          )
+          .subscribe({
+            next: (response) => {
+              state.set('setRefreshStampedToken', (prev) => ({
+                authState:
+                  prev.authState.type === AuthStateType.LOGGED_IN
+                    ? {
+                        ...prev.authState,
+                        token: response.token,
+                        lastTokenRefresh: Date.now(),
+                      }
+                    : prev.authState,
+              }))
+              subscriber.next(response)
+            },
+            error: (error) => subscriber.error(error),
+          })
+
+        document.addEventListener('visibilitychange', visibilityHandler)
+
+        return () => {
+          document.removeEventListener('visibilitychange', visibilityHandler)
+          timerSubscription.unsubscribe()
+        }
+      }).pipe(
+        takeWhile(() => state.get().authState.type === AuthStateType.LOGGED_IN),
+        map((response: {token: string}) => ({token: response.token})),
+      ),
+    ),
   )
 
   return refreshToken$.subscribe({


### PR DESCRIPTION
### Description

Follow-up to Dashboard dropping stamped auth tokens (sanity-io/ada#428). The original plan was to delete the "dashboard" branch of `refreshStampedToken`, but that branch is guarded by a truthiness check on `dashboardContext`, and every auth strategy (standalone, studio, dashboard) sets `dashboardContext` to at least `{}`. So the timer/visibility branch is the refresh path every consumer runs, including standalone apps that still obtain stamped tokens via the sanity.io/login flow, and removing it would regress them.

The actual dead code was the other branch: the Web Locks based refresh (`acquireTokenRefreshLock` plus the `_last_refresh` localStorage helpers) has been unreachable since #409 made `dashboardContext` always truthy, four days after #398 introduced it. This PR removes the lock code and makes the timer/visibility strategy the single unconditional path. No behavior change.

No SDK change was needed for the Dashboard side: the refresher already filters on tokens containing `-st`, so non-stamped tokens from the Dashboard never trigger it.

Linear: SDK-1855

### What to review

- `packages/core/src/auth/refreshStampedToken.ts`: the surviving observable is the old lines 200-270 verbatim, minus the `if (storeState.dashboardContext)` wrapper; the stream setup no longer watches `dashboardContext`.
- Multi-tab standalone behavior is unchanged: only visible tabs refresh, and refreshed tokens (with `lastTokenRefresh`) propagate to other tabs via localStorage storage events, which is what has prevented duplicate refreshes since the locks went dormant.
- `AuthenticationGuide.md` token refresh section updated to describe the actual behavior.

### Testing

Existing timer/visibility tests now run against a plain standalone initial state (previously they set a fake `dashboardContext`, which turned out to be irrelevant). Removed tests for the deleted lock helpers and the navigator.locks mocking. Added a test asserting the refreshed token is written to storage, since standalone multi-tab sync depends on it. All 129 auth tests pass; core type check passes.

### Fun gif

![Lock removed](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExNmI2Y256aGc4YWptazB5ZzZtcHpsdG9rNHFxZ2F1djc4bzZoOGRyOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/PvlUldaGE3fc0tgpEP/giphy.gif)