### PR TITLE
fix(core): converge local to server truth on idle fast-forward

### DIFF
--- a/packages/core/src/document/documentStore.concurrency.test.ts
+++ b/packages/core/src/document/documentStore.concurrency.test.ts
@@ -415,18 +415,7 @@ const KNOWN_DIVERGENCE: {
   client: 'A' | 'B'
   documentId: string
   reason: string
-}[] = [
-  {
-    scenario: 'publish-vs-edit',
-    firstWriter: 'B',
-    client: 'A',
-    documentId: PUBLISHED_ID,
-    reason:
-      "the publisher's own echo fast-forwards, keeping the optimistic published " +
-      "prediction as `local` even though the server's publish carried B's newer " +
-      'draft edit; nothing reconciles local with remote afterwards',
-  },
-]
+}[] = []
 
 const isKnownDivergence = (
   scenarioId: string,

--- a/packages/core/src/document/reducers.test.ts
+++ b/packages/core/src/document/reducers.test.ts
@@ -696,6 +696,129 @@ describe('applyRemoteDocument', () => {
     expect(newDocState?.unverifiedRevisions?.['txn10']).toBeUndefined()
   })
 
+  describe('fast-forward convergence of local', () => {
+    const docId = getDraftId(DocumentId('doc1'))
+    const otherDocId = getDraftId(DocumentId('doc2'))
+
+    const makeApplied = (overrides: Partial<AppliedTransaction>): AppliedTransaction => ({
+      transactionId: 'txnPending',
+      actions: [],
+      working: {},
+      previous: {},
+      base: {},
+      previousRevs: {},
+      timestamp: '2025-02-06T00:06:30.000Z',
+      outgoingActions: [],
+      outgoingMutations: [],
+      ...overrides,
+    })
+
+    const makeState = (applied: AppliedTransaction[]): SyncTransactionState => ({
+      queued: [],
+      applied,
+      outgoing: undefined,
+      grants,
+      documentStates: {
+        [docId]: {
+          id: docId,
+          subscriptions: ['sub1'],
+          local: {...exampleDoc, _id: docId, foo: 'optimistic'},
+          remote: {...exampleDoc, _id: docId, foo: 'old'},
+          unverifiedRevisions: {
+            txn10: {
+              transactionId: 'txn10',
+              documentId: docId,
+              previousRev: 'revOld',
+              timestamp: '2025-02-06T00:06:00.000Z',
+            },
+          },
+        },
+      },
+    })
+
+    const remote: RemoteDocument = {
+      type: 'sync',
+      documentId: docId,
+      document: {...exampleDoc, _id: docId, foo: 'server-truth'},
+      revision: 'txn10',
+      previousRev: 'revOld',
+      timestamp: '2025-02-06T00:07:00.000Z',
+    }
+
+    it('converges local to the server document when nothing else is pending', () => {
+      const events = new Subject<DocumentEvent>()
+      const newState = applyRemoteDocument(makeState([]), remote, events)
+      expect(newState.documentStates[docId]?.local).toEqual(remote.document)
+    })
+
+    it('converges local when pending work modifies only other documents', () => {
+      // a pending applied transaction on doc2 must not block convergence of
+      // doc1: nothing would ever revisit doc1's local otherwise
+      const otherDoc = {...exampleDoc, _id: otherDocId}
+      const pendingOnOtherDoc = makeApplied({
+        working: {[otherDocId]: {...otherDoc, _rev: 'txnPending'}},
+        previous: {[otherDocId]: otherDoc},
+        base: {[otherDocId]: otherDoc},
+        previousRevs: {[otherDocId]: 'txn0'},
+      })
+      const events = new Subject<DocumentEvent>()
+      const newState = applyRemoteDocument(makeState([pendingOnOtherDoc]), remote, events)
+      expect(newState.documentStates[docId]?.local).toEqual(remote.document)
+    })
+
+    it('converges local when pending work carries this document unmodified', () => {
+      // a draft edit carries the published document in its working set
+      // without changing it; presence alone must not block convergence
+      const thisDoc = {...exampleDoc, _id: docId}
+      const pendingCarryingUnmodified = makeApplied({
+        working: {
+          [docId]: thisDoc,
+          [otherDocId]: {...exampleDoc, _id: otherDocId, _rev: 'txnPending'},
+        },
+        previous: {[docId]: thisDoc, [otherDocId]: {...exampleDoc, _id: otherDocId}},
+        base: {[docId]: thisDoc, [otherDocId]: {...exampleDoc, _id: otherDocId}},
+        previousRevs: {[docId]: thisDoc._rev, [otherDocId]: 'txn0'},
+      })
+      const events = new Subject<DocumentEvent>()
+      const newState = applyRemoteDocument(makeState([pendingCarryingUnmodified]), remote, events)
+      expect(newState.documentStates[docId]?.local).toEqual(remote.document)
+    })
+
+    it('keeps the optimistic local when pending work modifies this document', () => {
+      const optimistic = {...exampleDoc, _id: docId, _rev: 'txnPending', foo: 'optimistic'}
+      const pendingOnThisDoc = makeApplied({
+        working: {[docId]: optimistic},
+        previous: {[docId]: {...exampleDoc, _id: docId}},
+        base: {[docId]: {...exampleDoc, _id: docId}},
+        previousRevs: {[docId]: 'txn0'},
+      })
+      const state = makeState([pendingOnThisDoc])
+      const events = new Subject<DocumentEvent>()
+      const newState = applyRemoteDocument(state, remote, events)
+      expect(newState.documentStates[docId]?.local).toBe(state.documentStates[docId]?.local)
+      expect(newState.documentStates[docId]?.remote).toEqual(remote.document)
+    })
+
+    it('keeps the optimistic local when a different in-flight transaction modifies this document', () => {
+      const optimistic = {...exampleDoc, _id: docId, _rev: 'txnOutgoing', foo: 'optimistic'}
+      const outgoing = {
+        ...makeApplied({
+          transactionId: 'txnOutgoing',
+          working: {[docId]: optimistic},
+          previous: {[docId]: {...exampleDoc, _id: docId}},
+          base: {[docId]: {...exampleDoc, _id: docId}},
+          previousRevs: {[docId]: 'txn0'},
+        }),
+        disableBatching: false,
+        batchedTransactionIds: ['txnOutgoing'],
+      }
+      const state = {...makeState([]), outgoing}
+      const events = new Subject<DocumentEvent>()
+      const newState = applyRemoteDocument(state, remote, events)
+      expect(newState.documentStates[docId]?.local).toBe(state.documentStates[docId]?.local)
+    })
+  })
+
   it('rebases local changes when no matching unverified revision is found', () => {
     // In this branch we simply let processActions rebase so that the local becomes the remote.
     const docId = getDraftId(DocumentId('doc1'))

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -5,7 +5,7 @@ import {type DocumentHandle} from '../config/sanityConfig'
 import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
 import {type StoreContext} from '../store/defineStore'
 import {insecureRandomId} from '../utils/ids'
-import {omitProperty} from '../utils/object'
+import {isDeepEqual, omitProperty} from '../utils/object'
 import {setCleanupTimeout} from '../utils/setCleanupTimeout'
 import {type Action} from './actions'
 import {DOCUMENT_STATE_CLEAR_DELAY} from './documentConstants'
@@ -534,6 +534,34 @@ export function applyRemoteDocument(
   // matches the previous revision we expected, we can "fast-forward" and skip
   // rebasing local changes on top of this new base
   if (revisionToVerify && revisionToVerify.previousRev === previousRev) {
+    // even on a clean fast-forward, the server's result can differ from our
+    // optimistic prediction: a publish derives the published content from the
+    // server's copy of the draft, which may carry concurrent edits our
+    // prediction never saw. once nothing else is pending locally for this
+    // document (no applied transaction and no in-flight transaction, other
+    // than the one this event just confirmed, modifies it), converge `local`
+    // to the server's document. while local work that modifies this document
+    // is pending, keep the optimistic `local` so those changes stay visible;
+    // that work's own echo (or rebase) recomputes `local` later.
+    //
+    // "modifies" matters: pending work on other documents must not block
+    // convergence here (nothing would ever revisit this document's `local`),
+    // and a pending draft edit carries the published document in its working
+    // set without changing it, so a presence check would block published-doc
+    // convergence whenever a draft edit is pending. this is the same
+    // modified-test `transitionAppliedTransactionsToOutgoing` uses
+    const modifiesDocument = (transaction: AppliedTransaction) =>
+      transaction.working[documentId]?._rev !== transaction.previousRevs[documentId]
+    const nothingElsePending =
+      !prev.applied.some(modifiesDocument) &&
+      (!prev.outgoing ||
+        prev.outgoing.transactionId === revision ||
+        !modifiesDocument(prev.outgoing))
+    const local =
+      nothingElsePending && !isDeepEqual(prevDocState.local, document)
+        ? document
+        : prevDocState.local
+
     return {
       ...prev,
       documentStates: {
@@ -542,6 +570,7 @@ export function applyRemoteDocument(
           ...prevDocState,
           remote: document,
           remoteRev: revision,
+          local,
           unverifiedRevisions,
         },
       },
@@ -592,6 +621,12 @@ export function applyRemoteDocument(
     }
   }
 
+  // when the recompute lands on a value deep-equal to the current local
+  // (the common case for echoes of our own transactions), keep the previous
+  // reference so subscribers don't re-render for an identical value
+  const nextLocal = working[documentId]
+  const local = isDeepEqual(prevDocState.local, nextLocal) ? prevDocState.local : nextLocal
+
   return {
     ...prev,
     applied: nextApplied,
@@ -601,7 +636,7 @@ export function applyRemoteDocument(
         ...prevDocState,
         remote: document,
         remoteRev: revision,
-        local: working[documentId],
+        local,
         unverifiedRevisions,
       },
     },


### PR DESCRIPTION
### Description

Fixes a divergence where a client could be left viewing stale content indefinitely after its own transaction was confirmed.

When a listener event confirms one of our own transactions with a matching `previousRev`, the store fast-forwards: it advances the `remote` snapshot but keeps the optimistic `local` untouched. The server's result can legitimately differ from our prediction, though. Concretely: client B edits the draft, client A publishes; B's edit lands first, so the server's publish carries B's edit into the published document. A's optimistic prediction was computed from A's own (older) draft. A's echo fast-forwards, nothing ever reconciles `local` with `remote`, and A keeps rendering the stale published content until an unrelated foreign event happens to arrive.

The fix: on a fast-forward, when no other pending local work modifies the document (no applied transaction and no in-flight transaction other than the confirmed one changes it), `local` now converges to the server's document. While pending work that modifies this document exists, the optimistic `local` is kept exactly as before and that work's own echo or rebase recomputes it. The pending-work check is per document and tests for modification (`working[documentId]?._rev !== previousRevs[documentId]`, the same test `transitionAppliedTransactionsToOutgoing` uses), not mere presence: pending edits to other documents must not block convergence here (nothing would ever revisit this document's `local`), and a pending draft edit carries the published document in its working set without changing it, so a presence check would block published-doc convergence whenever a draft edit is pending. A deep-equality guard keeps the previous `local` reference when the content is identical, so subscribers don't re-render for equal values.

The concurrency rig (#1055) caught this as its `publish-vs-edit` divergence.

Stacked on #1056.

### What to review

- The fast-forward branch of `applyRemoteDocument` in `packages/core/src/document/reducers.ts`: the per-document `modifiesDocument`/`nothingElsePending` condition and the `isDeepEqual` reference-preservation guard.
- Whether the "keep optimistic local while other work is pending" behavior matches your mental model of the outgoing/applied pipeline; the non-fast-forward rebase path is unchanged.
- The rig change: the `publish-vs-edit` entry is removed from `KNOWN_DIVERGENCE`, so the scenario now asserts convergence in both apply orders.

### Testing

- The concurrency rig's `publish-vs-edit` scenario flips from asserting the documented divergence to asserting that both clients converge to server truth (both apply orders).
- New `reducers.test.ts` unit tests for the fast-forward convergence: converges when nothing is pending, converges when pending work modifies only other documents, converges when pending work carries this document unmodified (the draft-edit-carrying-published case), and keeps the optimistic local when pending applied or in-flight work modifies this document.
- Existing `reducers.test.ts` fast-forward tests still pass unchanged.
- Full core suite, repo type check, and lint are green.

### Fun gif

![truth](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExNTZoank5NG9oMDltcGp1cDQzZ25jbnpndzNkYW9pazc5dG1qNzZlcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/dXFKDUolyLLi8gq6Cl/giphy.gif)

