### PR TITLE
fix(core): stop retrying live events connections rejected with a 4xx

### DIFF
--- a/packages/core/src/query/queryStore.test.ts
+++ b/packages/core/src/query/queryStore.test.ts
@@ -1,4 +1,10 @@
-import {DisconnectError, type LiveEvent, type SanityClient, type SyncTag} from '@sanity/client'
+import {
+  ConnectionFailedError,
+  DisconnectError,
+  type LiveEvent,
+  type SanityClient,
+  type SyncTag,
+} from '@sanity/client'
 import {delay, filter, firstValueFrom, Observable, of, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -387,6 +393,52 @@ describe('queryStore', () => {
 
     // A retry now creates a fresh key and fetches
     await expect(advanceAndAwait(resolveQuery(instance, {query}))).resolves.toEqual(mockData.movies)
+  })
+
+  it('stops live updates without retrying or erroring on a 4xx connection rejection', async () => {
+    const query = '*[_type == "movie"]'
+    const state = getQueryState(instance, {query})
+    const unsub = state.subscribe()
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
+
+    const clientState = vi.mocked(getClientState).mock.results[0]
+      ?.value as StateSource<SanityClient>
+    const client = await firstValueFrom(clientState.observable)
+    const eventsMock = vi.mocked(client.live.events)
+    const callsBefore = eventsMock.mock.calls.length
+
+    // The server rejected the connection with a 401 (e.g. expired token). The
+    // client surfaces this as a fatal ConnectionFailedError with the status —
+    // retrying would reconnect once per second forever against a server that
+    // keeps rejecting
+    liveEvents.error(new ConnectionFailedError('EventSource connection failed', {status: 401}))
+    await vi.advanceTimersByTimeAsync(LIVE_EVENTS_RETRY_DELAY * 5)
+
+    expect(() => state.getCurrent()).not.toThrow()
+    expect(eventsMock.mock.calls.length).toBe(callsBefore)
+    unsub()
+  })
+
+  it('retries a connection failure without a status (transient network failure)', async () => {
+    const query = '*[_type == "movie"]'
+    const state = getQueryState(instance, {query})
+    const unsub = state.subscribe()
+    await advanceAndAwait(firstValueFrom(state.observable.pipe(filter((i) => i !== undefined))))
+
+    const clientState = vi.mocked(getClientState).mock.results[0]
+      ?.value as StateSource<SanityClient>
+    const client = await firstValueFrom(clientState.observable)
+    const eventsMock = vi.mocked(client.live.events)
+    const callsBefore = eventsMock.mock.calls.length
+
+    // No status means the failure could be transient (native EventSource
+    // exposes no status) — reconnecting is correct here
+    liveEvents.error(new ConnectionFailedError('EventSource connection failed'))
+    await vi.advanceTimersByTimeAsync(LIVE_EVENTS_RETRY_DELAY * 2)
+
+    expect(() => state.getCurrent()).not.toThrow()
+    expect(eventsMock.mock.calls.length).toBeGreaterThan(callsBefore)
+    unsub()
   })
 
   it('stops live updates without retrying or erroring on DisconnectError', async () => {

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -1,4 +1,9 @@
-import {CorsOriginError, DisconnectError, type ResponseQueryOptions} from '@sanity/client'
+import {
+  ConnectionFailedError,
+  CorsOriginError,
+  DisconnectError,
+  type ResponseQueryOptions,
+} from '@sanity/client'
 import {type SanityQueryResult} from 'groq'
 import {
   catchError,
@@ -250,6 +255,19 @@ const listenToLiveClientAndSetLastLiveEventIds = ({
             // The server explicitly told this client to stop reconnecting —
             // end live updates without erroring the store (queries keep
             // serving, they just stop receiving live invalidation)
+            return EMPTY
+          }
+          if (
+            error instanceof ConnectionFailedError &&
+            typeof error.status === 'number' &&
+            error.status >= 400 &&
+            error.status < 500
+          ) {
+            // The server rejected the connection with a 4xx (e.g. a 401 from
+            // an expired token) — it will keep rejecting, so retrying would
+            // reconnect once per second forever. End live updates like a
+            // DisconnectError. A ConnectionFailedError without a status stays
+            // retryable: it may be a transient network failure.
             return EMPTY
           }
           throw error

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^1.0.5
       version: 1.0.5
     '@sanity/client':
-      specifier: ^7.23.0
-      version: 7.23.0
+      specifier: ^7.23.1
+      version: 7.23.1
     '@sanity/comlink':
       specifier: ^4.0.1
       version: 4.0.1
@@ -396,7 +396,7 @@ importers:
     dependencies:
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.23.0
+        version: 7.23.1
       '@sanity/uuid':
         specifier: ^3.0.3
         version: 3.0.3
@@ -483,7 +483,7 @@ importers:
         version: 1.0.0
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.23.0
+        version: 7.23.1
       '@sanity/comlink':
         specifier: 'catalog:'
         version: 4.0.1
@@ -580,7 +580,7 @@ importers:
     dependencies:
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.23.0
+        version: 7.23.1
       '@sanity/message-protocol':
         specifier: 'catalog:'
         version: 0.23.0
@@ -3316,8 +3316,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@sanity/client@7.23.0':
-    resolution: {integrity: sha512-4VFcLeP/lD0lhe5TD102tSnoW72ERT6xD/ZLb9pdLNMbZgbOciAy3m0hAYvs1vjA6663ZjNM6SLwl1Utq97DHA==}
+  '@sanity/client@7.23.1':
+    resolution: {integrity: sha512-zCKrdmsfFRYKXndkw5rVi3tyvr54QIdE+ISuAxFeHfJFiwWHFNu6pL4G8JmRyfxsD7Q9zyrD4C5hczVVmwGbgg==}
     engines: {node: '>=20'}
 
   '@sanity/codegen@3.88.1-typegen-experimental.0':
@@ -10810,7 +10810,7 @@ snapshots:
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.12.4)
       '@oclif/core': 4.11.11
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       boxen: 8.0.1
       debug: 4.4.3(supports-color@8.1.1)
       get-it: 8.8.0
@@ -10851,13 +10851,13 @@ snapshots:
       '@oclif/plugin-not-found': 3.2.87(@types/node@24.12.4)
       '@sanity/cli-build': 2.0.1(@babel/core@7.29.7)(@babel/runtime@7.29.2)(@noble/hashes@2.0.1)(@types/node@24.12.4)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(node-fetch@2.7.0)(rolldown@1.1.3)(terser@5.36.0)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
       '@sanity/cli-core': 2.1.3(@noble/hashes@2.0.1)(@types/node@24.12.4)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.36.0)(yaml@2.9.0)
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       '@sanity/codegen': 7.0.3(@oclif/core@4.11.11)(@sanity/cli-core@2.1.3(@noble/hashes@2.0.1)(@types/node@24.12.4)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.36.0)(yaml@2.9.0))(oxfmt@0.58.0)(react@19.2.7)
       '@sanity/descriptors': 1.3.0
       '@sanity/export': 6.2.0
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
-      '@sanity/import': 6.0.3(@sanity/client@7.23.0)(@types/react@19.2.17)
+      '@sanity/import': 6.0.3(@sanity/client@7.23.1)(@types/react@19.2.17)
       '@sanity/migrate': 7.0.3(@oclif/core@4.11.11)(@sanity/cli-core@2.1.3(@noble/hashes@2.0.1)(@types/node@24.12.4)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.36.0)(yaml@2.9.0))(@types/react@19.2.17)(xstate@5.32.2)
       '@sanity/runtime-cli': 17.1.0(@types/node@24.12.4)(esbuild@0.28.1)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)
       '@sanity/schema': 6.3.0(@types/react@19.2.17)
@@ -10944,7 +10944,7 @@ snapshots:
       - vue-tsc
       - xstate
 
-  '@sanity/client@7.23.0':
+  '@sanity/client@7.23.1':
     dependencies:
       '@sanity/eventsource': 5.0.2
       get-it: 8.8.0
@@ -11064,10 +11064,10 @@ snapshots:
     dependencies:
       '@sanity/signed-urls': 2.0.2
 
-  '@sanity/import@6.0.3(@sanity/client@7.23.0)(@types/react@19.2.17)':
+  '@sanity/import@6.0.3(@sanity/client@7.23.1)(@types/react@19.2.17)':
     dependencies:
       '@sanity/asset-utils': 2.3.0
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       '@sanity/generate-help-url': 4.0.0
       '@sanity/mutator': 6.3.0(@types/react@19.2.17)
       debug: 4.4.3(supports-color@8.1.1)
@@ -11112,7 +11112,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.11.11
       '@sanity/cli-core': 2.1.3(@noble/hashes@2.0.1)(@types/node@24.12.4)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.36.0)(yaml@2.9.0)
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       '@sanity/mutate': 0.18.1(xstate@5.32.2)
       '@sanity/types': 6.3.0(@types/react@19.2.17)
       '@sanity/util': 6.3.0(@types/react@19.2.17)
@@ -11130,7 +11130,7 @@ snapshots:
   '@sanity/mutate@0.18.1(xstate@5.32.2)':
     dependencies:
       '@isaacs/ttlcache': 2.1.5
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/uuid': 3.0.3
       hotscript: 1.0.13
@@ -11213,17 +11213,17 @@ snapshots:
       - supports-color
       - vue-tsc
 
-  '@sanity/presentation-comlink@2.1.0(@sanity/client@7.23.0)(@sanity/types@6.3.0(@types/react@19.2.17))':
+  '@sanity/presentation-comlink@2.1.0(@sanity/client@7.23.1)(@sanity/types@6.3.0(@types/react@19.2.17))':
     dependencies:
       '@sanity/comlink': 4.0.1
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.23.0)(@sanity/types@6.3.0(@types/react@19.2.17))
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.23.1)(@sanity/types@6.3.0(@types/react@19.2.17))
     transitivePeerDependencies:
       - '@sanity/client'
       - '@sanity/types'
 
-  '@sanity/preview-url-secret@4.0.7(@sanity/client@7.23.0)':
+  '@sanity/preview-url-secret@4.0.7(@sanity/client@7.23.1)':
     dependencies:
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       '@sanity/uuid': 3.0.2
 
   '@sanity/prism-groq@1.1.2(prismjs@1.27.0)':
@@ -11240,7 +11240,7 @@ snapshots:
       '@sanity-labs/design-tokens': 0.0.2-alpha.4
       '@sanity/blueprints': 0.20.1
       '@sanity/blueprints-parser': 0.4.0
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       adm-zip: 0.5.17
       array-treeify: 0.1.5
       cardinal: 2.1.1
@@ -11290,7 +11290,7 @@ snapshots:
   '@sanity/sdk@2.15.0(@types/react@19.2.17)(immer@10.1.1)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.2)':
     dependencies:
       '@sanity/bifur-client': 1.0.0
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       '@sanity/comlink': 4.0.1
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/diff-patch': 6.0.0
@@ -11336,7 +11336,7 @@ snapshots:
 
   '@sanity/types@6.3.0(@types/react@19.2.17)':
     dependencies:
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       '@sanity/media-library-types': 1.4.0
       '@types/react': 19.2.17
 
@@ -11380,7 +11380,7 @@ snapshots:
     dependencies:
       '@date-fns/tz': 1.5.0
       '@date-fns/utc': 2.1.1
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       '@sanity/types': 6.3.0(@types/react@19.2.17)
       date-fns: 4.4.0
       rxjs: 7.8.2
@@ -11396,9 +11396,9 @@ snapshots:
     dependencies:
       uuid: 11.1.0
 
-  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.23.0)(@sanity/types@6.3.0(@types/react@19.2.17))':
+  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.23.1)(@sanity/types@6.3.0(@types/react@19.2.17))':
     dependencies:
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
     optionalDependencies:
       '@sanity/types': 6.3.0(@types/react@19.2.17)
 
@@ -15459,7 +15459,7 @@ snapshots:
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
       '@sanity/cli': 7.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.2)(@noble/hashes@2.0.1)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.1.3)(vite@8.1.3(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)))(@types/node@24.12.4)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(node-fetch@2.7.0)(oxfmt@0.58.0)(rolldown@1.1.3)(terser@5.36.0)(typescript@6.0.3)(xstate@5.32.2)
-      '@sanity/client': 7.23.0
+      '@sanity/client': 7.23.1
       '@sanity/color': 3.0.6
       '@sanity/comlink': 4.0.1
       '@sanity/diff': 6.3.0
@@ -15476,8 +15476,8 @@ snapshots:
       '@sanity/migrate': 7.0.3(@oclif/core@4.11.11)(@sanity/cli-core@2.1.3(@noble/hashes@2.0.1)(@types/node@24.12.4)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.36.0)(yaml@2.9.0))(@types/react@19.2.17)(xstate@5.32.2)
       '@sanity/mutate': 0.18.1(xstate@5.32.2)
       '@sanity/mutator': 6.3.0(@types/react@19.2.17)
-      '@sanity/presentation-comlink': 2.1.0(@sanity/client@7.23.0)(@sanity/types@6.3.0(@types/react@19.2.17))
-      '@sanity/preview-url-secret': 4.0.7(@sanity/client@7.23.0)
+      '@sanity/presentation-comlink': 2.1.0(@sanity/client@7.23.1)(@sanity/types@6.3.0(@types/react@19.2.17))
+      '@sanity/preview-url-secret': 4.0.7(@sanity/client@7.23.1)
       '@sanity/prism-groq': 1.1.2(prismjs@1.27.0)
       '@sanity/schema': 6.3.0(@types/react@19.2.17)
       '@sanity/sdk': 2.15.0(@types/react@19.2.17)(immer@10.1.1)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ minimumReleaseAgeExclude:
 catalog:
   '@playwright/test': '^1.61.1'
   '@sanity/browserslist-config': '^1.0.5'
-  '@sanity/client': '^7.23.0'
+  '@sanity/client': '^7.23.1'
   '@sanity/comlink': '^4.0.1'
   '@sanity/message-protocol': '^0.23.0'
   '@sanity/pkg-utils': '^10.5.8'


### PR DESCRIPTION
### Description

- Bumps `@sanity/client` to `^7.23.1`, which stops the client-internal 1s-forever reconnect loop when a live events SSE connection is rejected with a 4xx (sanity-io/client#1226). Stuck apps in this state were generating ~86K requests/day each.
- With the fixed client, the rejection now surfaces as `ConnectionFailedError` with a `status` — and the query store's flat `retry({delay: 1000})` would recreate the same loop from the SDK side. The query store now treats a 4xx `ConnectionFailedError` as fatal (like `DisconnectError`): live updates stop, queries keep serving, no store-wide error. Status-less connection failures (native EventSource, transient network drops) still retry.

FIXES SDK-1891

### What to review

- `packages/core/src/query/queryStore.ts` — the new `ConnectionFailedError` case in the live events `catchError`.
- The 4xx range check: 408/429 are already retried inside the client and never surface here.

### Testing

- New test: a 401 `ConnectionFailedError` stops live updates without retrying or erroring the store.
- New test: a status-less `ConnectionFailedError` still retries (pins that the fatal check doesn't over-reach).

### Fun gif

![Hang up the phone](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGt3Y2J2Nm93bXR0czRlY2xrZXQ5ZDFtY2VwZDFpYmx1cW9tdnRnNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0MYt5jPR6QX5pnqM/giphy.gif)