### PR TITLE
fix(e2e): use correct var and task for dev:e2e

### DIFF
--- a/apps/kitchensink-react/package.json
+++ b/apps/kitchensink-react/package.json
@@ -8,6 +8,7 @@
     "clean": "rimraf dist",
     "deploy": "sanity deploy",
     "dev": "sanity dev",
+    "dev:e2e": "sanity dev",
     "install": "npm run schema:extract && npm run types:generate",
     "lint": "eslint .",
     "paramour": "npx paramour --config=./src/css/css.config.js --output=./src/css/paramour.css",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "depcheck": "DEPCHECK=true knip",
     "deploy:kitchensink": "turbo run deploy --filter=@sanity/kitchensink-react",
     "dev": "pnpm dev:kitchensink",
-    "dev:e2e": "SANITY_INTERNAL_ENV=staging SANITY_APP_E2E_ORGANIZATION_ID=oFvj4MZWQ turbo run dev --filter=@sanity/kitchensink-react",
+    "dev:e2e": "SANITY_INTERNAL_ENV=staging SANITY_APP_E2E_MODE=true turbo run dev:e2e --filter=@sanity/kitchensink-react",
     "dev:kitchensink": "turbo run dev --filter=@sanity/kitchensink-react",
     "dev:standalone": "turbo run dev --filter=@sanity/standalone-react",
     "fallow": "fallow",


### PR DESCRIPTION
### Description
In debugging some failing e2e tests in another branch, I discovered that the `dev:e2e` task wasn't updated with the rest of the recent changes to use `SANITY_APP` variables. This PR updates the command-line variable and uses a dedicated e2e task.

### What to review
Everything make sense?

### Testing
Not really possible to write a test; if you pull down and run `pnpm dev:e2e` you should see that the Kitchensink in staging no longer tries to look for projects in prod.

### Fun gif
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExOTRkNTViMjRhZ3p4MW8zdXZsYWx4eHZmczA3MDZqdmdlb2s0dWhnMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPCSX4UHmuS41TG/giphy.gif)