### PR TITLE
fix(fallow): add kitchensink app entrypoint

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
   "ignorePatterns": ["**/typedoc-theme/**"],
+  "entry": ["apps/kitchensink-react/src/App.tsx"],
   "audit": {
     "deadCodeBaseline": "fallow-baselines/dead-code.json",
     "healthBaseline": "fallow-baselines/health.json",


### PR DESCRIPTION
### Description
Fallow was failing every PR that made a change to the Kitchensink. Ref the CI jobs for:
https://github.com/sanity-io/sdk/pull/1024
https://github.com/sanity-io/sdk/pull/1029

 I suspect it's because the Sanity runtime creates our entrypoint silently, so it couldn't detect the actual `index.html` entrypoint and import. I've manually set it here.
 
 I don't believe this is required for the `standalone-react` application because its index.html is legible.

### What to review
Anything I'm missing.

### Testing
I ran this against one of the failing branches and got a 0 exit code.