### PR TITLE
fix(react): ensure explicit "default" resource is used

### DIFF
--- a/apps/kitchensink-react/src/App.tsx
+++ b/apps/kitchensink-react/src/App.tsx
@@ -7,7 +7,7 @@ import {type JSX, Suspense} from 'react'
 import {BrowserRouter, useNavigate} from 'react-router'
 
 import {AppRoutes} from './AppRoutes'
-import {devConfigs, e2eConfigs, e2eResources, isE2E} from './sanityConfigs'
+import {devResources, e2eResources, isE2E} from './sanityConfigs'
 
 // Enable SDK logging in the browser. The wildcard picks up new namespaces
 // automatically as logging is added to more modules.
@@ -32,8 +32,8 @@ export default function App(): JSX.Element {
     <ThemeProvider theme={theme}>
       <SanityApp
         fallback={<Spinner />}
-        config={isE2E ? e2eConfigs : devConfigs}
-        resources={isE2E ? e2eResources : {}}
+        config={isE2E ? {auth: {apiHost: 'https://api.sanity.work'}} : {}}
+        resources={isE2E ? e2eResources : devResources}
         inferMediaLibraryAndCanvas
       >
         <BrowserRouter>

--- a/apps/kitchensink-react/src/DocumentCollection/DocumentEditorRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentEditorRoute.tsx
@@ -6,13 +6,13 @@ import {
   useDocumentEvent,
   useDocuments,
   useDocumentSyncStatus,
+  useResource,
 } from '@sanity/sdk-react'
 import {Badge, Box, Button, Card, Checkbox, Flex, Label, Stack, Text, TextInput} from '@sanity/ui'
 import {type JSX, useMemo, useState} from 'react'
 
 import {DocumentEditorPanel} from '../components/DocumentEditorPanel'
 import {JsonDocumentEditor} from '../components/JsonDocumentEditor'
-import {devConfigs, e2eConfigs, isE2E} from '../sanityConfigs'
 
 const AUTHOR_INITIAL_VALUES = {
   name: 'New Author',
@@ -109,7 +109,7 @@ function Editor() {
   const [documentId, setDocumentId] = useState<string | null>(documents[0]?.documentId ?? null)
   const [newDocumentId, setNewDocumentId] = useState<string>('')
   const [liveEditMode, setLiveEditMode] = useState<boolean>(false)
-  const {projectId, dataset} = isE2E ? e2eConfigs[0] : devConfigs[0]
+  const resource = useResource()
 
   const docHandle = useMemo<DocumentHandle<'author'> | null>(
     () =>
@@ -117,12 +117,11 @@ function Editor() {
         ? createDocumentHandle({
             documentType: 'author',
             documentId,
-            projectId,
-            dataset,
+            resource,
             liveEdit: liveEditMode,
           })
         : null,
-    [documentId, projectId, dataset, liveEditMode],
+    [documentId, resource, liveEditMode],
   )
 
   const handleLoadDocument = () => {

--- a/apps/kitchensink-react/src/DocumentCollection/MultiResourceRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/MultiResourceRoute.tsx
@@ -1,10 +1,12 @@
 import {
+  DatasetResource,
   type DocumentHandle,
   useDocument,
   useDocumentPreview,
   useDocumentProjection,
   useDocuments,
   useEditDocument,
+  useResource,
 } from '@sanity/sdk-react'
 import {Box, TextInput} from '@sanity/ui'
 import {defineProjection} from 'groq'
@@ -15,7 +17,7 @@ import {
   type MultiResourceAuthorProjectionProjectionResult,
   MultiResourceMovieProjectionProjectionResult,
 } from '../../sanity.types'
-import {devConfigs, e2eConfigs, isE2E} from '../sanityConfigs'
+import {devResources, e2eResources, isE2E} from '../sanityConfigs'
 
 function LoadingFallback({message = 'Loading...'}: {message?: string}) {
   return (
@@ -338,24 +340,21 @@ function MoviePreview({docHandle}: {docHandle: DocumentHandle<'movie'>}) {
 }
 
 export function MultiResourceRoute(): JSX.Element {
-  const configs = isE2E ? e2eConfigs : devConfigs
   const [searchParams] = useSearchParams()
   const authorIdParam = searchParams.get('authorId')
   const movieIdParam = searchParams.get('movieId')
+  const defaultResource = useResource()
 
   const {data: authorDocuments} = useDocuments({
     documentType: 'author',
     batchSize: 1,
-    projectId: configs[0].projectId,
-    dataset: configs[0].dataset,
     ...(authorIdParam ? {filter: '_id == $authorId', params: {authorId: authorIdParam}} : {}),
   })
 
   const {data: movieDocuments} = useDocuments({
     documentType: 'movie',
     batchSize: 1,
-    projectId: configs[1].projectId,
-    dataset: configs[1].dataset,
+    resourceName: 'secondary',
     ...(movieIdParam ? {filter: '_id == $movieId', params: {movieId: movieIdParam}} : {}),
   })
 
@@ -370,13 +369,19 @@ export function MultiResourceRoute(): JSX.Element {
     return <Box padding={4}>Loading...</Box>
   }
 
+  // remove when we add the ability to use `useResource` with a `resourceName` param
+  const secondaryResource = isE2E ? e2eResources['secondary'] : devResources['secondary']
+
   return (
     <div>
       <p style={{marginBottom: '2rem'}}>
         This route demonstrates how to use multiple resources in a single page.
         <br />
-        Note you must have access to both resources ({configs[0].projectId}.{configs[0].dataset} and{' '}
-        {configs[1].projectId}.{configs[1].dataset}) to see the documents.
+        Note you must have access to both resources (
+        {(defaultResource as DatasetResource).projectId}.
+        {(defaultResource as DatasetResource).dataset} and{' '}
+        {(secondaryResource as DatasetResource).projectId}.
+        {(secondaryResource as DatasetResource).dataset}) to see the documents.
       </p>
 
       <h2 style={{marginBottom: '1rem'}}>Document Editors</h2>

--- a/apps/kitchensink-react/src/DocumentCollection/OrgDocumentExplorerRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/OrgDocumentExplorerRoute.tsx
@@ -1,4 +1,5 @@
 import {
+  DatasetResource,
   DocumentHandle,
   ResourceProvider,
   useDatasets,
@@ -7,6 +8,7 @@ import {
   useProject,
   useProjects,
   useQuery,
+  useResource,
   useSanityInstance,
   useUsers,
 } from '@sanity/sdk-react'
@@ -302,8 +304,9 @@ function DocumentList({documentType}: DocumentListProps) {
 const allTypes = defineQuery(`array::unique(*[]._type)`)
 
 function DocumentTypes() {
-  const {config} = useSanityInstance()
-  if (!config.dataset) throw new Error('Dataset required for this component')
+  const {projectId, dataset} = useResource() as DatasetResource
+  const config = {projectId, dataset}
+  if (!projectId || !dataset) throw new Error('Project and dataset required for this component')
 
   // Use GROQ with array::unique to get all document types in the dataset
   const {data: documentTypes} = useQuery({query: allTypes})
@@ -311,7 +314,7 @@ function DocumentTypes() {
   const [selectedType, setSelectedType] = useState<string | null>(firstDocumentType ?? null)
 
   // Reset to the first available type when the dataset or that first type changes.
-  const [prevConfig, setPrevConfig] = useState(config)
+  const [prevConfig, setPrevConfig] = useState({projectId, dataset})
   const [prevFirstDocumentType, setPrevFirstDocumentType] = useState(firstDocumentType)
   if (prevConfig !== config || prevFirstDocumentType !== firstDocumentType) {
     setPrevConfig(config)

--- a/apps/kitchensink-react/src/sanityConfigs.ts
+++ b/apps/kitchensink-react/src/sanityConfigs.ts
@@ -1,4 +1,4 @@
-import {type DocumentResource, type SanityConfig} from '@sanity/sdk'
+import {type DocumentResource} from '@sanity/sdk'
 
 // True when running against the e2e environment. The SANITY_APP_E2E_* vars are
 // auto-exposed on import.meta.env by the App SDK's Vite config (SANITY_APP_ prefix).
@@ -9,35 +9,26 @@ export const isE2E = !!import.meta.env['SANITY_APP_E2E_MODE']
 // the Dashboard's sandboxed iframe), while chromium/firefox run inside the Dashboard.
 const isStandalone = window.self === window.top
 
-export const devConfigs: SanityConfig[] = [
-  {
+export const devResources: Record<string, DocumentResource> = {
+  default: {
     projectId: 'ppsg7ml5',
     dataset: 'test',
   },
-  {
+  secondary: {
     projectId: 'vo1ysemo',
     dataset: 'production',
   },
-]
-
-export const e2eConfigs: SanityConfig[] = [
-  {
-    projectId: import.meta.env['SANITY_APP_E2E_PROJECT_ID'],
-    dataset: import.meta.env['SANITY_APP_E2E_DATASET_0'],
-    auth: {
-      apiHost: 'https://api.sanity.work',
-    },
-  },
-  {
-    projectId: import.meta.env['SANITY_APP_E2E_PROJECT_ID'],
-    dataset: import.meta.env['SANITY_APP_E2E_DATASET_1'],
-    auth: {
-      apiHost: 'https://api.sanity.work',
-    },
-  },
-]
+}
 
 export const e2eResources: Record<string, DocumentResource> = {
+  default: {
+    projectId: import.meta.env['SANITY_APP_E2E_PROJECT_ID'],
+    dataset: import.meta.env['SANITY_APP_E2E_DATASET_0'],
+  },
+  secondary: {
+    projectId: import.meta.env['SANITY_APP_E2E_PROJECT_ID'],
+    dataset: import.meta.env['SANITY_APP_E2E_DATASET_1'],
+  },
   // Standalone runs (webkit/Safari) have no Dashboard org context, so `inferMediaLibraryAndCanvas`
   // can't resolve anything — provide the media library and canvas resources explicitly.
   // Otherewise, omit these so we can ensure that inferMediaLibraryAndCanvas is e2e tested.

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -173,6 +173,7 @@ const listenForNewSubscribersAndFetch = ({state, instance}: StoreContext<QuerySt
             const perspective$ = isReleasePerspective(perspectiveFromOptions)
               ? getPerspectiveState(instance, {
                   perspective: perspectiveFromOptions,
+                  resource,
                 }).observable.pipe(filter(Boolean))
               : of(perspectiveFromOptions ?? QUERY_STORE_DEFAULT_PERSPECTIVE)
 

--- a/packages/react/src/components/SDKProvider.test.tsx
+++ b/packages/react/src/components/SDKProvider.test.tsx
@@ -1,4 +1,4 @@
-import {createSanityInstance} from '@sanity/sdk'
+import {createSanityInstance, type SanityConfig} from '@sanity/sdk'
 import {render} from '@testing-library/react'
 import React from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
@@ -25,22 +25,30 @@ vi.mock('../utils/resolveOrgResources', () => ({
 vi.mock('../context/ResourceProvider', () => ({
   ResourceProvider: ({
     children,
-    projectId,
-    dataset,
+    // exclude fallback: it's a real ResourceProvider prop but not part of config
+    fallback: _fallback,
+    resource,
+    ...config
   }: {
     children: React.ReactNode
-    projectId?: string
-    dataset?: string
+    fallback?: React.ReactNode
+    resource?: {projectId?: string; dataset?: string}
   }) => (
-    <div data-testid="resource-provider" data-config={JSON.stringify({projectId, dataset})}>
+    <div
+      data-testid="resource-provider"
+      data-config={JSON.stringify(config)}
+      data-resource={JSON.stringify(resource ?? null)}
+    >
       {children}
     </div>
   ),
 }))
 
 vi.mock('./auth/AuthBoundary', () => ({
-  AuthBoundary: ({children}: {children: React.ReactNode}) => (
-    <div data-testid="auth-boundary">{children}</div>
+  AuthBoundary: ({children, projectIds}: {children: React.ReactNode; projectIds?: string[]}) => (
+    <div data-testid="auth-boundary" data-project-ids={JSON.stringify(projectIds ?? [])}>
+      {children}
+    </div>
   ),
 }))
 
@@ -110,5 +118,92 @@ describe('SDKProvider', () => {
       projectId: 'project-1',
       dataset: 'production',
     })
+  })
+
+  it('preserves non-resource config fields (e.g. studio auth, perspective) on the root provider', () => {
+    const tokenSource = {subscribe: () => ({unsubscribe: () => {}})}
+    const config: SanityConfig = {
+      projectId: 'test-project',
+      dataset: 'production',
+      perspective: 'published',
+      studio: {authenticated: true, auth: {token: tokenSource}},
+    }
+
+    const {getAllByTestId} = render(
+      <SDKProvider config={config} fallback={<div>Loading...</div>}>
+        <div>Child Content</div>
+      </SDKProvider>,
+    )
+
+    const providers = getAllByTestId('resource-provider')
+    // The full first config is spread onto the root ResourceProvider so the
+    // root SanityInstance retains auth/perspective/etc. (The token source is a
+    // function and doesn't survive JSON serialization, so assert on the
+    // serializable fields and that the studio config object is carried through.)
+    const spreadConfig = JSON.parse(providers[0].getAttribute('data-config') || '{}')
+    expect(spreadConfig).toMatchObject({
+      projectId: 'test-project',
+      dataset: 'production',
+      perspective: 'published',
+      studio: {authenticated: true},
+    })
+  })
+
+  it('synthesizes the default resource from the first config when none is explicit', () => {
+    const config = {projectId: 'test-project', dataset: 'production'}
+
+    const {getAllByTestId} = render(
+      <SDKProvider config={config} fallback={<div>Loading...</div>}>
+        <div>Child Content</div>
+      </SDKProvider>,
+    )
+
+    const providers = getAllByTestId('resource-provider')
+    expect(JSON.parse(providers[0].getAttribute('data-resource') || 'null')).toEqual({
+      projectId: 'test-project',
+      dataset: 'production',
+    })
+  })
+
+  it('uses an explicitly provided "default" resource over the config-derived one', () => {
+    const config = {projectId: 'config-project', dataset: 'production'}
+    const resources = {default: {projectId: 'explicit-project', dataset: 'staging'}}
+
+    const {getAllByTestId} = render(
+      <SDKProvider config={config} resources={resources} fallback={<div>Loading...</div>}>
+        <div>Child Content</div>
+      </SDKProvider>,
+    )
+
+    const providers = getAllByTestId('resource-provider')
+    // Config fields still flow through for instance creation…
+    expect(JSON.parse(providers[0].getAttribute('data-config') || '{}')).toEqual(config)
+    // …but the explicit default resource wins as the resource context value.
+    expect(JSON.parse(providers[0].getAttribute('data-resource') || 'null')).toEqual(
+      resources.default,
+    )
+  })
+
+  it('collects deduped projectIds from both config and explicit resources', () => {
+    const configs = [
+      {projectId: 'project-1', dataset: 'production'},
+      {projectId: 'project-2', dataset: 'production'},
+    ]
+    const resources = {
+      // duplicates project-1 (should be deduped)
+      default: {projectId: 'project-1', dataset: 'production'},
+      other: {projectId: 'project-3', dataset: 'production'},
+    }
+
+    const {getByTestId} = render(
+      <SDKProvider config={configs} resources={resources} fallback={<div>Loading...</div>}>
+        <div>Child Content</div>
+      </SDKProvider>,
+    )
+
+    const projectIds = JSON.parse(
+      getByTestId('auth-boundary').getAttribute('data-project-ids') || '[]',
+    )
+    expect([...projectIds].sort()).toEqual(['project-1', 'project-2', 'project-3'])
   })
 })

--- a/packages/react/src/components/SDKProvider.tsx
+++ b/packages/react/src/components/SDKProvider.tsx
@@ -1,4 +1,9 @@
-import {type DocumentResource, isImportError, type SanityConfig} from '@sanity/sdk'
+import {
+  type DocumentResource,
+  isDatasetResource,
+  isImportError,
+  type SanityConfig,
+} from '@sanity/sdk'
 import {type ReactElement, type ReactNode, useEffect, useMemo} from 'react'
 import {ErrorBoundary, type FallbackProps} from 'react-error-boundary'
 
@@ -45,19 +50,13 @@ export function SDKProvider({
   inferMediaLibraryAndCanvas,
   ...props
 }: SDKProviderProps): ReactElement {
-  const allConfigs = Array.isArray(config) ? config : [config]
-  const resolvedConfig = allConfigs[0]
-  const projectIds = allConfigs.map((c) => c.projectId).filter((id): id is string => !!id)
+  // For legacy config support, extract the first config object as a default resource,
+  // matching the legacy behavior nesting ResourceProviders with the first config closest to users' application code.
+  // This should be removed when we remove legacy config support.
+  const defaultConfig = Array.isArray(config) ? config[0] : config
+  const defaultProjectId = defaultConfig?.projectId
+  const defaultDataset = defaultConfig?.dataset
 
-  // Extract static fields so the memo below doesn't take a reference dependency
-  // on `config` — inline config objects change identity on every render.
-  const singleConfig = Array.isArray(config) ? null : config
-  const defaultProjectId = singleConfig?.projectId
-  const defaultDataset = singleConfig?.dataset
-
-  // For a single config, synthesize a 'default' resource from its projectId/dataset
-  // so that hooks can resolve it via resourceName: 'default' or fall back to it
-  // automatically when no resource info is provided.
   const resourcesValue = useMemo(() => {
     const explicit = props.resources ?? {}
     if (defaultProjectId && defaultDataset && !Object.hasOwn(explicit, DEFAULT_RESOURCE_NAME)) {
@@ -72,10 +71,34 @@ export function SDKProvider({
     return explicit
   }, [defaultProjectId, defaultDataset, props.resources])
 
+  // Collect all projectIds from both resources and config, deduped so
+  // AuthBoundary doesn't verify the same project more than once.
+  const projectIds = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          [
+            ...Object.values(resourcesValue)
+              .filter(isDatasetResource)
+              .map((resource) => resource.projectId),
+            ...(Array.isArray(config) ? config : [config]).map((configObj) => configObj.projectId),
+          ].filter((id): id is string => !!id),
+        ),
+      ),
+    [resourcesValue, config],
+  )
+
   return (
     <ErrorBoundary FallbackComponent={ChunkAwareFallback}>
       <ResetChunkReloadFlagOnMount />
-      <ResourceProvider {...resolvedConfig} fallback={fallback}>
+      {/* Spread the first config so SanityInstance can use the auth,
+        perspective, and other config fields; `resource` lets an explicitly
+        provided `default` resource override the config-derived resource. */}
+      <ResourceProvider
+        {...defaultConfig}
+        resource={resourcesValue[DEFAULT_RESOURCE_NAME]}
+        fallback={fallback}
+      >
         <AuthBoundary {...props} projectIds={projectIds}>
           {/* OrganizationResourcesProvider wraps ResourcesContext.
             It merges explicit resources with lazily inferred org resources (media


### PR DESCRIPTION
### Description
After all the switching between making the resource changes a breaking v3 change and deciding to incorporate it in v2, there was a bit of confusion of logic. The sole `ResourceProvider` invoked in `SDKProvider` always used the configs passed in `config` and made the first one the `default` to match legacy behavior, but didn't access the new `resources` parameter.

This PR resolves that by making sure both are being read. This change also revealed a regression where resources weren't being passed to the perspective store if you changed perspectives; that's now fixed.

### What to review
The simpler logic chain in `SDKProvider`; any catches or gotchas?

### Testing
Kitchensink was switched to the future format to make sure we're e2e testing it. Some vitest tests were added for the SDKProvider changes; the perspective / query store regression was harder to address.

### Fun gif
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGRlN2h5b3N3bzJwbW9zbjZyeDRpb3ByNzlpZ2kxMHc3Z3kzOTg1MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT9IgG50Fb7Mi0prBC/giphy.gif)