### PR TITLE
feat(core)!: add global resource stores

### DIFF
--- a/.claude/rules/request-tag-conventions.md
+++ b/.claude/rules/request-tag-conventions.md
@@ -29,8 +29,6 @@ const client = clientFactory({requestTagPrefix: REQUEST_TAG_PREFIX})
 await client.request({uri: '/users/me', method: 'GET', tag: 'users.get-current'})
 
 // GOOD (non-auth code): omit requestTagPrefix to inherit the default
-const client = clientFactory({
-  /* ...other config... */
-})
+const client = clientFactory({/* ...other config... */})
 await client.request({uri: '/users/me', method: 'GET', tag: 'users.get-current'})
 ```

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -5,6 +5,8 @@ import {type SanityProject as _SanityProject} from '@sanity/client'
  */
 export type SanityProject = _SanityProject
 
+export {checkPermissions} from '../access/checkPermissions'
+export {type AccessResourceType} from '../access/checkPermissions'
 export type {
   AgentGenerateOptions,
   AgentGenerateResult,
@@ -24,6 +26,25 @@ export {
   agentTransform,
   agentTranslate,
 } from '../agent/agentActions'
+export {application, applications} from '../applications/applications'
+export {
+  type Application,
+  type ApplicationAccess,
+  type ApplicationBase,
+  type ApplicationDeployment,
+  type ApplicationInclude,
+  type ApplicationInterface,
+  type ApplicationsOptions,
+  type ApplicationsResponse,
+  type ApplicationStudioConfig,
+  type ApplicationWorkspace,
+} from '../applications/applications'
+export {userApplication, userApplications} from '../applications/userApplications'
+export {
+  type UserApplication,
+  type UserApplicationDeployment,
+  type UserApplicationsOptions,
+} from '../applications/userApplications'
 export {isStudioConfig} from '../auth/authMode'
 export {AuthStateType} from '../auth/authStateType'
 export {
@@ -179,20 +200,26 @@ export {type DocumentPermissionsResult, type PermissionDeniedReason} from '../do
 export {getReleaseDocumentId} from '../document/processActions/releaseUtil'
 export type {FavoriteStatusResponse} from '../favorites/favorites'
 export {getFavoritesState, resolveFavoritesState} from '../favorites/favorites'
+export {installation, installations} from '../installations/installations'
 export {
-  getOrganizationState,
+  type Installation,
+  type InstallationAccess,
+  type InstallationActiveConfig,
+  type InstallationBase,
+  type InstallationInclude,
+  type InstallationInterface,
+  type InstallationsOptions,
+  type InstallationsResponse,
+} from '../installations/installations'
+export {organization} from '../organization/organization'
+export {
   type Organization,
   type OrganizationBase,
   type OrganizationMember,
   type OrganizationOptions,
-  resolveOrganization,
 } from '../organization/organization'
-export {
-  getOrganizationsState,
-  type Organizations,
-  type OrganizationsOptions,
-  resolveOrganizations,
-} from '../organizations/organizations'
+export {organizations} from '../organizations/organizations'
+export {type Organizations, type OrganizationsOptions} from '../organizations/organizations'
 export {getPresence} from '../presence/presenceStore'
 export type {
   DisconnectEvent,
@@ -214,20 +241,20 @@ export type {
   ValuePending,
 } from '../preview/types'
 export {type OrgVerificationResult} from '../project/organizationVerification'
+export {project} from '../project/project'
 export {
-  getProjectState,
   type Project,
   type ProjectBase,
   type ProjectMember,
   type ProjectMemberRole,
   type ProjectMetadata,
   type ProjectOptions,
-  resolveProject,
 } from '../project/project'
 export {getProjectionState} from '../projection/getProjectionState'
 export {resolveProjection} from '../projection/resolveProjection'
 export {type ProjectionValuePending, type ValidProjection} from '../projection/types'
-export {getProjectsState, type ProjectsOptions, resolveProjects} from '../projects/projects'
+export {projects} from '../projects/projects'
+export {type ProjectsOptions} from '../projects/projects'
 export {
   getQueryKey,
   getQueryState,

--- a/packages/core/src/access/checkPermissions.test.ts
+++ b/packages/core/src/access/checkPermissions.test.ts
@@ -1,0 +1,55 @@
+import {type SanityClient} from '@sanity/client'
+import {of} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getClientState} from '../client/clientStore'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {checkPermissions} from './checkPermissions'
+
+vi.mock('../client/clientStore')
+
+describe('checkPermissions', () => {
+  let instance: SanityInstance
+  const request = vi.fn()
+
+  beforeEach(() => {
+    instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+    request.mockReset()
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of({observable: {request}} as unknown as SanityClient),
+    } as StateSource<SanityClient>)
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('checks permissions on the global client and unwraps the data envelope', async () => {
+    request.mockReturnValue(of({data: {'sanity.project.read': true}}))
+
+    const result = await checkPermissions.resolveState(instance, 'project', 'p1', [
+      'sanity.project.read',
+    ])
+
+    expect(result).toEqual({'sanity.project.read': true})
+    expect(getClientState).toHaveBeenCalledWith(instance, {
+      apiVersion: 'v2025-07-11',
+      scope: 'global',
+    })
+    expect(request).toHaveBeenCalledWith({
+      uri: '/access/project/p1/user-permissions/me/check',
+      query: {permissions: ['sanity.project.read']},
+      tag: 'access.check',
+    })
+  })
+
+  it('does not create distinct cache entries for different permission orderings', async () => {
+    request.mockReturnValue(of({data: {a: true, b: false}}))
+
+    await checkPermissions.resolveState(instance, 'organization', 'org1', ['b', 'a'])
+    await checkPermissions.resolveState(instance, 'organization', 'org1', ['a', 'b'])
+
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/access/checkPermissions.ts
+++ b/packages/core/src/access/checkPermissions.ts
@@ -1,0 +1,54 @@
+import {map, switchMap} from 'rxjs'
+
+import {getClientState} from '../client/clientStore'
+import {defineFetcher} from '../store/fetcherStore'
+
+const API_VERSION = 'v2025-07-11'
+
+/**
+ * The resource types the Access API can scope a permission check to.
+ *
+ * @see https://www.sanity.io/docs/http-reference/access-api
+ * @public
+ */
+export type AccessResourceType =
+  | 'organization'
+  | 'project'
+  | 'media-library'
+  | 'canvas'
+  | 'dashboard'
+  | 'view'
+
+/**
+ * Fetcher checking whether the current user holds the given permissions on a
+ * resource (`GET /access/:resourceType/:resourceId/user-permissions/me/check`),
+ * on the shared fetcher cache. Resolves to a map of each requested permission
+ * to whether the user has it. The key sorts the permission list, so permission
+ * order doesn't create distinct cache entries.
+ *
+ * @see https://www.sanity.io/docs/http-reference/access-api
+ * @internal
+ */
+export const checkPermissions = defineFetcher<
+  [resourceType: AccessResourceType, resourceId: string, permissions: string[]],
+  Record<string, boolean>
+>({
+  name: 'checkPermissions',
+  getKey: (_instance, resourceType, resourceId, permissions) =>
+    `${resourceType}:${resourceId}:${[...permissions].sort().join(',')}`,
+  fetch: (instance) => (resourceType, resourceId, permissions) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable
+          .request<{data: Record<string, boolean>}>({
+            uri: `/access/${resourceType}/${resourceId}/user-permissions/me/check`,
+            query: {permissions},
+            tag: 'access.check',
+          })
+          .pipe(map((response) => response.data)),
+      ),
+    ),
+  tags: (_data, resourceType, resourceId) => [
+    {type: 'access', id: `${resourceType}:${resourceId}`},
+  ],
+})

--- a/packages/core/src/applications/applications.test-d.ts
+++ b/packages/core/src/applications/applications.test-d.ts
@@ -1,0 +1,83 @@
+import {expectTypeOf, test} from 'vitest'
+
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {type FetcherSnapshot} from '../store/fetcherStore'
+import {
+  type Application,
+  application,
+  type ApplicationBase,
+  type ApplicationDeployment,
+  type ApplicationInclude,
+  type ApplicationInterface,
+  applications,
+  type ApplicationsResponse,
+  type ApplicationStudioConfig,
+} from './applications'
+
+const instance = {} as SanityInstance
+
+type ChildKeys = 'config' | 'activeDeployment'
+type DeploymentChildKeys = 'interfaces' | 'workspaces' | 'access'
+
+// Whether key `K` of `T` is optional, without an `{}`-based check.
+type KeyModifier<T, K extends keyof T> =
+  Pick<T, K> extends Required<Pick<T, K>> ? 'required' : 'optional'
+
+test('Application — no includes: only the base shape, no config or activeDeployment', () => {
+  expectTypeOf<Application>().toEqualTypeOf<ApplicationBase>()
+  expectTypeOf<Application<never>>().toEqualTypeOf<ApplicationBase>()
+  expectTypeOf<Extract<keyof Application, ChildKeys>>().toEqualTypeOf<never>()
+})
+
+test('Application — config.studio adds a required config.studio', () => {
+  expectTypeOf<
+    Application<'config.studio'>['config']['studio']
+  >().toEqualTypeOf<ApplicationStudioConfig>()
+  // mfManifest not requested → not present under config
+  expectTypeOf<
+    Extract<keyof Application<'config.studio'>['config'], 'mfManifest'>
+  >().toEqualTypeOf<never>()
+  // requesting only config does not pull in the deployment
+  expectTypeOf<
+    Extract<keyof Application<'config.studio'>, 'activeDeployment'>
+  >().toEqualTypeOf<never>()
+})
+
+test('Application — both config tokens merge under a single config', () => {
+  type Config = Application<'config.studio' | 'config.mfManifest'>['config']
+  expectTypeOf<Config['studio']>().toEqualTypeOf<ApplicationStudioConfig>()
+  expectTypeOf<Config['mfManifest']>().toEqualTypeOf<unknown>()
+})
+
+test('Application — activeDeployment token adds the deployment summary, no children', () => {
+  expectTypeOf<
+    Application<'activeDeployment'>['activeDeployment']
+  >().toEqualTypeOf<ApplicationDeployment<'activeDeployment'> | null>()
+  type Deployment = NonNullable<Application<'activeDeployment'>['activeDeployment']>
+  expectTypeOf<Extract<keyof Deployment, DeploymentChildKeys>>().toEqualTypeOf<never>()
+})
+
+test('Application — a child token forces the deployment in and adds only that child', () => {
+  type Deployment = NonNullable<Application<'interfaces'>['activeDeployment']>
+  expectTypeOf<Deployment['interfaces']>().toEqualTypeOf<ApplicationInterface[]>()
+  expectTypeOf<Extract<keyof Deployment, 'workspaces' | 'access'>>().toEqualTypeOf<never>()
+})
+
+test('Application — a wide include array makes config and activeDeployment optional', () => {
+  type Wide = Application<ApplicationInclude>
+  expectTypeOf<KeyModifier<Wide, 'activeDeployment'>>().toEqualTypeOf<'optional'>()
+  expectTypeOf<KeyModifier<Wide, 'config'>>().toEqualTypeOf<'optional'>()
+})
+
+test('applications.resolveState — resolves the wide list envelope', () => {
+  expectTypeOf(
+    applications.resolveState(instance, {organizationId: 'org_1'}),
+  ).resolves.toEqualTypeOf<ApplicationsResponse<ApplicationInclude>>()
+})
+
+test('application.getState — exposes the snapshot envelope', () => {
+  expectTypeOf(application.getState(instance, 'app_1')).toEqualTypeOf<
+    StateSource<FetcherSnapshot<Application<ApplicationInclude>>>
+  >()
+})

--- a/packages/core/src/applications/applications.test.ts
+++ b/packages/core/src/applications/applications.test.ts
@@ -1,0 +1,87 @@
+import {type SanityClient} from '@sanity/client'
+import {of} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getClientState} from '../client/clientStore'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {defineMutation} from '../store/fetcherStore'
+import {application, applications} from './applications'
+
+vi.mock('../client/clientStore')
+
+describe('applications', () => {
+  let instance: SanityInstance
+  const request = vi.fn()
+
+  beforeEach(() => {
+    instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+    request.mockReset()
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of({observable: {request}} as unknown as SanityClient),
+    } as StateSource<SanityClient>)
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('lists applications for an organization, serialising include as a sorted CSV', async () => {
+    const response = {nextCursor: null, data: [{id: 'app1'}]}
+    request.mockReturnValue(of(response))
+
+    const result = await applications.resolveState(instance, {
+      organizationId: 'org1',
+      include: ['workspaces', 'access'],
+      limit: 'none',
+    })
+
+    expect(result).toEqual(response)
+    expect(getClientState).toHaveBeenCalledWith(instance, {
+      apiVersion: 'vX',
+      scope: 'global',
+    })
+    expect(request).toHaveBeenCalledWith({
+      uri: '/applications',
+      query: {organizationId: 'org1', include: 'access,workspaces', limit: 'none'},
+      tag: 'applications.list',
+    })
+  })
+
+  it('fetches a single application by id', async () => {
+    const app = {id: 'app1', title: 'One'}
+    request.mockReturnValue(of(app))
+
+    const result = await application.resolveState(instance, 'app1')
+
+    expect(result).toEqual(app)
+    expect(request).toHaveBeenCalledWith({
+      uri: '/applications/app1',
+      query: {},
+      tag: 'applications.get',
+    })
+  })
+
+  it('refetches the list when a mutation invalidates the LIST tag', async () => {
+    let n = 0
+    request.mockImplementation(() => of({nextCursor: null, data: [{id: `app-${++n}`}]}))
+
+    const source = applications.getState(instance, {organizationId: 'org1'})
+    const unsubscribe = source.subscribe()
+    await vi.waitFor(() => expect(source.getCurrent().status).toBe('success'))
+    expect(request).toHaveBeenCalledTimes(1)
+
+    const install = defineMutation<undefined, {ok: boolean}>({
+      name: 'test-install-application',
+      mutationFn: () => () => of({ok: true}),
+      invalidates: [{type: 'application', id: 'LIST'}],
+    })
+
+    const {invalidated} = await install(instance, undefined)
+    await invalidated
+
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(source.getCurrent().data).toEqual({nextCursor: null, data: [{id: 'app-2'}]})
+    unsubscribe()
+  })
+})

--- a/packages/core/src/applications/applications.ts
+++ b/packages/core/src/applications/applications.ts
@@ -1,0 +1,270 @@
+import {switchMap} from 'rxjs'
+
+import {getClientState} from '../client/clientStore'
+import {defineFetcher} from '../store/fetcherStore'
+import {buildQuery} from '../utils/buildQuery'
+import {type Included, type IncludesAny} from '../utils/includeShape'
+
+// The Applications API is currently only available on vX.
+const API_VERSION = 'vX'
+
+/**
+ * Related data the Applications API can embed in a response. `interfaces`,
+ * `workspaces` and `access` are children of the active deployment and are
+ * embedded under {@link Application.activeDeployment}; `config.studio` and
+ * `config.mfManifest` are embedded under {@link Application.config}.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export type ApplicationInclude =
+  | 'interfaces'
+  | 'workspaces'
+  | 'access'
+  | 'config.studio'
+  | 'config.mfManifest'
+  | 'activeDeployment'
+
+/**
+ * An interface exposed by a deployment, embedded when `interfaces` is included.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface ApplicationInterface {
+  id: string
+  type: 'app' | 'worker' | 'asset_source' | 'panel'
+  name: string
+  title: string
+  version: string
+  /** Module federation module ID; resolved from the host mf-manifest at runtime */
+  moduleId: string
+  metadata: {group?: string; priority?: number} | null
+}
+
+/**
+ * A studio workspace of a deployment, embedded when `workspaces` is included.
+ * Studio applications only.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface ApplicationWorkspace {
+  id: string
+  name: string
+  title: string | null
+  subtitle: string | null
+  projectId: string
+  dataset: string
+  schemaDescriptorId: string | null
+  basePath: string | null
+  /** Sanitized SVG icon markup */
+  icon: string | null
+}
+
+/**
+ * A resource an application accesses, embedded when `access` is included.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface ApplicationAccess {
+  id: string
+  resourceType: 'datasets' | 'canvases' | 'dashboards' | 'media-libraries'
+  resourceId: string
+}
+
+/**
+ * Studio configuration, embedded under `config` when `config.studio` is included.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface ApplicationStudioConfig {
+  projectId: string
+  /** Release channel (`next`, `stable`, `latest`) or a pinned semver; null if unset */
+  autoUpdatingVersion: string | null
+}
+
+/**
+ * The active deployment as embedded under {@link Application.activeDeployment}.
+ * Its `interfaces`, `workspaces` and `access` children are each present only
+ * when the matching {@link ApplicationInclude} token was requested. `workspaces`
+ * is omitted (not `null`) for non-studio applications even when requested.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export type ApplicationDeployment<Include extends ApplicationInclude = never> = {
+  id: string
+  applicationId: string
+  size: number | null
+  version: string | null
+  isAutoUpdating: boolean | null
+  isActiveDeployment: boolean
+  deployedBy: string | null
+  createdAt: string
+  updatedAt: string
+} & Included<ApplicationInclude, 'interfaces', Include, {interfaces: ApplicationInterface[]}> &
+  Included<ApplicationInclude, 'workspaces', Include, {workspaces?: ApplicationWorkspace[]}> &
+  Included<ApplicationInclude, 'access', Include, {access: ApplicationAccess[]}>
+
+/**
+ * The always-present fields of an org-owned application returned by the
+ * Applications API (`/applications`), before any {@link ApplicationInclude}.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface ApplicationBase {
+  id: string
+  type: 'studio' | 'coreApp'
+  title: string
+  icon: string | null
+  isSingleton: boolean
+  visibility: 'default' | 'unlisted' | 'disabled'
+  slug: string | null
+  externalUrl: string | null
+  organizationId: string
+  createdAt: string
+  updatedAt: string
+}
+
+// Requesting any of these tokens forces the deployment summary into the response.
+type DeploymentToken = 'activeDeployment' | 'interfaces' | 'workspaces' | 'access'
+
+// `config` is present when either config child was requested; each child is
+// gated on its own token.
+type ApplicationConfigShape<Include extends ApplicationInclude> = Included<
+  ApplicationInclude,
+  'config.studio',
+  Include,
+  {config: {studio: ApplicationStudioConfig}}
+> &
+  Included<ApplicationInclude, 'config.mfManifest', Include, {config: {mfManifest: unknown}}>
+
+// `activeDeployment` is present when any deployment-related token was requested;
+// a wide include array makes it optional.
+type ApplicationDeploymentShape<Include extends ApplicationInclude> = [ApplicationInclude] extends [
+  Include,
+]
+  ? {activeDeployment?: ApplicationDeployment<Include> | null}
+  : IncludesAny<Include, DeploymentToken> extends true
+    ? {activeDeployment: ApplicationDeployment<Include> | null}
+    : unknown
+
+/**
+ * An org-owned application as returned by the Applications API
+ * (`/applications`). `config` and `activeDeployment` (with its
+ * `interfaces`/`workspaces`/`access` children) are present only when the
+ * corresponding {@link ApplicationInclude} tokens were requested.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export type Application<Include extends ApplicationInclude = never> = ApplicationBase &
+  ApplicationConfigShape<Include> &
+  ApplicationDeploymentShape<Include>
+
+/**
+ * Options for listing an organization's applications.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface ApplicationsOptions<Include extends ApplicationInclude = ApplicationInclude> {
+  organizationId: string
+  /** Filter by application type */
+  type?: string
+  include?: Include[]
+  /** Page size (1-100, default 50), or `'none'` to disable pagination */
+  limit?: number | 'none'
+  /** Cursor from a previous response's `nextCursor` */
+  cursor?: string
+}
+
+/**
+ * The cursor-paginated envelope returned by `GET /applications`.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface ApplicationsResponse<Include extends ApplicationInclude = never> {
+  nextCursor: string | null
+  data: Application<Include>[]
+}
+
+/** The API takes `include` as a comma-separated list; sorted so key and query agree */
+function serializeInclude(include: ApplicationInclude[] | undefined): string | undefined {
+  return include?.length ? [...include].sort().join(',') : undefined
+}
+
+/**
+ * Fetcher for an organization's applications (`GET /applications`), on the
+ * shared fetcher cache.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @internal
+ */
+export const applications = defineFetcher<
+  [options: ApplicationsOptions],
+  ApplicationsResponse<ApplicationInclude>
+>({
+  name: 'applications',
+  getKey: (_instance, options) =>
+    [
+      options.organizationId,
+      options.type ?? '',
+      serializeInclude(options.include) ?? '',
+      options.limit ?? '',
+      options.cursor ?? '',
+    ].join(':'),
+  fetch: (instance) => (options) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable.request<ApplicationsResponse<ApplicationInclude>>({
+          uri: '/applications',
+          query: buildQuery({
+            organizationId: options.organizationId,
+            type: options.type,
+            include: serializeInclude(options.include),
+            limit: options.limit,
+            cursor: options.cursor,
+          }),
+          tag: 'applications.list',
+        }),
+      ),
+    ),
+  tags: (data) => [
+    {type: 'application', id: 'LIST'},
+    ...data.data.map((app) => ({type: 'application', id: app.id})),
+  ],
+})
+
+/**
+ * Fetcher for a single application (`GET /applications/:id`), on the shared
+ * fetcher cache. No pre-seeding from {@link applications}: its list keys
+ * include the organization, which this fetcher's params can't reconstruct.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @internal
+ */
+export const application = defineFetcher<
+  [applicationId: string, options?: {include?: ApplicationInclude[]}],
+  Application<ApplicationInclude>
+>({
+  name: 'application',
+  getKey: (_instance, applicationId, options) =>
+    `${applicationId}:${serializeInclude(options?.include) ?? ''}`,
+  fetch: (instance) => (applicationId, options) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable.request<Application<ApplicationInclude>>({
+          uri: `/applications/${applicationId}`,
+          query: buildQuery({include: serializeInclude(options?.include)}),
+          tag: 'applications.get',
+        }),
+      ),
+    ),
+  tags: (data) => [{type: 'application', id: data.id}],
+})

--- a/packages/core/src/applications/userApplications.test.ts
+++ b/packages/core/src/applications/userApplications.test.ts
@@ -1,0 +1,58 @@
+import {type SanityClient} from '@sanity/client'
+import {of} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getClientState} from '../client/clientStore'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {userApplication, userApplications} from './userApplications'
+
+vi.mock('../client/clientStore')
+
+describe('userApplications', () => {
+  let instance: SanityInstance
+  const request = vi.fn()
+
+  beforeEach(() => {
+    instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+    request.mockReset()
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of({observable: {request}} as unknown as SanityClient),
+    } as StateSource<SanityClient>)
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('lists user applications for an organization on the global client', async () => {
+    const apps = [{id: 'ua1'}, {id: 'ua2'}]
+    request.mockReturnValue(of(apps))
+
+    const result = await userApplications.resolveState(instance, {organizationId: 'org1'})
+
+    expect(result).toEqual(apps)
+    expect(getClientState).toHaveBeenCalledWith(instance, {
+      apiVersion: 'v2024-08-01',
+      scope: 'global',
+    })
+    expect(request).toHaveBeenCalledWith({
+      uri: '/user-applications',
+      query: {organizationId: 'org1'},
+      tag: 'user-applications.list',
+    })
+  })
+
+  it('fetches a single user application by id', async () => {
+    const app = {id: 'ua1', appHost: 'my-studio'}
+    request.mockReturnValue(of(app))
+
+    const result = await userApplication.resolveState(instance, 'ua1')
+
+    expect(result).toEqual(app)
+    expect(request).toHaveBeenCalledWith({
+      uri: '/user-applications/ua1',
+      tag: 'user-applications.get',
+    })
+  })
+})

--- a/packages/core/src/applications/userApplications.ts
+++ b/packages/core/src/applications/userApplications.ts
@@ -1,0 +1,119 @@
+import {switchMap} from 'rxjs'
+
+import {getClientState} from '../client/clientStore'
+import {defineFetcher} from '../store/fetcherStore'
+import {buildQuery} from '../utils/buildQuery'
+
+// The version the CLI pins for this API family; verify against the deployed
+// API before promoting these stores past @internal.
+const API_VERSION = 'v2024-08-01'
+
+/**
+ * A deployment of a user application, embedded when `activeDeployment` is
+ * included on the User Applications API. Distinct from the org Applications
+ * API's {@link ApplicationDeployment} summary.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface UserApplicationDeployment {
+  id: string
+  version: string | null
+  isActiveDeployment: boolean
+  userApplicationId: string
+  isAutoUpdating: boolean | null
+  size: number | null
+  deployedAt: string
+  deployedBy: string | null
+  createdAt: string
+  updatedAt: string
+  manifest: unknown
+}
+
+/**
+ * A user application (deployed studio or custom app) as returned by
+ * `/user-applications`.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface UserApplication {
+  id: string
+  projectId: string | null
+  organizationId: string | null
+  title: string | null
+  type: string
+  urlType: string
+  appHost: string
+  dashboardStatus: string
+  createdAt: string
+  updatedAt: string
+  autoUpdatingVersion: string | null
+  activeDeployment: UserApplicationDeployment | null
+  manifestData: unknown
+  config: Record<string, unknown> | null
+  manifest: unknown
+}
+
+/**
+ * Options for listing an organization's user applications.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface UserApplicationsOptions {
+  organizationId: string
+}
+
+/**
+ * Fetcher for an organization's user applications (`GET /user-applications`),
+ * on the shared fetcher cache.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @internal
+ */
+export const userApplications = defineFetcher<
+  [options: UserApplicationsOptions],
+  UserApplication[]
+>({
+  name: 'userApplications',
+  getKey: (_instance, options) => options.organizationId,
+  fetch: (instance) => (options) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable.request<UserApplication[]>({
+          uri: '/user-applications',
+          query: buildQuery({organizationId: options.organizationId}),
+          tag: 'user-applications.list',
+        }),
+      ),
+    ),
+  tags: (data) => [
+    {type: 'user-application', id: 'LIST'},
+    ...data.map((app) => ({type: 'user-application', id: app.id})),
+  ],
+})
+
+/**
+ * Fetcher for a single user application (`GET /user-applications/:id`), on the
+ * shared fetcher cache. No pre-seeding from {@link userApplications}: its list
+ * keys include the organization, which this fetcher's params can't
+ * reconstruct.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @internal
+ */
+export const userApplication = defineFetcher<[userApplicationId: string], UserApplication>({
+  name: 'userApplication',
+  getKey: (_instance, userApplicationId) => userApplicationId,
+  fetch: (instance) => (userApplicationId) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable.request<UserApplication>({
+          uri: `/user-applications/${userApplicationId}`,
+          tag: 'user-applications.get',
+        }),
+      ),
+    ),
+  tags: (data) => [{type: 'user-application', id: data.id}],
+})

--- a/packages/core/src/auth/getOrganizationVerificationState.test.ts
+++ b/packages/core/src/auth/getOrganizationVerificationState.test.ts
@@ -1,4 +1,4 @@
-import {type Observable} from 'rxjs'
+import {map, type Observable} from 'rxjs'
 import {TestScheduler} from 'rxjs/testing'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -6,7 +6,7 @@ import {
   compareProjectOrganization,
   type OrgVerificationResult,
 } from '../project/organizationVerification'
-import {getProjectState} from '../project/project'
+import {project} from '../project/project'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
 import {getDashboardOrganizationId} from './dashboardUtils'
@@ -17,7 +17,7 @@ vi.mock('./dashboardUtils', () => ({
   getDashboardOrganizationId: vi.fn(),
 }))
 vi.mock('../project/project', () => ({
-  getProjectState: vi.fn(),
+  project: {getState: vi.fn()},
 }))
 // Mock the comparison function to check its inputs
 vi.mock('../project/organizationVerification', async (importOriginal) => {
@@ -54,11 +54,11 @@ describe('observeOrganizationVerificationState', () => {
     } as any) // Cast to any to bypass strict type checking in mock
   }
 
-  // Helper to mock getProjectState
+  // Helper to mock the project fetcher's state; wraps plain values in the snapshot envelope
   const mockProjectOrgId = (observable: Observable<{organizationId: string | null} | null>) => {
-    vi.mocked(getProjectState).mockReturnValue({
+    vi.mocked(project.getState).mockReturnValue({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      observable: observable as any, // Cast needed due to complex type
+      observable: observable.pipe(map((value) => ({data: value ?? undefined}))) as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as StateSource<any>)
   }
@@ -110,7 +110,7 @@ describe('observeOrganizationVerificationState', () => {
       expectObservable(result$).toBe(expectedMarble, expectedValues)
     })
     // No project fetch or comparison should occur
-    expect(getProjectState).not.toHaveBeenCalled()
+    expect(project.getState).not.toHaveBeenCalled()
     expect(compareProjectOrganization).not.toHaveBeenCalled()
   })
 

--- a/packages/core/src/auth/getOrganizationVerificationState.ts
+++ b/packages/core/src/auth/getOrganizationVerificationState.ts
@@ -4,14 +4,14 @@ import {
   compareProjectOrganization,
   type OrgVerificationResult,
 } from '../project/organizationVerification'
-import {getProjectState} from '../project/project'
+import {project} from '../project/project'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {getDashboardOrganizationId} from './dashboardUtils'
 
 /**
  * Creates an observable that emits the organization verification state for a given instance.
  * It combines the dashboard organization ID (from auth context) with the
- * project's actual organization ID (fetched via getProjectState) and compares them.
+ * project's actual organization ID (fetched via the project fetcher) and compares them.
  * @public
  */
 export function observeOrganizationVerificationState(
@@ -24,8 +24,8 @@ export function observeOrganizationVerificationState(
 
   // Create observables for each project's org ID
   const projectOrgIdObservables = projectIds.map((id) =>
-    getProjectState(instance, {projectId: id}).observable.pipe(
-      map((project) => ({projectId: id, orgId: project?.organizationId ?? null})),
+    project.getState(instance, {projectId: id}).observable.pipe(
+      map((snapshot) => ({projectId: id, orgId: snapshot.data?.organizationId ?? null})),
       // Ensure we only proceed if the orgId is loaded, distinct prevents unnecessary checks
       distinctUntilChanged((prev, curr) => prev.orgId === curr.orgId),
     ),

--- a/packages/core/src/installations/installations.test-d.ts
+++ b/packages/core/src/installations/installations.test-d.ts
@@ -1,0 +1,68 @@
+import {expectTypeOf, test} from 'vitest'
+
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {type FetcherSnapshot} from '../store/fetcherStore'
+import {
+  type Installation,
+  installation,
+  type InstallationAccess,
+  type InstallationActiveConfig,
+  type InstallationBase,
+  type InstallationInclude,
+  type InstallationInterface,
+  installations,
+  type InstallationsResponse,
+} from './installations'
+
+const instance = {} as SanityInstance
+
+type IncludeKeys = 'activeConfig' | 'access' | 'interfaces'
+
+// Whether key `K` of `T` is optional, without an `{}`-based check.
+type KeyModifier<T, K extends keyof T> =
+  Pick<T, K> extends Required<Pick<T, K>> ? 'required' : 'optional'
+
+test('Installation — no includes: only the base shape', () => {
+  expectTypeOf<Installation>().toEqualTypeOf<InstallationBase>()
+  expectTypeOf<Installation<never>>().toEqualTypeOf<InstallationBase>()
+  expectTypeOf<Extract<keyof Installation, IncludeKeys>>().toEqualTypeOf<never>()
+})
+
+test('Installation — each token adds its top-level field, required, others absent', () => {
+  expectTypeOf<Installation<'access'>['access']>().toEqualTypeOf<InstallationAccess[]>()
+  expectTypeOf<
+    Extract<keyof Installation<'access'>, 'activeConfig' | 'interfaces'>
+  >().toEqualTypeOf<never>()
+
+  expectTypeOf<Installation<'interfaces'>['interfaces']>().toEqualTypeOf<InstallationInterface[]>()
+  expectTypeOf<
+    Installation<'activeConfig'>['activeConfig']
+  >().toEqualTypeOf<InstallationActiveConfig | null>()
+})
+
+test('Installation — multiple tokens add each field', () => {
+  type Both = Installation<'access' | 'interfaces'>
+  expectTypeOf<Both['access']>().toEqualTypeOf<InstallationAccess[]>()
+  expectTypeOf<Both['interfaces']>().toEqualTypeOf<InstallationInterface[]>()
+  expectTypeOf<Extract<keyof Both, 'activeConfig'>>().toEqualTypeOf<never>()
+})
+
+test('Installation — a wide include array makes the fields optional', () => {
+  type Wide = Installation<InstallationInclude>
+  expectTypeOf<KeyModifier<Wide, 'access'>>().toEqualTypeOf<'optional'>()
+  expectTypeOf<KeyModifier<Wide, 'interfaces'>>().toEqualTypeOf<'optional'>()
+  expectTypeOf<KeyModifier<Wide, 'activeConfig'>>().toEqualTypeOf<'optional'>()
+})
+
+test('installations.resolveState — resolves the wide list envelope', () => {
+  expectTypeOf(
+    installations.resolveState(instance, {organizationId: 'org_1'}),
+  ).resolves.toEqualTypeOf<InstallationsResponse<InstallationInclude>>()
+})
+
+test('installation.getState — exposes the snapshot envelope', () => {
+  expectTypeOf(installation.getState(instance, 'inst_1')).toEqualTypeOf<
+    StateSource<FetcherSnapshot<Installation<InstallationInclude>>>
+  >()
+})

--- a/packages/core/src/installations/installations.test.ts
+++ b/packages/core/src/installations/installations.test.ts
@@ -1,0 +1,62 @@
+import {type SanityClient} from '@sanity/client'
+import {of} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getClientState} from '../client/clientStore'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {installation, installations} from './installations'
+
+vi.mock('../client/clientStore')
+
+describe('installations', () => {
+  let instance: SanityInstance
+  const request = vi.fn()
+
+  beforeEach(() => {
+    instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+    request.mockReset()
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of({observable: {request}} as unknown as SanityClient),
+    } as StateSource<SanityClient>)
+  })
+
+  afterEach(() => {
+    instance.dispose()
+  })
+
+  it('lists installations for an organization on the global client', async () => {
+    const response = {nextCursor: null, data: [{id: 'inst1'}]}
+    request.mockReturnValue(of(response))
+
+    const result = await installations.resolveState(instance, {
+      organizationId: 'org1',
+      include: ['interfaces'],
+    })
+
+    expect(result).toEqual(response)
+    expect(getClientState).toHaveBeenCalledWith(instance, {
+      apiVersion: 'vX',
+      scope: 'global',
+    })
+    expect(request).toHaveBeenCalledWith({
+      uri: '/installations',
+      query: {organizationId: 'org1', include: 'interfaces'},
+      tag: 'installations.list',
+    })
+  })
+
+  it('fetches a single installation by id', async () => {
+    const inst = {id: 'inst1', applicationId: 'app1'}
+    request.mockReturnValue(of(inst))
+
+    const result = await installation.resolveState(instance, 'inst1')
+
+    expect(result).toEqual(inst)
+    expect(request).toHaveBeenCalledWith({
+      uri: '/installations/inst1',
+      query: {},
+      tag: 'installations.get',
+    })
+  })
+})

--- a/packages/core/src/installations/installations.ts
+++ b/packages/core/src/installations/installations.ts
@@ -1,0 +1,202 @@
+import {switchMap} from 'rxjs'
+
+import {getClientState} from '../client/clientStore'
+import {defineFetcher} from '../store/fetcherStore'
+import {buildQuery} from '../utils/buildQuery'
+import {type Included} from '../utils/includeShape'
+
+// The Applications API is currently only available on vX.
+const API_VERSION = 'vX'
+
+/**
+ * Related data the Installations API can embed in a response. Each token adds
+ * a top-level field to the {@link Installation} item.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export type InstallationInclude = 'activeConfig' | 'access' | 'interfaces'
+
+/**
+ * A resource an installation accesses, embedded when `access` is included.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface InstallationAccess {
+  id: string
+  resourceType: 'datasets' | 'canvases' | 'dashboards' | 'media-libraries'
+  resourceId: string
+}
+
+/**
+ * An interface exposed by an installation, embedded when `interfaces` is
+ * included.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface InstallationInterface {
+  id: string
+  type: 'app' | 'worker' | 'asset_source' | 'panel'
+  name: string
+  title: string
+  version: string
+  /** Module federation module ID; resolved from the host mf-manifest at runtime */
+  moduleId: string
+  metadata: {group?: string; priority?: number} | null
+}
+
+/**
+ * The active config of an installation, embedded when `activeConfig` is
+ * included. `null` when nothing is deployed.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface InstallationActiveConfig {
+  id: string
+  installationId: string
+  deployedBy: string | null
+  version: string
+  isActive: boolean
+  createdAt: string
+}
+
+/**
+ * The always-present fields of an active singleton installation returned by the
+ * Installations API (`/installations`), before any {@link InstallationInclude}.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface InstallationBase {
+  id: string
+  applicationId: string
+  organizationId: string
+  installedBy: string | null
+  createdAt: string
+  updatedAt: string
+  application: {
+    title: string
+    slug: string | null
+  }
+}
+
+/**
+ * An active singleton installation as returned by the Installations API
+ * (`/installations`). `activeConfig`, `access` and `interfaces` are top-level
+ * fields, each present only when the matching {@link InstallationInclude} token
+ * was requested.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export type Installation<Include extends InstallationInclude = never> = InstallationBase &
+  Included<
+    InstallationInclude,
+    'activeConfig',
+    Include,
+    {activeConfig: InstallationActiveConfig | null}
+  > &
+  Included<InstallationInclude, 'access', Include, {access: InstallationAccess[]}> &
+  Included<InstallationInclude, 'interfaces', Include, {interfaces: InstallationInterface[]}>
+
+/**
+ * Options for listing an organization's installations.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface InstallationsOptions<Include extends InstallationInclude = InstallationInclude> {
+  organizationId: string
+  include?: Include[]
+  /** Page size (1-100, default 50), or `'none'` to disable pagination */
+  limit?: number | 'none'
+  /** Cursor from a previous response's `nextCursor` */
+  cursor?: string
+}
+
+/**
+ * The cursor-paginated envelope returned by `GET /installations`.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export interface InstallationsResponse<Include extends InstallationInclude = never> {
+  nextCursor: string | null
+  data: Installation<Include>[]
+}
+
+/** The API takes `include` as a comma-separated list; sorted so key and query agree */
+function serializeInclude(include: InstallationInclude[] | undefined): string | undefined {
+  return include?.length ? [...include].sort().join(',') : undefined
+}
+
+/**
+ * Fetcher for an organization's installations (`GET /installations`), on the
+ * shared fetcher cache.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @internal
+ */
+export const installations = defineFetcher<
+  [options: InstallationsOptions],
+  InstallationsResponse<InstallationInclude>
+>({
+  name: 'installations',
+  getKey: (_instance, options) =>
+    [
+      options.organizationId,
+      serializeInclude(options.include) ?? '',
+      options.limit ?? '',
+      options.cursor ?? '',
+    ].join(':'),
+  fetch: (instance) => (options) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable.request<InstallationsResponse<InstallationInclude>>({
+          uri: '/installations',
+          query: buildQuery({
+            organizationId: options.organizationId,
+            include: serializeInclude(options.include),
+            limit: options.limit,
+            cursor: options.cursor,
+          }),
+          tag: 'installations.list',
+        }),
+      ),
+    ),
+  tags: (data) => [
+    {type: 'installation', id: 'LIST'},
+    ...data.data.map((installation) => ({type: 'installation', id: installation.id})),
+  ],
+})
+
+/**
+ * Fetcher for a single installation (`GET /installations/:id`), on the shared
+ * fetcher cache. No pre-seeding from {@link installations}: its list keys
+ * include the organization, which this fetcher's params can't reconstruct.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @internal
+ */
+export const installation = defineFetcher<
+  [installationId: string, options?: {include?: InstallationInclude[]}],
+  Installation<InstallationInclude>
+>({
+  name: 'installation',
+  getKey: (_instance, installationId, options) =>
+    `${installationId}:${serializeInclude(options?.include) ?? ''}`,
+  fetch: (instance) => (installationId, options) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable.request<Installation<InstallationInclude>>({
+          uri: `/installations/${installationId}`,
+          query: buildQuery({include: serializeInclude(options?.include)}),
+          tag: 'installations.get',
+        }),
+      ),
+    ),
+  tags: (data) => [{type: 'installation', id: data.id}],
+})

--- a/packages/core/src/organization/organization.test-d.ts
+++ b/packages/core/src/organization/organization.test-d.ts
@@ -2,101 +2,35 @@ import {expectTypeOf, test} from 'vitest'
 
 import {type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {
-  getOrganizationState,
-  type Organization,
-  type OrganizationBase,
-  type OrganizationMember,
-  resolveOrganization,
-} from './organization'
+import {type FetcherSnapshot} from '../store/fetcherStore'
+import {type Organization, organization, type OrganizationMember} from './organization'
 
 const instance = {} as SanityInstance
 
-test('resolveOrganization — default call: members and features both omitted by default', () => {
-  expectTypeOf(resolveOrganization(instance, {organizationId: 'org_1'})).resolves.toEqualTypeOf<
-    Organization<false, false>
-  >()
-  type Result = Awaited<ReturnType<typeof resolveOrganization<false, false>>>
-  expectTypeOf<Result['id']>().toEqualTypeOf<string>()
-})
-
-test('resolveOrganization — includeMembers: true adds members to the type', () => {
+test('organization.resolveState — resolves the wide-boolean detail shape', () => {
   expectTypeOf(
-    resolveOrganization(instance, {organizationId: 'org_1', includeMembers: true}),
-  ).resolves.toEqualTypeOf<Organization<true, false>>()
-  type Result = Awaited<ReturnType<typeof resolveOrganization<true, false>>>
-  expectTypeOf<Result['members']>().toEqualTypeOf<OrganizationMember[]>()
+    organization.resolveState(instance, {organizationId: 'org_1'}),
+  ).resolves.toEqualTypeOf<Organization<boolean, boolean>>()
 })
 
-test('resolveOrganization — includeFeatures: true adds features to the type', () => {
-  expectTypeOf(
-    resolveOrganization(instance, {organizationId: 'org_1', includeFeatures: true}),
-  ).resolves.toEqualTypeOf<Organization<false, true>>()
+test('Organization — literal flags narrow members and features', () => {
+  expectTypeOf<Organization<true, true>['members']>().toEqualTypeOf<OrganizationMember[]>()
+  expectTypeOf<Organization<true, true>['features']>().toEqualTypeOf<string[]>()
+  expectTypeOf<keyof Organization<false, false> & ('members' | 'features')>().toEqualTypeOf<never>()
 })
 
-test('resolveOrganization — both flags true → both arrays present', () => {
-  expectTypeOf(
-    resolveOrganization(instance, {
-      organizationId: 'org_1',
-      includeMembers: true,
-      includeFeatures: true,
-    }),
-  ).resolves.toEqualTypeOf<Organization<true, true>>()
-})
-
-test('resolveOrganization — rejects non-boolean flag values', () => {
-  // @ts-expect-error — includeMembers must be a boolean
-  void resolveOrganization(instance, {organizationId: 'org_1', includeMembers: 'yes'})
-})
-
-test('resolveOrganization — requires organizationId', () => {
-  // @ts-expect-error — organizationId is required
-  void resolveOrganization(instance, {})
-})
-
-test('resolveOrganization — non-literal boolean flag makes members optional', () => {
-  const includeMembers = false as boolean
-  expectTypeOf(
-    resolveOrganization(instance, {organizationId: 'org_1', includeMembers}),
-  ).resolves.toEqualTypeOf<Organization<boolean, false>>()
-})
-
-test('getOrganizationState — default call returns bare-base StateSource', () => {
-  expectTypeOf(getOrganizationState(instance, {organizationId: 'org_1'})).toEqualTypeOf<
-    StateSource<Organization<false, false> | undefined>
+test('organization.getState — exposes the snapshot envelope', () => {
+  expectTypeOf(organization.getState(instance, {organizationId: 'org_1'})).toEqualTypeOf<
+    StateSource<FetcherSnapshot<Organization<boolean, boolean>>>
   >()
 })
 
-test('getOrganizationState — both flags true narrows the StateSource value type', () => {
-  expectTypeOf(
-    getOrganizationState(instance, {
-      organizationId: 'org_1',
-      includeMembers: true,
-      includeFeatures: true,
-    }),
-  ).toEqualTypeOf<StateSource<Organization<true, true> | undefined>>()
+test('organization — requires organizationId in options', () => {
+  // @ts-expect-error organizationId is required
+  void organization.resolveState(instance, {})
 })
 
-test('Organization — wide boolean for IncludeMembers makes members optional', () => {
-  expectTypeOf<Organization<boolean, true>>().toEqualTypeOf<
-    OrganizationBase & {members?: OrganizationMember[]} & {features: string[]}
-  >()
-  expectTypeOf<Pick<Organization<boolean, true>, 'members'>>().toEqualTypeOf<{
-    members?: OrganizationMember[]
-  }>()
-})
-
-test('Organization — wide boolean for IncludeFeatures makes features optional', () => {
-  expectTypeOf<Organization<true, boolean>>().toEqualTypeOf<
-    OrganizationBase & {members: OrganizationMember[]} & {features?: string[]}
-  >()
-  expectTypeOf<Pick<Organization<true, boolean>, 'features'>>().toEqualTypeOf<{
-    features?: string[]
-  }>()
-})
-
-test('Organization — both wide booleans make both fields optional', () => {
-  expectTypeOf<Organization<boolean, boolean>>().toEqualTypeOf<
-    OrganizationBase & {members?: OrganizationMember[]} & {features?: string[]}
-  >()
+test('organization — rejects non-boolean flag values', () => {
+  // @ts-expect-error includeMembers must be a boolean
+  void organization.resolveState(instance, {organizationId: 'org_1', includeMembers: 'yes'})
 })

--- a/packages/core/src/organization/organization.test.ts
+++ b/packages/core/src/organization/organization.test.ts
@@ -5,7 +5,7 @@ import {afterEach, beforeEach, describe, it} from 'vitest'
 import {getClientState} from '../client/clientStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {getOrganizationCacheKey, resolveOrganization} from './organization'
+import {getOrganizationCacheKey, organization} from './organization'
 
 vi.mock('../client/clientStore')
 
@@ -21,8 +21,8 @@ describe('organization', () => {
   })
 
   it('calls `client.observable.request` against `/organizations/<id>` and returns the result', async () => {
-    const organization = {id: 'org_1'}
-    const request = vi.fn().mockReturnValue(of(organization))
+    const detail = {id: 'org_1'}
+    const request = vi.fn().mockReturnValue(of(detail))
 
     const mockClient = {
       observable: {request} as unknown as SanityClient['observable'],
@@ -32,12 +32,12 @@ describe('organization', () => {
       observable: of(mockClient),
     } as StateSource<SanityClient>)
 
-    const result = await resolveOrganization(instance, {organizationId: 'org_1'})
-    expect(result).toEqual(organization)
+    const result = await organization.resolveState(instance, {organizationId: 'org_1'})
+    expect(result).toEqual(detail)
     expect(request).toHaveBeenCalledWith({
       uri: '/organizations/org_1',
       query: {includeMembers: 'false', includeFeatures: 'false'},
-      tag: 'organization.get',
+      tag: 'organizations.get',
     })
   })
 
@@ -51,7 +51,7 @@ describe('organization', () => {
       observable: of(mockClient),
     } as StateSource<SanityClient>)
 
-    await resolveOrganization(instance, {
+    await organization.resolveState(instance, {
       organizationId: 'org_1',
       includeMembers: true,
       includeFeatures: true,
@@ -63,14 +63,14 @@ describe('organization', () => {
         includeMembers: 'true',
         includeFeatures: 'true',
       },
-      tag: 'organization.get',
+      tag: 'organizations.get',
     })
   })
 
   it('throws when no organizationId is provided', async () => {
-    await expect(resolveOrganization(instance, {organizationId: ''} as never)).rejects.toThrow(
-      'An organizationId is required to use the organization API.',
-    )
+    await expect(
+      organization.resolveState(instance, {organizationId: ''} as never),
+    ).rejects.toThrow('An organizationId is required to use the organization API.')
   })
 })
 

--- a/packages/core/src/organization/organization.ts
+++ b/packages/core/src/organization/organization.ts
@@ -2,8 +2,8 @@ import {switchMap} from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
 import {type SanityInstance} from '../store/createSanityInstance'
-import {type StateSource} from '../store/createStateSourceAction'
-import {createFetcherStore} from '../utils/createFetcherStore'
+import {defineFetcher} from '../store/fetcherStore'
+import {buildQuery} from '../utils/buildQuery'
 
 const API_VERSION = 'v2025-02-19'
 
@@ -110,57 +110,29 @@ export function getOrganizationCacheKey(
   return `organization:${organizationId}${membersKey}${featuresKey}`
 }
 
-const organization = createFetcherStore({
-  name: 'Organization',
-  getKey: getOrganizationCacheKey,
-  fetcher: (instance) => (options?: OrganizationOptions<boolean, boolean>) => {
-    const organizationId = resolveOrganizationId(options)
-
-    return getClientState(instance, {
-      apiVersion: API_VERSION,
-      scope: 'global',
-    }).observable.pipe(
-      switchMap((client) => {
-        const normalized = normalizeOrganizationOptions(options)
-        const query = Object.fromEntries(
-          Object.entries(normalized)
-            .filter(([, value]) => value !== undefined)
-            .map(([key, value]) => [key, String(value)]),
-        )
-
-        return client.observable.request({
-          uri: `/organizations/${organizationId}`,
-          query,
-          tag: 'organization.get',
-        })
-      }),
-    )
-  },
-})
-
 /**
- * Public signature for the organization state source. The conditional generics
- * cannot flow through `BoundStoreAction`, so we declare the signature here
- * and assign the (already-correct) runtime function to it.
+ * Fetcher for a single organization (`GET /organizations/:id`), on the shared
+ * fetcher cache. No pre-seeding from the organizations list: it returns a
+ * subset of the detail fields, and a partial seed would serve as fresh for
+ * the whole stale window.
+ *
+ * @internal
  */
-type GetOrganizationState = <
-  IncludeMembers extends boolean = false,
-  IncludeFeatures extends boolean = false,
->(
-  instance: SanityInstance,
-  options: OrganizationOptions<IncludeMembers, IncludeFeatures>,
-) => StateSource<Organization<IncludeMembers, IncludeFeatures> | undefined>
-
-type ResolveOrganization = <
-  IncludeMembers extends boolean = false,
-  IncludeFeatures extends boolean = false,
->(
-  instance: SanityInstance,
-  options: OrganizationOptions<IncludeMembers, IncludeFeatures>,
-) => Promise<Organization<IncludeMembers, IncludeFeatures>>
-
-/** @public */
-export const getOrganizationState: GetOrganizationState = organization.getState
-
-/** @public */
-export const resolveOrganization: ResolveOrganization = organization.resolveState
+export const organization = defineFetcher<
+  [options?: OrganizationOptions<boolean, boolean>],
+  Organization<boolean, boolean>
+>({
+  name: 'organization',
+  getKey: getOrganizationCacheKey,
+  fetch: (instance) => (options) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable.request<Organization<boolean, boolean>>({
+          uri: `/organizations/${resolveOrganizationId(options)}`,
+          query: buildQuery(normalizeOrganizationOptions(options)),
+          tag: 'organizations.get',
+        }),
+      ),
+    ),
+  tags: (data) => [{type: 'organization', id: data.id}],
+})

--- a/packages/core/src/organizations/organizations.test-d.ts
+++ b/packages/core/src/organizations/organizations.test-d.ts
@@ -3,41 +3,26 @@ import {expectTypeOf, test} from 'vitest'
 import {type OrganizationMember} from '../organization/organization'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {getOrganizationsState, type Organizations, resolveOrganizations} from './organizations'
+import {type FetcherSnapshot} from '../store/fetcherStore'
+import {type Organizations, organizations} from './organizations'
 
 const instance = {} as SanityInstance
 
-test('resolveOrganizations — default call: bare list shape', () => {
-  expectTypeOf(resolveOrganizations(instance)).resolves.toEqualTypeOf<Organizations<false, false>>()
-})
-
-test('resolveOrganizations — includeMembers: true narrows the generic', () => {
-  expectTypeOf(resolveOrganizations(instance, {includeMembers: true})).resolves.toEqualTypeOf<
-    Organizations<true, false>
+test('organizations.resolveState — resolves the wide-boolean list shape', () => {
+  expectTypeOf(organizations.resolveState(instance)).resolves.toEqualTypeOf<
+    Organizations<boolean, boolean>
   >()
 })
 
-test('resolveOrganizations — includeFeatures: true narrows the generic', () => {
-  expectTypeOf(resolveOrganizations(instance, {includeFeatures: true})).resolves.toEqualTypeOf<
-    Organizations<false, true>
+test('organizations.getState — exposes the snapshot envelope', () => {
+  expectTypeOf(organizations.getState(instance)).toEqualTypeOf<
+    StateSource<FetcherSnapshot<Organizations<boolean, boolean>>>
   >()
 })
 
-test('resolveOrganizations — both flags true', () => {
-  expectTypeOf(
-    resolveOrganizations(instance, {includeMembers: true, includeFeatures: true}),
-  ).resolves.toEqualTypeOf<Organizations<true, true>>()
-})
-
-test('resolveOrganizations — rejects non-boolean flag values', () => {
-  // @ts-expect-error — includeMembers must be a boolean
-  void resolveOrganizations(instance, {includeMembers: 'yes'})
-})
-
-test('resolveOrganizations — includeImplicitMemberships does not change the data shape', () => {
-  expectTypeOf(
-    resolveOrganizations(instance, {includeImplicitMemberships: true}),
-  ).resolves.toEqualTypeOf<Organizations<false, false>>()
+test('organizations — rejects non-boolean flag values', () => {
+  // @ts-expect-error includeMembers must be a boolean
+  void organizations.resolveState(instance, {includeMembers: 'yes'})
 })
 
 test('Organizations — list items expose the documented subset of keys', () => {
@@ -68,10 +53,4 @@ test('Organizations<true, true>[number] exposes both members[] and features[]', 
   type Item = Organizations<true, true>[number]
   expectTypeOf<Item['members']>().toEqualTypeOf<OrganizationMember[]>()
   expectTypeOf<Item['features']>().toEqualTypeOf<string[]>()
-})
-
-test('getOrganizationsState — default call returns the bare-base StateSource', () => {
-  expectTypeOf(getOrganizationsState(instance)).toEqualTypeOf<
-    StateSource<Organizations<false, false> | undefined>
-  >()
 })

--- a/packages/core/src/organizations/organizations.test.ts
+++ b/packages/core/src/organizations/organizations.test.ts
@@ -5,7 +5,7 @@ import {afterEach, beforeEach, describe, it} from 'vitest'
 import {getClientState} from '../client/clientStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {getOrganizationsCacheKey, resolveOrganizations} from './organizations'
+import {getOrganizationsCacheKey, organizations} from './organizations'
 
 vi.mock('../client/clientStore')
 
@@ -21,8 +21,8 @@ describe('organizations', () => {
   })
 
   it('calls `client.observable.request` against `/organizations` and returns the result', async () => {
-    const organizations = [{id: 'org_1'}, {id: 'org_2'}]
-    const request = vi.fn().mockReturnValue(of(organizations))
+    const list = [{id: 'org_1'}, {id: 'org_2'}]
+    const request = vi.fn().mockReturnValue(of(list))
 
     const mockClient = {
       observable: {request} as unknown as SanityClient['observable'],
@@ -32,8 +32,8 @@ describe('organizations', () => {
       observable: of(mockClient),
     } as StateSource<SanityClient>)
 
-    const result = await resolveOrganizations(instance)
-    expect(result).toEqual(organizations)
+    const result = await organizations.resolveState(instance)
+    expect(result).toEqual(list)
     expect(request).toHaveBeenCalledWith({
       uri: '/organizations',
       query: {
@@ -41,7 +41,7 @@ describe('organizations', () => {
         includeMembers: 'false',
         includeFeatures: 'false',
       },
-      tag: 'organizations.get',
+      tag: 'organizations.list',
     })
   })
 
@@ -55,7 +55,7 @@ describe('organizations', () => {
       observable: of(mockClient),
     } as StateSource<SanityClient>)
 
-    await resolveOrganizations(instance, {
+    await organizations.resolveState(instance, {
       includeMembers: true,
       includeFeatures: true,
       includeImplicitMemberships: true,
@@ -68,7 +68,7 @@ describe('organizations', () => {
         includeMembers: 'true',
         includeFeatures: 'true',
       },
-      tag: 'organizations.get',
+      tag: 'organizations.list',
     })
   })
 })

--- a/packages/core/src/organizations/organizations.ts
+++ b/packages/core/src/organizations/organizations.ts
@@ -7,8 +7,8 @@ import {
   type OrganizationOptions,
 } from '../organization/organization'
 import {type SanityInstance} from '../store/createSanityInstance'
-import {type StateSource} from '../store/createStateSourceAction'
-import {createFetcherStore} from '../utils/createFetcherStore'
+import {defineFetcher} from '../store/fetcherStore'
+import {buildQuery} from '../utils/buildQuery'
 
 const API_VERSION = 'v2025-02-19'
 
@@ -57,7 +57,7 @@ export interface OrganizationsOptions<
   includeImplicitMemberships?: boolean
 }
 
-function normalizeOrganizationOptions(options?: OrganizationsOptions<boolean, boolean>) {
+function normalizeOrganizationsOptions(options?: OrganizationsOptions<boolean, boolean>) {
   return {
     includeImplicitMemberships: options?.includeImplicitMemberships ?? false,
     includeMembers: options?.includeMembers ?? false,
@@ -71,62 +71,37 @@ export function getOrganizationsCacheKey(
   options?: OrganizationsOptions<boolean, boolean>,
 ): string {
   const {includeMembers, includeFeatures, includeImplicitMemberships} =
-    normalizeOrganizationOptions(options)
+    normalizeOrganizationsOptions(options)
   const membersKey = includeMembers ? ':members' : ''
   const featuresKey = includeFeatures ? ':features' : ''
   const implicitKey = includeImplicitMemberships ? ':implicit' : ''
   return `organizations${membersKey}${featuresKey}${implicitKey}`
 }
 
-const organizations = createFetcherStore({
-  name: 'Organizations',
-  getKey: getOrganizationsCacheKey,
-  fetcher: (instance) => (options?: OrganizationsOptions<boolean, boolean>) => {
-    return getClientState(instance, {
-      apiVersion: API_VERSION,
-      scope: 'global',
-    }).observable.pipe(
-      switchMap((client) => {
-        const normalized = normalizeOrganizationOptions(options)
-        const query = Object.fromEntries(
-          Object.entries(normalized)
-            .filter(([, value]) => value !== undefined)
-            .map(([key, value]) => [key, String(value)]),
-        )
-
-        return client.observable.request({
-          uri: `/organizations`,
-          query,
-          tag: 'organizations.get',
-        })
-      }),
-    )
-  },
-})
-
 /**
- * Public signature for the organization state source. The conditional generics
- * cannot flow through `BoundStoreAction`, so we declare the signature here
- * and assign the (already-correct) runtime function to it.
+ * Fetcher for the current user's organizations (`GET /organizations`), on the
+ * shared fetcher cache.
+ *
+ * @internal
  */
-type GetOrganizationsState = <
-  IncludeMembers extends boolean = false,
-  IncludeFeatures extends boolean = false,
->(
-  instance: SanityInstance,
-  options?: OrganizationsOptions<IncludeMembers, IncludeFeatures>,
-) => StateSource<Organizations<IncludeMembers, IncludeFeatures> | undefined>
-
-type ResolveOrganizations = <
-  IncludeMembers extends boolean = false,
-  IncludeFeatures extends boolean = false,
->(
-  instance: SanityInstance,
-  options?: OrganizationsOptions<IncludeMembers, IncludeFeatures>,
-) => Promise<Organizations<IncludeMembers, IncludeFeatures>>
-
-/** @public */
-export const getOrganizationsState: GetOrganizationsState = organizations.getState
-
-/** @public */
-export const resolveOrganizations: ResolveOrganizations = organizations.resolveState
+export const organizations = defineFetcher<
+  [options?: OrganizationsOptions<boolean, boolean>],
+  Organizations<boolean, boolean>
+>({
+  name: 'organizations',
+  getKey: getOrganizationsCacheKey,
+  fetch: (instance) => (options) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable.request<Organizations<boolean, boolean>>({
+          uri: '/organizations',
+          query: buildQuery(normalizeOrganizationsOptions(options)),
+          tag: 'organizations.list',
+        }),
+      ),
+    ),
+  tags: (data) => [
+    {type: 'organization', id: 'LIST'},
+    ...data.map((org) => ({type: 'organization', id: org.id})),
+  ],
+})

--- a/packages/core/src/project/project.test-d.ts
+++ b/packages/core/src/project/project.test-d.ts
@@ -2,92 +2,36 @@ import {expectTypeOf, test} from 'vitest'
 
 import {type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {
-  getProjectState,
-  type Project,
-  type ProjectBase,
-  type ProjectMember,
-  resolveProject,
-} from './project'
+import {type FetcherSnapshot} from '../store/fetcherStore'
+import {type Project, project, type ProjectMember} from './project'
 
 const instance = {} as SanityInstance
 
-test('resolveProject — default call: members and features both included by default', () => {
-  expectTypeOf(resolveProject(instance)).resolves.toEqualTypeOf<Project<true, true>>()
-  type Result = Awaited<ReturnType<typeof resolveProject<true, true>>>
-  expectTypeOf<Result['members']>().toEqualTypeOf<ProjectMember[]>()
-})
-
-test('resolveProject — includeMembers: false drops members from the type', () => {
-  expectTypeOf(resolveProject(instance, {includeMembers: false})).resolves.toEqualTypeOf<
-    Project<false, true>
+test('project.resolveState — resolves the wide-boolean detail shape', () => {
+  expectTypeOf(project.resolveState(instance, {projectId: 'p'})).resolves.toEqualTypeOf<
+    Project<boolean, boolean>
   >()
 })
 
-test('resolveProject — includeFeatures: false drops features from the type', () => {
-  expectTypeOf(resolveProject(instance, {includeFeatures: false})).resolves.toEqualTypeOf<
-    Project<true, false>
+test('Project — literal flags narrow members and features', () => {
+  expectTypeOf<Project<true, true>['members']>().toEqualTypeOf<ProjectMember[]>()
+  expectTypeOf<Project<true, true>['features']>().toEqualTypeOf<string[]>()
+  expectTypeOf<keyof Project<false, false> & ('members' | 'features')>().toEqualTypeOf<never>()
+})
+
+test('Project<boolean, boolean> — members and features are optional', () => {
+  type Item = Project<boolean, boolean>
+  expectTypeOf<Item['members']>().toEqualTypeOf<ProjectMember[] | undefined>()
+  expectTypeOf<Item['features']>().toEqualTypeOf<string[] | undefined>()
+})
+
+test('project.getState — exposes the snapshot envelope', () => {
+  expectTypeOf(project.getState(instance, {projectId: 'p'})).toEqualTypeOf<
+    StateSource<FetcherSnapshot<Project<boolean, boolean>>>
   >()
 })
 
-test('resolveProject — both flags false → bare base shape', () => {
-  expectTypeOf(
-    resolveProject(instance, {includeMembers: false, includeFeatures: false}),
-  ).resolves.toEqualTypeOf<Project<false, false>>()
-  type Result = Awaited<ReturnType<typeof resolveProject<false, false>>>
-  expectTypeOf<Result['id']>().toEqualTypeOf<string>()
-})
-
-test('resolveProject — rejects non-boolean flag values', () => {
-  // @ts-expect-error — includeMembers must be a boolean
-  void resolveProject(instance, {includeMembers: 'yes'})
-})
-
-test('resolveProject — projectId alone does not change the data shape', () => {
-  expectTypeOf(resolveProject(instance, {projectId: 'p'})).resolves.toEqualTypeOf<
-    Project<true, true>
-  >()
-})
-
-test('resolveProject — non-literal boolean flag makes members optional', () => {
-  const includeMembers = false as boolean
-  expectTypeOf(resolveProject(instance, {includeMembers})).resolves.toEqualTypeOf<
-    Project<boolean, true>
-  >()
-})
-
-test('getProjectState — default call returns members + features StateSource', () => {
-  expectTypeOf(getProjectState(instance)).toEqualTypeOf<
-    StateSource<Project<true, true> | undefined>
-  >()
-})
-
-test('getProjectState — both flags false narrows to the bare base shape', () => {
-  expectTypeOf(
-    getProjectState(instance, {includeMembers: false, includeFeatures: false}),
-  ).toEqualTypeOf<StateSource<Project<false, false> | undefined>>()
-})
-
-test('Project — wide boolean for IncludeMembers makes members optional', () => {
-  expectTypeOf<Project<boolean, true>>().toEqualTypeOf<
-    ProjectBase & {members?: ProjectMember[]} & {features: string[]}
-  >()
-  expectTypeOf<Pick<Project<boolean, true>, 'members'>>().toEqualTypeOf<{
-    members?: ProjectMember[]
-  }>()
-})
-
-test('Project — wide boolean for IncludeFeatures makes features optional', () => {
-  expectTypeOf<Project<true, boolean>>().toEqualTypeOf<
-    ProjectBase & {members: ProjectMember[]} & {features?: string[]}
-  >()
-  expectTypeOf<Pick<Project<true, boolean>, 'features'>>().toEqualTypeOf<{
-    features?: string[]
-  }>()
-})
-
-test('Project — both wide booleans make both fields optional', () => {
-  expectTypeOf<Project<boolean, boolean>>().toEqualTypeOf<
-    ProjectBase & {members?: ProjectMember[]} & {features?: string[]}
-  >()
+test('project — rejects non-boolean flag values', () => {
+  // @ts-expect-error includeMembers must be a boolean
+  void project.resolveState(instance, {includeMembers: 'yes'})
 })

--- a/packages/core/src/project/project.test.ts
+++ b/packages/core/src/project/project.test.ts
@@ -3,9 +3,10 @@ import {of} from 'rxjs'
 import {afterEach, beforeEach, describe, it} from 'vitest'
 
 import {getClientState} from '../client/clientStore'
+import {projects} from '../projects/projects'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {getProjectCacheKey, resolveProject} from './project'
+import {getProjectCacheKey, project} from './project'
 
 vi.mock('../client/clientStore')
 
@@ -21,8 +22,8 @@ describe('project', () => {
   })
 
   it('calls `client.observable.request` against `/projects/<id>` and returns the result', async () => {
-    const project = {id: 'a'}
-    const request = vi.fn().mockReturnValue(of(project))
+    const detail = {id: 'a'}
+    const request = vi.fn().mockReturnValue(of(detail))
 
     const mockClient = {
       observable: {request} as unknown as SanityClient['observable'],
@@ -32,12 +33,12 @@ describe('project', () => {
       observable: of(mockClient),
     } as StateSource<SanityClient>)
 
-    const result = await resolveProject(instance, {projectId: 'a'})
-    expect(result).toEqual(project)
+    const result = await project.resolveState(instance, {projectId: 'a'})
+    expect(result).toEqual(detail)
     expect(request).toHaveBeenCalledWith({
       uri: '/projects/a',
       query: {includeMembers: 'true', includeFeatures: 'true'},
-      tag: 'project.get',
+      tag: 'projects.get',
     })
   })
 
@@ -51,7 +52,7 @@ describe('project', () => {
       observable: of(mockClient),
     } as StateSource<SanityClient>)
 
-    await resolveProject(instance, {
+    await project.resolveState(instance, {
       projectId: 'a',
       includeMembers: false,
       includeFeatures: false,
@@ -63,7 +64,7 @@ describe('project', () => {
         includeMembers: 'false',
         includeFeatures: 'false',
       },
-      tag: 'project.get',
+      tag: 'projects.get',
     })
   })
 
@@ -77,12 +78,58 @@ describe('project', () => {
       observable: of(mockClient),
     } as StateSource<SanityClient>)
 
-    await resolveProject(instance)
+    await project.resolveState(instance)
     expect(request).toHaveBeenCalledWith({
       uri: '/projects/p',
       query: {includeMembers: 'true', includeFeatures: 'true'},
-      tag: 'project.get',
+      tag: 'projects.get',
     })
+  })
+
+  it('pre-seeds a memberless detail read from the cached default list without fetching', async () => {
+    const request = vi.fn().mockReturnValue(
+      of([
+        {id: 'p1', displayName: 'One'},
+        {id: 'p2', displayName: 'Two'},
+      ]),
+    )
+    const mockClient = {
+      observable: {request} as unknown as SanityClient['observable'],
+    } as SanityClient
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of(mockClient),
+    } as StateSource<SanityClient>)
+
+    await projects.resolveState(instance)
+    expect(request).toHaveBeenCalledTimes(1)
+
+    const source = project.getState(instance, {projectId: 'p1', includeMembers: false})
+    const unsubscribe = source.subscribe()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(source.getCurrent()).toMatchObject({status: 'success', data: {id: 'p1'}})
+    expect(request).toHaveBeenCalledTimes(1)
+    unsubscribe()
+  })
+
+  it('does not pre-seed a detail read that includes members', async () => {
+    const list = [{id: 'p1', displayName: 'One'}]
+    const detail = {id: 'p1', displayName: 'One', members: []}
+    const request = vi.fn().mockReturnValueOnce(of(list)).mockReturnValueOnce(of(detail))
+    const mockClient = {
+      observable: {request} as unknown as SanityClient['observable'],
+    } as SanityClient
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: of(mockClient),
+    } as StateSource<SanityClient>)
+
+    await projects.resolveState(instance)
+
+    const result = await project.resolveState(instance, {projectId: 'p1'})
+    expect(result).toEqual(detail)
+    expect(request).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -2,9 +2,10 @@ import {switchMap} from 'rxjs'
 
 import {getClientState} from '../client/clientStore'
 import {type ProjectHandle} from '../config/sanityConfig'
+import {projects} from '../projects/projects'
 import {type SanityInstance} from '../store/createSanityInstance'
-import {type StateSource} from '../store/createStateSourceAction'
-import {createFetcherStore} from '../utils/createFetcherStore'
+import {defineFetcher} from '../store/fetcherStore'
+import {buildQuery} from '../utils/buildQuery'
 
 const API_VERSION = 'v2025-02-19'
 
@@ -111,57 +112,37 @@ export function getProjectCacheKey(
   return `project:${projectId}${membersKey}${featuresKey}`
 }
 
-const project = createFetcherStore({
-  name: 'Project',
+/**
+ * Fetcher for a single project (`GET /projects/:id`), on the shared fetcher
+ * cache. Pre-seeds from the default {@link projects} list entry when it can
+ * satisfy the read — the default list carries features but not members, so
+ * only `includeMembers: false` reads seed.
+ *
+ * @internal
+ */
+export const project = defineFetcher<
+  [options?: ProjectOptions<boolean, boolean>],
+  Project<boolean, boolean>
+>({
+  name: 'project',
   getKey: getProjectCacheKey,
-  fetcher: (instance) => (options?: ProjectOptions<boolean, boolean>) => {
+  fetch: (instance) => (options) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable.request<Project<boolean, boolean>>({
+          uri: `/projects/${resolveProjectId(instance, options)}`,
+          query: buildQuery(normalizeProjectOptions(options)),
+          tag: 'projects.get',
+        }),
+      ),
+    ),
+  tags: (data) => [{type: 'project', id: data.id}],
+  initialData: (instance, options) => {
+    if (normalizeProjectOptions(options).includeMembers) return undefined
+    const snapshot = projects.getState(instance).getCurrent()
+    if (snapshot.status !== 'success') return undefined
     const projectId = resolveProjectId(instance, options)
-
-    return getClientState(instance, {
-      apiVersion: API_VERSION,
-      scope: 'global',
-    }).observable.pipe(
-      switchMap((client) => {
-        const normalized = normalizeProjectOptions(options)
-        const query = Object.fromEntries(
-          Object.entries(normalized)
-            .filter(([, value]) => value !== undefined)
-            .map(([key, value]) => [key, String(value)]),
-        )
-
-        return client.observable.request({
-          uri: `/projects/${projectId}`,
-          query,
-          tag: 'project.get',
-        })
-      }),
-    )
+    const match = snapshot.data.find((item) => item.id === projectId)
+    return match && {data: match, dataUpdatedAt: snapshot.dataUpdatedAt}
   },
 })
-
-/**
- * Public signature for the project state source. The conditional generics
- * cannot flow through `BoundStoreAction`, so we declare the signature here
- * and assign the (already-correct) runtime function to it.
- */
-type GetProjectState = <
-  IncludeMembers extends boolean = true,
-  IncludeFeatures extends boolean = true,
->(
-  instance: SanityInstance,
-  options?: ProjectOptions<IncludeMembers, IncludeFeatures>,
-) => StateSource<Project<IncludeMembers, IncludeFeatures> | undefined>
-
-type ResolveProject = <
-  IncludeMembers extends boolean = true,
-  IncludeFeatures extends boolean = true,
->(
-  instance: SanityInstance,
-  options?: ProjectOptions<IncludeMembers, IncludeFeatures>,
-) => Promise<Project<IncludeMembers, IncludeFeatures>>
-
-/** @public */
-export const getProjectState: GetProjectState = project.getState
-
-/** @public */
-export const resolveProject: ResolveProject = project.resolveState

--- a/packages/core/src/projects/projects.test-d.ts
+++ b/packages/core/src/projects/projects.test-d.ts
@@ -3,36 +3,30 @@ import {expectTypeOf, test} from 'vitest'
 import {type Project, type ProjectMember} from '../project/project'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {getProjectsState, resolveProjects} from './projects'
+import {type FetcherSnapshot} from '../store/fetcherStore'
+import {projects} from './projects'
 
 const instance = {} as SanityInstance
 
-test('resolveProjects — default call: features included, members omitted', () => {
-  expectTypeOf(resolveProjects(instance)).resolves.toEqualTypeOf<Project<false, true>[]>()
-})
-
-test('resolveProjects — includeMembers: true adds members to the type', () => {
-  expectTypeOf(resolveProjects(instance, {includeMembers: true})).resolves.toEqualTypeOf<
-    Project<true, true>[]
-  >()
-  type Result = Awaited<ReturnType<typeof resolveProjects<true, true>>>
-  expectTypeOf<Result[number]['members']>().toEqualTypeOf<ProjectMember[]>()
-})
-
-test('resolveProjects — includeFeatures: false drops features from the type', () => {
-  expectTypeOf(resolveProjects(instance, {includeFeatures: false})).resolves.toEqualTypeOf<
-    Project<false, false>[]
+test('projects.resolveState — resolves the wide-boolean list shape', () => {
+  expectTypeOf(projects.resolveState(instance)).resolves.toEqualTypeOf<
+    Project<boolean, boolean>[]
   >()
 })
 
-test('resolveProjects — organizationId alone does not change the data shape', () => {
-  expectTypeOf(resolveProjects(instance, {organizationId: 'org_123'})).resolves.toEqualTypeOf<
-    Project<false, true>[]
+test('Project<boolean, boolean> — members and features are optional', () => {
+  type Item = Project<boolean, boolean>
+  expectTypeOf<Item['members']>().toEqualTypeOf<ProjectMember[] | undefined>()
+  expectTypeOf<Item['features']>().toEqualTypeOf<string[] | undefined>()
+})
+
+test('projects.getState — exposes the snapshot envelope', () => {
+  expectTypeOf(projects.getState(instance)).toEqualTypeOf<
+    StateSource<FetcherSnapshot<Project<boolean, boolean>[]>>
   >()
 })
 
-test('getProjectsState — default call returns features-only StateSource', () => {
-  expectTypeOf(getProjectsState(instance)).toEqualTypeOf<
-    StateSource<Project<false, true>[] | undefined>
-  >()
+test('projects — rejects non-boolean flag values', () => {
+  // @ts-expect-error includeMembers must be a boolean
+  void projects.resolveState(instance, {includeMembers: 'yes'})
 })

--- a/packages/core/src/projects/projects.test.ts
+++ b/packages/core/src/projects/projects.test.ts
@@ -5,7 +5,7 @@ import {afterEach, beforeEach, describe, it} from 'vitest'
 import {getClientState} from '../client/clientStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
-import {getProjectsCacheKey, resolveProjects} from './projects'
+import {getProjectsCacheKey, projects} from './projects'
 
 vi.mock('../client/clientStore')
 
@@ -21,8 +21,8 @@ describe('projects', () => {
   })
 
   it('calls `client.observable.request` against `/projects` and returns the result', async () => {
-    const projects = [{id: 'a'}, {id: 'b'}]
-    const request = vi.fn().mockReturnValue(of(projects))
+    const list = [{id: 'a'}, {id: 'b'}]
+    const request = vi.fn().mockReturnValue(of(list))
 
     const mockClient = {
       observable: {request} as unknown as SanityClient['observable'],
@@ -32,12 +32,12 @@ describe('projects', () => {
       observable: of(mockClient),
     } as StateSource<SanityClient>)
 
-    const result = await resolveProjects(instance)
-    expect(result).toEqual(projects)
+    const result = await projects.resolveState(instance)
+    expect(result).toEqual(list)
     expect(request).toHaveBeenCalledWith({
       uri: '/projects',
       query: {includeMembers: 'false', includeFeatures: 'true', onlyExplicitMembership: 'false'},
-      tag: 'projects.get',
+      tag: 'projects.list',
     })
   })
 
@@ -51,7 +51,7 @@ describe('projects', () => {
       observable: of(mockClient),
     } as StateSource<SanityClient>)
 
-    await resolveProjects(instance, {
+    await projects.resolveState(instance, {
       organizationId: 'org123',
       includeMembers: true,
       includeFeatures: false,
@@ -65,7 +65,7 @@ describe('projects', () => {
         includeFeatures: 'false',
         onlyExplicitMembership: 'false',
       },
-      tag: 'projects.get',
+      tag: 'projects.list',
     })
   })
 })

--- a/packages/core/src/projects/projects.ts
+++ b/packages/core/src/projects/projects.ts
@@ -3,8 +3,8 @@ import {switchMap} from 'rxjs'
 import {getClientState} from '../client/clientStore'
 import {type Project} from '../project/project'
 import {type SanityInstance} from '../store/createSanityInstance'
-import {type StateSource} from '../store/createStateSourceAction'
-import {createFetcherStore} from '../utils/createFetcherStore'
+import {defineFetcher} from '../store/fetcherStore'
+import {buildQuery} from '../utils/buildQuery'
 
 const API_VERSION = 'v2025-02-19'
 
@@ -42,54 +42,30 @@ export function getProjectsCacheKey(
   return `projects${orgKey}${membersKey}${featuresKey}${explicitKey}`
 }
 
-const projects = createFetcherStore({
-  name: 'Projects',
-  getKey: getProjectsCacheKey,
-  fetcher: (instance) => (options?: ProjectsOptions<boolean, boolean>) =>
-    getClientState(instance, {
-      apiVersion: API_VERSION,
-      scope: 'global',
-    }).observable.pipe(
-      switchMap((client) => {
-        const normalized = normalizeProjectsOptions(options)
-        const query = Object.fromEntries(
-          Object.entries(normalized)
-            .filter(([, value]) => value !== undefined)
-            .map(([key, value]) => [key, String(value)]),
-        )
-
-        return client.observable.request({
-          uri: '/projects',
-          query,
-          tag: 'projects.get',
-        })
-      }),
-    ),
-})
-
 /**
- * Public signature for the projects state source. The conditional generics
- * cannot flow through `BoundStoreAction`, so we declare the signature here
- * and assign the (already-correct) runtime function to it.
+ * Fetcher for the current user's projects (`GET /projects`), on the shared
+ * fetcher cache.
+ *
+ * @internal
  */
-type GetProjectsState = <
-  IncludeMembers extends boolean = false,
-  IncludeFeatures extends boolean = true,
->(
-  instance: SanityInstance,
-  options?: ProjectsOptions<IncludeMembers, IncludeFeatures>,
-) => StateSource<Project<IncludeMembers, IncludeFeatures>[] | undefined>
-
-type ResolveProjects = <
-  IncludeMembers extends boolean = false,
-  IncludeFeatures extends boolean = true,
->(
-  instance: SanityInstance,
-  options?: ProjectsOptions<IncludeMembers, IncludeFeatures>,
-) => Promise<Project<IncludeMembers, IncludeFeatures>[]>
-
-/** @public */
-export const getProjectsState: GetProjectsState = projects.getState
-
-/** @public */
-export const resolveProjects: ResolveProjects = projects.resolveState
+export const projects = defineFetcher<
+  [options?: ProjectsOptions<boolean, boolean>],
+  Project<boolean, boolean>[]
+>({
+  name: 'projects',
+  getKey: getProjectsCacheKey,
+  fetch: (instance) => (options) =>
+    getClientState(instance, {apiVersion: API_VERSION, scope: 'global'}).observable.pipe(
+      switchMap((client) =>
+        client.observable.request<Project<boolean, boolean>[]>({
+          uri: '/projects',
+          query: buildQuery(normalizeProjectsOptions(options)),
+          tag: 'projects.list',
+        }),
+      ),
+    ),
+  tags: (data) => [
+    {type: 'project', id: 'LIST'},
+    ...data.map((project) => ({type: 'project', id: project.id})),
+  ],
+})

--- a/packages/core/src/utils/buildQuery.test.ts
+++ b/packages/core/src/utils/buildQuery.test.ts
@@ -1,0 +1,14 @@
+import {describe, expect, it} from 'vitest'
+
+import {buildQuery} from './buildQuery'
+
+describe('buildQuery', () => {
+  it('stringifies scalars, drops undefined, and passes string arrays through', () => {
+    expect(buildQuery({a: true, b: 0, c: 'x', d: undefined, e: ['p', 'q']})).toEqual({
+      a: 'true',
+      b: '0',
+      c: 'x',
+      e: ['p', 'q'],
+    })
+  })
+})

--- a/packages/core/src/utils/buildQuery.ts
+++ b/packages/core/src/utils/buildQuery.ts
@@ -1,0 +1,17 @@
+/**
+ * Serialises store options into a `@sanity/client` request query object.
+ * Scalars are stringified and `undefined` values dropped; string arrays pass
+ * through untouched so the client serialises them as repeated keys
+ * (`permissions=a&permissions=b`).
+ *
+ * @internal
+ */
+export function buildQuery(
+  params: Record<string, string | number | boolean | string[] | undefined>,
+): Record<string, string | string[]> {
+  return Object.fromEntries(
+    Object.entries(params)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => [key, Array.isArray(value) ? value : String(value)]),
+  )
+}

--- a/packages/core/src/utils/includeShape.ts
+++ b/packages/core/src/utils/includeShape.ts
@@ -1,0 +1,36 @@
+/**
+ * A response field that the API embeds only when its `include` token was
+ * requested. Given the full set of tokens `All`, the token `Key` this field
+ * maps to, and the tokens actually `Requested`, it resolves to:
+ *
+ * - `unknown` (field absent) when nothing — or nothing matching `Key` — was requested
+ * - `Field` (present, as declared) when a literal request list contains `Key`
+ * - `Partial<Field>` (optional) when `Requested` is the wide `All` union, i.e.
+ *   an `include` array whose members aren't known at the type level
+ *
+ * Absent arms return `unknown` so they vanish under intersection. Mirrors the
+ * `boolean extends Flag` trick the organization/project types use, but for an
+ * include-token union rather than a boolean flag.
+ *
+ * @internal
+ */
+export type Included<All extends string, Key extends All, Requested extends All, Field> = [
+  All,
+] extends [Requested]
+  ? Partial<Field>
+  : [Key] extends [Requested]
+    ? Field
+    : unknown
+
+/**
+ * Whether the requested include tokens intersect a given set — used to decide
+ * whether a parent field (e.g. an application's `activeDeployment`) is present,
+ * when requesting any of several tokens forces it in.
+ *
+ * @internal
+ */
+export type IncludesAny<Requested extends string, Set extends string> = [Requested & Set] extends [
+  never,
+]
+  ? false
+  : true

--- a/packages/react/src/hooks/helpers/mapStateSource.ts
+++ b/packages/react/src/hooks/helpers/mapStateSource.ts
@@ -1,0 +1,19 @@
+import {type StateSource} from '@sanity/sdk'
+import {distinctUntilChanged, map} from 'rxjs'
+
+/**
+ * Derives a `StateSource` by mapping another source's values. Bridges the
+ * data-only shape the current hooks expose onto the fetcher snapshot envelope
+ * until the hook layer migrates to consuming snapshots directly (SDK-1448).
+ *
+ * @internal
+ */
+export function mapStateSource<T, U>(source: StateSource<T>, fn: (value: T) => U): StateSource<U> {
+  return {
+    subscribe: source.subscribe,
+    getCurrent: () => fn(source.getCurrent()),
+    get observable() {
+      return source.observable.pipe(map(fn), distinctUntilChanged())
+    },
+  }
+}

--- a/packages/react/src/hooks/organizations/useOrganization.test.ts
+++ b/packages/react/src/hooks/organizations/useOrganization.test.ts
@@ -1,13 +1,15 @@
-import {getOrganizationState, type OrganizationOptions, type SanityInstance} from '@sanity/sdk'
+import {organization, type OrganizationOptions, type SanityInstance} from '@sanity/sdk'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
 
 vi.mock('@sanity/sdk', () => ({
-  getOrganizationState: vi.fn(() => ({
-    getCurrent: vi.fn(() => undefined),
-  })),
-  resolveOrganization: vi.fn(),
+  organization: {
+    getState: vi.fn(() => ({
+      getCurrent: vi.fn(() => ({status: 'pending', data: undefined})),
+    })),
+    resolveState: vi.fn(),
+  },
 }))
 vi.mock('../helpers/createStateSourceHook', () => ({
   createStateSourceHook: vi.fn(),
@@ -15,16 +17,8 @@ vi.mock('../helpers/createStateSourceHook', () => ({
 
 describe('useOrganization', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     vi.resetModules()
-    vi.mock('@sanity/sdk', () => ({
-      getOrganizationState: vi.fn(() => ({
-        getCurrent: vi.fn(() => undefined),
-      })),
-      resolveOrganization: vi.fn(),
-    }))
-    vi.mock('../helpers/createStateSourceHook', () => ({
-      createStateSourceHook: vi.fn(),
-    }))
   })
 
   it('should call createStateSourceHook with correct arguments on import', async () => {
@@ -40,26 +34,21 @@ describe('useOrganization', () => {
     )
   })
 
-  it('shouldSuspend should call getOrganizationState and getCurrent', async () => {
+  it('shouldSuspend suspends while the fetcher snapshot is pending', async () => {
     await import('./useOrganization')
 
     const mockCreateStateSourceHook = createStateSourceHook as ReturnType<typeof vi.fn>
     expect(mockCreateStateSourceHook.mock.calls.length).toBeGreaterThan(0)
-    const createStateSourceHookArgs = mockCreateStateSourceHook.mock.calls[0][0]
-    const shouldSuspend = createStateSourceHookArgs.shouldSuspend
+    const {shouldSuspend} = mockCreateStateSourceHook.mock.calls[0][0]
 
     const mockInstance = {} as SanityInstance
     const mockOptions: OrganizationOptions = {organizationId: 'org_1'}
 
     const result = shouldSuspend(mockInstance, mockOptions)
 
-    const mockGetOrganizationState = getOrganizationState as ReturnType<typeof vi.fn>
-    expect(mockGetOrganizationState).toHaveBeenCalledWith(mockInstance, mockOptions)
-
-    expect(mockGetOrganizationState.mock.results.length).toBeGreaterThan(0)
-    const getOrganizationStateMockResult = mockGetOrganizationState.mock.results[0].value
-    expect(getOrganizationStateMockResult.getCurrent).toHaveBeenCalled()
-
+    expect(organization.getState).toHaveBeenCalledWith(mockInstance, mockOptions)
+    const organizationStateMockResult = vi.mocked(organization.getState).mock.results[0].value
+    expect(organizationStateMockResult.getCurrent).toHaveBeenCalled()
     expect(result).toBe(true)
   })
 })

--- a/packages/react/src/hooks/organizations/useOrganization.ts
+++ b/packages/react/src/hooks/organizations/useOrganization.ts
@@ -1,11 +1,19 @@
 import {
-  getOrganizationState,
   type Organization,
+  organization,
   type OrganizationOptions,
-  resolveOrganization,
+  type SanityInstance,
+  type StateSource,
 } from '@sanity/sdk'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
+import {mapStateSource} from '../helpers/mapStateSource'
+
+const getOrganizationData = (
+  instance: SanityInstance,
+  options: OrganizationOptions<boolean, boolean>,
+): StateSource<Organization<boolean, boolean> | undefined> =>
+  mapStateSource(organization.getState(instance, options), (snapshot) => snapshot.data)
 
 /**
  * Returns metadata for a given organisation.
@@ -31,10 +39,10 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
  * @function
  */
 export const useOrganization = createStateSourceHook({
-  getState: getOrganizationState,
+  getState: getOrganizationData,
   shouldSuspend: (instance, ...params) =>
-    getOrganizationState(instance, ...params).getCurrent() === undefined,
-  suspender: resolveOrganization,
+    getOrganizationData(instance, ...params).getCurrent() === undefined,
+  suspender: organization.resolveState,
 }) as <IncludeMembers extends boolean = false, IncludeFeatures extends boolean = false>(
   options: OrganizationOptions<IncludeMembers, IncludeFeatures>,
 ) => Organization<IncludeMembers, IncludeFeatures>

--- a/packages/react/src/hooks/organizations/useOrganizations.test.ts
+++ b/packages/react/src/hooks/organizations/useOrganizations.test.ts
@@ -1,13 +1,15 @@
-import {getOrganizationsState, type SanityInstance} from '@sanity/sdk'
+import {organizations, type SanityInstance} from '@sanity/sdk'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
 
 vi.mock('@sanity/sdk', () => ({
-  getOrganizationsState: vi.fn(() => ({
-    getCurrent: vi.fn(() => undefined),
-  })),
-  resolveOrganizations: vi.fn(),
+  organizations: {
+    getState: vi.fn(() => ({
+      getCurrent: vi.fn(() => ({status: 'pending', data: undefined})),
+    })),
+    resolveState: vi.fn(),
+  },
 }))
 vi.mock('../helpers/createStateSourceHook', () => ({
   createStateSourceHook: vi.fn(),
@@ -15,16 +17,8 @@ vi.mock('../helpers/createStateSourceHook', () => ({
 
 describe('useOrganizations', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     vi.resetModules()
-    vi.mock('@sanity/sdk', () => ({
-      getOrganizationsState: vi.fn(() => ({
-        getCurrent: vi.fn(() => undefined),
-      })),
-      resolveOrganizations: vi.fn(),
-    }))
-    vi.mock('../helpers/createStateSourceHook', () => ({
-      createStateSourceHook: vi.fn(),
-    }))
   })
 
   it('should call createStateSourceHook with correct arguments on import', async () => {
@@ -40,25 +34,19 @@ describe('useOrganizations', () => {
     )
   })
 
-  it('shouldSuspend should call getOrganizationsState and getCurrent', async () => {
+  it('shouldSuspend suspends while the fetcher snapshot is pending', async () => {
     await import('./useOrganizations')
 
     const mockCreateStateSourceHook = createStateSourceHook as ReturnType<typeof vi.fn>
     expect(mockCreateStateSourceHook.mock.calls.length).toBeGreaterThan(0)
-    const createStateSourceHookArgs = mockCreateStateSourceHook.mock.calls[0][0]
-    const shouldSuspend = createStateSourceHookArgs.shouldSuspend
+    const {shouldSuspend} = mockCreateStateSourceHook.mock.calls[0][0]
 
     const mockInstance = {} as SanityInstance
-
     const result = shouldSuspend(mockInstance, undefined)
 
-    const mockGetOrganizationsState = getOrganizationsState as ReturnType<typeof vi.fn>
-    expect(mockGetOrganizationsState).toHaveBeenCalledWith(mockInstance, undefined)
-
-    expect(mockGetOrganizationsState.mock.results.length).toBeGreaterThan(0)
-    const getOrganizationsStateMockResult = mockGetOrganizationsState.mock.results[0].value
-    expect(getOrganizationsStateMockResult.getCurrent).toHaveBeenCalled()
-
+    expect(organizations.getState).toHaveBeenCalledWith(mockInstance, undefined)
+    const organizationsStateMockResult = vi.mocked(organizations.getState).mock.results[0].value
+    expect(organizationsStateMockResult.getCurrent).toHaveBeenCalled()
     expect(result).toBe(true)
   })
 
@@ -66,8 +54,7 @@ describe('useOrganizations', () => {
     await import('./useOrganizations')
 
     const mockCreateStateSourceHook = createStateSourceHook as ReturnType<typeof vi.fn>
-    const createStateSourceHookArgs = mockCreateStateSourceHook.mock.calls[0][0]
-    const shouldSuspend = createStateSourceHookArgs.shouldSuspend
+    const {shouldSuspend} = mockCreateStateSourceHook.mock.calls[0][0]
 
     const mockInstance = {} as SanityInstance
 

--- a/packages/react/src/hooks/organizations/useOrganizations.ts
+++ b/packages/react/src/hooks/organizations/useOrganizations.ts
@@ -1,11 +1,19 @@
 import {
-  getOrganizationsState,
   type Organizations,
+  organizations,
   type OrganizationsOptions,
-  resolveOrganizations,
+  type SanityInstance,
+  type StateSource,
 } from '@sanity/sdk'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
+import {mapStateSource} from '../helpers/mapStateSource'
+
+const getOrganizationsData = (
+  instance: SanityInstance,
+  options?: OrganizationsOptions<boolean, boolean>,
+): StateSource<Organizations<boolean, boolean> | undefined> =>
+  mapStateSource(organizations.getState(instance, options), (snapshot) => snapshot.data)
 
 /**
  * Returns metadata for each organisation the current user has access to.
@@ -36,10 +44,10 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
  * @function
  */
 export const useOrganizations = createStateSourceHook({
-  getState: getOrganizationsState,
+  getState: getOrganizationsData,
   shouldSuspend: (instance, ...params) =>
-    getOrganizationsState(instance, ...params).getCurrent() === undefined,
-  suspender: resolveOrganizations,
+    getOrganizationsData(instance, ...params).getCurrent() === undefined,
+  suspender: organizations.resolveState,
 }) as <IncludeMembers extends boolean = false, IncludeFeatures extends boolean = false>(
   options?: OrganizationsOptions<IncludeMembers, IncludeFeatures>,
 ) => Organizations<IncludeMembers, IncludeFeatures>

--- a/packages/react/src/hooks/projects/useProject.test.tsx
+++ b/packages/react/src/hooks/projects/useProject.test.tsx
@@ -1,10 +1,5 @@
-import {
-  createSanityInstance,
-  getProjectState,
-  type Project,
-  resolveProject,
-  type StateSource,
-} from '@sanity/sdk'
+import {createSanityInstance, type Project, project, type StateSource} from '@sanity/sdk'
+import {type FetcherSnapshot} from '@sanity/sdk/_internal'
 import {type ReactNode} from 'react'
 import {type Observable} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
@@ -16,30 +11,34 @@ import {useProject} from './useProject'
 
 vi.mock('@sanity/sdk', async (importOriginal) => {
   const original = await importOriginal<typeof import('@sanity/sdk')>()
-  return {...original, getProjectState: vi.fn(), resolveProject: vi.fn()}
+  return {...original, project: {getState: vi.fn(), resolveState: vi.fn()}}
 })
 
-const stateSource = (current: Project | undefined): StateSource<Project | undefined> =>
+const stateSource = (current: Project | undefined): StateSource<FetcherSnapshot<Project>> =>
   ({
-    getCurrent: vi.fn(() => current),
+    getCurrent: vi.fn(() =>
+      current
+        ? {status: 'success', data: current, isFetching: false}
+        : {status: 'pending', data: undefined, isFetching: true},
+    ),
     subscribe: vi.fn(),
     get observable(): Observable<unknown> {
       throw new Error('Not implemented')
     },
-  }) as unknown as StateSource<Project | undefined>
+  }) as unknown as StateSource<FetcherSnapshot<Project>>
 
 const sanityInstance = expect.objectContaining({config: expect.any(Object)})
 
 describe('useProject', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(getProjectState).mockReturnValue(stateSource({id: 'p'} as unknown as Project))
+    vi.mocked(project.getState).mockReturnValue(stateSource({id: 'p'} as unknown as Project))
   })
 
   it('resolves the projectId from the instance config resource', () => {
     // test-utils wraps with ResourceProvider projectId="test" dataset="test".
     renderHook(() => useProject())
-    expect(getProjectState).toHaveBeenCalledWith(
+    expect(project.getState).toHaveBeenCalledWith(
       sanityInstance,
       expect.objectContaining({projectId: 'test'}),
     )
@@ -47,7 +46,7 @@ describe('useProject', () => {
 
   it('lets an explicit projectId override the ambient resource', () => {
     renderHook(() => useProject({projectId: 'explicit-project'}))
-    expect(getProjectState).toHaveBeenCalledWith(
+    expect(project.getState).toHaveBeenCalledWith(
       sanityInstance,
       expect.objectContaining({projectId: 'explicit-project'}),
     )
@@ -64,7 +63,7 @@ describe('useProject', () => {
         </ResourceProvider>
       ),
     })
-    expect(getProjectState).toHaveBeenCalledWith(
+    expect(project.getState).toHaveBeenCalledWith(
       sanityInstance,
       expect.objectContaining({projectId: 'resource-project'}),
     )
@@ -80,7 +79,7 @@ describe('useProject', () => {
     })
     // A dataset-less config can't form a DatasetResource; the projectId is carried
     // via ProjectContext and injected so project-scoped reads still resolve it.
-    expect(getProjectState).toHaveBeenCalledWith(
+    expect(project.getState).toHaveBeenCalledWith(
       sanityInstance,
       expect.objectContaining({projectId: 'config-project'}),
     )
@@ -99,16 +98,16 @@ describe('useProject', () => {
         </SanityInstanceContext.Provider>
       ),
     })
-    expect(getProjectState).toHaveBeenCalledWith(
+    expect(project.getState).toHaveBeenCalledWith(
       emptyInstance,
       expect.objectContaining({projectId: 'bare-project'}),
     )
   })
 
-  it('suspends via resolveProject until project data is available', () => {
-    vi.mocked(getProjectState).mockReturnValue(stateSource(undefined))
-    vi.mocked(resolveProject).mockReturnValue(new Promise(() => {}))
+  it('suspends via the project fetcher until project data is available', () => {
+    vi.mocked(project.getState).mockReturnValue(stateSource(undefined))
+    vi.mocked(project.resolveState).mockReturnValue(new Promise(() => {}))
     renderHook(() => useProject())
-    expect(resolveProject).toHaveBeenCalled()
+    expect(project.resolveState).toHaveBeenCalled()
   })
 })

--- a/packages/react/src/hooks/projects/useProject.ts
+++ b/packages/react/src/hooks/projects/useProject.ts
@@ -1,13 +1,26 @@
-import {getProjectState, type Project, type ProjectOptions, resolveProject} from '@sanity/sdk'
+import {
+  type Project,
+  project,
+  type ProjectOptions,
+  type SanityInstance,
+  type StateSource,
+} from '@sanity/sdk'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
+import {mapStateSource} from '../helpers/mapStateSource'
 import {useResolvedProjectId} from '../helpers/useResolvedProjectId'
 
+const getProjectData = (
+  instance: SanityInstance,
+  options?: ProjectOptions<boolean, boolean>,
+): StateSource<Project<boolean, boolean> | undefined> =>
+  mapStateSource(project.getState(instance, options), (snapshot) => snapshot.data)
+
 const useProjectBase = createStateSourceHook({
-  getState: getProjectState,
+  getState: getProjectData,
   shouldSuspend: (instance, ...params) =>
-    getProjectState(instance, ...params).getCurrent() === undefined,
-  suspender: resolveProject,
+    getProjectData(instance, ...params).getCurrent() === undefined,
+  suspender: project.resolveState,
 })
 
 /**

--- a/packages/react/src/hooks/projects/useProjects.test.ts
+++ b/packages/react/src/hooks/projects/useProjects.test.ts
@@ -1,33 +1,25 @@
-import {getProjectsState, type SanityInstance} from '@sanity/sdk'
+import {projects, type SanityInstance} from '@sanity/sdk'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
 
 // Mock dependencies
 vi.mock('@sanity/sdk', () => ({
-  getProjectsState: vi.fn(() => ({
-    getCurrent: vi.fn(() => undefined), // Mocking getCurrent to satisfy the call within shouldSuspend
-  })),
-  resolveProjects: vi.fn(),
+  projects: {
+    getState: vi.fn(() => ({
+      getCurrent: vi.fn(() => ({status: 'pending', data: undefined})),
+    })),
+    resolveState: vi.fn(),
+  },
 }))
 vi.mock('../helpers/createStateSourceHook', () => ({
   createStateSourceHook: vi.fn(),
 }))
 
 describe('useProjects', () => {
-  // Use beforeEach to reset modules and ensure mocks are fresh for each test
   beforeEach(() => {
+    vi.clearAllMocks()
     vi.resetModules()
-    // Re-mock dependencies for each test after resetModules
-    vi.mock('@sanity/sdk', () => ({
-      getProjectsState: vi.fn(() => ({
-        getCurrent: vi.fn(() => undefined),
-      })),
-      resolveProjects: vi.fn(),
-    }))
-    vi.mock('../helpers/createStateSourceHook', () => ({
-      createStateSourceHook: vi.fn(),
-    }))
   })
 
   it('should call createStateSourceHook with correct arguments on import', async () => {
@@ -40,68 +32,51 @@ describe('useProjects', () => {
       expect.objectContaining({
         getState: expect.any(Function),
         shouldSuspend: expect.any(Function),
-        suspender: expect.any(Function), // Actual function reference doesn't matter here as it's mocked
-        // Note: getConfig is not used in useProjects
+        suspender: expect.any(Function),
       }),
     )
   })
 
-  it('shouldSuspend should call getProjectsState and getCurrent', async () => {
-    // Dynamically import the hook *after* mocks are set up and modules reset
+  it('shouldSuspend suspends while the fetcher snapshot is pending', async () => {
     await import('./useProjects')
 
-    // Get the arguments passed to createStateSourceHook
     const mockCreateStateSourceHook = createStateSourceHook as ReturnType<typeof vi.fn>
     expect(mockCreateStateSourceHook.mock.calls.length).toBeGreaterThan(0)
-    const createStateSourceHookArgs = mockCreateStateSourceHook.mock.calls[0][0]
-    const shouldSuspend = createStateSourceHookArgs.shouldSuspend
+    const {shouldSuspend} = mockCreateStateSourceHook.mock.calls[0][0]
 
-    // Mock instance for the test call
-    const mockInstance = {} as SanityInstance // Use specific type
+    const mockInstance = {} as SanityInstance
+    const result = shouldSuspend(mockInstance, undefined)
 
-    // Call the shouldSuspend function with both required parameters
-    const result = shouldSuspend(mockInstance, undefined) // Pass undefined for options
-
-    // Assert that getProjectsState was called with the correct arguments
-    const mockGetProjectsState = getProjectsState as ReturnType<typeof vi.fn>
-    expect(mockGetProjectsState).toHaveBeenCalledWith(mockInstance, undefined)
-
-    // Assert that getCurrent was called on the result of getProjectsState
-    expect(mockGetProjectsState.mock.results.length).toBeGreaterThan(0)
-    const getProjectsStateMockResult = mockGetProjectsState.mock.results[0].value
-    expect(getProjectsStateMockResult.getCurrent).toHaveBeenCalled()
-
-    // Assert the result of shouldSuspend based on the mocked getCurrent value
-    expect(result).toBe(true) // Since getCurrent is mocked to return undefined
+    // The hook reads the fetcher's snapshot and suspends while data is undefined
+    expect(projects.getState).toHaveBeenCalledWith(mockInstance, undefined)
+    const projectsStateMockResult = vi.mocked(projects.getState).mock.results[0].value
+    expect(projectsStateMockResult.getCurrent).toHaveBeenCalled()
+    expect(result).toBe(true)
   })
 
-  it('should call createStateSourceHook with correct getState function signature', async () => {
+  it('getState maps the snapshot envelope to bare data', async () => {
     await import('./useProjects')
 
     const mockCreateStateSourceHook = createStateSourceHook as ReturnType<typeof vi.fn>
-    expect(mockCreateStateSourceHook).toHaveBeenCalled()
+    const {getState} = mockCreateStateSourceHook.mock.calls[0][0]
 
-    const createStateSourceHookArgs = mockCreateStateSourceHook.mock.calls[0][0]
-    const getState = createStateSourceHookArgs.getState
-
-    // Test that getState can handle the new options parameter
     const mockInstance = {} as SanityInstance
-    const mockOptions = {organizationId: 'org123', includeMembers: false}
+    vi.mocked(projects.getState).mockReturnValueOnce({
+      getCurrent: () => ({status: 'success', data: [{id: 'a'}]}),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
 
-    // This should not throw
-    expect(() => getState(mockInstance, mockOptions)).not.toThrow()
+    expect(getState(mockInstance, undefined).getCurrent()).toEqual([{id: 'a'}])
   })
 
   it('should handle different parameter combinations in shouldSuspend', async () => {
     await import('./useProjects')
 
     const mockCreateStateSourceHook = createStateSourceHook as ReturnType<typeof vi.fn>
-    const createStateSourceHookArgs = mockCreateStateSourceHook.mock.calls[0][0]
-    const shouldSuspend = createStateSourceHookArgs.shouldSuspend
+    const {shouldSuspend} = mockCreateStateSourceHook.mock.calls[0][0]
 
     const mockInstance = {} as SanityInstance
 
-    // Test with different options
     expect(() => shouldSuspend(mockInstance, undefined)).not.toThrow()
     expect(() => shouldSuspend(mockInstance, {organizationId: 'org123'})).not.toThrow()
     expect(() => shouldSuspend(mockInstance, {includeMembers: false})).not.toThrow()

--- a/packages/react/src/hooks/projects/useProjects.ts
+++ b/packages/react/src/hooks/projects/useProjects.ts
@@ -1,6 +1,13 @@
-import {getProjectsState, type Project, type ProjectsOptions, resolveProjects} from '@sanity/sdk'
+import {
+  type Project,
+  projects,
+  type ProjectsOptions,
+  type SanityInstance,
+  type StateSource,
+} from '@sanity/sdk'
 
 import {createStateSourceHook} from '../helpers/createStateSourceHook'
+import {mapStateSource} from '../helpers/mapStateSource'
 
 /**
  * @public
@@ -9,6 +16,12 @@ import {createStateSourceHook} from '../helpers/createStateSourceHook'
  * @deprecated use the Project type directly.
  */
 export type ProjectWithoutMembers = Project
+
+const getProjectsData = (
+  instance: SanityInstance,
+  options?: ProjectsOptions<boolean, boolean>,
+): StateSource<Project<boolean, boolean>[] | undefined> =>
+  mapStateSource(projects.getState(instance, options), (snapshot) => snapshot.data)
 
 /**
  * Returns metadata for each project you have access to.
@@ -41,10 +54,10 @@ export type ProjectWithoutMembers = Project
  * @function
  */
 export const useProjects = createStateSourceHook({
-  getState: getProjectsState,
+  getState: getProjectsData,
   shouldSuspend: (instance, ...params) =>
-    getProjectsState(instance, ...params).getCurrent() === undefined,
-  suspender: resolveProjects,
+    getProjectsData(instance, ...params).getCurrent() === undefined,
+  suspender: projects.resolveState,
 }) as <IncludeMembers extends boolean = false, IncludeFeatures extends boolean = true>(
   options?: ProjectsOptions<IncludeMembers, IncludeFeatures>,
 ) => Project<IncludeMembers, IncludeFeatures>[]


### PR DESCRIPTION
## Why

The SDK can only read projects, organizations and datasets, and those stores fetch once and never refresh — stale data can't revalidate and a write can't be reflected without a reload. This implements the resource-store catalogue on the fetcher infrastructure from #1034, giving the SDK read access to the platform's org-level resources with real cache behaviour.

## What it does

- Adds read-only fetchers for organizations, projects, applications, installations, and user-applications (list + detail each), plus an Access API check for the current user's permissions on a resource. All are internal.
- Rebuilds the projects and organizations stores on the new infrastructure: stale-while-revalidate reads, tag-based invalidation, and project detail reads seeded from the already-cached list.

**Breaking:** `getProjectsState`, `resolveProjects`, `getProjectState`, `resolveProject`, `getOrganizationsState`, `resolveOrganizations`, `getOrganizationState` and `resolveOrganization` are no longer exported. The React hooks keep their existing return shapes until the new hook layer lands (SDK-1448).