### PR TITLE
fix(react): fall back to iframe title in local development

### DIFF
--- a/packages/react/src/hooks/dashboard/useWindowTitle.test.ts
+++ b/packages/react/src/hooks/dashboard/useWindowTitle.test.ts
@@ -101,6 +101,37 @@ describe('useWindowTitle', () => {
     })
   })
 
+  it('should fall back to the iframe title when the dashboard resource has no title', async () => {
+    document.title = 'Local App'
+
+    const mockFetch = vi.fn().mockResolvedValue(
+      createContextResponse({
+        type: 'application',
+        title: '',
+        manifest: null,
+        activeDeployment: null,
+      }),
+    )
+    vi.mocked(useWindowConnection).mockReturnValue({
+      fetch: mockFetch,
+      sendMessage: vi.fn(),
+    })
+
+    const {rerender} = renderHook(({viewTitle}) => useWindowTitle(viewTitle), {
+      initialProps: {viewTitle: 'Teams'},
+    })
+
+    await waitFor(() => {
+      expect(document.title).toBe('Teams | Local App')
+    })
+
+    rerender({viewTitle: 'Week 10'})
+
+    await waitFor(() => {
+      expect(document.title).toBe('Week 10 | Local App')
+    })
+  })
+
   it('should prepend view title when provided', async () => {
     const mockFetch = vi.fn().mockResolvedValue(
       createContextResponse({

--- a/packages/react/src/hooks/dashboard/useWindowTitle.ts
+++ b/packages/react/src/hooks/dashboard/useWindowTitle.ts
@@ -23,7 +23,7 @@ interface ContextResponse {
 }
 
 function resolveAppTitle(resource: ContextResource): string | undefined {
-  return resource.manifest?.title ?? resource.activeDeployment?.manifest?.title ?? resource.title
+  return resource.manifest?.title || resource.activeDeployment?.manifest?.title || resource.title
 }
 
 /**
@@ -81,7 +81,9 @@ export function useWindowTitle(viewTitle?: string): void {
     async function fetchAppTitle(signal: AbortSignal) {
       try {
         const data = await fetch<ContextResponse>('dashboard/v1/context', undefined, {signal})
-        const title = resolveAppTitle(data.context.resource)
+        // Local development resources do not have a registered title or deployment manifest.
+        // In that case, use the title rendered into the iframe HTML by the Sanity CLI.
+        const title = resolveAppTitle(data.context.resource) || document.title
         if (title) {
           setAppTitle(title)
         }


### PR DESCRIPTION
### Description

Local Dashboard development resources do not have a registered title or deployment manifest. The useWindowTitle hook therefore resolved no app title and never updated the iframe document title as its view title changed.

This change falls back to the title rendered into the iframe HTML by the Sanity CLI when a successful Dashboard context response contains no usable title. Non-empty manifest, active deployment, and resource titles retain their existing precedence.

### What to review

- The fallback runs only after Dashboard context resolves without a usable title.
- Empty title values no longer prevent lower-priority title sources from being considered.
- The regression test covers both the initial local-development view title and a subsequent navigation update.

### Testing

- SDK React package: 67 test files passed, 357 tests passed, 3 skipped
- Focused useWindowTitle suite: 10 tests passed
- TypeScript check passed
- Package build passed
- Formatting passed
- Lint passed with two unrelated existing warnings

### Fun gif

Not included.