### PR TITLE
chore: migrate from eslint-plugin-import to eslint-plugin-import-x

### DIFF
--- a/apps/kitchensink-react/eslint.config.mjs
+++ b/apps/kitchensink-react/eslint.config.mjs
@@ -5,19 +5,6 @@ import reactConfig from '@repo/config-eslint/react'
 export default [
   {
     ignores: [
-      '.DS_Store',
-      '**/node_modules',
-      '**/build',
-      '**/dist',
-      '.env',
-      '.env.*',
-      '!.env.example',
-
-      // Ignore files for PNPM, NPM and YARN
-      'pnpm-lock.yaml',
-      'package-lock.json',
-      'yarn.lock',
-
       // Ignore files for Sanity TypeGen
       'sanity.types.ts',
 
@@ -28,23 +15,18 @@ export default [
   ...baseESLintConfig,
   ...reactConfig,
   {
-    // Node tooling scripts (e.g. typegen) legitimately use console output and
-    // import dev-only build dependencies.
+    // Node tooling scripts (e.g. typegen) legitimately use console output.
     files: ['scripts/**'],
     rules: {
       'no-console': 'off',
-      'import/no-extraneous-dependencies': [
-        'error',
-        {devDependencies: true, optionalDependencies: false, includeTypes: false},
-      ],
     },
   },
   {
-    // Sanity config files import the `sanity` package and Vite, which are
-    // build-time devDependencies for this App SDK app.
-    files: ['sanity.config.ts', 'sanity.cli.ts'],
+    // Tooling scripts and Sanity config files import the `sanity` package and
+    // Vite, which are build-time devDependencies for this App SDK app.
+    files: ['scripts/**', 'sanity.config.ts', 'sanity.cli.ts'],
     rules: {
-      'import/no-extraneous-dependencies': [
+      'import-x/no-extraneous-dependencies': [
         'error',
         {devDependencies: true, optionalDependencies: false, includeTypes: false},
       ],

--- a/apps/standalone-react/eslint.config.mjs
+++ b/apps/standalone-react/eslint.config.mjs
@@ -2,21 +2,4 @@
 import baseESLintConfig from '@repo/config-eslint'
 import reactConfig from '@repo/config-eslint/react'
 
-export default [
-  {
-    ignores: [
-      '.DS_Store',
-      '**/node_modules',
-      '**/build',
-      '**/dist',
-      '.env',
-      '.env.*',
-      '!.env.example',
-      'pnpm-lock.yaml',
-      'package-lock.json',
-      'yarn.lock',
-    ],
-  },
-  ...baseESLintConfig,
-  ...reactConfig,
-]
+export default [...baseESLintConfig, ...reactConfig]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,25 +4,22 @@ import baseESLintConfig from '@repo/config-eslint'
 export default [
   {
     ignores: [
-      '.DS_Store',
-      '**/node_modules',
-      '**/build',
-      '**/dist',
-      '**/coverage',
-      '**/docs',
+      // Packages and apps lint themselves; the base config covers the rest.
       '**/packages/',
       '**/apps',
       '**/.turbo',
-      '.env',
-      '.env.*',
-      '!.env.example',
-
-      // Ignore files for PNPM, NPM and YARN
-      'pnpm-lock.yaml',
-      'package-lock.json',
-      'yarn.lock',
       'sanity.types.ts',
     ],
   },
   ...baseESLintConfig,
+  {
+    // Root-level scripts are repo tooling and may import devDependencies.
+    files: ['scripts/**'],
+    rules: {
+      'import-x/no-extraneous-dependencies': [
+        'error',
+        {devDependencies: true, optionalDependencies: false, includeTypes: false},
+      ],
+    },
+  },
 ]

--- a/packages/@repo/config-eslint/index.mjs
+++ b/packages/@repo/config-eslint/index.mjs
@@ -3,7 +3,7 @@ import js from '@eslint/js'
 import eslintConfigPrettier from 'eslint-config-prettier'
 import turboConfig from 'eslint-config-turbo/flat'
 import {createTypeScriptImportResolver} from 'eslint-import-resolver-typescript'
-import * as importPlugin from 'eslint-plugin-import'
+import {importX} from 'eslint-plugin-import-x'
 import simpleImportSort from 'eslint-plugin-simple-import-sort'
 import unusedImports from 'eslint-plugin-unused-imports'
 import globals from 'globals'
@@ -32,23 +32,23 @@ export default [
   },
   js.configs.recommended,
   eslintConfigPrettier,
-  importPlugin.flatConfigs?.typescript,
+  importX.flatConfigs?.typescript,
   ...tsLint.configs.recommended,
   ...turboConfig,
   {
     rules: {
-      'import/consistent-type-specifier-style': ['error', 'prefer-inline'],
-      'import/first': 'error',
-      'import/newline-after-import': 'error',
-      'import/no-cycle': 'error',
-      'import/no-duplicates': [
+      'import-x/consistent-type-specifier-style': ['error', 'prefer-inline'],
+      'import-x/first': 'error',
+      'import-x/newline-after-import': 'error',
+      'import-x/no-cycle': 'error',
+      'import-x/no-duplicates': [
         'error',
         {
           'prefer-inline': true,
         },
       ],
-      'import/no-self-import': 'error',
-      'import/no-extraneous-dependencies': [
+      'import-x/no-self-import': 'error',
+      'import-x/no-extraneous-dependencies': [
         'error',
         {
           devDependencies: [
@@ -60,6 +60,7 @@ export default [
             '**/e2e/**',
             '**/config-eslint/**',
             '**/vite.config.ts',
+            '**/vite.config.mjs',
             '**/eslint.config.mjs',
             '**/vitest.mjs',
             '**/vitest.config.ts',
@@ -73,7 +74,7 @@ export default [
           includeTypes: false,
         },
       ],
-      'import/order': 'off',
+      'import-x/order': 'off',
       'no-console': 'error',
       'no-multi-spaces': 'error',
       'no-restricted-imports': [
@@ -131,14 +132,9 @@ export default [
       },
     },
     settings: {
-      'import/resolver-next': [
+      'import-x/resolver-next': [
         createTypeScriptImportResolver({
           alwaysTryTypes: true,
-          extensions: ['.js', '.ts', '.mjs', '.mts'],
-
-          // use an array of glob patterns; v4 warns on multiple projects unless opted out
-          noWarnOnMultipleProjects: true,
-          project: ['packages/*/tsconfig.json', 'apps/*/tsconfig.json'],
         }),
       ],
     },

--- a/packages/@repo/config-eslint/package.json
+++ b/packages/@repo/config-eslint/package.json
@@ -17,7 +17,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-config-turbo": "^2.10.3",
     "eslint-import-resolver-typescript": "^4.4.5",
-    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-import-x": "^4.17.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/packages/@repo/config-eslint/react.mjs
+++ b/packages/@repo/config-eslint/react.mjs
@@ -25,7 +25,6 @@ export default [
     rules: {
       ...reactHooks.configs.recommended.rules,
       ...reactRefresh.configs.recommended.rules,
-      'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',
       'react-refresh/only-export-components': ['warn', {allowConstantExport: true}],
     },

--- a/packages/@repo/e2e/eslint.config.mjs
+++ b/packages/@repo/e2e/eslint.config.mjs
@@ -1,9 +1,3 @@
 import baseConfig from '@repo/config-eslint'
 
-export default [
-  ...baseConfig,
-  {
-    files: ['**/*.ts', '**/*.tsx'],
-    rules: {},
-  },
-]
+export default baseConfig

--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -2,26 +2,4 @@
 import baseESLintConfig from '@repo/config-eslint'
 import tsdocConfig from '@repo/config-eslint/tsdoc'
 
-export default [
-  {
-    ignores: [
-      '.DS_Store',
-      '**/node_modules',
-      '**/build',
-      '**/dist',
-      '**/coverage',
-      '**/public',
-      '**/docs',
-      '.env',
-      '.env.*',
-      '!.env.example',
-
-      // Ignore files for PNPM, NPM and YARN
-      'pnpm-lock.yaml',
-      'package-lock.json',
-      'yarn.lock',
-    ],
-  },
-  ...baseESLintConfig,
-  ...tsdocConfig,
-]
+export default [...baseESLintConfig, ...tsdocConfig]

--- a/packages/core/src/auth/authStore.test.ts
+++ b/packages/core/src/auth/authStore.test.ts
@@ -62,7 +62,7 @@ vi.mock('../utils/logger', async (importOriginal) => {
 })
 
 // Import createLogger after mocking
-// eslint-disable-next-line import/first
+// eslint-disable-next-line import-x/first
 import {createLogger} from '../utils/logger'
 
 describe('authStore', () => {

--- a/packages/core/src/auth/handleAuthCallback.test.ts
+++ b/packages/core/src/auth/handleAuthCallback.test.ts
@@ -38,7 +38,7 @@ vi.mock('../utils/logger', async (importOriginal) => {
 })
 
 // Import createLogger after mocking
-// eslint-disable-next-line import/first
+// eslint-disable-next-line import-x/first
 import {createLogger} from '../utils/logger'
 
 let instance: SanityInstance | undefined

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -33,7 +33,7 @@ import {type DatasetHandle} from '../config/sanityConfig'
  * 3. releasesStore uses queryStore as a data source
  * 4. however, queryStore does not use getPerspectiveState for the perspective used in releasesStore ("raw")
  */
-// eslint-disable-next-line import/no-cycle
+// eslint-disable-next-line import-x/no-cycle
 import {getPerspectiveState} from '../releases/getPerspectiveState'
 import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
 import {bindActionByResource, type BoundResourceKey} from '../store/createActionBinder'

--- a/packages/core/src/releases/getPerspectiveState.ts
+++ b/packages/core/src/releases/getPerspectiveState.ts
@@ -10,7 +10,7 @@ import {createStateSourceAction, type SelectorContext} from '../store/createStat
  * 3. queryStore calls getPerspectiveState for computing release perspectives
  * 4. however, queryStore does not use getPerspectiveState for the perspective used in releasesStore ("raw")
  */
-// eslint-disable-next-line import/no-cycle
+// eslint-disable-next-line import-x/no-cycle
 import {releasesStore, type ReleasesStoreState} from './releasesStore'
 import {isReleasePerspective} from './utils/isReleasePerspective'
 import {sortReleases} from './utils/sortReleases'

--- a/packages/core/src/releases/releasesStore.ts
+++ b/packages/core/src/releases/releasesStore.ts
@@ -9,7 +9,7 @@ import {type DocumentResource} from '../config/sanityConfig'
  * 3. getPerspectiveState uses releasesStore as a data source
  * 4. however, queryStore does not use getPerspectiveState for the perspective used in releasesStore ("raw")
  */
-// eslint-disable-next-line import/no-cycle
+// eslint-disable-next-line import-x/no-cycle
 import {getQueryState} from '../query/queryStore'
 import {bindActionByResource, type BoundResourceKey} from '../store/createActionBinder'
 import {type SanityInstance} from '../store/createSanityInstance'

--- a/packages/react/eslint.config.mjs
+++ b/packages/react/eslint.config.mjs
@@ -3,27 +3,4 @@ import baseESLintConfig from '@repo/config-eslint'
 import reactConfig from '@repo/config-eslint/react'
 import tsdocConfig from '@repo/config-eslint/tsdoc'
 
-export default [
-  {
-    ignores: [
-      '.DS_Store',
-      '**/node_modules',
-      '**/build',
-      '**/dist',
-      '**/coverage',
-      '**/public',
-      '**/docs',
-      '.env',
-      '.env.*',
-      '!.env.example',
-
-      // Ignore files for PNPM, NPM and YARN
-      'pnpm-lock.yaml',
-      'package-lock.json',
-      'yarn.lock',
-    ],
-  },
-  ...baseESLintConfig,
-  ...tsdocConfig,
-  ...reactConfig,
-]
+export default [...baseESLintConfig, ...tsdocConfig, ...reactConfig]

--- a/packages/react/src/hooks/document/useApplyDocumentActions.ts
+++ b/packages/react/src/hooks/document/useApplyDocumentActions.ts
@@ -4,7 +4,7 @@ import {type SanityDocument} from 'groq'
 import {type ResourceHandle} from '../../config/handles'
 import {useApplyActions} from '../helpers/useApplyActions'
 // this import is used in an `{@link useEditDocument}`
-// eslint-disable-next-line import/consistent-type-specifier-style
+// eslint-disable-next-line import-x/consistent-type-specifier-style
 import type {useEditDocument} from './useEditDocument'
 
 /**

--- a/packages/react/src/hooks/document/useDocument.ts
+++ b/packages/react/src/hooks/document/useDocument.ts
@@ -7,9 +7,9 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
 import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
 import {useTrackHookUsage} from '../helpers/useTrackHookUsage'
 // used in an `{@link useDocumentProjection}` and `{@link useQuery}`
-// eslint-disable-next-line import/consistent-type-specifier-style
+// eslint-disable-next-line import-x/consistent-type-specifier-style
 import type {useDocumentProjection} from '../projection/useDocumentProjection'
-// eslint-disable-next-line import/consistent-type-specifier-style
+// eslint-disable-next-line import-x/consistent-type-specifier-style
 import type {useQuery} from '../query/useQuery'
 
 const useDocumentValue = createStateSourceHook({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,10 +342,10 @@ importers:
         version: 2.10.3(eslint@10.6.0(jiti@2.7.0))(turbo@2.9.18)
       eslint-import-resolver-typescript:
         specifier: ^4.4.5
-        version: 4.4.5(eslint-plugin-import@2.32.0)(eslint@10.6.0(jiti@2.7.0))
-      eslint-plugin-import:
-        specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.6.0(jiti@2.7.0))
+        version: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@10.6.0(jiti@2.7.0))
+      eslint-plugin-import-x:
+        specifier: ^4.17.1
+        version: 4.17.1(@typescript-eslint/utils@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@10.6.0(jiti@2.7.0))
@@ -4602,6 +4602,10 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  comment-parser@1.4.7:
+    resolution: {integrity: sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==}
+    engines: {node: '>= 12.0.0'}
+
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
@@ -5035,6 +5039,19 @@ packages:
       eslint-import-resolver-typescript:
         optional: true
       eslint-import-resolver-webpack:
+        optional: true
+
+  eslint-plugin-import-x@4.17.1:
+    resolution: {integrity: sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/utils': ^8.56.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      eslint-import-resolver-node: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/utils':
+        optional: true
+      eslint-import-resolver-node:
         optional: true
 
   eslint-plugin-import@2.32.0:
@@ -10674,7 +10691,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.0':
     optional: true
 
-  '@rtsao/scc@1.1.0': {}
+  '@rtsao/scc@1.1.0':
+    optional: true
 
   '@rushstack/node-core-library@5.23.1(@types/node@24.12.4)':
     dependencies:
@@ -11607,7 +11625,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/json5@0.0.29': {}
+  '@types/json5@0.0.29':
+    optional: true
 
   '@types/linkify-it@5.0.0': {}
 
@@ -12141,6 +12160,7 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       es-shim-unscopables: 1.1.0
+    optional: true
 
   array.prototype.flat@1.3.3:
     dependencies:
@@ -12493,6 +12513,8 @@ snapshots:
 
   commander@2.20.3: {}
 
+  comment-parser@1.4.7: {}
+
   commondir@1.0.1: {}
 
   compare-func@2.0.0:
@@ -12638,6 +12660,7 @@ snapshots:
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
+    optional: true
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -12958,8 +12981,9 @@ snapshots:
       resolve: 1.22.11
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
-  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import@2.32.0)(eslint@10.6.0(jiti@2.7.0)):
+  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@10.6.0(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.6.0(jiti@2.7.0)
@@ -12971,6 +12995,7 @@ snapshots:
       unrs-resolver: 1.12.2
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.6.0(jiti@2.7.0))
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@10.6.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -12981,7 +13006,26 @@ snapshots:
       '@typescript-eslint/parser': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3)
       eslint: 10.6.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import@2.32.0)(eslint@10.6.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@10.6.0(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@10.6.0(jiti@2.7.0)):
+    dependencies:
+      '@typescript-eslint/types': 8.62.1
+      comment-parser: 1.4.7
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.6.0(jiti@2.7.0)
+      eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
+      is-glob: 4.0.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      stable-hash-x: 0.2.0
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
@@ -13013,6 +13057,7 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    optional: true
 
   eslint-plugin-react-compiler@19.1.0-rc.2(eslint@10.6.0(jiti@2.7.0)):
     dependencies:
@@ -14145,6 +14190,7 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+    optional: true
 
   json5@2.2.3: {}
 
@@ -14571,6 +14617,7 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-abstract: 1.24.2
+    optional: true
 
   object.values@1.2.1:
     dependencies:
@@ -15960,6 +16007,7 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+    optional: true
 
   tsconfig-paths@4.2.0:
     dependencies:

--- a/scripts/uploadBundles.mts
+++ b/scripts/uploadBundles.mts
@@ -4,7 +4,6 @@ import {readdir, readFile, stat, writeFile} from 'node:fs/promises'
 import {type SourceMapPayload} from 'node:module'
 import path from 'node:path'
 
-/* eslint-disable import/no-extraneous-dependencies */
 import {Storage, type UploadOptions} from '@google-cloud/storage'
 import {type NormalizedReadResult, readPackageUp} from 'read-package-up'
 


### PR DESCRIPTION
### Description

Migrates from the unmaintained-for-flat-config `eslint-plugin-import` to `eslint-plugin-import-x`.

- Swap `eslint-plugin-import` → `eslint-plugin-import-x@^4.17.1`; rename all `import/*` rules and settings to `import-x/*`.
- Simplify the TS resolver to `createTypeScriptImportResolver({alwaysTryTypes: true})` — the previous `extensions` override broke resolution of extensionless `.tsx` imports (silently disabling `no-cycle` for React components), and the `project` globs were dead config in per-package turbo runs.
- Fix violations surfaced because `no-extraneous-dependencies` was silently inert under the old plugin (it never reported anything): allow `vite.config.mjs` in the shared devDependencies globs and allow root `scripts/**` to import devDependencies.
- Dedupe configs: remove local `ignores` blocks that duplicated the base config, merge kitchensink's two identical `no-extraneous-dependencies` overrides, drop e2e's empty rules block and a `rules-of-hooks` line already set by the preset.

Lint is also ~2.4× faster: `eslint .` on `packages/core` went from ~8.3s to ~3.5s.

### What to review

- `packages/@repo/config-eslint/index.mjs` — the rule/settings rename and resolver change.
- The per-package `eslint.config.mjs` cleanups are behavior-preserving deletions.

### Testing

`pnpm lint` passes across the workspace. Resolver behavior verified by invoking `createTypeScriptImportResolver` directly (`.tsx` now resolves; previously it didn't), and `react-hooks` rules confirmed still at error level via `--print-config`.

### Fun gif

![Sweeping up](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)