### PR TITLE
refactor(core): break import cycle between query and releases stores

### DIFF
--- a/packages/core/src/client/liveEvents.test.ts
+++ b/packages/core/src/client/liveEvents.test.ts
@@ -1,0 +1,151 @@
+import {
+  ConnectionFailedError,
+  CorsOriginError,
+  DisconnectError,
+  type LiveEvent,
+  type LiveEventMessage,
+  type SanityClient,
+} from '@sanity/client'
+import {of, Subject} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {getClientState} from './clientStore'
+import {LIVE_EVENTS_RETRY_DELAY, observeLiveEvents} from './liveEvents'
+
+vi.mock('./clientStore', () => ({getClientState: vi.fn()}))
+
+describe('observeLiveEvents', () => {
+  let instance: SanityInstance
+  let liveEventSubjects: Subject<LiveEvent>[]
+  let events: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    instance = createSanityInstance({projectId: 'test', dataset: 'test'})
+
+    liveEventSubjects = []
+    events = vi.fn().mockImplementation(() => {
+      const subject = new Subject<LiveEvent>()
+      liveEventSubjects.push(subject)
+      return subject
+    })
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of({
+        config: vi.fn().mockReturnValue({token: 'token'}),
+        live: {events},
+      } as unknown as SanityClient),
+    } as StateSource<SanityClient>)
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('emits only message events', () => {
+    const messages: LiveEventMessage[] = []
+    const subscription = observeLiveEvents(instance, {onCorsError: vi.fn()}).subscribe((message) =>
+      messages.push(message),
+    )
+
+    liveEventSubjects[0].next({type: 'welcome'} as LiveEvent)
+    liveEventSubjects[0].next({type: 'message', id: 'e1', tags: ['s1:a']} as LiveEvent)
+
+    expect(messages).toEqual([{type: 'message', id: 'e1', tags: ['s1:a']}])
+    subscription.unsubscribe()
+  })
+
+  it('reports CORS errors through onCorsError and completes without erroring', () => {
+    const onCorsError = vi.fn()
+    const error = vi.fn()
+    const complete = vi.fn()
+    observeLiveEvents(instance, {onCorsError}).subscribe({error, complete})
+
+    const corsError = new CorsOriginError({projectId: 'test'})
+    liveEventSubjects[0].error(corsError)
+
+    expect(onCorsError).toHaveBeenCalledWith(corsError)
+    expect(error).not.toHaveBeenCalled()
+    expect(complete).toHaveBeenCalled()
+  })
+
+  it('completes without retrying on DisconnectError', async () => {
+    vi.useFakeTimers()
+    try {
+      const error = vi.fn()
+      const complete = vi.fn()
+      observeLiveEvents(instance, {onCorsError: vi.fn()}).subscribe({error, complete})
+
+      liveEventSubjects[0].error(new DisconnectError('Server disconnected client'))
+      await vi.advanceTimersByTimeAsync(LIVE_EVENTS_RETRY_DELAY * 5)
+
+      expect(error).not.toHaveBeenCalled()
+      expect(complete).toHaveBeenCalled()
+      expect(events).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('completes without retrying on a 4xx connection rejection', async () => {
+    vi.useFakeTimers()
+    try {
+      const error = vi.fn()
+      const complete = vi.fn()
+      observeLiveEvents(instance, {onCorsError: vi.fn()}).subscribe({error, complete})
+
+      // The server rejected the connection with a 401 (e.g. expired token) —
+      // it will keep rejecting, so retrying would reconnect once per second
+      // forever
+      liveEventSubjects[0].error(
+        new ConnectionFailedError('EventSource connection failed', {status: 401}),
+      )
+      await vi.advanceTimersByTimeAsync(LIVE_EVENTS_RETRY_DELAY * 5)
+
+      expect(error).not.toHaveBeenCalled()
+      expect(complete).toHaveBeenCalled()
+      expect(events).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries a connection failure without a status (transient network failure)', async () => {
+    vi.useFakeTimers()
+    try {
+      const error = vi.fn()
+      const subscription = observeLiveEvents(instance, {onCorsError: vi.fn()}).subscribe({error})
+
+      // No status means the failure could be transient (native EventSource
+      // exposes no status) — reconnecting is correct here
+      liveEventSubjects[0].error(new ConnectionFailedError('EventSource connection failed'))
+      await vi.advanceTimersByTimeAsync(LIVE_EVENTS_RETRY_DELAY)
+
+      expect(events).toHaveBeenCalledTimes(2)
+      expect(error).not.toHaveBeenCalled()
+      subscription.unsubscribe()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries the connection after server-initiated errors', async () => {
+    vi.useFakeTimers()
+    try {
+      const error = vi.fn()
+      const subscription = observeLiveEvents(instance, {onCorsError: vi.fn()}).subscribe({error})
+      expect(events).toHaveBeenCalledTimes(1)
+
+      liveEventSubjects[0].error(new Error('ChannelError'))
+      await vi.advanceTimersByTimeAsync(LIVE_EVENTS_RETRY_DELAY)
+
+      expect(events).toHaveBeenCalledTimes(2)
+      expect(error).not.toHaveBeenCalled()
+      subscription.unsubscribe()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/core/src/client/liveEvents.ts
+++ b/packages/core/src/client/liveEvents.ts
@@ -1,0 +1,107 @@
+import {
+  ConnectionFailedError,
+  CorsOriginError,
+  DisconnectError,
+  type LiveEventMessage,
+} from '@sanity/client'
+import {catchError, defer, EMPTY, filter, type Observable, retry, switchMap} from 'rxjs'
+
+import {type DocumentResource} from '../config/sanityConfig'
+import {type SanityInstance} from '../store/createSanityInstance'
+import {getClientState} from './clientStore'
+
+/**
+ * All live-events subscriptions must use identical connection options
+ * (API version, request tag, `includeDrafts`): `@sanity/client` caches the
+ * underlying EventSource per URL + options, so divergent options would
+ * silently split what should be a single shared connection.
+ */
+const LIVE_EVENTS_API_VERSION = 'v2025-05-06'
+
+/**
+ * Delay before re-establishing the live events connection after a
+ * server-initiated error (e.g. ChannelError, MessageError). Live errors are
+ * retried rather than surfaced because an errored live connection would
+ * otherwise poison the consuming store. Plain connection drops never reach
+ * this — they are reconnected inside `@sanity/client`.
+ *
+ * @internal
+ */
+export const LIVE_EVENTS_RETRY_DELAY = 1000
+
+/**
+ * Options for {@link observeLiveEvents}.
+ * @internal
+ */
+export interface ObserveLiveEventsOptions {
+  /** Resource to scope the underlying client and live connection to. */
+  resource?: DocumentResource
+  /**
+   * Called when the connection fails due to a CORS misconfiguration. The
+   * error is swallowed (the stream never errors; it idles until a new client
+   * is emitted) so consumers can surface it as store state instead of a
+   * stream error.
+   */
+  onCorsError: (error: unknown) => void
+}
+
+/**
+ * Emits Live Content API messages for a dataset so consumers can invalidate
+ * fetched data via sync tags.
+ *
+ * All consumers observe the same underlying EventSource connection:
+ * `@sanity/client` caches the live-events stream per URL and connection
+ * options, and every subscription made through this function uses the same
+ * API version and request tag.
+ *
+ * @internal
+ */
+export function observeLiveEvents(
+  instance: SanityInstance,
+  {resource, onCorsError}: ObserveLiveEventsOptions,
+): Observable<LiveEventMessage> {
+  return getClientState(instance, {
+    apiVersion: LIVE_EVENTS_API_VERSION,
+    resource,
+  }).observable.pipe(
+    switchMap((client) =>
+      defer(() =>
+        client.live.events({includeDrafts: !!client.config().token, tag: 'live-events'}),
+      ).pipe(
+        catchError((error) => {
+          if (error instanceof CorsOriginError) {
+            // Swallow CORS errors without bubbling up so that they can be
+            // handled by the consumer (e.g. shown via the Cors Error component)
+            onCorsError(error)
+            return EMPTY
+          }
+          if (error instanceof DisconnectError) {
+            // The server explicitly told this client to stop reconnecting —
+            // end live updates without erroring (consumers keep serving data,
+            // they just stop receiving live invalidation)
+            return EMPTY
+          }
+          if (
+            error instanceof ConnectionFailedError &&
+            typeof error.status === 'number' &&
+            error.status >= 400 &&
+            error.status < 500
+          ) {
+            // The server rejected the connection with a 4xx (e.g. a 401 from
+            // an expired token) — it will keep rejecting, so retrying would
+            // reconnect once per second forever. End live updates like a
+            // DisconnectError. A ConnectionFailedError without a status stays
+            // retryable: it may be a transient network failure.
+            return EMPTY
+          }
+          throw error
+        }),
+        // Server-initiated live errors (e.g. ChannelError, MessageError) are
+        // retried, not surfaced. Dropped connections are already reconnected
+        // inside @sanity/client.
+        retry({delay: LIVE_EVENTS_RETRY_DELAY}),
+      ),
+    ),
+    filter((e): e is LiveEventMessage => e.type === 'message'),
+  )
+}

--- a/packages/core/src/query/queryStore.test.ts
+++ b/packages/core/src/query/queryStore.test.ts
@@ -1,5 +1,6 @@
 import {
   ConnectionFailedError,
+  CorsOriginError,
   DisconnectError,
   type LiveEvent,
   type SanityClient,
@@ -9,11 +10,12 @@ import {delay, filter, firstValueFrom, Observable, of, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {getClientState} from '../client/clientStore'
+import {LIVE_EVENTS_RETRY_DELAY} from '../client/liveEvents'
 import {isCanvasResource} from '../config/sanityConfig'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
 import {getQueryState, resolveQuery} from './queryStore'
-import {LIVE_EVENTS_RETRY_DELAY, QUERY_STATE_CLEAR_DELAY} from './queryStoreConstants'
+import {QUERY_STATE_CLEAR_DELAY} from './queryStoreConstants'
 
 vi.mock('../client/clientStore', () => ({
   getClientState: vi.fn(),
@@ -438,6 +440,21 @@ describe('queryStore', () => {
 
     expect(() => state.getCurrent()).not.toThrow()
     expect(eventsMock.mock.calls.length).toBeGreaterThan(callsBefore)
+    unsub()
+  })
+
+  it('surfaces CORS errors on the live connection as a store-wide error', async () => {
+    const query = '*[_type == "movie"]'
+    const state = getQueryState(instance, {query})
+    const unsub = state.subscribe()
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
+
+    liveEvents.error(new CorsOriginError({projectId: 'test'}))
+    await vi.advanceTimersByTimeAsync(0)
+
+    // the swallowed CORS error is recorded as store state so the query
+    // selector rethrows it (handled by the Cors Error component)
+    expect(() => state.getCurrent()).toThrow(CorsOriginError)
     unsub()
   })
 

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -1,14 +1,8 @@
-import {
-  ConnectionFailedError,
-  CorsOriginError,
-  DisconnectError,
-  type ResponseQueryOptions,
-} from '@sanity/client'
+import {type ResponseQueryOptions} from '@sanity/client'
 import {type SanityQueryResult} from 'groq'
 import {
   catchError,
   combineLatest,
-  defer,
   distinctUntilChanged,
   EMPTY,
   filter,
@@ -22,7 +16,6 @@ import {
   of,
   pairwise,
   race,
-  retry,
   share,
   startWith,
   switchMap,
@@ -30,15 +23,8 @@ import {
 } from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
+import {observeLiveEvents} from '../client/liveEvents'
 import {type DatasetHandle} from '../config/sanityConfig'
-/*
- * Although this is an import dependency cycle, it is not a logical cycle:
- * 1. queryStore uses getPerspectiveState when resolving release perspectives
- * 2. getPerspectiveState uses releasesStore as a data source
- * 3. releasesStore uses queryStore as a data source
- * 4. however, queryStore does not use getPerspectiveState for the perspective used in releasesStore ("raw")
- */
-// eslint-disable-next-line import-x/no-cycle
 import {getPerspectiveState} from '../releases/getPerspectiveState'
 import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
 import {bindActionByResource, type BoundResourceKey} from '../store/createActionBinder'
@@ -53,7 +39,6 @@ import {defineStore, type StoreContext} from '../store/defineStore'
 import {insecureRandomId} from '../utils/ids'
 import {setCleanupTimeout} from '../utils/setCleanupTimeout'
 import {
-  LIVE_EVENTS_RETRY_DELAY,
   QUERY_STATE_CLEAR_DELAY,
   QUERY_STORE_API_VERSION,
   QUERY_STORE_DEFAULT_PERSPECTIVE,
@@ -237,52 +222,14 @@ const listenToLiveClientAndSetLastLiveEventIds = ({
   instance,
   key: {resource},
 }: StoreContext<QueryStoreState, BoundResourceKey>) => {
-  const liveMessages$ = getClientState(instance, {
-    apiVersion: QUERY_STORE_API_VERSION,
+  const liveMessages$ = observeLiveEvents(instance, {
     resource,
-  }).observable.pipe(
-    switchMap((client) =>
-      defer(() =>
-        client.live.events({includeDrafts: !!client.config().token, tag: 'query-store'}),
-      ).pipe(
-        catchError((error) => {
-          if (error instanceof CorsOriginError) {
-            // Swallow only CORS errors in store without bubbling up so that they are handled by the Cors Error component
-            state.set('setError', {error})
-            return EMPTY
-          }
-          if (error instanceof DisconnectError) {
-            // The server explicitly told this client to stop reconnecting —
-            // end live updates without erroring the store (queries keep
-            // serving, they just stop receiving live invalidation)
-            return EMPTY
-          }
-          if (
-            error instanceof ConnectionFailedError &&
-            typeof error.status === 'number' &&
-            error.status >= 400 &&
-            error.status < 500
-          ) {
-            // The server rejected the connection with a 4xx (e.g. a 401 from
-            // an expired token) — it will keep rejecting, so retrying would
-            // reconnect once per second forever. End live updates like a
-            // DisconnectError. A ConnectionFailedError without a status stays
-            // retryable: it may be a transient network failure.
-            return EMPTY
-          }
-          throw error
-        }),
-        // Server-initiated live errors (e.g. ChannelError, MessageError) are
-        // retried, not surfaced: an error here would reach the outer
-        // subscription's errorHandler, set the store-wide `state.error`, and
-        // permanently brick every query selector (nothing ever clears it).
-        // Dropped connections are already reconnected inside @sanity/client.
-        retry({delay: LIVE_EVENTS_RETRY_DELAY}),
-      ),
-    ),
-    share(),
-    filter((e) => e.type === 'message'),
-  )
+    // Surface CORS errors as store state (handled by the Cors Error
+    // component) instead of erroring the stream: a stream error here would
+    // reach the outer subscription's errorHandler, set the store-wide
+    // `state.error`, and permanently brick every query selector.
+    onCorsError: (error) => state.set('setError', {error}),
+  }).pipe(share())
 
   return state.observable
     .pipe(

--- a/packages/core/src/query/queryStoreConstants.ts
+++ b/packages/core/src/query/queryStoreConstants.ts
@@ -8,12 +8,3 @@
 export const QUERY_STATE_CLEAR_DELAY = 1000
 export const QUERY_STORE_API_VERSION = 'v2025-05-06'
 export const QUERY_STORE_DEFAULT_PERSPECTIVE = 'drafts'
-
-/**
- * Delay before re-establishing the live events connection after a
- * server-initiated error (e.g. ChannelError, MessageError). Live errors are
- * retried rather than surfaced because an errored live connection would
- * otherwise poison the whole store. Plain connection drops never reach this —
- * they are reconnected inside `@sanity/client`.
- */
-export const LIVE_EVENTS_RETRY_DELAY = 1000

--- a/packages/core/src/releases/getPerspectiveState.test.ts
+++ b/packages/core/src/releases/getPerspectiveState.test.ts
@@ -3,12 +3,11 @@ import {filter, firstValueFrom, of, Subject, take} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
 import {type PerspectiveHandle, type ReleasePerspective} from '../config/sanityConfig'
-import {getQueryState} from '../query/queryStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
-import {type StateSource} from '../store/createStateSourceAction'
 import {getPerspectiveState} from './getPerspectiveState'
+import {observeReleases} from './observeReleases'
 
-vi.mock('../query/queryStore')
+vi.mock('./observeReleases')
 
 vi.mock('../client/clientStore', () => ({
   getClientState: vi.fn(() => ({
@@ -44,11 +43,7 @@ describe('getPerspectiveState', () => {
     instance = createSanityInstance({projectId: 'test', dataset: 'test'})
 
     mockReleasesQuerySubject = new Subject<ReleaseDocument[] | undefined>()
-    vi.mocked(getQueryState).mockReturnValue({
-      subscribe: () => () => {},
-      getCurrent: () => undefined,
-      observable: mockReleasesQuerySubject.asObservable(),
-    } as StateSource<ReleaseDocument[] | undefined>)
+    vi.mocked(observeReleases).mockReturnValue(mockReleasesQuerySubject.asObservable())
   })
 
   afterEach(() => {

--- a/packages/core/src/releases/getPerspectiveState.ts
+++ b/packages/core/src/releases/getPerspectiveState.ts
@@ -3,14 +3,6 @@ import {createSelector} from 'reselect'
 import {type DocumentResource, type PerspectiveHandle} from '../config/sanityConfig'
 import {bindActionByResource, type BoundStoreAction} from '../store/createActionBinder'
 import {createStateSourceAction, type SelectorContext} from '../store/createStateSourceAction'
-/*
- * Although this is an import dependency cycle, it is not a logical cycle:
- * 1. getPerspectiveState uses releasesStore as a data source
- * 2. releasesStore uses queryStore as a data source
- * 3. queryStore calls getPerspectiveState for computing release perspectives
- * 4. however, queryStore does not use getPerspectiveState for the perspective used in releasesStore ("raw")
- */
-// eslint-disable-next-line import-x/no-cycle
 import {releasesStore, type ReleasesStoreState} from './releasesStore'
 import {isReleasePerspective} from './utils/isReleasePerspective'
 import {sortReleases} from './utils/sortReleases'
@@ -53,7 +45,6 @@ const memoizedOptionsSelector = createSelector(
   },
 )
 
-// Lazily bind the action itself to avoid circular import initialization issues with `releasesStore`
 const _getPerspectiveStateSelector = createStateSourceAction({
   selector: createSelector(
     [selectInstancePerspective, selectActiveReleases, memoizedOptionsSelector],
@@ -89,7 +80,10 @@ type BoundGetPerspectiveState = BoundStoreAction<
   ReturnType<typeof _getPerspectiveStateSelector>
 >
 
-let _boundGetPerspectiveState: BoundGetPerspectiveState | undefined
+const _boundGetPerspectiveState = bindActionByResource(
+  releasesStore,
+  _getPerspectiveStateSelector,
+) as BoundGetPerspectiveState
 
 /**
  * Provides a subscribable state source for a "perspective" for the Sanity client,
@@ -103,13 +97,6 @@ let _boundGetPerspectiveState: BoundGetPerspectiveState | undefined
  *
  * @public
  */
-export const getPerspectiveState: BoundGetPerspectiveState = (instance, ...rest) => {
-  if (!_boundGetPerspectiveState) {
-    _boundGetPerspectiveState = bindActionByResource(
-      releasesStore,
-      _getPerspectiveStateSelector,
-    ) as BoundGetPerspectiveState
-  }
+export const getPerspectiveState: BoundGetPerspectiveState = (instance, ...rest) =>
   // bindActionByResource keyFn destructures { resource } from the first param, so pass {} when no options
-  return _boundGetPerspectiveState(instance, ...(rest.length ? rest : [{}]))
-}
+  _boundGetPerspectiveState(instance, ...(rest.length ? rest : [{}]))

--- a/packages/core/src/releases/observeReleases.test.ts
+++ b/packages/core/src/releases/observeReleases.test.ts
@@ -1,0 +1,127 @@
+import {type LiveEventMessage, type ReleaseDocument, type SanityClient} from '@sanity/client'
+import {of, Subject} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getClientState} from '../client/clientStore'
+import {observeLiveEvents} from '../client/liveEvents'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {observeReleases} from './observeReleases'
+
+vi.mock('../client/clientStore', () => ({getClientState: vi.fn()}))
+vi.mock('../client/liveEvents', () => ({observeLiveEvents: vi.fn()}))
+
+describe('observeReleases', () => {
+  let instance: SanityInstance
+  let liveMessages: Subject<LiveEventMessage>
+  let fetch: ReturnType<typeof vi.fn>
+
+  const release = {
+    _id: 'r1',
+    _type: 'system.release',
+    name: 'r1',
+    metadata: {title: 'R1', releaseType: 'asap'},
+  } as ReleaseDocument
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    instance = createSanityInstance({projectId: 'test', dataset: 'test'})
+    liveMessages = new Subject<LiveEventMessage>()
+
+    fetch = vi.fn().mockReturnValue(of({result: [release], syncTags: ['s1:tag']}))
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of({observable: {fetch}} as unknown as SanityClient),
+    } as StateSource<SanityClient>)
+    vi.mocked(observeLiveEvents).mockReturnValue(liveMessages.asObservable())
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('emits undefined synchronously, then fetches releases through the raw perspective', () => {
+    const releases$ = observeReleases(instance, {onCorsError: vi.fn()})
+    const emissions: (ReleaseDocument[] | undefined)[] = []
+    const subscription = releases$.subscribe((releases) => emissions.push(releases))
+
+    // the synchronous undefined lets the releases store immediately record an
+    // empty list, so consumers (e.g. suspending React hooks) never hang on a
+    // fetch that has not resolved yet
+    expect(emissions).toEqual([undefined, [release]])
+    expect(fetch).toHaveBeenCalledWith(
+      'releases::all()',
+      {},
+      expect.objectContaining({
+        perspective: 'raw',
+        tag: 'releases',
+        lastLiveEventId: undefined,
+      }),
+    )
+    subscription.unsubscribe()
+  })
+
+  it('refetches with the live event id when a message matches the sync tags', () => {
+    const releases$ = observeReleases(instance, {onCorsError: vi.fn()})
+    const emissions: (ReleaseDocument[] | undefined)[] = []
+    const subscription = releases$.subscribe((releases) => emissions.push(releases))
+
+    liveMessages.next({type: 'message', id: 'event-1', tags: ['s1:tag']} as LiveEventMessage)
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch).toHaveBeenLastCalledWith(
+      'releases::all()',
+      {},
+      expect.objectContaining({lastLiveEventId: 'event-1'}),
+    )
+    expect(emissions).toHaveLength(3) // initial undefined + two fetch results
+    subscription.unsubscribe()
+  })
+
+  it('ignores live events that do not match the sync tags', () => {
+    const releases$ = observeReleases(instance, {onCorsError: vi.fn()})
+    const subscription = releases$.subscribe()
+
+    liveMessages.next({type: 'message', id: 'event-1', tags: ['s1:other']} as LiveEventMessage)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    subscription.unsubscribe()
+  })
+
+  it('refetches for a matching message that arrived while a fetch was still in flight', () => {
+    const fetchResponses: Subject<{result: ReleaseDocument[]; syncTags: string[]}>[] = []
+    fetch.mockImplementation(() => {
+      const response$ = new Subject<{result: ReleaseDocument[]; syncTags: string[]}>()
+      fetchResponses.push(response$)
+      return response$
+    })
+
+    const releases$ = observeReleases(instance, {onCorsError: vi.fn()})
+    const emissions: (ReleaseDocument[] | undefined)[] = []
+    const subscription = releases$.subscribe((releases) => emissions.push(releases))
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // A message lands while the initial fetch is in flight — its sync tags are
+    // not known yet, so it can't be evaluated right away…
+    liveMessages.next({type: 'message', id: 'event-1', tags: ['s1:tag']} as LiveEventMessage)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // …but once the fetch completes with matching tags, it must trigger a
+    // refetch instead of being dropped (which would leave the store stale)
+    fetchResponses[0].next({result: [release], syncTags: ['s1:tag']})
+    fetchResponses[0].complete()
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch).toHaveBeenLastCalledWith(
+      'releases::all()',
+      {},
+      expect.objectContaining({lastLiveEventId: 'event-1'}),
+    )
+
+    fetchResponses[1].next({result: [release], syncTags: ['s1:tag']})
+    fetchResponses[1].complete()
+    expect(emissions).toHaveLength(3) // initial undefined + two fetch results
+
+    subscription.unsubscribe()
+  })
+})

--- a/packages/core/src/releases/observeReleases.ts
+++ b/packages/core/src/releases/observeReleases.ts
@@ -1,0 +1,102 @@
+import {type ReleaseDocument, type SyncTag} from '@sanity/client'
+import {
+  BehaviorSubject,
+  combineLatest,
+  distinctUntilChanged,
+  filter,
+  map,
+  type Observable,
+  startWith,
+  switchMap,
+  tap,
+} from 'rxjs'
+
+import {getClientState} from '../client/clientStore'
+import {observeLiveEvents} from '../client/liveEvents'
+import {type DocumentResource} from '../config/sanityConfig'
+import {type SanityInstance} from '../store/createSanityInstance'
+
+const RELEASES_QUERY = 'releases::all()'
+const RELEASES_API_VERSION = 'v2025-05-06'
+
+/**
+ * Options for {@link observeReleases}.
+ * @internal
+ */
+export interface ObserveReleasesOptions {
+  /** Resource to scope the underlying client and live connection to. */
+  resource?: DocumentResource
+  /**
+   * Called when the live events connection fails due to a CORS
+   * misconfiguration. See `observeLiveEvents`.
+   */
+  onCorsError: (error: unknown) => void
+}
+
+/**
+ * Emits every release document (including archived and published), refetching
+ * whenever a Live Content API event matches the query's sync tags.
+ *
+ * This fetches directly through the client store — deliberately not via the
+ * query store — because release data is itself an input to query perspective
+ * resolution (`getPerspectiveState`); fetching through the query store would
+ * make the two stores mutually dependent.
+ *
+ * @internal
+ */
+export function observeReleases(
+  instance: SanityInstance,
+  {resource, onCorsError}: ObserveReleasesOptions,
+): Observable<ReleaseDocument[] | undefined> {
+  const client$ = getClientState(instance, {
+    apiVersion: RELEASES_API_VERSION,
+    resource,
+  }).observable
+
+  return client$.pipe(
+    switchMap((client) => {
+      const syncTags$ = new BehaviorSubject<SyncTag[] | undefined>(undefined)
+
+      // Pair the latest live message with the latest known sync tags so that
+      // a message arriving while a fetch is still in flight is re-evaluated
+      // (and refetched if it matches) once that fetch's tags land — instead
+      // of being dropped and leaving the store stale until the next event.
+      const refetchEventId$ = combineLatest([
+        observeLiveEvents(instance, {resource, onCorsError}).pipe(startWith(undefined)),
+        syncTags$,
+      ]).pipe(
+        filter(
+          ([message, syncTags]) =>
+            message === undefined || message.tags.some((tag) => syncTags?.includes(tag)),
+        ),
+        map(([message]) => message?.id),
+        distinctUntilChanged(),
+      )
+
+      return refetchEventId$.pipe(
+        switchMap((lastLiveEventId) =>
+          client.observable.fetch<ReleaseDocument[]>(
+            RELEASES_QUERY,
+            {},
+            {
+              perspective: 'raw',
+              filterResponse: false,
+              returnQuery: false,
+              lastLiveEventId,
+              tag: 'releases',
+            },
+          ),
+        ),
+        tap((response) => {
+          syncTags$.next(response.syncTags)
+        }),
+        map((response) => response.result),
+      )
+    }),
+    // Emit synchronously on subscribe (mirroring StateSource semantics, which
+    // the releases store previously consumed) so the store can immediately
+    // record an empty list: consumers distinguish "no releases yet" from
+    // "never loaded", and the React hooks don't suspend on first load.
+    startWith(undefined),
+  )
+}

--- a/packages/core/src/releases/releasesStore.test.ts
+++ b/packages/core/src/releases/releasesStore.test.ts
@@ -2,13 +2,12 @@ import {type ReleaseDocument} from '@sanity/client'
 import {NEVER, Observable, type Observer, of, Subject} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {getQueryState, resolveQuery} from '../query/queryStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
-import {type StateSource} from '../store/createStateSourceAction'
+import {observeReleases} from './observeReleases'
 import {getActiveReleasesState, getAllReleasesState} from './releasesStore'
 
 // Mock dependencies
-vi.mock('../query/queryStore')
+vi.mock('./observeReleases')
 
 describe('releasesStore', () => {
   let instance: SanityInstance
@@ -18,13 +17,7 @@ describe('releasesStore', () => {
 
     instance = createSanityInstance({projectId: 'test', dataset: 'test'})
 
-    vi.mocked(getQueryState).mockReturnValue({
-      subscribe: () => () => {},
-      getCurrent: () => undefined,
-      observable: NEVER as Observable<ReleaseDocument[] | undefined>,
-    } as StateSource<ReleaseDocument[] | undefined>)
-
-    vi.mocked(resolveQuery).mockResolvedValue(undefined)
+    vi.mocked(observeReleases).mockReturnValue(NEVER as Observable<ReleaseDocument[] | undefined>)
   })
 
   afterEach(() => {
@@ -35,13 +28,11 @@ describe('releasesStore', () => {
     const state = getActiveReleasesState(instance)
 
     expect(state.getCurrent()).toBeUndefined()
-    expect(getQueryState).toHaveBeenCalledWith(
+    expect(observeReleases).toHaveBeenCalledWith(
       instance,
       expect.objectContaining({
-        query: 'releases::all()',
-        perspective: 'raw',
-        tag: 'releases',
         resource: {dataset: 'test', projectId: 'test'},
+        onCorsError: expect.any(Function),
       }),
     )
   })
@@ -52,11 +43,7 @@ describe('releasesStore', () => {
       .fn<(observer: Observer<ReleaseDocument[] | undefined>) => () => void>()
       .mockReturnValue(teardown)
 
-    vi.mocked(getQueryState).mockReturnValue({
-      subscribe: () => () => {},
-      getCurrent: () => undefined,
-      observable: new Observable(subscriber),
-    } as StateSource<ReleaseDocument[] | undefined>)
+    vi.mocked(observeReleases).mockReturnValue(new Observable(subscriber))
 
     // note that the order of the releases is important here -- they get sorted
     const mockReleases: ReleaseDocument[] = [
@@ -87,11 +74,7 @@ describe('releasesStore', () => {
 
   it('should update active releases state when the query emits new data', async () => {
     const releasesSubject = new Subject<ReleaseDocument[]>()
-    vi.mocked(getQueryState).mockReturnValue({
-      subscribe: () => () => {},
-      getCurrent: () => undefined,
-      observable: releasesSubject.asObservable(),
-    } as StateSource<ReleaseDocument[] | undefined>)
+    vi.mocked(observeReleases).mockReturnValue(releasesSubject.asObservable())
 
     const state = getActiveReleasesState(instance, {resource: {projectId: 'test', dataset: 'test'}})
 
@@ -133,12 +116,8 @@ describe('releasesStore', () => {
   })
 
   it('should handle empty array from the query', async () => {
-    // Configure query to return an empty array
-    vi.mocked(getQueryState).mockReturnValue({
-      subscribe: () => () => {},
-      getCurrent: () => [],
-      observable: of([]),
-    } as StateSource<ReleaseDocument[] | undefined>)
+    // Configure the releases source to return an empty array
+    vi.mocked(observeReleases).mockReturnValue(of([]))
 
     const state = getActiveReleasesState(instance, {resource: {projectId: 'test', dataset: 'test'}})
 
@@ -149,32 +128,20 @@ describe('releasesStore', () => {
 
   it('should handle null/undefined from the query by defaulting to empty array', async () => {
     // Test null case
-    vi.mocked(getQueryState).mockReturnValue({
-      subscribe: () => () => {},
-      getCurrent: () => null as unknown as ReleaseDocument[] | undefined,
-      observable: of(null as unknown as ReleaseDocument[] | undefined),
-    } as StateSource<ReleaseDocument[] | undefined>)
+    vi.mocked(observeReleases).mockReturnValue(of(null as unknown as ReleaseDocument[] | undefined))
     const state = getActiveReleasesState(instance, {resource: {projectId: 'test', dataset: 'test'}})
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(state.getCurrent()).toEqual([])
 
     // Test undefined case
-    vi.mocked(getQueryState).mockReturnValue({
-      subscribe: () => () => {},
-      getCurrent: () => undefined,
-      observable: of(undefined),
-    } as StateSource<ReleaseDocument[] | undefined>)
+    vi.mocked(observeReleases).mockReturnValue(of(undefined))
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(state.getCurrent()).toEqual([])
   })
 
   it('exposes archived/published releases through getAllReleasesState but filters them out of getActiveReleasesState', async () => {
     const subject = new Subject<ReleaseDocument[]>()
-    vi.mocked(getQueryState).mockReturnValue({
-      subscribe: () => () => {},
-      getCurrent: () => undefined,
-      observable: subject.asObservable(),
-    } as StateSource<ReleaseDocument[] | undefined>)
+    vi.mocked(observeReleases).mockReturnValue(subject.asObservable())
 
     const active = getActiveReleasesState(instance, {
       resource: {projectId: 'test', dataset: 'test'},
@@ -216,13 +183,37 @@ describe('releasesStore', () => {
     expect(allNames).toHaveLength(3)
   })
 
+  it('surfaces CORS errors from the live connection as a store-wide error', async () => {
+    const subject = new Subject<ReleaseDocument[]>()
+    vi.mocked(observeReleases).mockReturnValue(subject.asObservable())
+
+    const state = getActiveReleasesState(instance, {resource: {projectId: 'test', dataset: 'test'}})
+
+    subject.next([
+      {
+        _id: 'r1',
+        _type: 'system.release',
+        name: 'r1',
+        state: 'active',
+        metadata: {releaseType: 'asap'},
+      } as ReleaseDocument,
+    ])
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(state.getCurrent()).toHaveLength(1)
+
+    const [, options] = vi.mocked(observeReleases).mock.lastCall!
+    const corsError = new Error('CORS misconfiguration')
+    options.onCorsError(corsError)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // the CORS error is recorded as store state so the releases selector
+    // rethrows it (handled by the Cors Error component)
+    expect(() => state.getCurrent()).toThrow(corsError)
+  })
+
   it('should surface the error when the releases query errors', async () => {
     const subject = new Subject<ReleaseDocument[]>()
-    vi.mocked(getQueryState).mockReturnValue({
-      subscribe: () => () => {},
-      getCurrent: () => undefined,
-      observable: subject.asObservable(),
-    } as StateSource<ReleaseDocument[] | undefined>)
+    vi.mocked(observeReleases).mockReturnValue(subject.asObservable())
 
     const active = getActiveReleasesState(instance, {
       resource: {projectId: 'test', dataset: 'test'},

--- a/packages/core/src/releases/releasesStore.ts
+++ b/packages/core/src/releases/releasesStore.ts
@@ -2,19 +2,11 @@ import {type ReleaseDocument} from '@sanity/client'
 import {map} from 'rxjs'
 
 import {type DocumentResource} from '../config/sanityConfig'
-/*
- * Although this is an import dependency cycle, it is not a logical cycle:
- * 1. releasesStore uses queryStore as a data source
- * 2. queryStore calls getPerspectiveState for computing release perspectives
- * 3. getPerspectiveState uses releasesStore as a data source
- * 4. however, queryStore does not use getPerspectiveState for the perspective used in releasesStore ("raw")
- */
-// eslint-disable-next-line import-x/no-cycle
-import {getQueryState} from '../query/queryStore'
 import {bindActionByResource, type BoundResourceKey} from '../store/createActionBinder'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {createStateSourceAction, type StateSource} from '../store/createStateSourceAction'
 import {defineStore, type StoreContext} from '../store/defineStore'
+import {observeReleases} from './observeReleases'
 import {sortReleases} from './utils/sortReleases'
 
 const ARCHIVED_RELEASE_STATES = ['archived', 'published']
@@ -101,18 +93,16 @@ export const getAllReleasesState = (
   options?: {resource?: DocumentResource},
 ): StateSource<ReleaseDocument[] | undefined> => _getAllReleasesState(instance, options ?? {})
 
-const RELEASES_QUERY = 'releases::all()'
-
 const subscribeToReleases = ({
   instance,
   state,
   key: {resource},
 }: StoreContext<ReleasesStoreState, BoundResourceKey>) => {
-  const {observable: releases$} = getQueryState<ReleaseDocument[]>(instance, {
-    query: RELEASES_QUERY,
-    perspective: 'raw',
+  const releases$ = observeReleases(instance, {
     resource,
-    tag: 'releases',
+    // Surface CORS errors as store state instead of erroring the stream so
+    // they can be handled by the Cors Error component
+    onCorsError: (error) => state.set('setError', {error}),
   })
   return (
     releases$
@@ -129,7 +119,8 @@ const subscribeToReleases = ({
           })
         }),
       )
-      // the query is retried by the queryStore, so we don't need to retry here
+      // live-connection errors are already retried inside observeLiveEvents;
+      // a fetch error is terminal and surfaced via setError
       .subscribe({error: (error) => state.set('setError', {error})})
   )
 }


### PR DESCRIPTION
### Description

Removes the import cycle `queryStore → getPerspectiveState → releasesStore → queryStore` that was suppressed with three `import-x/no-cycle` disables (added in #1021).

- New `client/liveEvents.ts`: shared `observeLiveEvents()` extracted from queryStore (CORS/disconnect/retry handling). Both consumers share one EventSource — `@sanity/client` caches the live stream per URL + connection options, so the request tag is now `live-events` (was `query-store`) for both.
- New `releases/observeReleases.ts`: releasesStore fetches `releases::all()` directly via clientStore instead of through queryStore, breaking the cycle. Live invalidation semantics (mid-fetch messages, sync-tag matching, initial synchronous emission) mirror the old queryStore path.
- `getPerspectiveState` now binds at module scope; the lazy-binding workaround for circular init is no longer needed.
- All three `eslint-disable-next-line import-x/no-cycle` comments removed; the rule now passes at error level.

### What to review

- The RxJS in `observeReleases.ts`: mid-flight live messages are re-evaluated once sync tags land (combineLatest + BehaviorSubject), with `distinctUntilChanged` on the event id preventing refetch loops.
- `startWith(undefined)` in `observeReleases` preserves the synchronous initial emission the store previously got from `StateSource`, so the releases hooks don't newly suspend.
- Observability note: dashboards filtering on the `sanity.sdk.query-store` live-connection tag should switch to `sanity.sdk.live-events`.

### Testing

New unit tests for `observeReleases` (initial emission, sync-tag refetch with `lastLiveEventId`, non-matching tags, mid-flight message re-evaluation) and `liveEvents` (message filtering, CORS callback, DisconnectError, retry), plus CORS-path tests for both stores. Existing queryStore live tests still exercise the real extracted code (only clientStore is mocked). 1007 core + 322 react tests pass.

### Fun gif

![Cutting the knot](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)