### PR TITLE
chore(kitchensink): use shared components in OrgDocumentExplorer

### DIFF
--- a/apps/kitchensink-react/e2e/document-list.spec.ts
+++ b/apps/kitchensink-react/e2e/document-list.spec.ts
@@ -58,4 +58,33 @@ test.describe('Document List', () => {
       }).toPass({timeout: 10000})
     }
   })
+
+  test('progressively loads more documents as the sentinel scrolls into view', async ({
+    page,
+    createDocuments,
+    getPageContext,
+  }) => {
+    // `useDocuments` loads in batches of 25, so 30 documents guarantees a
+    // second batch that only arrives once the LoadMore sentinel is visible.
+    await createDocuments(
+      Array.from({length: 30}, (_, i) => ({
+        _type: 'author',
+        name: `LoadMore Author ${i}`,
+      })),
+      {asDraft: false},
+    )
+
+    await page.goto('./document-list')
+    const pageContext = await getPageContext(page)
+
+    const previews = pageContext.locator('[data-testid^="document-preview-"]')
+
+    // First batch renders (25 items) before any scrolling.
+    await expect.poll(() => previews.count(), {timeout: 15000}).toBeGreaterThanOrEqual(25)
+    const initialCount = await previews.count()
+
+    // Scrolling the sentinel into view triggers the next batch.
+    await pageContext.getByTestId('load-more').scrollIntoViewIfNeeded()
+    await expect.poll(() => previews.count(), {timeout: 15000}).toBeGreaterThan(initialCount)
+  })
 })

--- a/apps/kitchensink-react/e2e/document-projection.spec.ts
+++ b/apps/kitchensink-react/e2e/document-projection.spec.ts
@@ -147,4 +147,46 @@ test.describe('Document Projection', () => {
     await expect(nameCell).toBeVisible()
     await expect(nameCell).toContainText('Test Author Projection')
   })
+
+  test('paginates through author documents', async ({page, createDocuments, getPageContext}) => {
+    // The projection route filters to authors with `count(favoriteBooks) > 0`,
+    // so every author needs at least one favorite book to be listed.
+    const {
+      documentIds: [bookId],
+    } = await createDocuments([{_type: 'book', title: 'Pagination Book'}], {asDraft: false})
+
+    await createDocuments(
+      Array.from({length: 12}, (_, i) => ({
+        _type: 'author',
+        name: `Pagination Author ${i}`,
+        favoriteBooks: [{_type: 'reference', _ref: bookId}],
+      })),
+      {asDraft: false},
+    )
+
+    await page.goto('./document-projection')
+    const pageContext = await getPageContext(page)
+
+    await pageContext.getByTestId('projection-table').waitFor()
+
+    // A page size of 5 across at least 12 authors yields 3+ pages.
+    await pageContext.getByTestId('list-page-size').selectOption('5')
+
+    const rows = pageContext.locator('[data-testid^="author-row-"]')
+    await expect.poll(() => rows.count(), {timeout: 15000}).toBe(5)
+
+    const status = pageContext.getByTestId('pagination-status').first()
+    await expect(status).toContainText('Page 1 of')
+    await expect(pageContext.getByTestId('pagination-previous').first()).toBeDisabled()
+    await expect(pageContext.getByTestId('pagination-next').first()).toBeEnabled()
+
+    // Advance to page 2, then jump to the last page and confirm it's terminal
+    await pageContext.getByTestId('pagination-next').first().click()
+    await expect(status).toContainText('Page 2 of')
+    await expect.poll(() => rows.count(), {timeout: 15000}).toBe(5)
+
+    await pageContext.getByTestId('pagination-last').first().click()
+    await expect(pageContext.getByTestId('pagination-next').first()).toBeDisabled()
+    await expect(pageContext.getByTestId('pagination-previous').first()).toBeEnabled()
+  })
 })

--- a/apps/kitchensink-react/e2e/org-document-explorer.spec.ts
+++ b/apps/kitchensink-react/e2e/org-document-explorer.spec.ts
@@ -1,0 +1,88 @@
+import {expect, test} from '@repo/e2e'
+
+test.describe('Organization Document Explorer', () => {
+  test('navigates the project → dataset → type hierarchy and paginates documents', async ({
+    page,
+    getClient,
+    createDocuments,
+    getPageContext,
+  }) => {
+    const client = getClient()
+    const {projectId, dataset} = client.config()
+    if (!projectId || !dataset) {
+      throw new Error('E2E client is missing a projectId/dataset')
+    }
+
+    // Create enough authors to span multiple pages at a page size of 5.
+    await createDocuments(
+      Array.from({length: 12}, (_, i) => ({
+        _type: 'author',
+        name: `Org Explorer Author ${i}`,
+      })),
+      {asDraft: false},
+    )
+
+    await page.goto('./org-document-explorer')
+    const pageContext = await getPageContext(page)
+
+    // Drill down from project to dataset to document type
+    const projectSelect = pageContext.getByTestId('org-project-select')
+    await projectSelect.selectOption(projectId)
+
+    const datasetSelect = pageContext.getByTestId('org-dataset-select')
+    await datasetSelect.selectOption(dataset)
+
+    const typeSelect = pageContext.getByTestId('org-doctype-select')
+    await typeSelect.selectOption('author')
+
+    // The documents table should render.
+    const table = pageContext.getByTestId('org-document-table')
+    await expect(table).toBeVisible()
+
+    // Shrink the page size so 12 authors span to 3 pages
+    await pageContext.getByTestId('list-page-size-author').selectOption('5')
+
+    const rows = pageContext.locator('[data-testid^="org-document-row-"]')
+    await expect.poll(() => rows.count(), {timeout: 15000}).toBe(5)
+
+    const status = pageContext.getByTestId('pagination-status').first()
+    /*
+     * Don't specify particular pages:
+     * Tests run in parallel so there may be more than 3 pages due to docs created in other tests
+     */
+    await expect(status).toContainText('Page 1 of')
+    await expect(pageContext.getByTestId('pagination-previous').first()).toBeDisabled() // test hasPreviousPage
+    await expect(pageContext.getByTestId('pagination-next').first()).toBeEnabled() // test hasNextPage
+
+    // Advancing a page keeps a full page of rows and updates the status.
+    await pageContext.getByTestId('pagination-next').first().click()
+    await expect(status).toContainText('Page 2 of')
+    await expect.poll(() => rows.count(), {timeout: 15000}).toBe(5)
+    await expect(pageContext.getByTestId('pagination-previous').first()).toBeEnabled() // test hasPreviousPage
+  })
+
+  test('views organization users in a dialog', async ({page, getClient, getPageContext}) => {
+    const {projectId} = getClient().config()
+    if (!projectId) {
+      throw new Error('E2E client is missing a projectId')
+    }
+
+    await page.goto('./org-document-explorer')
+    const pageContext = await getPageContext(page)
+
+    const projectSelect = pageContext.getByTestId('org-project-select')
+    await projectSelect.waitFor()
+    await projectSelect.selectOption(projectId)
+
+    // Open the users dialog from the project header.
+    const viewUsers = pageContext.getByRole('button', {name: 'View Users'})
+    await viewUsers.waitFor()
+    await viewUsers.click()
+
+    await expect(pageContext.getByText('Project Users')).toBeVisible()
+
+    // At least the current user should be listed
+    const users = pageContext.locator('[data-testid^="user-list-item-"]')
+    await expect.poll(() => users.count(), {timeout: 15000}).toBeGreaterThan(0)
+  })
+})

--- a/apps/kitchensink-react/src/DocumentCollection/DocumentDashboardInteractionsRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentDashboardInteractionsRoute.tsx
@@ -11,8 +11,8 @@ import {type JSX, Suspense} from 'react'
 import {ErrorBoundary} from 'react-error-boundary'
 
 import {DocumentListLayout} from '../components/DocumentListLayout/DocumentListLayout'
+import {LoadMore} from '../components/LoadMore'
 import {DocumentPreview} from './DocumentPreview'
-import {LoadMore} from './LoadMore'
 
 function useStudioResource<T extends DocumentHandle>(docHandle: T) {
   const {config} = useSanityInstance()

--- a/apps/kitchensink-react/src/DocumentCollection/DocumentListRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentListRoute.tsx
@@ -3,8 +3,8 @@ import {Box, Heading} from '@sanity/ui'
 import {type JSX} from 'react'
 
 import {DocumentListLayout} from '../components/DocumentListLayout/DocumentListLayout'
+import {LoadMore} from '../components/LoadMore'
 import {DocumentPreview} from './DocumentPreview'
-import {LoadMore} from './LoadMore'
 
 export function DocumentListRoute(): JSX.Element {
   const {isPending, data, hasMore, loadMore} = useDocuments({

--- a/apps/kitchensink-react/src/DocumentCollection/DocumentProjectionRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/DocumentProjectionRoute.tsx
@@ -1,9 +1,11 @@
 import {DocumentHandle, useDocumentProjection, usePaginatedDocuments} from '@sanity/sdk-react'
-import {Box, Button, Card, Flex, Label, Spinner, Stack, Text, TextInput} from '@sanity/ui'
+import {Box, Button, Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
 import groq, {defineProjection} from 'groq'
 import {JSX, ReactNode, Suspense, useRef, useState} from 'react'
 import {ErrorBoundary} from 'react-error-boundary'
 
+import {PaginatedListToolbar} from '../components/PaginatedListToolbar'
+import {PaginationControls} from '../components/PaginationControls'
 // Import the custom table components
 import {Table, TD, TH, TR} from '../components/TableElements'
 
@@ -133,111 +135,6 @@ function AuthorRow({
 }
 
 // Define interface for pagination controls props
-interface PaginationControlsProps {
-  currentPage: number
-  totalPages: number
-  hasFirstPage: boolean
-  hasPreviousPage: boolean
-  hasNextPage: boolean
-  hasLastPage: boolean
-  firstPage: () => void
-  previousPage: () => void
-  nextPage: () => void
-  lastPage: () => void
-  goToPage: (pageNumber: number) => void
-  isPending: boolean
-}
-
-// Pagination controls component
-function PaginationControls({
-  currentPage,
-  totalPages,
-  hasFirstPage,
-  hasPreviousPage,
-  hasNextPage,
-  hasLastPage,
-  firstPage,
-  previousPage,
-  nextPage,
-  lastPage,
-  goToPage,
-  isPending,
-}: PaginationControlsProps) {
-  const buttonStyle = {
-    minWidth: '40px',
-    margin: '0 4px',
-    textAlign: 'center',
-  } as const
-
-  // Generate page number buttons
-  const pageButtons = () => {
-    const buttons = []
-    const maxVisiblePages = 5
-    let startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2))
-    const endPage = Math.min(totalPages, startPage + maxVisiblePages - 1)
-
-    if (endPage - startPage + 1 < maxVisiblePages) {
-      startPage = Math.max(1, endPage - maxVisiblePages + 1)
-    }
-
-    for (let i = startPage; i <= endPage; i++) {
-      buttons.push(
-        <Button
-          key={i}
-          mode={i === currentPage ? 'default' : 'ghost'}
-          onClick={() => goToPage(i)}
-          style={{
-            ...buttonStyle,
-            fontWeight: i === currentPage ? 'bold' : 'normal',
-          }}
-        >
-          {i}
-        </Button>,
-      )
-    }
-    return buttons
-  }
-
-  return (
-    <Flex align="center" justify="space-between" padding={3}>
-      <Flex>
-        <Button
-          onClick={firstPage}
-          disabled={!hasFirstPage}
-          style={buttonStyle}
-          text="<<"
-          mode="ghost"
-        />
-        <Button
-          onClick={previousPage}
-          disabled={!hasPreviousPage}
-          style={buttonStyle}
-          text="<"
-          mode="ghost"
-        />
-        {pageButtons()}
-        <Button
-          onClick={nextPage}
-          disabled={!hasNextPage}
-          style={buttonStyle}
-          text=">"
-          mode="ghost"
-        />
-        <Button
-          onClick={lastPage}
-          disabled={!hasLastPage}
-          style={buttonStyle}
-          text=">>"
-          mode="ghost"
-        />
-      </Flex>
-      <Text size={1} style={{opacity: isPending ? 0.5 : 1}}>
-        Page {currentPage} of {totalPages}
-      </Text>
-    </Flex>
-  )
-}
-
 export function DocumentProjectionRoute(): JSX.Element {
   const [searchTerm, setSearchTerm] = useState('')
   const [pageSize, setPageSize] = useState(5)
@@ -282,46 +179,16 @@ export function DocumentProjectionRoute(): JSX.Element {
     <Stack space={4}>
       <Card padding={4}>
         <Stack space={4}>
-          <Flex justify="space-between" align="center">
-            <Box style={{width: '300px'}}>
-              <Label htmlFor="search" size={1} style={{marginBottom: '4px', display: 'block'}}>
-                Search Authors
-              </Label>
-              <TextInput
-                id="search"
-                value={searchTerm}
-                onChange={handleSearchChange}
-                placeholder="Search by name..."
-                style={{width: '100%'}}
-              />
-            </Box>
-            <Box>
-              <Label htmlFor="pageSize" size={1} style={{marginBottom: '4px', display: 'block'}}>
-                Items per page
-              </Label>
-              <select
-                id="pageSize"
-                value={pageSize}
-                onChange={handlePageSizeChange}
-                style={{
-                  padding: '8px',
-                  borderRadius: '4px',
-                  border: '1px solid #ccc',
-                }}
-              >
-                <option value={5}>5</option>
-                <option value={10}>10</option>
-                <option value={25}>25</option>
-                <option value={50}>50</option>
-              </select>
-            </Box>
-          </Flex>
-
-          <Box style={{borderRadius: '4px', border: '1px solid #eee', padding: '8px'}}>
-            <Text size={1}>
-              Showing {startIndex + 1}-{Math.min(endIndex, count)} of {count} authors
-            </Text>
-          </Box>
+          <PaginatedListToolbar
+            noun="authors"
+            searchTerm={searchTerm}
+            onSearchChange={handleSearchChange}
+            pageSize={pageSize}
+            onPageSizeChange={handlePageSizeChange}
+            count={count}
+            startIndex={startIndex}
+            endIndex={endIndex}
+          />
 
           <PaginationControls
             currentPage={currentPage}

--- a/apps/kitchensink-react/src/DocumentCollection/OrgDocumentExplorerRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/OrgDocumentExplorerRoute.tsx
@@ -2,10 +2,7 @@ import {
   DocumentHandle,
   ResourceProvider,
   useDatasets,
-  useDocument,
   useDocumentPreview,
-  useDocumentSyncStatus,
-  useEditDocument,
   usePaginatedDocuments,
   useProject,
   useProjects,
@@ -27,15 +24,18 @@ import {
   Spinner,
   Stack,
   Text,
-  TextInput,
 } from '@sanity/ui'
 import {defineQuery} from 'groq'
-import {type JsonData, JsonEditor} from 'json-edit-react'
 import {JSX, startTransition, Suspense, useCallback, useRef, useState} from 'react'
 import {ErrorBoundary} from 'react-error-boundary'
 
+import {JsonDocumentEditor} from '../components/JsonDocumentEditor'
+import {LoadMore} from '../components/LoadMore'
+import {PaginatedListToolbar} from '../components/PaginatedListToolbar'
+import {PaginationControls} from '../components/PaginationControls'
 // Import the custom table components
 import {Table, TD, TH, TR} from '../components/TableElements'
+import {UserListItem} from '../components/UserListItem'
 
 interface DocumentEditorDialogProps {
   documentId: string
@@ -51,60 +51,22 @@ function DocumentEditorDialog({
   open,
 }: DocumentEditorDialogProps) {
   const handle = {documentId, documentType}
-  const {data: document} = useDocument(handle)
-  const editDocument = useEditDocument(handle)
-  const isSaving = useDocumentSyncStatus(handle)
-
-  const editorStyles = {
-    container: {
-      height: '100%',
-      border: '1px solid #e2e2e2',
-      borderRadius: '4px',
-      padding: '8px',
-      backgroundColor: '#fafafa',
-    },
-  }
 
   return (
-    <>
-      <Dialog
-        header={`Editing ${documentType}: ${documentId}`}
-        id="document-editor-dialog"
-        onClose={onClose}
-        open={open}
-        width={2}
-      >
-        <ErrorBoundary
-          fallback={
-            <Box padding={4}>
-              <Card tone="critical" padding={4}>
-                <Text>Error loading document editor. Please try again.</Text>
-              </Card>
-            </Box>
-          }
-        >
-          <Stack space={4} padding={4}>
-            <Box style={{height: '70vh', overflow: 'auto'}}>
-              {document && (
-                <div style={editorStyles.container}>
-                  <JsonEditor data={document} setData={editDocument as (data: JsonData) => void} />
-                </div>
-              )}
-            </Box>
-            <Flex justify="flex-end" gap={2}>
-              <Button mode="ghost" text="Cancel" onClick={onClose} disabled={isSaving} />
-              <Button
-                tone="primary"
-                text={isSaving ? 'Syncing...' : 'Close'}
-                onClick={onClose}
-                disabled={isSaving}
-                loading={isSaving}
-              />
-            </Flex>
-          </Stack>
-        </ErrorBoundary>
-      </Dialog>
-    </>
+    <Dialog
+      header={`Editing ${documentType}: ${documentId}`}
+      id="document-editor-dialog"
+      onClose={onClose}
+      open={open}
+      width={2}
+    >
+      <Stack space={4} padding={4}>
+        <JsonDocumentEditor documentHandle={handle} wrapInCard={false} maxHeight="70vh" />
+        <Flex justify="flex-end">
+          <Button tone="primary" text="Close" onClick={onClose} />
+        </Flex>
+      </Stack>
+    </Dialog>
   )
 }
 
@@ -182,111 +144,6 @@ function DocumentRowError({error}: {error: Error}) {
   )
 }
 
-// Pagination controls component
-interface PaginationControlsProps {
-  currentPage: number
-  totalPages: number
-  hasFirstPage: boolean
-  hasPreviousPage: boolean
-  hasNextPage: boolean
-  hasLastPage: boolean
-  firstPage: () => void
-  previousPage: () => void
-  nextPage: () => void
-  lastPage: () => void
-  goToPage: (pageNumber: number) => void
-  isPending: boolean
-}
-
-function PaginationControls({
-  currentPage,
-  totalPages,
-  hasFirstPage,
-  hasPreviousPage,
-  hasNextPage,
-  hasLastPage,
-  firstPage,
-  previousPage,
-  nextPage,
-  lastPage,
-  goToPage,
-  isPending,
-}: PaginationControlsProps) {
-  const buttonStyle = {
-    minWidth: '40px',
-    margin: '0 4px',
-    textAlign: 'center',
-  } as const
-
-  // Generate page number buttons
-  const pageButtons = () => {
-    const buttons = []
-    const maxVisiblePages = 5
-    let startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2))
-    const endPage = Math.min(totalPages, startPage + maxVisiblePages - 1)
-
-    if (endPage - startPage + 1 < maxVisiblePages) {
-      startPage = Math.max(1, endPage - maxVisiblePages + 1)
-    }
-
-    for (let i = startPage; i <= endPage; i++) {
-      buttons.push(
-        <Button
-          key={i}
-          mode={i === currentPage ? 'default' : 'ghost'}
-          onClick={() => goToPage(i)}
-          style={{
-            ...buttonStyle,
-            fontWeight: i === currentPage ? 'bold' : 'normal',
-          }}
-        >
-          {i}
-        </Button>,
-      )
-    }
-    return buttons
-  }
-
-  return (
-    <Flex align="center" justify="space-between" padding={3}>
-      <Flex>
-        <Button
-          onClick={firstPage}
-          disabled={!hasFirstPage}
-          style={buttonStyle}
-          text="<<"
-          mode="ghost"
-        />
-        <Button
-          onClick={previousPage}
-          disabled={!hasPreviousPage}
-          style={buttonStyle}
-          text="<"
-          mode="ghost"
-        />
-        {pageButtons()}
-        <Button
-          onClick={nextPage}
-          disabled={!hasNextPage}
-          style={buttonStyle}
-          text=">"
-          mode="ghost"
-        />
-        <Button
-          onClick={lastPage}
-          disabled={!hasLastPage}
-          style={buttonStyle}
-          text=">>"
-          mode="ghost"
-        />
-      </Flex>
-      <Text size={1} style={{opacity: isPending ? 0.5 : 1}}>
-        Page {currentPage} of {totalPages}
-      </Text>
-    </Flex>
-  )
-}
-
 // Component to display documents of a specific type within a dataset
 interface DocumentListProps {
   documentType: string
@@ -347,54 +204,17 @@ function DocumentList({documentType}: DocumentListProps) {
       </Heading>
 
       <Stack space={4} marginTop={4}>
-        <Flex justify="space-between" align="center">
-          <Box style={{width: '300px'}}>
-            <Label
-              htmlFor={`search-${documentType}`}
-              size={1}
-              style={{marginBottom: '4px', display: 'block'}}
-            >
-              Search Documents
-            </Label>
-            <TextInput
-              id={`search--${documentType}`}
-              value={searchTerm}
-              onChange={handleSearchChange}
-              placeholder="Search documents..."
-              style={{width: '100%'}}
-            />
-          </Box>
-          <Box>
-            <Label
-              htmlFor={`pageSize-${documentType}`}
-              size={1}
-              style={{marginBottom: '4px', display: 'block'}}
-            >
-              Items per page
-            </Label>
-            <select
-              id={`pageSize-${documentType}`}
-              value={pageSize}
-              onChange={handlePageSizeChange}
-              style={{
-                padding: '8px',
-                borderRadius: '4px',
-                border: '1px solid #ccc',
-              }}
-            >
-              <option value={5}>5</option>
-              <option value={10}>10</option>
-              <option value={25}>25</option>
-              <option value={50}>50</option>
-            </select>
-          </Box>
-        </Flex>
-
-        <Box style={{borderRadius: '4px', border: '1px solid #eee', padding: '8px'}}>
-          <Text size={1}>
-            Showing {startIndex + 1}-{Math.min(endIndex, count)} of {count} documents
-          </Text>
-        </Box>
+        <PaginatedListToolbar
+          noun="documents"
+          idSuffix={documentType}
+          searchTerm={searchTerm}
+          onSearchChange={handleSearchChange}
+          pageSize={pageSize}
+          onPageSizeChange={handlePageSizeChange}
+          count={count}
+          startIndex={startIndex}
+          endIndex={endIndex}
+        />
 
         <PaginationControls
           currentPage={currentPage}
@@ -638,29 +458,10 @@ function UsersDialogContent() {
           ) : (
             <Stack space={2}>
               {data.map((user) => (
-                <Card key={user.profile.id} padding={3} radius={2}>
-                  <Flex align="center" gap={2}>
-                    <Avatar size={1} src={user.profile.imageUrl} />
-                    <Box>
-                      <Text weight="semibold">{user.profile.displayName}</Text>
-                      <Text size={1} muted>
-                        {user.profile.email}
-                      </Text>
-                    </Box>
-                  </Flex>
-                </Card>
+                <UserListItem key={user.profile.id} user={user} />
               ))}
 
-              {hasMore && (
-                <Button
-                  onClick={loadMore}
-                  text={isPending ? 'Loading...' : 'Load more'}
-                  tone="primary"
-                  mode="ghost"
-                  disabled={isPending}
-                  loading={isPending}
-                />
-              )}
+              <LoadMore as="div" isPending={isPending} hasMore={hasMore} onLoadMore={loadMore} />
             </Stack>
           )}
         </>

--- a/apps/kitchensink-react/src/DocumentCollection/OrgDocumentExplorerRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/OrgDocumentExplorerRoute.tsx
@@ -81,7 +81,7 @@ function DocumentTableRow(doc: DocumentHandle) {
 
   return (
     <>
-      <TR ref={ref}>
+      <TR ref={ref} data-testid={`org-document-row-${doc.documentId}`}>
         <TD padding={3}>{data.title}</TD>
         <TD padding={3}>{data.subtitle || '-'}</TD>
         <TD padding={3}>{doc.documentType}</TD>
@@ -92,6 +92,7 @@ function DocumentTableRow(doc: DocumentHandle) {
             text="View"
             tone="primary"
             mode="ghost"
+            data-testid={`org-document-view-${doc.documentId}`}
             onClick={handleOpenDialog}
           />
         </TD>
@@ -231,7 +232,7 @@ function DocumentList({documentType}: DocumentListProps) {
           isPending={isPending}
         />
 
-        <Table style={{opacity: isPending ? 0.7 : 1}}>
+        <Table style={{opacity: isPending ? 0.7 : 1}} data-testid="org-document-table">
           <thead>
             <TR>
               <TH padding={3}>Title</TH>
@@ -340,6 +341,7 @@ function DocumentTypes() {
         </Label>
         <Select
           id={`doctype-${config.dataset}`}
+          data-testid="org-doctype-select"
           value={selectedType || ''}
           onChange={handleTypeChange}
           style={{width: '100%', marginTop: '8px'}}
@@ -394,6 +396,7 @@ function DatasetExplorer() {
         </Label>
         <Select
           id={`dataset-${config.projectId}`}
+          data-testid="org-dataset-select"
           value={selectedDataset || ''}
           onChange={handleDatasetChange}
           style={{width: '100%', marginTop: '8px'}}
@@ -564,6 +567,7 @@ function ProjectsExplorer() {
         </Label>
         <Select
           id="project-selector"
+          data-testid="org-project-select"
           value={selectedProject || ''}
           onChange={handleProjectChange}
           style={{width: '100%', marginTop: '8px'}}

--- a/apps/kitchensink-react/src/DocumentCollection/SearchRoute.tsx
+++ b/apps/kitchensink-react/src/DocumentCollection/SearchRoute.tsx
@@ -3,8 +3,8 @@ import {Box, Heading, Stack, Text, TextInput} from '@sanity/ui'
 import {type JSX, useState} from 'react'
 
 import {DocumentListLayout} from '../components/DocumentListLayout/DocumentListLayout'
+import {LoadMore} from '../components/LoadMore'
 import {DocumentPreview} from './DocumentPreview'
-import {LoadMore} from './LoadMore'
 
 export function SearchRoute(): JSX.Element {
   const [searchQuery, setSearchQuery] = useState('')

--- a/apps/kitchensink-react/src/components/LoadMore.tsx
+++ b/apps/kitchensink-react/src/components/LoadMore.tsx
@@ -53,7 +53,15 @@ export function LoadMore({
   }, [isVisible])
 
   return (
-    <Flex as={as} style={{height: 12}} ref={ref} flex="auto" justify="center" padding={3}>
+    <Flex
+      as={as}
+      data-testid="load-more"
+      style={{height: 12}}
+      ref={ref}
+      flex="auto"
+      justify="center"
+      padding={3}
+    >
       {isPending && <Text>Loading…</Text>}
     </Flex>
   )

--- a/apps/kitchensink-react/src/components/LoadMore.tsx
+++ b/apps/kitchensink-react/src/components/LoadMore.tsx
@@ -2,12 +2,24 @@ import {Flex, Text} from '@sanity/ui'
 import {useEffect, useLayoutEffect, useRef, useState} from 'react'
 
 interface LoadMoreProps {
+  // Whether a fetch is currently in flight (renders a "Loading…" hint).
   isPending?: boolean
+  // Whether there are more items to load. When false, reaching the sentinel
+  // does nothing.
   hasMore: boolean
+  // Called when the sentinel scrolls into view and `hasMore` is still true.
   onLoadMore: () => void
+  // Element the sentinel renders as. Defaults to `li` for use inside an `ol`/
+  // `ul`; pass `div` when rendering outside a list (e.g. inside a Stack).
   as?: React.ElementType | keyof React.JSX.IntrinsicElements
 }
 
+/**
+ * Infinite-scroll sentinel for progressively loaded lists (`useDocuments`,
+ * `useUsers`, …). Render it as the last child of a scrollable list: when it
+ * scrolls into view it calls `onLoadMore`, so pages load automatically as the
+ * user scrolls rather than via a "Load more" button.
+ */
 export function LoadMore({
   onLoadMore,
   hasMore,
@@ -17,6 +29,7 @@ export function LoadMore({
   const ref = useRef<HTMLDivElement>(null)
   const [isVisible, setIsVisible] = useState(false)
 
+  // Track whether the sentinel is currently intersecting the viewport.
   useEffect(() => {
     const intersectionObserver = new IntersectionObserver(([entry]) => {
       setIsVisible(entry.isIntersecting)
@@ -26,8 +39,9 @@ export function LoadMore({
     return () => intersectionObserver.disconnect()
   }, [])
 
-  // don't want `hasMore` affecting the useEffect below
-  // so we wrap and sync it in a non-reactive ref
+  // `hasMore` and `onLoadMore` are mirrored into refs so the load effect below
+  // depends only on `isVisible`. Otherwise a new `onLoadMore` identity or a
+  // `hasMore` flip would re-run the effect and could double-fire a fetch.
   const hasMoreRef = useRef(hasMore)
   useLayoutEffect(() => {
     hasMoreRef.current = hasMore

--- a/apps/kitchensink-react/src/components/PaginatedListToolbar.tsx
+++ b/apps/kitchensink-react/src/components/PaginatedListToolbar.tsx
@@ -1,0 +1,85 @@
+import {Box, Flex, Label, Text, TextInput} from '@sanity/ui'
+import {ChangeEvent, JSX} from 'react'
+
+export interface PaginatedListToolbarProps {
+  // The plural noun for the listed items, e.g. "documents" or "authors". Used
+  // in the summary text and, capitalized, in the search field label.
+  noun: string
+  searchTerm: string
+  onSearchChange: (event: ChangeEvent<HTMLInputElement>) => void
+  pageSize: number
+  onPageSizeChange: (event: ChangeEvent<HTMLSelectElement>) => void
+  count: number
+  startIndex: number
+  endIndex: number
+  // Optional suffix to keep input ids unique when several toolbars render on
+  // the same page.
+  idSuffix?: string
+}
+
+const pageSizeOptions = [5, 10, 25, 50]
+
+// Shared list toolbar: a search field, a page-size selector, and a
+// "Showing X-Y of Z" summary. Pagination state is owned by the caller (via
+// `usePaginatedDocuments`) and passed in.
+export function PaginatedListToolbar({
+  noun,
+  searchTerm,
+  onSearchChange,
+  pageSize,
+  onPageSizeChange,
+  count,
+  startIndex,
+  endIndex,
+  idSuffix = '',
+}: PaginatedListToolbarProps): JSX.Element {
+  const nounLabel = noun.charAt(0).toUpperCase() + noun.slice(1)
+  const searchId = `search-${idSuffix}`
+  const pageSizeId = `pageSize-${idSuffix}`
+
+  return (
+    <>
+      <Flex justify="space-between" align="center">
+        <Box style={{width: '300px'}}>
+          <Label htmlFor={searchId} size={1} style={{marginBottom: '4px', display: 'block'}}>
+            Search {nounLabel}
+          </Label>
+          <TextInput
+            id={searchId}
+            value={searchTerm}
+            onChange={onSearchChange}
+            placeholder={`Search ${noun}...`}
+            style={{width: '100%'}}
+          />
+        </Box>
+        <Box>
+          <Label htmlFor={pageSizeId} size={1} style={{marginBottom: '4px', display: 'block'}}>
+            Items per page
+          </Label>
+          <select
+            id={pageSizeId}
+            value={pageSize}
+            onChange={onPageSizeChange}
+            style={{
+              padding: '8px',
+              borderRadius: '4px',
+              border: '1px solid #ccc',
+            }}
+          >
+            {pageSizeOptions.map((size) => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+        </Box>
+      </Flex>
+
+      <Box style={{borderRadius: '4px', border: '1px solid #eee', padding: '8px'}}>
+        <Text size={1}>
+          Showing {startIndex + 1}-{Math.min(endIndex, count)} of {count} {noun}
+        </Text>
+      </Box>
+    </>
+  )
+}

--- a/apps/kitchensink-react/src/components/PaginatedListToolbar.tsx
+++ b/apps/kitchensink-react/src/components/PaginatedListToolbar.tsx
@@ -34,8 +34,12 @@ export function PaginatedListToolbar({
   idSuffix = '',
 }: PaginatedListToolbarProps): JSX.Element {
   const nounLabel = noun.charAt(0).toUpperCase() + noun.slice(1)
-  const searchId = `search-${idSuffix}`
-  const pageSizeId = `pageSize-${idSuffix}`
+  // Only append a suffix segment when one is provided, so single-toolbar pages
+  // keep stable ids/test ids (`list-page-size`) while multiple toolbars stay
+  // unique (`list-page-size-author`).
+  const suffix = idSuffix ? `-${idSuffix}` : ''
+  const searchId = `search${suffix}`
+  const pageSizeId = `pageSize${suffix}`
 
   return (
     <>
@@ -46,6 +50,7 @@ export function PaginatedListToolbar({
           </Label>
           <TextInput
             id={searchId}
+            data-testid={`list-search-input${suffix}`}
             value={searchTerm}
             onChange={onSearchChange}
             placeholder={`Search ${noun}...`}
@@ -58,6 +63,7 @@ export function PaginatedListToolbar({
           </Label>
           <select
             id={pageSizeId}
+            data-testid={`list-page-size${suffix}`}
             value={pageSize}
             onChange={onPageSizeChange}
             style={{
@@ -76,7 +82,7 @@ export function PaginatedListToolbar({
       </Flex>
 
       <Box style={{borderRadius: '4px', border: '1px solid #eee', padding: '8px'}}>
-        <Text size={1}>
+        <Text size={1} data-testid={`list-summary${suffix}`}>
           Showing {startIndex + 1}-{Math.min(endIndex, count)} of {count} {noun}
         </Text>
       </Box>

--- a/apps/kitchensink-react/src/components/PaginationControls.tsx
+++ b/apps/kitchensink-react/src/components/PaginationControls.tsx
@@ -1,0 +1,109 @@
+import {Button, Flex, Text} from '@sanity/ui'
+import {JSX} from 'react'
+
+// Props mirror the pagination slice of the `usePaginatedDocuments` return value.
+export interface PaginationControlsProps {
+  currentPage: number
+  totalPages: number
+  hasFirstPage: boolean
+  hasPreviousPage: boolean
+  hasNextPage: boolean
+  hasLastPage: boolean
+  firstPage: () => void
+  previousPage: () => void
+  nextPage: () => void
+  lastPage: () => void
+  goToPage: (pageNumber: number) => void
+  isPending: boolean
+}
+
+const buttonStyle = {
+  minWidth: '40px',
+  margin: '0 4px',
+  textAlign: 'center',
+} as const
+
+// Shared pagination bar: first/prev/next/last plus a windowed set of numbered
+// page buttons and a "Page X of Y" indicator.
+export function PaginationControls({
+  currentPage,
+  totalPages,
+  hasFirstPage,
+  hasPreviousPage,
+  hasNextPage,
+  hasLastPage,
+  firstPage,
+  previousPage,
+  nextPage,
+  lastPage,
+  goToPage,
+  isPending,
+}: PaginationControlsProps): JSX.Element {
+  // Generate page number buttons
+  const pageButtons = () => {
+    const buttons = []
+    const maxVisiblePages = 5
+    let startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2))
+    const endPage = Math.min(totalPages, startPage + maxVisiblePages - 1)
+
+    if (endPage - startPage + 1 < maxVisiblePages) {
+      startPage = Math.max(1, endPage - maxVisiblePages + 1)
+    }
+
+    for (let i = startPage; i <= endPage; i++) {
+      buttons.push(
+        <Button
+          key={i}
+          mode={i === currentPage ? 'default' : 'ghost'}
+          onClick={() => goToPage(i)}
+          style={{
+            ...buttonStyle,
+            fontWeight: i === currentPage ? 'bold' : 'normal',
+          }}
+        >
+          {i}
+        </Button>,
+      )
+    }
+    return buttons
+  }
+
+  return (
+    <Flex align="center" justify="space-between" padding={3}>
+      <Flex>
+        <Button
+          onClick={firstPage}
+          disabled={!hasFirstPage}
+          style={buttonStyle}
+          text="<<"
+          mode="ghost"
+        />
+        <Button
+          onClick={previousPage}
+          disabled={!hasPreviousPage}
+          style={buttonStyle}
+          text="<"
+          mode="ghost"
+        />
+        {pageButtons()}
+        <Button
+          onClick={nextPage}
+          disabled={!hasNextPage}
+          style={buttonStyle}
+          text=">"
+          mode="ghost"
+        />
+        <Button
+          onClick={lastPage}
+          disabled={!hasLastPage}
+          style={buttonStyle}
+          text=">>"
+          mode="ghost"
+        />
+      </Flex>
+      <Text size={1} style={{opacity: isPending ? 0.5 : 1}}>
+        Page {currentPage} of {totalPages}
+      </Text>
+    </Flex>
+  )
+}

--- a/apps/kitchensink-react/src/components/PaginationControls.tsx
+++ b/apps/kitchensink-react/src/components/PaginationControls.tsx
@@ -54,6 +54,7 @@ export function PaginationControls({
       buttons.push(
         <Button
           key={i}
+          data-testid={`pagination-page-${i}`}
           mode={i === currentPage ? 'default' : 'ghost'}
           onClick={() => goToPage(i)}
           style={{
@@ -69,9 +70,10 @@ export function PaginationControls({
   }
 
   return (
-    <Flex align="center" justify="space-between" padding={3}>
+    <Flex align="center" justify="space-between" padding={3} data-testid="pagination-controls">
       <Flex>
         <Button
+          data-testid="pagination-first"
           onClick={firstPage}
           disabled={!hasFirstPage}
           style={buttonStyle}
@@ -79,6 +81,7 @@ export function PaginationControls({
           mode="ghost"
         />
         <Button
+          data-testid="pagination-previous"
           onClick={previousPage}
           disabled={!hasPreviousPage}
           style={buttonStyle}
@@ -87,6 +90,7 @@ export function PaginationControls({
         />
         {pageButtons()}
         <Button
+          data-testid="pagination-next"
           onClick={nextPage}
           disabled={!hasNextPage}
           style={buttonStyle}
@@ -94,6 +98,7 @@ export function PaginationControls({
           mode="ghost"
         />
         <Button
+          data-testid="pagination-last"
           onClick={lastPage}
           disabled={!hasLastPage}
           style={buttonStyle}
@@ -101,7 +106,7 @@ export function PaginationControls({
           mode="ghost"
         />
       </Flex>
-      <Text size={1} style={{opacity: isPending ? 0.5 : 1}}>
+      <Text size={1} style={{opacity: isPending ? 0.5 : 1}} data-testid="pagination-status">
         Page {currentPage} of {totalPages}
       </Text>
     </Flex>

--- a/apps/kitchensink-react/src/components/UserListItem.tsx
+++ b/apps/kitchensink-react/src/components/UserListItem.tsx
@@ -1,0 +1,52 @@
+import {useUsers} from '@sanity/sdk-react'
+import {Avatar, Box, Card, Flex, Text} from '@sanity/ui'
+import {ComponentProps, JSX} from 'react'
+import {Link} from 'react-router'
+
+import {FallbackAvatar} from './FallbackAvatar'
+
+type SanityUser = ReturnType<typeof useUsers>['data'][number]
+
+export interface UserListItemProps {
+  user: SanityUser
+  // When provided, the whole row becomes a link to this route.
+  href?: string
+  avatarSize?: ComponentProps<typeof Avatar>['size']
+}
+
+// Shared user row: fallback avatar + display name + email, optionally wrapped
+// in a link. Used by the Users route and the org explorer's users dialog.
+export function UserListItem({user, href, avatarSize = 2}: UserListItemProps): JSX.Element {
+  const card = (
+    <Card
+      width="fill"
+      marginBottom={2}
+      tone="inherit"
+      style={href ? {cursor: 'pointer'} : undefined}
+    >
+      <Flex align="center" gap={2} padding={2}>
+        <FallbackAvatar
+          size={avatarSize}
+          src={user.profile.imageUrl}
+          displayName={user.profile.displayName}
+        />
+        <Box paddingY={2}>
+          <Flex direction="column" gap={1}>
+            <Text>{user.profile.displayName}</Text>
+            <Text muted>{user.profile.email}</Text>
+          </Flex>
+        </Box>
+      </Flex>
+    </Card>
+  )
+
+  if (href) {
+    return (
+      <Link to={href} style={{textDecoration: 'none'}}>
+        {card}
+      </Link>
+    )
+  }
+
+  return card
+}

--- a/apps/kitchensink-react/src/components/UserListItem.tsx
+++ b/apps/kitchensink-react/src/components/UserListItem.tsx
@@ -22,6 +22,7 @@ export function UserListItem({user, href, avatarSize = 2}: UserListItemProps): J
       width="fill"
       marginBottom={2}
       tone="inherit"
+      data-testid={`user-list-item-${user.profile.id}`}
       style={href ? {cursor: 'pointer'} : undefined}
     >
       <Flex align="center" gap={2} padding={2}>

--- a/apps/kitchensink-react/src/routes/UsersRoute.tsx
+++ b/apps/kitchensink-react/src/routes/UsersRoute.tsx
@@ -1,11 +1,9 @@
 import {useUsers} from '@sanity/sdk-react'
-import {Box, Card, Flex, Text} from '@sanity/ui'
 import {type JSX} from 'react'
-import {Link} from 'react-router'
 
-import {FallbackAvatar} from '../components/FallbackAvatar'
+import {LoadMore} from '../components/LoadMore'
 import {PageLayout} from '../components/PageLayout'
-import {LoadMore} from '../DocumentCollection/LoadMore'
+import {UserListItem} from '../components/UserListItem'
 
 export function UsersRoute(): JSX.Element {
   const {data, hasMore, isPending, loadMore} = useUsers({batchSize: 10})
@@ -15,23 +13,7 @@ export function UsersRoute(): JSX.Element {
       <ol className="DocumentListLayout list-none" style={{gap: 2}}>
         {data.map((user) => (
           <li key={user.profile.id}>
-            <Link to={`/users/${user.profile.id}`} style={{textDecoration: 'none'}}>
-              <Card width="fill" marginBottom={2} style={{cursor: 'pointer'}} tone="inherit">
-                <Flex align="center" gap={2} padding={2}>
-                  <FallbackAvatar
-                    size={2}
-                    src={user.profile.imageUrl}
-                    displayName={user.profile.displayName}
-                  />
-                  <Box paddingY={2}>
-                    <Flex direction="column" gap={1}>
-                      <Text>{user.profile.displayName}</Text>
-                      <Text muted>{user.profile.email}</Text>
-                    </Flex>
-                  </Box>
-                </Flex>
-              </Card>
-            </Link>
+            <UserListItem user={user} href={`/users/${user.profile.id}`} />
           </li>
         ))}
         <LoadMore isPending={isPending} hasMore={hasMore} onLoadMore={loadMore} />


### PR DESCRIPTION
### Description
In working on an issue regarding `ResourceProvider`s and `SanityInstance`s, I found myself working in the Org Document Explorer Route. This PR abstracts out some resuable logic to keep the focus mostly on how the SDK hooks interact.

I also scaffolded some e2e tests since they didn't exist yet for the route and the pagination / progressive loading utils weren't tested either.

### What to review
Are the abstractions clear? I specifically didn't fully abstract a table component mostly for debugging / isolation for debugging / isolation purposes but let me know if I should go further; Fallow is yelling at me about it.

### Testing
The e2e tests should hopefully suffice.

### Fun gif
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNGFmZGNmYTNlNTd0c2J1ZnFkaDM5ZDAwZ2k4emE0eGJid2s0emd1cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5tqARwUhTkW0BiGYFR/giphy.gif)
