### PR TITLE
docs: add Cursor Cloud dev environment instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,11 @@ You are working in a TypeScript codebase with React 19, Vitest, and Sanity.io as
 - All exported members need TSDoc comments. ESLint's TSDoc plugin enforces this.
 - Do not edit files under `dist/` or `node_modules/`.
 - Do not introduce React-specific dependencies into `packages/core`. Keep it framework-agnostic.
+
+## Cursor Cloud specific instructions
+
+- Runtime: the VM ships Node 22.14.0 (`/exec-daemon/node`) and pnpm 10.33.4 by default in the agent's normal shell. `.nvmrc` pins 24.17.0, but Node 22 is fully supported (the CI test matrix runs both 22 and 24), so the default Node is fine for install/lint/test/build/dev.
+- `pnpm install` runs a kitchensink `postinstall` that calls `sanity schema extract` + typegen; it needs network access to Sanity but requires no secrets and completes in the standard install.
+- No env vars/secrets are needed to install, lint, test, build, or start either dev app. Sanity project IDs are hardcoded and point at public dev projects. `.env.local` (copy from `.env.example`) is only needed for the Playwright e2e suite (`pnpm test:e2e`), which targets Sanity staging.
+- Dev servers (see root `package.json` scripts): `pnpm dev` → kitchensink via `sanity dev` on port 3333 (meant to be opened embedded in the Sanity Dashboard for auth); `pnpm dev:standalone` → Vite on port 3334 (uses the `www.sanity.io/login` redirect flow). Both start and serve without login; showing authenticated content requires an interactive Sanity login in the browser.
+- tmux gotcha: a tmux `bash -l` login shell does NOT inherit Node/pnpm on PATH (you'll get `pnpm: command not found`). The agent's default Shell tool environment does. When starting long-running dev servers in tmux, first `export PATH="/exec-daemon:/home/ubuntu/.nvm/versions/node/v22.22.2/bin:$PATH"` (or run them from the normal Shell environment).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the Cloud Agent development environment for this monorepo. No application code was changed — only a `## Cursor Cloud specific instructions` section was added to `AGENTS.md` with durable, non-obvious setup/run notes for future agents.

## Environment setup

- Update script: `pnpm install` (installs deps; kitchensink `postinstall` runs Sanity schema extract + typegen).
- Runtime: VM default Node 22.14.0 + pnpm 10.33.4 (Node 22 is CI-supported; `.nvmrc` pins 24.17.0).

## Verification

All checks pass on the current environment:

- `pnpm test` — 146 files, 1319 passed / 3 skipped
- `pnpm ts:check` — passed
- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm build` — packages + both apps built
- Dev servers serve HTTP 200: `pnpm dev` (kitchensink, port 3333) and `pnpm dev:standalone` (standalone, port 3334)

## Notes

Showing authenticated content in either demo app requires an interactive Sanity login in the browser; the servers start and serve without any secrets. `.env.local` is only needed for the Playwright e2e suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c1fb78a-ff68-494c-bc05-5dc0b808987e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c1fb78a-ff68-494c-bc05-5dc0b808987e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

