### PR TITLE
feat(react): authenticate AuthBoundary from the workbench OS

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,6 +62,7 @@
     "@sanity/message-protocol": "catalog:",
     "@sanity/sdk": "workspace:*",
     "@sanity/types": "catalog:",
+    "@sanity/workbench": "0.1.0-alpha.24",
     "groq": "catalog:",
     "react-compiler-runtime": "catalog:",
     "react-error-boundary": "catalog:",

--- a/packages/react/src/components/auth/AuthBoundary.tsx
+++ b/packages/react/src/components/auth/AuthBoundary.tsx
@@ -4,6 +4,8 @@ import {useEffect, useMemo} from 'react'
 import {ErrorBoundary, type FallbackProps} from 'react-error-boundary'
 
 import {ComlinkTokenRefreshProvider} from '../../context/ComlinkTokenRefresh'
+import {isWorkbenchEnvironment} from '../../context/workbenchToken'
+import {WorkbenchTokenRefreshProvider} from '../../context/WorkbenchTokenRefresh'
 import {useAuthState} from '../../hooks/auth/useAuthState'
 import {useLoginUrl} from '../../hooks/auth/useLoginUrl'
 import {useVerifyOrgProjects} from '../../hooks/auth/useVerifyOrgProjects'
@@ -141,9 +143,11 @@ export function AuthBoundary({
 
   return (
     <ComlinkTokenRefreshProvider>
-      <ErrorBoundary FallbackComponent={FallbackComponent} resetKeys={[sessionResetKey]}>
-        <AuthSwitch {...props} />
-      </ErrorBoundary>
+      <WorkbenchTokenRefreshProvider>
+        <ErrorBoundary FallbackComponent={FallbackComponent} resetKeys={[sessionResetKey]}>
+          <AuthSwitch {...props} />
+        </ErrorBoundary>
+      </WorkbenchTokenRefreshProvider>
     </ComlinkTokenRefreshProvider>
   )
 }
@@ -182,8 +186,9 @@ function AuthSwitch({
   const loginUrl = useLoginUrl()
 
   useEffect(() => {
-    if (isLoggedOut && !isInIframe() && !isStudio) {
-      // We don't want to redirect to login if we're in the Dashboard nor in studio mode
+    if (isLoggedOut && !isInIframe() && !isStudio && !isWorkbenchEnvironment()) {
+      // We don't want to redirect to login if we're in the Dashboard, in studio
+      // mode, or in the workbench (the OS owns the session and mints the token)
       window.location.href = loginUrl
     }
   }, [isLoggedOut, loginUrl, isStudio])

--- a/packages/react/src/context/WorkbenchTokenRefresh.test.tsx
+++ b/packages/react/src/context/WorkbenchTokenRefresh.test.tsx
@@ -1,0 +1,106 @@
+import {AuthStateType, setAuthToken} from '@sanity/sdk'
+import {act, render} from '@testing-library/react'
+import {of} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {useAuthState} from '../hooks/auth/useAuthState'
+import {ResourceProvider} from './ResourceProvider'
+import {
+  isWorkbenchEnvironment,
+  observeWorkbenchToken,
+  refreshWorkbenchToken,
+} from './workbenchToken'
+import {WorkbenchTokenRefreshProvider} from './WorkbenchTokenRefresh'
+
+vi.mock('@sanity/sdk', async () => {
+  const actual = await vi.importActual('@sanity/sdk')
+  return {
+    ...actual,
+    setAuthToken: vi.fn(),
+  }
+})
+
+vi.mock('../hooks/auth/useAuthState', () => ({
+  useAuthState: vi.fn(),
+}))
+
+vi.mock('./workbenchToken', () => ({
+  isWorkbenchEnvironment: vi.fn(() => false),
+  observeWorkbenchToken: vi.fn(() => undefined),
+  refreshWorkbenchToken: vi.fn(),
+}))
+
+const mockSetAuthToken = setAuthToken as Mock
+const mockUseAuthState = useAuthState as Mock
+const mockIsWorkbenchEnvironment = isWorkbenchEnvironment as Mock
+const mockObserveWorkbenchToken = observeWorkbenchToken as Mock
+const mockRefreshWorkbenchToken = refreshWorkbenchToken as Mock
+
+const renderProvider = () =>
+  render(
+    <ResourceProvider projectId="test-project" dataset="test-dataset" fallback={null}>
+      <WorkbenchTokenRefreshProvider>
+        <div>Test</div>
+      </WorkbenchTokenRefreshProvider>
+    </ResourceProvider>,
+  )
+
+describe('WorkbenchTokenRefreshProvider', () => {
+  beforeEach(() => {
+    mockUseAuthState.mockReturnValue({type: AuthStateType.LOGGED_IN})
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('when not in the workbench', () => {
+    it('does not subscribe to the OS token', () => {
+      mockIsWorkbenchEnvironment.mockReturnValue(false)
+
+      act(() => {
+        renderProvider()
+      })
+
+      expect(mockSetAuthToken).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when in the workbench', () => {
+    beforeEach(() => {
+      mockIsWorkbenchEnvironment.mockReturnValue(true)
+    })
+
+    it('mirrors the OS token into the auth store', () => {
+      mockObserveWorkbenchToken.mockReturnValue(of('workbench-token'))
+
+      act(() => {
+        renderProvider()
+      })
+
+      expect(mockSetAuthToken).toHaveBeenCalledWith(expect.anything(), 'workbench-token')
+    })
+
+    it('asks the OS to reissue the token on a 401', () => {
+      mockObserveWorkbenchToken.mockReturnValue(of('workbench-token'))
+
+      const {rerender} = renderProvider()
+
+      mockUseAuthState.mockReturnValue({
+        type: AuthStateType.ERROR,
+        error: {statusCode: 401, message: 'Unauthorized'},
+      })
+      act(() => {
+        rerender(
+          <ResourceProvider projectId="test-project" dataset="test-dataset" fallback={null}>
+            <WorkbenchTokenRefreshProvider>
+              <div>Test</div>
+            </WorkbenchTokenRefreshProvider>
+          </ResourceProvider>,
+        )
+      })
+
+      expect(mockRefreshWorkbenchToken).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/react/src/context/WorkbenchTokenRefresh.tsx
+++ b/packages/react/src/context/WorkbenchTokenRefresh.tsx
@@ -1,0 +1,61 @@
+import {type ClientError} from '@sanity/client'
+import {AuthStateType, setAuthToken} from '@sanity/sdk'
+import React, {type PropsWithChildren, useEffect, useRef} from 'react'
+
+import {useAuthState} from '../hooks/auth/useAuthState'
+import {useSanityInstance} from '../hooks/context/useSanityInstance'
+import {
+  isWorkbenchEnvironment,
+  observeWorkbenchToken,
+  refreshWorkbenchToken,
+} from './workbenchToken'
+
+/**
+ * Keeps the SDK auth token in sync with the workbench "OS".
+ *
+ * When running as a federated remote inside the workbench the OS owns the
+ * session, so we subscribe to its `auth.token` stream and mirror each value into
+ * the auth store — a token logs us in, `null` logs us out, and later OS
+ * sign-in/out propagates automatically. When a request is rejected with a 401
+ * (the token expired), we ask the OS to reissue rather than tearing the session
+ * down; the new token arrives back through the same subscription.
+ */
+function WorkbenchTokenRefresh({children}: PropsWithChildren) {
+  const instance = useSanityInstance()
+  const authState = useAuthState()
+  const processed401ErrorRef = useRef<unknown | null>(null)
+
+  useEffect(() => {
+    const token$ = observeWorkbenchToken()
+    if (!token$) return undefined
+    const subscription = token$.subscribe((token) => setAuthToken(instance, token))
+    return () => subscription.unsubscribe()
+  }, [instance])
+
+  useEffect(() => {
+    const has401Error =
+      authState.type === AuthStateType.ERROR && (authState.error as ClientError)?.statusCode === 401
+
+    if (has401Error && processed401ErrorRef.current !== authState.error) {
+      processed401ErrorRef.current = authState.error
+      refreshWorkbenchToken()
+    } else if (!has401Error) {
+      processed401ErrorRef.current = null
+    }
+  }, [authState])
+
+  return children
+}
+
+/**
+ * Provides workbench OS token refresh. No-op outside the workbench, where the
+ * app uses its normal auth flow.
+ * @public
+ */
+export const WorkbenchTokenRefreshProvider: React.FC<PropsWithChildren> = ({children}) => {
+  if (isWorkbenchEnvironment()) {
+    return <WorkbenchTokenRefresh>{children}</WorkbenchTokenRefresh>
+  }
+
+  return children
+}

--- a/packages/react/src/context/workbenchToken.ts
+++ b/packages/react/src/context/workbenchToken.ts
@@ -1,0 +1,63 @@
+import {from, type Observable, of} from 'rxjs'
+import {catchError, switchMap} from 'rxjs/operators'
+
+// The workbench host installs its shared message bus on this well-known global
+// symbol before it loads federated remotes. It must match the key used by
+// `@sanity/workbench` (`Symbol.for('sanity.os.bus')`).
+const OS_BUS_KEY = Symbol.for('sanity.os.bus')
+
+/**
+ * Whether this app is running as a federated remote inside the workbench.
+ *
+ * Federation shares the host's realm, so the installed bus is visible on
+ * `globalThis`. This is `false` in a standalone app, where we must never import
+ * `@sanity/workbench` (it would install a bus and add bundle weight for no
+ * reason). Note: this is a different embedding model to the Core UI iframe,
+ * which is detected separately via the dashboard context — that signal is not
+ * set on the federation path.
+ *
+ * @internal
+ */
+export function isWorkbenchEnvironment(): boolean {
+  return typeof globalThis === 'object' && OS_BUS_KEY in globalThis
+}
+
+/**
+ * Observes the session token issued by the workbench "OS", tracking the OS auth
+ * state over time.
+ *
+ * Returns `undefined` when the app is not embedded in the workbench, so the
+ * caller uses its normal auth flow. Inside the workbench, subscribes to the
+ * `auth.token` state topic, emitting the current token — or `null` when the OS
+ * is signed out — and re-emitting as the OS auth state changes, so sign-in/out
+ * propagates instead of being captured once. Any bus error is treated as "no
+ * token" (`null`). The token is used in-memory only and never persisted.
+ *
+ * @internal
+ */
+export function observeWorkbenchToken(): Observable<string | null> | undefined {
+  if (!isWorkbenchEnvironment()) return undefined
+
+  return from(import('@sanity/workbench')).pipe(
+    switchMap(({os}) => os.subscribe('auth.token')),
+    // Any failure (importing the host bundle, or the subscription) means "no OS token".
+    catchError(() => of(null)),
+  )
+}
+
+/**
+ * Asks the workbench "OS" to reissue the session token, e.g. after its current
+ * one was rejected with a 401. Fire-and-forget: the reissued token arrives via
+ * the `auth.token` subscription in {@link observeWorkbenchToken}. No-op outside
+ * the workbench.
+ *
+ * @internal
+ */
+export function refreshWorkbenchToken(): void {
+  if (!isWorkbenchEnvironment()) return
+
+  void import('@sanity/workbench').then(
+    ({os}) => os.emit('auth.token.refresh', undefined),
+    () => {},
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,9 @@ importers:
       '@sanity/types':
         specifier: 'catalog:'
         version: 6.5.0(@types/react@19.2.17)
+      '@sanity/workbench':
+        specifier: 0.1.0-alpha.24
+        version: 0.1.0-alpha.24(@sanity/sdk@packages+core)(node-fetch@2.7.0)(react@19.2.7)(xstate@5.32.2)
       groq:
         specifier: 'catalog:'
         version: 3.88.1-typegen-experimental.0
@@ -3542,6 +3545,13 @@ packages:
   '@sanity/workbench-cli@1.1.3':
     resolution: {integrity: sha512-LsQG4/6MrUlanNM+/pjFP9e7KMbSzQGTavegrCxH6E2TbIZL+DtSESiMMvVyC933XHeU2zN0UpOIPwgAwT6sYA==}
     engines: {node: '>=22.12'}
+
+  '@sanity/workbench@0.1.0-alpha.24':
+    resolution: {integrity: sha512-235mR37+z8eg9OQqhUwgkQ4dZnveFHczUTgW2jk81qm1pP6vMlTdEAiKpz1Tq4zU9zRfg2xck51DP1VlkVzdWA==}
+    engines: {node: '>=20.19.1 <22 || >=22.12'}
+    peerDependencies:
+      '@sanity/sdk': ^2.9.0
+      xstate: ^5.31.0
 
   '@sanity/worker-channels@2.0.0':
     resolution: {integrity: sha512-mC+8yPQuw2rHXdHigFPU9thNa6vTaPmh7jFR6RvloE8s+6dmnk9bHdPXRbrrUqafxzK3L9aH2E170ubXyxcAIA==}
@@ -11545,6 +11555,20 @@ snapshots:
       - utf-8-validate
       - vue-tsc
       - yaml
+
+  '@sanity/workbench@0.1.0-alpha.24(@sanity/sdk@packages+core)(node-fetch@2.7.0)(react@19.2.7)(xstate@5.32.2)':
+    dependencies:
+      '@module-federation/runtime': 2.6.0(node-fetch@2.7.0)
+      '@sanity/message-protocol': 0.23.0
+      '@sanity/sdk': link:packages/core
+      '@sanity/telemetry': 1.1.0(react@19.2.7)
+      rxjs: 7.8.2
+      semver: 7.8.5
+      xstate: 5.32.2
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - node-fetch
+      - react
 
   '@sanity/worker-channels@2.0.0': {}
 


### PR DESCRIPTION
Inside the workbench, the OS owns the session — there's no login redirect to fall back on. `AuthBoundary` now takes its token from the OS and asks it to reissue on a 401, instead of showing a login screen it should never render.