### PR TITLE
feat: infer organization resources if parameter passed

### DIFF
--- a/apps/kitchensink-react/src/App.tsx
+++ b/apps/kitchensink-react/src/App.tsx
@@ -7,7 +7,7 @@ import {type JSX, Suspense} from 'react'
 import {BrowserRouter, useNavigate} from 'react-router'
 
 import {AppRoutes} from './AppRoutes'
-import {devConfigs, devResources, e2eConfigs, isE2E} from './sanityConfigs'
+import {devConfigs, e2eConfigs, e2eResources, isE2E} from './sanityConfigs'
 
 // Enable SDK logging in the browser. The wildcard picks up new namespaces
 // automatically as logging is added to more modules.
@@ -33,7 +33,8 @@ export default function App(): JSX.Element {
       <SanityApp
         fallback={<Spinner />}
         config={isE2E ? e2eConfigs : devConfigs}
-        resources={devResources}
+        resources={isE2E ? e2eResources : {}}
+        inferMediaLibraryAndCanvas
       >
         <BrowserRouter>
           <Suspense>

--- a/apps/kitchensink-react/src/sanityConfigs.ts
+++ b/apps/kitchensink-react/src/sanityConfigs.ts
@@ -4,6 +4,11 @@ import {type DocumentResource, type SanityConfig} from '@sanity/sdk'
 // auto-exposed on import.meta.env by the App SDK's Vite config (SANITY_APP_ prefix).
 export const isE2E = !!import.meta.env['SANITY_APP_E2E_MODE']
 
+// True when the app is the top-level window rather than embedded in the Dashboard
+// iframe. Webkit/Safari runs the e2e suite standalone (it can't execute scripts in
+// the Dashboard's sandboxed iframe), while chromium/firefox run inside the Dashboard.
+const isStandalone = window.self === window.top
+
 export const devConfigs: SanityConfig[] = [
   {
     projectId: 'ppsg7ml5',
@@ -14,15 +19,6 @@ export const devConfigs: SanityConfig[] = [
     dataset: 'production',
   },
 ]
-
-export const devResources: Record<string, DocumentResource> = {
-  'media-library': {
-    mediaLibraryId: isE2E ? import.meta.env['SANITY_APP_E2E_MEDIA_LIBRARY_ID'] : 'mlPGY7BEqt52',
-  },
-  'canvas': {
-    canvasId: isE2E ? import.meta.env['SANITY_APP_E2E_CANVAS_ID'] : 'cag5gSK37IGV',
-  },
-}
 
 export const e2eConfigs: SanityConfig[] = [
   {
@@ -40,3 +36,13 @@ export const e2eConfigs: SanityConfig[] = [
     },
   },
 ]
+
+export const e2eResources: Record<string, DocumentResource> = {
+  // Standalone runs (webkit/Safari) have no Dashboard org context, so `inferMediaLibraryAndCanvas`
+  // can't resolve anything — provide the media library and canvas resources explicitly.
+  // Otherewise, omit these so we can ensure that inferMediaLibraryAndCanvas is e2e tested.
+  ...(isStandalone && {
+    'media-library': {mediaLibraryId: import.meta.env['SANITY_APP_E2E_MEDIA_LIBRARY_ID']},
+    'canvas': {canvasId: import.meta.env['SANITY_APP_E2E_CANVAS_ID']},
+  }),
+}

--- a/packages/react/src/components/SDKProvider.test.tsx
+++ b/packages/react/src/components/SDKProvider.test.tsx
@@ -23,8 +23,16 @@ vi.mock('../utils/resolveOrgResources', () => ({
 }))
 
 vi.mock('../context/ResourceProvider', () => ({
-  ResourceProvider: ({children, resource}: {children: React.ReactNode; resource?: unknown}) => (
-    <div data-testid="resource-provider" data-resource={JSON.stringify(resource ?? null)}>
+  ResourceProvider: ({
+    children,
+    projectId,
+    dataset,
+  }: {
+    children: React.ReactNode
+    projectId?: string
+    dataset?: string
+  }) => (
+    <div data-testid="resource-provider" data-config={JSON.stringify({projectId, dataset})}>
       {children}
     </div>
   ),

--- a/packages/react/src/components/SDKProvider.test.tsx
+++ b/packages/react/src/components/SDKProvider.test.tsx
@@ -1,41 +1,51 @@
+import {createSanityInstance} from '@sanity/sdk'
 import {render} from '@testing-library/react'
 import React from 'react'
-import {describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {useDashboardOrganizationId} from '../hooks/auth/useDashboardOrganizationId'
+import {resolveOrgResources} from '../utils/resolveOrgResources'
 import {SDKProvider} from './SDKProvider'
 
-// Mock ResourceProvider to test nesting behavior
-vi.mock('../context/ResourceProvider', () => ({
-  ResourceProvider: ({
-    children,
-    ...props
-  }: {
-    children: React.ReactNode
-    projectId?: string
-    dataset?: string
-  }) => {
-    return (
-      <div
-        data-testid="resource-provider"
-        data-config={JSON.stringify({
-          projectId: props.projectId,
-          dataset: props.dataset,
-        })}
-      >
-        {children}
-      </div>
-    )
-  },
+const instance = createSanityInstance()
+
+// Returns the same object on every call so the module-level WeakMap cache works across renders.
+vi.mock('../hooks/context/useSanityInstance', () => {
+  return {useSanityInstance: () => instance}
+})
+
+vi.mock('../hooks/auth/useDashboardOrganizationId', () => ({
+  useDashboardOrganizationId: vi.fn(),
 }))
 
-// Mock AuthBoundary
-vi.mock('./auth/AuthBoundary', () => ({
-  AuthBoundary: ({children}: {children: React.ReactNode}) => {
-    return <div data-testid="auth-boundary">{children}</div>
-  },
+vi.mock('../utils/resolveOrgResources', () => ({
+  resolveOrgResources: vi.fn(),
 }))
+
+vi.mock('../context/ResourceProvider', () => ({
+  ResourceProvider: ({children, resource}: {children: React.ReactNode; resource?: unknown}) => (
+    <div data-testid="resource-provider" data-resource={JSON.stringify(resource ?? null)}>
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('./auth/AuthBoundary', () => ({
+  AuthBoundary: ({children}: {children: React.ReactNode}) => (
+    <div data-testid="auth-boundary">{children}</div>
+  ),
+}))
+
+const mockResolveOrgResources = vi.mocked(resolveOrgResources)
+const mockUseDashboardOrganizationId = vi.mocked(useDashboardOrganizationId)
 
 describe('SDKProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockResolveOrgResources.mockResolvedValue({})
+    mockUseDashboardOrganizationId.mockReturnValue(undefined)
+  })
+
   it('renders single ResourceProvider with AuthBoundary for a single config', () => {
     const config = {
       projectId: 'test-project',

--- a/packages/react/src/components/SDKProvider.tsx
+++ b/packages/react/src/components/SDKProvider.tsx
@@ -3,8 +3,8 @@ import {type ReactElement, type ReactNode, useEffect, useMemo} from 'react'
 import {ErrorBoundary, type FallbackProps} from 'react-error-boundary'
 
 import {DEFAULT_RESOURCE_NAME} from '../constants'
+import {OrganizationResourcesProvider} from '../context/OrganizationResourcesProvider'
 import {ResourceProvider} from '../context/ResourceProvider'
-import {ResourcesContext} from '../context/ResourcesContext'
 import {AuthBoundary, type AuthBoundaryProps} from './auth/AuthBoundary'
 import {ChunkLoadError} from './errors/ChunkLoadError'
 import {clearChunkReloadFlag} from './errors/chunkReloadStorage'
@@ -17,6 +17,8 @@ export interface SDKProviderProps extends AuthBoundaryProps {
   config: SanityConfig | SanityConfig[]
   fallback: ReactNode
   resources?: Record<string, DocumentResource>
+  /** When set, automatically fetches and registers the organization's media library and canvas as named resources. */
+  inferMediaLibraryAndCanvas?: boolean
 }
 
 /**
@@ -40,6 +42,7 @@ export function SDKProvider({
   children,
   config,
   fallback,
+  inferMediaLibraryAndCanvas,
   ...props
 }: SDKProviderProps): ReactElement {
   const allConfigs = Array.isArray(config) ? config : [config]
@@ -59,7 +62,10 @@ export function SDKProvider({
     const explicit = props.resources ?? {}
     if (defaultProjectId && defaultDataset && !Object.hasOwn(explicit, DEFAULT_RESOURCE_NAME)) {
       return {
-        [DEFAULT_RESOURCE_NAME]: {projectId: defaultProjectId, dataset: defaultDataset},
+        [DEFAULT_RESOURCE_NAME]: {
+          projectId: defaultProjectId,
+          dataset: defaultDataset,
+        },
         ...explicit,
       }
     }
@@ -71,7 +77,15 @@ export function SDKProvider({
       <ResetChunkReloadFlagOnMount />
       <ResourceProvider {...resolvedConfig} fallback={fallback}>
         <AuthBoundary {...props} projectIds={projectIds}>
-          <ResourcesContext.Provider value={resourcesValue}>{children}</ResourcesContext.Provider>
+          {/* OrganizationResourcesProvider wraps ResourcesContext.
+            It merges explicit resources with lazily inferred org resources (media
+            library, canvas) and provides the combined map to the subtree. */}
+          <OrganizationResourcesProvider
+            resources={resourcesValue}
+            inferMediaLibraryAndCanvas={inferMediaLibraryAndCanvas}
+          >
+            {children}
+          </OrganizationResourcesProvider>
         </AuthBoundary>
       </ResourceProvider>
     </ErrorBoundary>

--- a/packages/react/src/components/SanityApp.tsx
+++ b/packages/react/src/components/SanityApp.tsx
@@ -23,6 +23,35 @@ export interface SanityAppProps {
   children: React.ReactNode
   /* Fallback content to show when child components are suspending. Same as the `fallback` prop for React Suspense. */
   fallback: React.ReactNode
+  /**
+   * Set this to automatically fetch and register the organization's media library and canvas as named resources.
+   * These resources will be available to hooks as `media-library` and `canvas`.
+   *
+   * The SDK App must be running in the organization's Dashboard to use this feature.
+   *
+   * @example
+   * ```tsx
+   *
+   * const MyApp = () => {
+   *   // should "just work" because of inferMediaLibraryAndCanvas.
+   *   const {data: assets} = useDocuments({
+   *     documentType: 'sanity.asset',
+   *     resourceName: 'media-library',
+   *   })
+   *   return (
+   *     <div>
+   *       {assets.map((asset) => (
+   *         <div key={asset._id}>{asset.originalFilename}</div>
+   *       ))}
+   *     </div>
+   *   )
+   * }
+   * <SanityApp inferMediaLibraryAndCanvas>
+   *   <MyApp />
+   * </SanityApp>
+   * ```
+   */
+  inferMediaLibraryAndCanvas?: boolean
 }
 
 const REDIRECT_URL = 'https://sanity.io/welcome'

--- a/packages/react/src/context/OrganizationResourcesProvider.test.tsx
+++ b/packages/react/src/context/OrganizationResourcesProvider.test.tsx
@@ -1,0 +1,191 @@
+import {createSanityInstance, type DocumentResource} from '@sanity/sdk'
+import {act, render} from '@testing-library/react'
+import {type ReactNode, Suspense, useContext, useEffect} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useDashboardOrganizationId} from '../hooks/auth/useDashboardOrganizationId'
+import {resolveOrgResources} from '../utils/resolveOrgResources'
+import {OrganizationResourcesProvider} from './OrganizationResourcesProvider'
+import {ResourcesContext} from './ResourcesContext'
+
+function promiseWithResolvers<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return {promise, resolve}
+}
+
+const instance = createSanityInstance()
+
+// Returns the same object on every call so the module-level WeakMap cache works across renders.
+vi.mock('../hooks/context/useSanityInstance', () => {
+  return {useSanityInstance: () => instance}
+})
+
+vi.mock('../hooks/auth/useDashboardOrganizationId', () => ({
+  useDashboardOrganizationId: vi.fn(),
+}))
+
+vi.mock('../utils/resolveOrgResources', () => ({
+  resolveOrgResources: vi.fn(),
+}))
+
+const mockResolveOrgResources = vi.mocked(resolveOrgResources)
+const mockUseDashboardOrganizationId = vi.mocked(useDashboardOrganizationId)
+
+describe('OrganizationResourcesProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockResolveOrgResources.mockResolvedValue({})
+    mockUseDashboardOrganizationId.mockReturnValue(undefined)
+  })
+
+  // Captures ResourcesContext via useEffect (side-effect territory, not render)
+  // to satisfy the react-compiler purity rule.
+  function makeCapture() {
+    const deferred = promiseWithResolvers<Record<string, DocumentResource>>()
+
+    const CaptureContexts = () => {
+      const resources = useContext(ResourcesContext)
+      useEffect(() => {
+        deferred.resolve(resources)
+      }, [resources])
+      return null
+    }
+
+    return {CaptureContexts, capturedResources: deferred.promise}
+  }
+
+  function renderProvider(
+    children: ReactNode,
+    options?: {
+      resources?: Record<string, DocumentResource>
+      inferMediaLibraryAndCanvas?: boolean
+    },
+  ) {
+    return render(
+      <Suspense fallback={<div>loading</div>}>
+        <OrganizationResourcesProvider
+          resources={options?.resources}
+          inferMediaLibraryAndCanvas={options?.inferMediaLibraryAndCanvas}
+        >
+          {children}
+        </OrganizationResourcesProvider>
+      </Suspense>,
+    )
+  }
+
+  it('does not suspend when inferMediaLibraryAndCanvas is not set', async () => {
+    const {CaptureContexts, capturedResources} = makeCapture()
+    renderProvider(<CaptureContexts />)
+    const resources = await capturedResources
+    expect(Object.keys(resources)).toHaveLength(0)
+    expect(mockResolveOrgResources).not.toHaveBeenCalled()
+  })
+
+  it('suspends children while org resources are being fetched, then renders with resolved resources', async () => {
+    const testOrgId = 'org-suspend-test'
+    mockUseDashboardOrganizationId.mockReturnValue(testOrgId)
+    const {promise, resolve} = promiseWithResolvers<void>()
+    mockResolveOrgResources.mockReturnValue(
+      promise.then(() => ({
+        mediaLibrary: {mediaLibraryId: 'ml-id'},
+        canvas: {canvasId: 'canvas-id'},
+      })) as ReturnType<typeof mockResolveOrgResources>,
+    )
+
+    const {CaptureContexts, capturedResources} = makeCapture()
+    await act(async () => {
+      renderProvider(<CaptureContexts />, {inferMediaLibraryAndCanvas: true})
+    })
+
+    await act(async () => {
+      resolve()
+    })
+
+    const resources = await capturedResources
+    expect(resources['media-library']).toEqual({mediaLibraryId: 'ml-id'})
+    expect(resources['canvas']).toEqual({canvasId: 'canvas-id'})
+  })
+
+  it('renders without inferred entries and logs a warning when resolveOrgResources rejects', async () => {
+    const testOrgId = 'org-warn-test'
+    mockUseDashboardOrganizationId.mockReturnValue(testOrgId)
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockResolveOrgResources.mockRejectedValue(new Error('fetch failed'))
+
+    const {CaptureContexts, capturedResources} = makeCapture()
+    await act(async () => {
+      renderProvider(<CaptureContexts />, {inferMediaLibraryAndCanvas: true})
+    })
+
+    const resources = await capturedResources
+    expect(resources['media-library']).toBeUndefined()
+    expect(resources['canvas']).toBeUndefined()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[sanity/sdk] Failed to infer org resources:',
+      expect.any(Error),
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('caches Promise references for the same organizationId', () => {
+    const testOrgId = 'org-cache-unique'
+    mockUseDashboardOrganizationId.mockReturnValue(testOrgId)
+
+    render(
+      <Suspense fallback={null}>
+        <OrganizationResourcesProvider inferMediaLibraryAndCanvas>
+          {null}
+        </OrganizationResourcesProvider>
+      </Suspense>,
+    )
+    render(
+      <Suspense fallback={null}>
+        <OrganizationResourcesProvider inferMediaLibraryAndCanvas>
+          {null}
+        </OrganizationResourcesProvider>
+      </Suspense>,
+    )
+
+    // resolveOrgResources should only have been called once across both providers.
+    expect(mockResolveOrgResources).toHaveBeenCalledTimes(1)
+  })
+
+  it('explicit resources are passed through to ResourcesContext', async () => {
+    const explicitResources = {
+      default: {projectId: 'p1', dataset: 'prod'},
+      secondary: {projectId: 'p2', dataset: 'staging'},
+    }
+
+    const {CaptureContexts, capturedResources} = makeCapture()
+    renderProvider(<CaptureContexts />, {resources: explicitResources})
+
+    expect(await capturedResources).toEqual(explicitResources)
+  })
+
+  it('explicit resources take precedence over inferred ones', async () => {
+    const testOrgId = 'org-override-test'
+    mockUseDashboardOrganizationId.mockReturnValue(testOrgId)
+    mockResolveOrgResources.mockResolvedValue({
+      mediaLibrary: {mediaLibraryId: 'inferred-ml'},
+      canvas: {canvasId: 'inferred-canvas'},
+    })
+
+    const explicitResources = {'media-library': {mediaLibraryId: 'explicit-ml'}}
+    const {CaptureContexts, capturedResources} = makeCapture()
+    await act(async () => {
+      renderProvider(<CaptureContexts />, {
+        resources: explicitResources,
+        inferMediaLibraryAndCanvas: true,
+      })
+    })
+
+    const resources = await capturedResources
+    expect(resources['media-library']).toEqual({mediaLibraryId: 'explicit-ml'})
+  })
+})

--- a/packages/react/src/context/OrganizationResourcesProvider.test.tsx
+++ b/packages/react/src/context/OrganizationResourcesProvider.test.tsx
@@ -19,9 +19,11 @@ function promiseWithResolvers<T>(): {
   return {promise, resolve}
 }
 
-const instance = createSanityInstance()
+// Reset to a fresh instance per test so the module-level WeakMap cache (keyed by
+// instance) starts empty. `useSanityInstance` returns the same object across
+// renders within a test, which is what the cache relies on.
+let instance = createSanityInstance()
 
-// Returns the same object on every call so the module-level WeakMap cache works across renders.
 vi.mock('../hooks/context/useSanityInstance', () => {
   return {useSanityInstance: () => instance}
 })
@@ -40,6 +42,7 @@ const mockUseDashboardOrganizationId = vi.mocked(useDashboardOrganizationId)
 describe('OrganizationResourcesProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    instance = createSanityInstance()
     mockResolveOrgResources.mockResolvedValue({})
     mockUseDashboardOrganizationId.mockReturnValue(undefined)
   })
@@ -88,8 +91,7 @@ describe('OrganizationResourcesProvider', () => {
   })
 
   it('suspends children while org resources are being fetched, then renders with resolved resources', async () => {
-    const testOrgId = 'org-suspend-test'
-    mockUseDashboardOrganizationId.mockReturnValue(testOrgId)
+    mockUseDashboardOrganizationId.mockReturnValue('org-suspend-test')
     const {promise, resolve} = promiseWithResolvers<void>()
     mockResolveOrgResources.mockReturnValue(
       promise.then(() => ({
@@ -113,8 +115,7 @@ describe('OrganizationResourcesProvider', () => {
   })
 
   it('renders without inferred entries and logs a warning when resolveOrgResources rejects', async () => {
-    const testOrgId = 'org-warn-test'
-    mockUseDashboardOrganizationId.mockReturnValue(testOrgId)
+    mockUseDashboardOrganizationId.mockReturnValue('org-warn-test')
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockResolveOrgResources.mockRejectedValue(new Error('fetch failed'))
 
@@ -133,10 +134,8 @@ describe('OrganizationResourcesProvider', () => {
     consoleSpy.mockRestore()
   })
 
-  it('caches Promise references for the same organizationId', () => {
-    const testOrgId = 'org-cache-unique'
-    mockUseDashboardOrganizationId.mockReturnValue(testOrgId)
-
+  it('caches Promise references across providers for the same instance', () => {
+    mockUseDashboardOrganizationId.mockReturnValue('org-cache-test')
     render(
       <Suspense fallback={null}>
         <OrganizationResourcesProvider inferMediaLibraryAndCanvas>
@@ -169,8 +168,7 @@ describe('OrganizationResourcesProvider', () => {
   })
 
   it('explicit resources take precedence over inferred ones', async () => {
-    const testOrgId = 'org-override-test'
-    mockUseDashboardOrganizationId.mockReturnValue(testOrgId)
+    mockUseDashboardOrganizationId.mockReturnValue('org-override-test')
     mockResolveOrgResources.mockResolvedValue({
       mediaLibrary: {mediaLibraryId: 'inferred-ml'},
       canvas: {canvasId: 'inferred-canvas'},

--- a/packages/react/src/context/OrganizationResourcesProvider.tsx
+++ b/packages/react/src/context/OrganizationResourcesProvider.tsx
@@ -1,0 +1,116 @@
+import {type DocumentResource, type SanityInstance} from '@sanity/sdk'
+import {type ReactElement, type ReactNode, use, useMemo} from 'react'
+
+import {useDashboardOrganizationId} from '../hooks/auth/useDashboardOrganizationId'
+import {useSanityInstance} from '../hooks/context/useSanityInstance'
+import {resolveOrgResources} from '../utils/resolveOrgResources'
+import {ResourcesContext} from './ResourcesContext'
+
+const DEFAULT_MEDIA_LIBRARY_RESOURCE_NAME = 'media-library'
+const DEFAULT_CANVAS_RESOURCE_NAME = 'canvas'
+
+type OrgResource = typeof DEFAULT_MEDIA_LIBRARY_RESOURCE_NAME | typeof DEFAULT_CANVAS_RESOURCE_NAME
+type OrgResourcePromises = Map<OrgResource, PromiseLike<DocumentResource | undefined>>
+
+// Module-level cache keyed by SanityInstance so Promise references are stable
+// across Suspense unmount/remount cycles. React's use() tracks promises by
+// identity, so stable references prevent unnecessary re-suspensions.
+// WeakMap entries are GC'd when the instance is disposed.
+// There is only one org available at a time, so we don't need to key by organizationId.
+const inferredResourceCache = new WeakMap<SanityInstance, Map<string, OrgResourcePromises>>()
+
+function getOrgResourcePromises(
+  instance: SanityInstance,
+  organizationId: string,
+): OrgResourcePromises {
+  let orgCache = inferredResourceCache.get(instance)
+  if (!orgCache) {
+    orgCache = new Map()
+    inferredResourceCache.set(instance, orgCache)
+  }
+
+  let promises = orgCache.get(organizationId)
+  if (!promises) {
+    const basePromise = resolveOrgResources(instance, organizationId).then(
+      (result) => result,
+      (error) => {
+        // eslint-disable-next-line no-console
+        console.warn('[sanity/sdk] Failed to infer org resources:', error)
+        return {mediaLibrary: undefined, canvas: undefined}
+      },
+    )
+    promises = new Map([
+      [DEFAULT_MEDIA_LIBRARY_RESOURCE_NAME, basePromise.then((r) => r.mediaLibrary)],
+      [DEFAULT_CANVAS_RESOURCE_NAME, basePromise.then((r) => r.canvas)],
+    ])
+    orgCache.set(organizationId, promises)
+  }
+
+  return promises
+}
+
+/**
+ * Inner component that suspends via use() until both inference promises settle.
+ * Requires a Suspense boundary from the caller (usually a top ResourceProvider).
+ */
+function InferredResourcesProvider({
+  instance,
+  orgId,
+  explicitResources,
+  children,
+}: {
+  instance: SanityInstance
+  orgId: string
+  explicitResources: Record<string, DocumentResource>
+  children: ReactNode
+}): ReactElement {
+  const promises = getOrgResourcePromises(instance, orgId)
+  const ml = use(promises.get(DEFAULT_MEDIA_LIBRARY_RESOURCE_NAME)!)
+  const canvas = use(promises.get(DEFAULT_CANVAS_RESOURCE_NAME)!)
+
+  const resources = useMemo(() => {
+    const inferred: Record<string, DocumentResource> = {}
+    if (ml !== undefined) inferred[DEFAULT_MEDIA_LIBRARY_RESOURCE_NAME] = ml
+    if (canvas !== undefined) inferred[DEFAULT_CANVAS_RESOURCE_NAME] = canvas
+    return {...inferred, ...explicitResources}
+  }, [ml, canvas, explicitResources])
+
+  return <ResourcesContext.Provider value={resources}>{children}</ResourcesContext.Provider>
+}
+
+/**
+ * When `inferMediaLibraryAndCanvas` is set, this component suspends until
+ * inference resolves. The nearest Suspense boundary (e.g. from ResourceProvider)
+ * shows its fallback during that window.
+
+ * If a user explicitly names a 'media-library' or 'canvas' resource,
+ * this component will use that resource instead of inferring it.
+ */
+export function OrganizationResourcesProvider({
+  resources: explicitResources = {},
+  inferMediaLibraryAndCanvas,
+  children,
+}: {
+  resources?: Record<string, DocumentResource>
+  inferMediaLibraryAndCanvas?: boolean
+  children: ReactNode
+}): ReactElement {
+  const instance = useSanityInstance()
+  const orgId = useDashboardOrganizationId()
+
+  if (!inferMediaLibraryAndCanvas || !orgId) {
+    return (
+      <ResourcesContext.Provider value={explicitResources}>{children}</ResourcesContext.Provider>
+    )
+  }
+
+  return (
+    <InferredResourcesProvider
+      instance={instance}
+      orgId={orgId}
+      explicitResources={explicitResources}
+    >
+      {children}
+    </InferredResourcesProvider>
+  )
+}

--- a/packages/react/src/context/OrganizationResourcesProvider.tsx
+++ b/packages/react/src/context/OrganizationResourcesProvider.tsx
@@ -16,20 +16,15 @@ type OrgResourcePromises = Map<OrgResource, PromiseLike<DocumentResource | undef
 // across Suspense unmount/remount cycles. React's use() tracks promises by
 // identity, so stable references prevent unnecessary re-suspensions.
 // WeakMap entries are GC'd when the instance is disposed.
-// There is only one org available at a time, so we don't need to key by organizationId.
-const inferredResourceCache = new WeakMap<SanityInstance, Map<string, OrgResourcePromises>>()
+// There is only ever one org at a time, so the instance alone is a sufficient
+// key — organizationId only scopes the fetch, it doesn't need to key the cache.
+const inferredResourceCache = new WeakMap<SanityInstance, OrgResourcePromises>()
 
 function getOrgResourcePromises(
   instance: SanityInstance,
   organizationId: string,
 ): OrgResourcePromises {
-  let orgCache = inferredResourceCache.get(instance)
-  if (!orgCache) {
-    orgCache = new Map()
-    inferredResourceCache.set(instance, orgCache)
-  }
-
-  let promises = orgCache.get(organizationId)
+  let promises = inferredResourceCache.get(instance)
   if (!promises) {
     const basePromise = resolveOrgResources(instance, organizationId).then(
       (result) => result,
@@ -43,7 +38,7 @@ function getOrgResourcePromises(
       [DEFAULT_MEDIA_LIBRARY_RESOURCE_NAME, basePromise.then((r) => r.mediaLibrary)],
       [DEFAULT_CANVAS_RESOURCE_NAME, basePromise.then((r) => r.canvas)],
     ])
-    orgCache.set(organizationId, promises)
+    inferredResourceCache.set(instance, promises)
   }
 
   return promises

--- a/packages/react/src/utils/resolveOrgResources.test.ts
+++ b/packages/react/src/utils/resolveOrgResources.test.ts
@@ -1,0 +1,94 @@
+import {type SanityClient} from '@sanity/client'
+import {getClientState, type SanityInstance, type StateSource} from '@sanity/sdk'
+import {firstValueFrom} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {resolveOrgResources} from './resolveOrgResources'
+
+vi.mock('@sanity/sdk', () => ({
+  getClientState: vi.fn(),
+}))
+
+vi.mock('rxjs', () => ({
+  firstValueFrom: vi.fn(),
+}))
+
+const mockGetClientState = vi.mocked(getClientState)
+const mockFirstValueFrom = vi.mocked(firstValueFrom)
+
+const mockRequest = vi.fn()
+const mockClient = {request: mockRequest}
+const mockInstance = {} as SanityInstance
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetClientState.mockReturnValue({
+    observable: 'mock-observable',
+  } as unknown as StateSource<SanityClient>)
+  mockFirstValueFrom.mockResolvedValue(mockClient as unknown as SanityClient)
+})
+
+describe('resolveOrgResources', () => {
+  it('returns both mediaLibrary and canvas when both requests succeed', async () => {
+    mockRequest
+      .mockResolvedValueOnce({data: [{id: 'ml-123'}]})
+      .mockResolvedValueOnce({data: [{id: 'canvas-456'}]})
+
+    const result = await resolveOrgResources(mockInstance, 'org-id')
+
+    expect(result).toEqual({
+      mediaLibrary: {mediaLibraryId: 'ml-123'},
+      canvas: {canvasId: 'canvas-456'},
+    })
+  })
+
+  it('returns only mediaLibrary when canvas request fails', async () => {
+    mockRequest
+      .mockResolvedValueOnce({data: [{id: 'ml-123'}]})
+      .mockRejectedValueOnce(new Error('canvas not found'))
+
+    const result = await resolveOrgResources(mockInstance, 'org-id')
+
+    expect(result).toEqual({
+      mediaLibrary: {mediaLibraryId: 'ml-123'},
+      canvas: undefined,
+    })
+  })
+
+  it('returns only canvas when mediaLibrary request fails', async () => {
+    mockRequest
+      .mockRejectedValueOnce(new Error('media library not found'))
+      .mockResolvedValueOnce({data: [{id: 'canvas-456'}]})
+
+    const result = await resolveOrgResources(mockInstance, 'org-id')
+
+    expect(result).toEqual({
+      mediaLibrary: undefined,
+      canvas: {canvasId: 'canvas-456'},
+    })
+  })
+
+  it('returns undefined for both when both requests fail', async () => {
+    mockRequest
+      .mockRejectedValueOnce(new Error('error 1'))
+      .mockRejectedValueOnce(new Error('error 2'))
+
+    const result = await resolveOrgResources(mockInstance, 'org-id')
+
+    expect(result).toEqual({
+      mediaLibrary: undefined,
+      canvas: undefined,
+    })
+  })
+
+  it('returns undefined for both when data arrays are empty', async () => {
+    mockRequest.mockResolvedValueOnce({data: []}).mockResolvedValueOnce({data: []})
+
+    const result = await resolveOrgResources(mockInstance, 'org-id')
+
+    expect(result).toEqual({
+      mediaLibrary: undefined,
+      canvas: undefined,
+    })
+  })
+})

--- a/packages/react/src/utils/resolveOrgResources.test.ts
+++ b/packages/react/src/utils/resolveOrgResources.test.ts
@@ -28,13 +28,15 @@ beforeEach(() => {
   mockFirstValueFrom.mockResolvedValue(mockClient as unknown as SanityClient)
 })
 
+const ORG_ID = 'org-1'
+
 describe('resolveOrgResources', () => {
   it('returns both mediaLibrary and canvas when both requests succeed', async () => {
     mockRequest
       .mockResolvedValueOnce({data: [{id: 'ml-123'}]})
       .mockResolvedValueOnce({data: [{id: 'canvas-456'}]})
 
-    const result = await resolveOrgResources(mockInstance, 'org-id')
+    const result = await resolveOrgResources(mockInstance, ORG_ID)
 
     expect(result).toEqual({
       mediaLibrary: {mediaLibraryId: 'ml-123'},
@@ -42,12 +44,27 @@ describe('resolveOrgResources', () => {
     })
   })
 
+  it('scopes both requests to the organization', async () => {
+    mockRequest
+      .mockResolvedValueOnce({data: [{id: 'ml-123'}]})
+      .mockResolvedValueOnce({data: [{id: 'canvas-456'}]})
+
+    await resolveOrgResources(mockInstance, ORG_ID)
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({uri: '/media-libraries', query: {organizationId: ORG_ID}}),
+    )
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({uri: '/canvases', query: {organizationId: ORG_ID}}),
+    )
+  })
+
   it('returns only mediaLibrary when canvas request fails', async () => {
     mockRequest
       .mockResolvedValueOnce({data: [{id: 'ml-123'}]})
       .mockRejectedValueOnce(new Error('canvas not found'))
 
-    const result = await resolveOrgResources(mockInstance, 'org-id')
+    const result = await resolveOrgResources(mockInstance, ORG_ID)
 
     expect(result).toEqual({
       mediaLibrary: {mediaLibraryId: 'ml-123'},
@@ -60,7 +77,7 @@ describe('resolveOrgResources', () => {
       .mockRejectedValueOnce(new Error('media library not found'))
       .mockResolvedValueOnce({data: [{id: 'canvas-456'}]})
 
-    const result = await resolveOrgResources(mockInstance, 'org-id')
+    const result = await resolveOrgResources(mockInstance, ORG_ID)
 
     expect(result).toEqual({
       mediaLibrary: undefined,
@@ -73,7 +90,7 @@ describe('resolveOrgResources', () => {
       .mockRejectedValueOnce(new Error('error 1'))
       .mockRejectedValueOnce(new Error('error 2'))
 
-    const result = await resolveOrgResources(mockInstance, 'org-id')
+    const result = await resolveOrgResources(mockInstance, ORG_ID)
 
     expect(result).toEqual({
       mediaLibrary: undefined,
@@ -84,7 +101,7 @@ describe('resolveOrgResources', () => {
   it('returns undefined for both when data arrays are empty', async () => {
     mockRequest.mockResolvedValueOnce({data: []}).mockResolvedValueOnce({data: []})
 
-    const result = await resolveOrgResources(mockInstance, 'org-id')
+    const result = await resolveOrgResources(mockInstance, ORG_ID)
 
     expect(result).toEqual({
       mediaLibrary: undefined,

--- a/packages/react/src/utils/resolveOrgResources.ts
+++ b/packages/react/src/utils/resolveOrgResources.ts
@@ -22,37 +22,48 @@ interface OrgResources {
 }
 
 /**
+ * Gets the id of the first resource from a settled request result. The request
+ * is already scoped to a single organization, so the first item is the one we want.
+ */
+function getFirstResourceId(
+  result: PromiseSettledResult<OrgResourcesApiResponse>,
+): string | undefined {
+  if (result.status !== 'fulfilled') return undefined
+  return result.value.data?.[0]?.id
+}
+
+/**
  * Fetches the media library and canvas resources for the given organization.
- * Each resource is fetched independently — a failure for one does not prevent
- * the other from resolving.
+ * Both requests are scoped to `organizationId` so each response contains only
+ * that org's resources. Each resource is fetched independently — a failure for
+ * one does not prevent the other from resolving.
  */
 export async function resolveOrgResources(
   instance: SanityInstance,
   organizationId: string,
 ): Promise<OrgResources> {
   const client = await firstValueFrom(
-    getClientState(instance, {apiVersion: API_VERSION}).observable,
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable,
   )
 
   const [mediaLibrariesResult, canvasesResult] = await Promise.allSettled([
     client.request<OrgResourcesApiResponse>({
-      url: `/media-libraries?organizationId=${encodeURIComponent(organizationId)}`,
+      uri: `/media-libraries`,
+      query: {organizationId},
       tag: 'org-resources.media-libraries',
     }),
     client.request<OrgResourcesApiResponse>({
-      url: `/canvases?organizationId=${encodeURIComponent(organizationId)}`,
+      uri: `/canvases`,
+      query: {organizationId},
       tag: 'org-resources.canvases',
     }),
   ])
 
+  const mediaLibraryId = getFirstResourceId(mediaLibrariesResult)
+  const canvasId = getFirstResourceId(canvasesResult)
+
   return {
-    mediaLibrary:
-      mediaLibrariesResult.status === 'fulfilled' && mediaLibrariesResult.value.data?.[0]?.id
-        ? {mediaLibraryId: mediaLibrariesResult.value.data[0].id}
-        : undefined,
-    canvas:
-      canvasesResult.status === 'fulfilled' && canvasesResult.value.data?.[0]?.id
-        ? {canvasId: canvasesResult.value.data[0].id}
-        : undefined,
+    mediaLibrary: mediaLibraryId ? {mediaLibraryId} : undefined,
+    canvas: canvasId ? {canvasId} : undefined,
   }
 }

--- a/packages/react/src/utils/resolveOrgResources.ts
+++ b/packages/react/src/utils/resolveOrgResources.ts
@@ -1,0 +1,58 @@
+import {
+  type CanvasResource,
+  getClientState,
+  type MediaLibraryResource,
+  type SanityInstance,
+} from '@sanity/sdk'
+import {firstValueFrom} from 'rxjs'
+
+const API_VERSION = 'v2026-07-09'
+
+interface OrgResourcesApiItem {
+  id: string
+}
+
+interface OrgResourcesApiResponse {
+  data: OrgResourcesApiItem[]
+}
+
+interface OrgResources {
+  mediaLibrary?: MediaLibraryResource
+  canvas?: CanvasResource
+}
+
+/**
+ * Fetches the media library and canvas resources for the given organization.
+ * Each resource is fetched independently — a failure for one does not prevent
+ * the other from resolving.
+ */
+export async function resolveOrgResources(
+  instance: SanityInstance,
+  organizationId: string,
+): Promise<OrgResources> {
+  const client = await firstValueFrom(
+    getClientState(instance, {apiVersion: API_VERSION}).observable,
+  )
+
+  const [mediaLibrariesResult, canvasesResult] = await Promise.allSettled([
+    client.request<OrgResourcesApiResponse>({
+      url: `/media-libraries?organizationId=${encodeURIComponent(organizationId)}`,
+      tag: 'org-resources.media-libraries',
+    }),
+    client.request<OrgResourcesApiResponse>({
+      url: `/canvases?organizationId=${encodeURIComponent(organizationId)}`,
+      tag: 'org-resources.canvases',
+    }),
+  ])
+
+  return {
+    mediaLibrary:
+      mediaLibrariesResult.status === 'fulfilled' && mediaLibrariesResult.value.data?.[0]?.id
+        ? {mediaLibraryId: mediaLibrariesResult.value.data[0].id}
+        : undefined,
+    canvas:
+      canvasesResult.status === 'fulfilled' && canvasesResult.value.data?.[0]?.id
+        ? {canvasId: canvasesResult.value.data[0].id}
+        : undefined,
+  }
+}


### PR DESCRIPTION
### Description
In working on docs for working with multiple resources, I realized I was writing about resources that aren't project/dataset pairs -- you can pass a `mediaLibraryId` or a `canvasId`. However, those ids are pretty hard to get ahold of, and I'd prefer our users have a smooth experience.

This PR adds a boolean parameter that will inject the correct resources into the `SanityApp` runtime so users don't have to worry about these things and hopefully realize the expanded potential of the SDK. This lives in `sdk-react` rather than `core` so that users can use a `resourceName` rather than an `id` -- there's no concept of `resourceName` in core and you can pass any resource anywhere anyway.

### What to review
Most of the essential code is in the React context directory. I'd love feedback on the caching / avoiding re-render strategy especially.

### Testing
Tests added for all new utils and Kitchensink updated to ensure we're e2e testing this as well where we can.

### Fun gif
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2Jzd3pqZmx3Zmx1YTh1ZWYzM20ydmt3c250ODZtcDk2Z3NrNmoxdiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/cCZIBp9U0MiuQ/giphy.gif)