### PR TITLE
fix(document): include all versions when listening to documents

### DIFF
--- a/apps/kitchensink-react/e2e/releases.spec.ts
+++ b/apps/kitchensink-react/e2e/releases.spec.ts
@@ -108,6 +108,9 @@ test.describe('Releases Route', () => {
     const previewCard = pageContext.getByTestId('document-preview-card')
     await previewCard.scrollIntoViewIfNeeded()
 
+    const dataCard = pageContext.getByTestId('document-data-card')
+    await dataCard.scrollIntoViewIfNeeded()
+
     // Verify the projection also shows the release version
     await expect(async () => {
       const projectionContent = await projectionCard.textContent()
@@ -118,6 +121,12 @@ test.describe('Releases Route', () => {
     await expect(async () => {
       const previewContent = await previewCard.textContent()
       expect(previewContent).toContain('"title": "Release Test Author"')
+    }).toPass({timeout: 15000})
+
+    // Verify useDocument (the document-data-card) also resolves the release version
+    await expect(async () => {
+      const dataContent = await dataCard.textContent()
+      expect(dataContent).toContain('"name": "Release Test Author"')
     }).toPass({timeout: 15000})
 
     await client.action([
@@ -160,6 +169,13 @@ test.describe('Releases Route', () => {
     await expect(async () => {
       const previewContent = await previewCard.textContent()
       expect(previewContent).toContain('"title": "Updated Release Test Author"')
+    }).toPass({timeout: 20000, intervals: [2000, 3000, 5000]})
+
+    // Verify useDocument live-updates the version document under a release
+    // perspective when it is edited elsewhere
+    await expect(async () => {
+      const dataContent = await dataCard.textContent()
+      expect(dataContent).toContain('"name": "Updated Release Test Author"')
     }).toPass({timeout: 20000, intervals: [2000, 3000, 5000]})
   })
 })

--- a/packages/core/src/document/sharedListener.test.ts
+++ b/packages/core/src/document/sharedListener.test.ts
@@ -51,6 +51,7 @@ describe('createSharedListener', () => {
       {
         events: ['mutation', 'welcome', 'reconnect'],
         includeResult: false,
+        includeAllVersions: true,
         tag: 'document-listener',
       },
     )

--- a/packages/core/src/document/sharedListener.ts
+++ b/packages/core/src/document/sharedListener.ts
@@ -43,6 +43,8 @@ export function createSharedListener(
         {
           events: ['mutation', 'welcome', 'reconnect'],
           includeResult: false,
+          // the document store handles version documents, so we need to include all versions
+          includeAllVersions: true,
           tag: 'document-listener',
           // // from manual testing, it seems like mendoza patches may be
           // // causing some ambiguity/wonkiness


### PR DESCRIPTION
### Description
In addressing #998 I noticed that a version document wasn't updating when I was changing it from a studio. It turns out we were missing a `listen` parameter. This will make our events stream slightly noisier, but doesn't really affect the document store, since we only act on ids we are listening to.

### What to review
Does the additional parameter make sense?

### Testing
This isn't really able to be covered by vitest, since we mock events. I did update our e2e tests for this case.

### Fun gif
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHAxbnY3eHNoem50OW82cW5uYzRueTdxYXhmYmVtZTJtank1Z2hnNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/U8o1ssggvfKAo/giphy.gif)