### PR TITLE
fix(core): preserve inc/dec operational intent through the snapshot diff

### DIFF
--- a/packages/core/src/document/documentStore.concurrency.test.ts
+++ b/packages/core/src/document/documentStore.concurrency.test.ts
@@ -392,11 +392,6 @@ const getSpanMarks = (doc: RigDocument | null, blockKey: string): string[] | und
  */
 const KNOWN_LOSS: {scenario: string; firstWriter?: 'A' | 'B'; reason: string}[] = [
   {
-    scenario: 'counter-inc-inc',
-    reason:
-      'user-supplied inc ops are re-derived as set ops by the snapshot diff, so concurrent increments collapse to last-write-wins',
-  },
-  {
     scenario: 'preserved-set-text-vs-typing',
     reason:
       'preserveOperations forwards whole-value sets verbatim, so whichever preserved set lands second overwrites the concurrent one (server-side last-write-wins)',

--- a/packages/core/src/document/processActions.test.ts
+++ b/packages/core/src/document/processActions.test.ts
@@ -4,7 +4,7 @@ import {describe, expect, it} from 'vitest'
 
 import {type Action, type DocumentAction} from './actions'
 import {ActionError, processActions} from './processActions/processActions'
-import {type DocumentSet} from './processMutations'
+import {type DocumentSet, processMutations} from './processMutations'
 
 // Helper: Create a sample document that conforms to SanityDocument.
 const createDoc = (id: string, title: string, rev: string = 'initial'): SanityDocument => ({
@@ -441,6 +441,190 @@ describe('processActions', () => {
       expect(editedDoc).toBeDefined()
       expect(editedDoc?.['title']).toBe('New Draft Title')
       expect(result.outgoingActions[0].actionType).toBe('sanity.action.document.edit')
+    })
+
+    it('preserves inc/dec operations instead of collapsing them into sets', () => {
+      const draft = {...createDoc('drafts.doc1', 'Title', '1'), count: 5, score: 10}
+      const base: DocumentSet = {'drafts.doc1': draft}
+      const working: DocumentSet = {'drafts.doc1': draft}
+      const actions: DocumentAction[] = [
+        {
+          documentId: 'doc1',
+          documentType: 'article',
+          type: 'document.edit',
+          patches: [{inc: {count: 1}, dec: {score: 3}}],
+        },
+      ]
+      const result = processActions({
+        actions,
+        transactionId,
+        base,
+        working,
+        timestamp,
+        grants: defaultGrants,
+      })
+
+      // the local working copy reflects the applied increments
+      expect(result.working['drafts.doc1']).toMatchObject({count: 6, score: 7})
+      // the outgoing patch keeps the operational inc/dec instead of a set.
+      // the setIfMissing seeds the base value in case the field was removed
+      // concurrently: the server runs setIfMissing before inc/dec, and inc on
+      // a missing path would otherwise fail the whole transaction
+      const patches = result.outgoingActions.map((action) => 'patch' in action && action.patch)
+      expect(patches).toEqual([
+        {setIfMissing: {count: 5, score: 10}, inc: {count: 1}, dec: {score: 3}},
+      ])
+    })
+
+    it('accumulates multiple inc/dec records on the same path into one operation', () => {
+      const draft = {...createDoc('drafts.doc1', 'Title', '1'), count: 5}
+      const base: DocumentSet = {'drafts.doc1': draft}
+      const working: DocumentSet = {'drafts.doc1': draft}
+      const actions: DocumentAction[] = [
+        {
+          documentId: 'doc1',
+          documentType: 'article',
+          type: 'document.edit',
+          patches: [{inc: {count: 1}}, {inc: {count: 2}}, {dec: {count: 4}}],
+        },
+      ]
+      const result = processActions({
+        actions,
+        transactionId,
+        base,
+        working,
+        timestamp,
+        grants: defaultGrants,
+      })
+
+      // 5 + 1 + 2 - 4 = 4 locally
+      expect(result.working['drafts.doc1']).toMatchObject({count: 4})
+      // the three records collapse into one accumulated dec (net -1) with the
+      // base value seeded for the concurrent-removal degradation path
+      const patches = result.outgoingActions.map((action) => 'patch' in action && action.patch)
+      expect(patches).toEqual([{setIfMissing: {count: 5}, dec: {count: 1}}])
+    })
+
+    it('keeps the diffed set when an inc is combined with a set of the same field', () => {
+      const draft = {...createDoc('drafts.doc1', 'Title', '1'), count: 5}
+      const base: DocumentSet = {'drafts.doc1': draft}
+      const working: DocumentSet = {'drafts.doc1': draft}
+      const actions: DocumentAction[] = [
+        {
+          documentId: 'doc1',
+          documentType: 'article',
+          type: 'document.edit',
+          // set to 100 first, then inc: the final value (101) is not
+          // explainable by the inc alone, so it must remain a set
+          patches: [{set: {count: 100}}, {inc: {count: 1}}],
+        },
+      ]
+      const result = processActions({
+        actions,
+        transactionId,
+        base,
+        working,
+        timestamp,
+        grants: defaultGrants,
+      })
+
+      expect(result.working['drafts.doc1']).toMatchObject({count: 101})
+      const patches = result.outgoingActions.map((action) => 'patch' in action && action.patch)
+      expect(patches).toEqual([{set: {count: 101}}])
+    })
+
+    it('preserves inc operations targeting keyed array items', () => {
+      const draft = {
+        ...createDoc('drafts.doc1', 'Title', '1'),
+        items: [{_key: 'itemA', qty: 2}],
+      }
+      const base: DocumentSet = {'drafts.doc1': draft}
+      const working: DocumentSet = {'drafts.doc1': draft}
+      const actions: DocumentAction[] = [
+        {
+          documentId: 'doc1',
+          documentType: 'article',
+          type: 'document.edit',
+          patches: [{inc: {'items[_key=="itemA"].qty': 3}}],
+        },
+      ]
+      const result = processActions({
+        actions,
+        transactionId,
+        base,
+        working,
+        timestamp,
+        grants: defaultGrants,
+      })
+
+      expect(result.working['drafts.doc1']?.['items']).toEqual([{_key: 'itemA', qty: 5}])
+      const patches = result.outgoingActions.map((action) => 'patch' in action && action.patch)
+      expect(patches).toEqual([
+        {setIfMissing: {'items[_key=="itemA"].qty': 2}, inc: {'items[_key=="itemA"].qty': 3}},
+      ])
+    })
+
+    it('preserves inc operations through the liveEdit mutation path', () => {
+      const liveDoc = {...createLiveEditDoc('live-doc', 'Title', '1'), count: 5}
+      const base: DocumentSet = {'live-doc': liveDoc}
+      const working: DocumentSet = {'live-doc': liveDoc}
+      const actions: DocumentAction[] = [
+        {
+          documentId: 'live-doc',
+          documentType: 'liveArticle',
+          type: 'document.edit',
+          liveEdit: true,
+          patches: [{inc: {count: 2}}],
+        },
+      ]
+      const result = processActions({
+        actions,
+        transactionId,
+        base,
+        working,
+        timestamp,
+        grants: defaultGrants,
+      })
+
+      expect(result.working['live-doc']).toMatchObject({count: 7})
+      expect(result.outgoingMutations).toEqual([
+        {patch: {id: 'live-doc', setIfMissing: {count: 5}, inc: {count: 2}}},
+      ])
+    })
+
+    it('degrades to the diffed set result when the inc target was removed concurrently', () => {
+      const draft = {...createDoc('drafts.doc1', 'Title', '1'), count: 5}
+      const base: DocumentSet = {'drafts.doc1': draft}
+      const working: DocumentSet = {'drafts.doc1': draft}
+      const actions: DocumentAction[] = [
+        {
+          documentId: 'doc1',
+          documentType: 'article',
+          type: 'document.edit',
+          patches: [{inc: {count: 1}}],
+        },
+      ]
+      const result = processActions({
+        actions,
+        transactionId,
+        base,
+        working,
+        timestamp,
+        grants: defaultGrants,
+      })
+      const patch = result.outgoingActions.map((action) => 'patch' in action && action.patch)[0]
+
+      // simulate the server applying the emitted patch to a document where
+      // another client removed the counter in the meantime: setIfMissing
+      // seeds the base value, then inc applies, matching what the collapsed
+      // set would have written (instead of inc failing the transaction)
+      const {count: _count, ...draftWithoutCount} = draft
+      const serverResult = processMutations({
+        documents: {'drafts.doc1': draftWithoutCount as SanityDocument},
+        mutations: [{patch: {id: 'drafts.doc1', ...(patch as object)}}],
+        transactionId: 'txn-server',
+      })
+      expect(serverResult['drafts.doc1']).toMatchObject({count: 6})
     })
 
     it('should edit a document when base and working diverge', () => {

--- a/packages/core/src/document/processActions/edit.ts
+++ b/packages/core/src/document/processActions/edit.ts
@@ -13,6 +13,7 @@ import {
   checkGrant,
   createMutationApplier,
   PermissionActionError,
+  preserveNumericOperations,
 } from './shared'
 
 export function handleEdit(
@@ -100,10 +101,16 @@ export function handleEdit(
   // when the caller asked us to preserve their operations, forward their
   // patches verbatim instead of re-deriving them from a snapshot diff. this
   // keeps keyed array operations addressable so concurrent edits from other
-  // clients interleave instead of being overwritten
+  // clients interleave instead of being overwritten. otherwise, diff the
+  // snapshots but swap back any `inc`/`dec` the diff collapsed into a `set`,
+  // so concurrent increments accumulate instead of last-write-winning
   const patches = action.preserveOperations
     ? (action.patches ?? [])
-    : diffValue(baseBefore, baseAfter)
+    : preserveNumericOperations(
+        baseBefore,
+        action.patches,
+        diffValue(baseBefore, baseAfter) as PatchOperations[],
+      )
 
   const workingMutations: Mutation[] = []
   if (!isReleasePerspective(action.perspective) && !working[draftId] && working[publishedId]) {

--- a/packages/core/src/document/processActions/shared.ts
+++ b/packages/core/src/document/processActions/shared.ts
@@ -1,4 +1,5 @@
 import {diffValue} from '@sanity/diff-patch'
+import {jsonMatch, stringifyPath} from '@sanity/json-match'
 import {type Mutation, type PatchOperations, type SanityDocument} from '@sanity/types'
 import {evaluateSync, type ExprNode} from 'groq-js'
 
@@ -92,6 +93,111 @@ export function createMutationApplier(options: {
   }
 }
 
+/**
+ * Re-applies the operational intent of user-supplied `inc`/`dec` patches to a
+ * set of snapshot-diffed patches.
+ *
+ * The outgoing patches sent to Content Lake are re-derived by diffing the
+ * base document before and after the user's patches were applied. That diff
+ * collapses an `inc` into a `set` of the resulting number, which turns
+ * concurrent increments from different clients into last-write-wins. This
+ * helper finds diffed `set` operations that are exactly explained by the
+ * user's `inc`/`dec` operations and swaps them back, so the server applies
+ * the increment against whatever value is current at commit time.
+ *
+ * A `set` is only swapped when its value equals the base value plus the
+ * accumulated user deltas for that exact path; anything else (e.g. an `inc`
+ * combined with a `set` of the same field) keeps the diffed `set`.
+ *
+ * Content Lake fails the whole transaction when `inc`/`dec` targets a missing
+ * path (unlike `set`, which always succeeds). To avoid turning a concurrent
+ * field removal into a transaction revert, the emitted patch seeds the target
+ * with a `setIfMissing` of the base value; the server executes `setIfMissing`
+ * before `inc`/`dec` within a single patch, so a concurrently removed field
+ * degrades to the same result the diffed `set` would have produced. A path
+ * into a concurrently removed keyed array item can still fail the
+ * transaction (`setIfMissing` cannot create array items); the transaction is
+ * then reverted and reported, which is preferable to silently resurrecting
+ * the item.
+ */
+export function preserveNumericOperations(
+  baseBefore: SanityDocument | null | undefined,
+  userPatches: PatchOperations[] | undefined,
+  diffedPatches: PatchOperations[],
+): PatchOperations[] {
+  if (!baseBefore || !userPatches?.length) return diffedPatches
+
+  // accumulate the user's inc/dec deltas per concrete (stringified) path,
+  // tracking the expected final value by replaying the additions in order
+  const targets = new Map<string, {baseValue: number; expectedValue: number; delta: number}>()
+  for (const patch of userPatches) {
+    for (const [op, sign] of [
+      ['inc', 1],
+      ['dec', -1],
+    ] as const) {
+      const record = patch[op]
+      if (!record) continue
+      for (const [pathExpression, amount] of Object.entries(record)) {
+        if (typeof amount !== 'number') continue
+        for (const match of jsonMatch(baseBefore, pathExpression)) {
+          const path = stringifyPath(match.path)
+          const existing = targets.get(path)
+          if (existing) {
+            existing.expectedValue += sign * amount
+            existing.delta += sign * amount
+          } else if (typeof match.value === 'number') {
+            targets.set(path, {
+              baseValue: match.value,
+              expectedValue: match.value + sign * amount,
+              delta: sign * amount,
+            })
+          }
+        }
+      }
+    }
+  }
+  if (!targets.size) return diffedPatches
+
+  const preserved = new Map<string, {delta: number; baseValue: number}>()
+  const next = diffedPatches.flatMap((patch) => {
+    if (!patch.set) return [patch]
+
+    const keptSet: Record<string, unknown> = {}
+    for (const [path, value] of Object.entries(patch.set)) {
+      const target = targets.get(path)
+      if (target && typeof value === 'number' && value === target.expectedValue) {
+        preserved.set(path, {delta: target.delta, baseValue: target.baseValue})
+      } else {
+        keptSet[path] = value
+      }
+    }
+
+    if (Object.keys(keptSet).length === Object.keys(patch.set).length) return [patch]
+    const {set: _set, ...rest} = patch
+    const withKept = Object.keys(keptSet).length ? {...rest, set: keptSet} : rest
+    return Object.keys(withKept).length ? [withKept] : []
+  })
+
+  if (!preserved.size) return next
+
+  const setIfMissing: Record<string, unknown> = {}
+  const inc: Record<string, number> = {}
+  const dec: Record<string, number> = {}
+  for (const [path, {delta, baseValue}] of preserved) {
+    setIfMissing[path] = baseValue
+    if (delta >= 0) inc[path] = delta
+    else dec[path] = -delta
+  }
+  return [
+    ...next,
+    {
+      setIfMissing,
+      ...(Object.keys(inc).length && {inc}),
+      ...(Object.keys(dec).length && {dec}),
+    },
+  ]
+}
+
 interface ApplySingleDocPatchOptions {
   base: DocumentSet
   working: DocumentSet
@@ -181,7 +287,11 @@ export function applySingleDocPatch({
   const baseAfter = base[documentId]
   const diffedPatches = preserveOperations
     ? (patches as PatchOperations[])
-    : (diffValue(baseBefore, baseAfter) as PatchOperations[])
+    : preserveNumericOperations(
+        baseBefore,
+        patches,
+        diffValue(baseBefore, baseAfter) as PatchOperations[],
+      )
 
   const workingBefore = working[documentId] as SanityDocument
   if (!checkGrant(grants.update, workingBefore, identity)) {


### PR DESCRIPTION
### Description

Concurrent `inc`/`dec` operations from different clients no longer collapse to last-write-wins.

The outgoing patches sent to Content Lake are re-derived by diffing the document before and after the user's patches apply. That diff collapses an `inc` into a `set` of the resulting number, so two clients incrementing the same counter concurrently resolve to last-write-wins: the server applies `set count=1` twice instead of `inc 1` twice.

`preserveNumericOperations` (new, in `processActions/shared.ts`) runs after the snapshot diff and swaps diffed `set`s back to the user's operational `inc`/`dec` form, so the server applies the increment against whatever value is current at commit time. A `set` is only swapped when its value equals the base value plus the accumulated user deltas for that exact path, so an `inc` combined with a `set` of the same field still submits the diffed `set` (matching current behavior). Applies to both the Actions API path and the liveEdit mutations path.

**Server-semantics note (verified against gradient):** Content Lake fails the whole transaction with a 400 when `inc`/`dec` targets a missing or non-numeric path, unlike `set` which always succeeds. To avoid turning a concurrent field removal into a batched-transaction revert, the emitted patch also seeds the target with `setIfMissing: {path: baseValue}`. Gradient executes `setIfMissing` before `inc`/`dec` within a single patch (`pkg/documents/mutation/patch.go`), so a concurrently removed field degrades to exactly the value the collapsed `set` would have written. A path into a concurrently removed keyed array item can still fail the transaction (`setIfMissing` cannot create array items); that reverts and reports instead of silently resurrecting the item.

Stacked on #1055.

### What to review

- `preserveNumericOperations` in `packages/core/src/document/processActions/shared.ts`: the delta accumulation, the exact-match guard, the `setIfMissing` seeding, and the split into `inc`/`dec` records.
- Its two call sites: `handleEdit` (`processActions/edit.ts`) and `applySingleDocPatch` (liveEdit/release edit path).
- The flipped expectation in `documentStore.concurrency.test.ts`: `counter-inc-inc` moved out of `KNOWN_LOSS` and now asserts both increments count in both apply orders.

### Testing

- New unit tests in `processActions.test.ts`: plain inc/dec preservation, inc+set of the same field staying a set, keyed-array-item targets, the liveEdit mutation path, and the degradation path (applying the emitted patch to a document whose counter was removed concurrently produces the collapsed-set result via `setIfMissing`, instead of a transaction failure).
- The concurrency rig's `counter-inc-inc` scenario now asserts `count === 2` in both apply orders.
- Server semantics (inc-on-missing fails the transaction; per-patch operation order `setIfMissing` before `inc`/`dec`) verified by reading gradient's `pkg/documents/patching/inc.go` and `pkg/documents/mutation/patch.go`.
- Full core suite, repo type check, and lint are green.

### Fun gif

![Counter going up](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o7btPCcdNniyf0ArS/giphy.gif)
