### PR TITLE
feat(core): harden the shared listener for reconnects and multi-document transactions

### DIFF
--- a/packages/core/src/document/listen.test.ts
+++ b/packages/core/src/document/listen.test.ts
@@ -205,4 +205,60 @@ describe('sortListenerEvents operator', () => {
     const events = await lastValueFrom(source$.pipe(sortListenerEvents(), toArray()))
     expect(events).toEqual([other])
   })
+
+  it('should discard replayed events already reflected in the base', async () => {
+    // The snapshot is at rev2; a resumed listener replays the event that
+    // produced rev2. It should be discarded instead of clogging the buffer.
+    const sync = createSyncEvent('rev2')
+    const replayed = createMutationEvent({
+      id: 'replayed',
+      previousRev: 'rev1',
+      resultRev: 'rev2',
+    })
+    const source$ = of(sync, replayed)
+    const events = await lastValueFrom(source$.pipe(sortListenerEvents(), toArray()))
+    expect(events).toEqual([sync])
+  })
+
+  it('should discard the replayed part of a chain and apply the rest', async () => {
+    // The snapshot is at rev2; the listener replays rev1->rev2 followed by a
+    // genuinely new rev2->rev3. Only the new event should be emitted.
+    const sync = createSyncEvent('rev2')
+    const replayed = createMutationEvent({
+      id: 'replayed',
+      previousRev: 'rev1',
+      resultRev: 'rev2',
+    })
+    const fresh = createMutationEvent({
+      id: 'fresh',
+      previousRev: 'rev2',
+      resultRev: 'rev3',
+    })
+    const source$ = of(sync, replayed, fresh)
+    const events = await lastValueFrom(source$.pipe(sortListenerEvents(), toArray()))
+    expect(events).toEqual([sync, fresh])
+  })
+
+  it('should discard a multi-event replayed chain that leads up to the base', async () => {
+    const sync = createSyncEvent('rev3')
+    // two replayed events that together lead up to the base revision
+    const replayedA = createMutationEvent({
+      id: 'replayedA',
+      previousRev: 'rev1',
+      resultRev: 'rev2',
+    })
+    const replayedB = createMutationEvent({
+      id: 'replayedB',
+      previousRev: 'rev2',
+      resultRev: 'rev3',
+    })
+    const fresh = createMutationEvent({
+      id: 'fresh',
+      previousRev: 'rev3',
+      resultRev: 'rev4',
+    })
+    const source$ = of(sync, replayedA, replayedB, fresh)
+    const events = await lastValueFrom(source$.pipe(sortListenerEvents(), toArray()))
+    expect(events).toEqual([sync, fresh])
+  })
 })

--- a/packages/core/src/document/listen.ts
+++ b/packages/core/src/document/listen.ts
@@ -98,9 +98,48 @@ interface SortListenerEventsOptions {
 }
 
 /**
+ * Orders the given mutation events into chains where each event's
+ * `previousRev` points at another event's `resultRev`. Events whose
+ * `previousRev` matches no other event start a new chain. The buffer may have
+ * multiple holes in it, so multiple chains can exist at once.
+ */
+function toOrderedChains(events: MutationEvent[]): MutationEvent[][] {
+  const chainStarts = events.filter(
+    (event) => !events.some((other) => other.resultRev === event.previousRev),
+  )
+
+  return chainStarts.map((start) => {
+    const chain: MutationEvent[] = []
+    let current: MutationEvent | undefined = start
+    while (current) {
+      chain.push(current)
+      const currentResultRev: string | undefined = current.resultRev
+      current = events.find((event) => event.previousRev === currentResultRev)
+    }
+    return chain
+  })
+}
+
+/**
+ * Discards the leading events of a chain up to and including the event whose
+ * `resultRev` equals the given revision. These events describe changes that
+ * are already reflected in the current base (e.g. events replayed by a
+ * resumed listener after the snapshot was refetched).
+ */
+function discardChainTo(chain: MutationEvent[], revision: string | undefined): MutationEvent[] {
+  const revisionIndex = chain.findIndex((event) => event.resultRev === revision)
+  if (revisionIndex === -1) return chain
+  return chain.slice(revisionIndex + 1)
+}
+
+/**
  * Takes an input observable of listener events that might arrive out of order, and emits them in sequence
  * If we receive mutation events that doesn't line up in [previousRev, resultRev] pairs we'll put them in a buffer and
  * check if we have an unbroken chain every time we receive a new event
+ *
+ * Buffered chains that lead up to the current base revision are discarded:
+ * they describe changes already reflected in the base (e.g. events replayed
+ * by a resumed listener after the snapshot was refetched)
  *
  * If the buffer grows beyond `maxBufferSize`, or if `resolveChainDeadline` milliseconds passes before the chain resolves
  * an OutOfSyncError will be thrown on the stream
@@ -132,38 +171,40 @@ export function sortListenerEvents(options?: SortListenerEventsOptions) {
                 'Invalid state. Cannot process mutation event without a base sync event',
               )
             }
-            // Add the new mutation event into the buffer
-            const buffer = state.buffer.concat(event)
-            const emitEvents: MutationEvent[] = []
-            let baseRevision = state.base.revision
-            let progress = true
+            const baseRevision = state.base.revision
 
-            // Try to apply as many buffered mutations as possible.
-            while (progress) {
-              progress = false
-              // Look for a mutation whose previousRev matches the current base.
-              const idx = buffer.findIndex((e) => e.previousRev === baseRevision)
-              if (idx !== -1) {
-                // Remove the event from the buffer and “apply” it.
-                const [next] = buffer.splice(idx, 1)
-                emitEvents.push(next)
-                // If the mutation is a deletion, the new base revision is undefined.
-                baseRevision = next.transition === 'disappear' ? undefined : next.resultRev
-                progress = true
+            // Order the buffered events (plus the new one) into chains, then
+            // drop the parts of each chain the base already reflects.
+            const chains = toOrderedChains(state.buffer.concat(event))
+              .map((chain) => discardChainTo(chain, baseRevision))
+              .filter((chain) => chain.length > 0)
+
+            // A chain whose head continues the current base revision can be
+            // applied. There can be at most one; anything else stays buffered.
+            const applicable = chains.find((chain) => chain[0].previousRev === baseRevision)
+            const buffer = chains.filter((chain) => chain !== applicable).flat()
+
+            if (applicable) {
+              const last = applicable[applicable.length - 1]
+              return {
+                // If the chain ends in a deletion, the new base revision is undefined.
+                base: {revision: last.transition === 'disappear' ? undefined : last.resultRev},
+                buffer,
+                emitEvents: applicable,
               }
             }
 
             if (buffer.length >= maxBufferSize) {
               throw new MaxBufferExceededError(
                 `Too many unchainable mutation events (${buffer.length}) waiting to resolve.`,
-                {base: {revision: baseRevision}, buffer, emitEvents},
+                {base: {revision: baseRevision}, buffer, emitEvents: []},
               )
             }
 
             return {
               base: {revision: baseRevision},
               buffer,
-              emitEvents,
+              emitEvents: [],
             }
           }
           // Any other event is simply forwarded.
@@ -208,7 +249,11 @@ export const listen = (
 
   return sharedListener.events.pipe(
     concatMap((e) => {
-      if (e.type === 'welcome') {
+      // `welcome` means a fresh listener connection and `reset` means a
+      // resumed listener could not replay what was missed; both require
+      // refetching the snapshot. a `welcomeback` means the resume succeeded
+      // and the missed events were replayed, so no refetch is needed
+      if (e.type === 'welcome' || e.type === 'reset') {
         return fetchDocument(documentId).pipe(
           map((document): SyncEvent => ({type: 'sync', document})),
         )

--- a/packages/core/src/document/listenerEventOperators.test.ts
+++ b/packages/core/src/document/listenerEventOperators.test.ts
@@ -1,0 +1,311 @@
+import {
+  type ListenEvent,
+  type MutationEvent,
+  type ReconnectEvent,
+  type WelcomeEvent,
+} from '@sanity/client'
+import {type SanityDocument} from '@sanity/types'
+import {from, lastValueFrom, type Observable, Subject} from 'rxjs'
+import {toArray} from 'rxjs/operators'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {dedupeListenerEvents, groupTransactionEvents} from './listenerEventOperators'
+
+function listenEventsOf(
+  ...events: ListenEvent<SanityDocument>[]
+): Observable<ListenEvent<SanityDocument>> {
+  return from(events)
+}
+
+function createMutationEvent({
+  transactionId,
+  documentId = 'doc1',
+  transactionCurrentEvent = 1,
+  transactionTotalEvents = 1,
+}: {
+  transactionId: string
+  documentId?: string
+  transactionCurrentEvent?: number
+  transactionTotalEvents?: number
+}): MutationEvent {
+  return {
+    type: 'mutation',
+    documentId,
+    eventId: `${transactionId}#${documentId}`,
+    identity: 'user',
+    mutations: [],
+    timestamp: new Date().toISOString(),
+    transactionId,
+    transactionCurrentEvent,
+    transactionTotalEvents,
+    transition: 'update',
+    visibility: 'query',
+    resultRev: transactionId,
+  }
+}
+
+const welcomeEvent: WelcomeEvent = {type: 'welcome', listenerName: 'listener'}
+const reconnectEvent = {type: 'reconnect'} as ReconnectEvent
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('dedupeListenerEvents', () => {
+  it('passes unique mutation events through', async () => {
+    const m1 = createMutationEvent({transactionId: 'txn1'})
+    const m2 = createMutationEvent({transactionId: 'txn2'})
+    const events = await lastValueFrom(
+      listenEventsOf(m1, m2).pipe(dedupeListenerEvents(), toArray()),
+    )
+    expect(events).toEqual([m1, m2])
+  })
+
+  it('drops replayed duplicates of the same transaction and document', async () => {
+    const m1 = createMutationEvent({transactionId: 'txn1'})
+    const replay = createMutationEvent({transactionId: 'txn1'})
+    const events = await lastValueFrom(
+      listenEventsOf(m1, replay).pipe(dedupeListenerEvents(), toArray()),
+    )
+    expect(events).toEqual([m1])
+  })
+
+  it('does not dedupe events of the same transaction for different documents', async () => {
+    const draft = createMutationEvent({transactionId: 'txn1', documentId: 'drafts.doc1'})
+    const published = createMutationEvent({transactionId: 'txn1', documentId: 'doc1'})
+    const events = await lastValueFrom(
+      listenEventsOf(draft, published).pipe(dedupeListenerEvents(), toArray()),
+    )
+    expect(events).toEqual([draft, published])
+  })
+
+  it('passes non-mutation events through untouched', async () => {
+    const events = await lastValueFrom(
+      listenEventsOf(welcomeEvent, reconnectEvent).pipe(dedupeListenerEvents(), toArray()),
+    )
+    expect(events).toEqual([welcomeEvent, reconnectEvent])
+  })
+
+  it('allows a key again after its TTL has passed', async () => {
+    vi.useFakeTimers()
+    const source = new Subject<ListenEvent<SanityDocument>>()
+    const received: ListenEvent<SanityDocument>[] = []
+    const subscription = source
+      .pipe(dedupeListenerEvents({ttl: 1000}))
+      .subscribe((e) => received.push(e))
+
+    source.next(createMutationEvent({transactionId: 'txn1'}))
+    source.next(createMutationEvent({transactionId: 'txn1'}))
+    expect(received).toHaveLength(1)
+
+    vi.advanceTimersByTime(1001)
+    source.next(createMutationEvent({transactionId: 'txn1'}))
+    expect(received).toHaveLength(2)
+
+    subscription.unsubscribe()
+  })
+
+  it('evicts the oldest entries when the cache exceeds maxEntries', async () => {
+    const source = new Subject<ListenEvent<SanityDocument>>()
+    const received: ListenEvent<SanityDocument>[] = []
+    const subscription = source
+      .pipe(dedupeListenerEvents({maxEntries: 2}))
+      .subscribe((e) => received.push(e))
+
+    source.next(createMutationEvent({transactionId: 'txn1'}))
+    source.next(createMutationEvent({transactionId: 'txn2'}))
+    source.next(createMutationEvent({transactionId: 'txn3'}))
+    // txn1 was evicted to make room, so a replay of it passes through again
+    source.next(createMutationEvent({transactionId: 'txn1'}))
+    expect(received).toHaveLength(4)
+
+    subscription.unsubscribe()
+  })
+})
+
+describe('groupTransactionEvents', () => {
+  it('passes single-event transactions through immediately', async () => {
+    const m1 = createMutationEvent({transactionId: 'txn1'})
+    const events = await lastValueFrom(listenEventsOf(m1).pipe(groupTransactionEvents(), toArray()))
+    expect(events).toEqual([m1])
+  })
+
+  it('holds multi-document transaction events until the transaction is complete', () => {
+    const source = new Subject<ListenEvent<SanityDocument>>()
+    const received: ListenEvent<SanityDocument>[] = []
+    const subscription = source.pipe(groupTransactionEvents()).subscribe((e) => received.push(e))
+
+    const draftEvent = createMutationEvent({
+      transactionId: 'txn-publish',
+      documentId: 'drafts.doc1',
+      transactionCurrentEvent: 1,
+      transactionTotalEvents: 2,
+    })
+    const publishedEvent = createMutationEvent({
+      transactionId: 'txn-publish',
+      documentId: 'doc1',
+      transactionCurrentEvent: 2,
+      transactionTotalEvents: 2,
+    })
+
+    source.next(draftEvent)
+    expect(received).toEqual([])
+
+    source.next(publishedEvent)
+    expect(received).toEqual([draftEvent, publishedEvent])
+
+    subscription.unsubscribe()
+  })
+
+  it('holds intervening events until the open transaction completes, then releases them after it', () => {
+    const source = new Subject<ListenEvent<SanityDocument>>()
+    const received: ListenEvent<SanityDocument>[] = []
+    const subscription = source.pipe(groupTransactionEvents()).subscribe((e) => received.push(e))
+
+    const draftEvent = createMutationEvent({
+      transactionId: 'txn-publish',
+      documentId: 'drafts.doc1',
+      transactionCurrentEvent: 1,
+      transactionTotalEvents: 2,
+    })
+    // an unrelated single-document mutation interleaved between the two
+    // halves of the publish (legacy listener pipeline behavior)
+    const intervening = createMutationEvent({transactionId: 'txn-other', documentId: 'doc9'})
+    const publishedEvent = createMutationEvent({
+      transactionId: 'txn-publish',
+      documentId: 'doc1',
+      transactionCurrentEvent: 2,
+      transactionTotalEvents: 2,
+    })
+
+    source.next(draftEvent)
+    source.next(intervening)
+    expect(received).toEqual([])
+
+    source.next(publishedEvent)
+    expect(received).toEqual([draftEvent, publishedEvent, intervening])
+
+    subscription.unsubscribe()
+  })
+
+  it('groups a held multi-document transaction after the open one completes', () => {
+    const source = new Subject<ListenEvent<SanityDocument>>()
+    const received: ListenEvent<SanityDocument>[] = []
+    const subscription = source.pipe(groupTransactionEvents()).subscribe((e) => received.push(e))
+
+    const a1 = createMutationEvent({
+      transactionId: 'txn-a',
+      documentId: 'drafts.doc1',
+      transactionTotalEvents: 2,
+    })
+    const b1 = createMutationEvent({
+      transactionId: 'txn-b',
+      documentId: 'drafts.doc2',
+      transactionTotalEvents: 2,
+    })
+    const b2 = createMutationEvent({
+      transactionId: 'txn-b',
+      documentId: 'doc2',
+      transactionTotalEvents: 2,
+    })
+    const a2 = createMutationEvent({
+      transactionId: 'txn-a',
+      documentId: 'doc1',
+      transactionTotalEvents: 2,
+    })
+
+    source.next(a1)
+    source.next(b1)
+    source.next(b2)
+    expect(received).toEqual([])
+
+    source.next(a2)
+    // txn-a completes and is emitted contiguously; the held txn-b events are
+    // re-processed and, being complete, emitted contiguously right after
+    expect(received).toEqual([a1, a2, b1, b2])
+
+    subscription.unsubscribe()
+  })
+
+  it('releases everything in arrival order when the held queue exceeds its cap', () => {
+    const source = new Subject<ListenEvent<SanityDocument>>()
+    const received: ListenEvent<SanityDocument>[] = []
+    const subscription = source
+      .pipe(groupTransactionEvents({maxHeldEvents: 2}))
+      .subscribe((e) => received.push(e))
+
+    const partial = createMutationEvent({
+      transactionId: 'txn-incomplete',
+      documentId: 'drafts.doc1',
+      transactionTotalEvents: 2,
+    })
+    const held1 = createMutationEvent({transactionId: 'txn-h1', documentId: 'doc8'})
+    const held2 = createMutationEvent({transactionId: 'txn-h2', documentId: 'doc9'})
+    const overflow = createMutationEvent({transactionId: 'txn-h3', documentId: 'doc10'})
+
+    source.next(partial)
+    source.next(held1)
+    source.next(held2)
+    expect(received).toEqual([])
+
+    source.next(overflow)
+    expect(received).toEqual([partial, held1, held2, overflow])
+
+    subscription.unsubscribe()
+  })
+
+  it('flushes buffered events before non-mutation events', () => {
+    const source = new Subject<ListenEvent<SanityDocument>>()
+    const received: ListenEvent<SanityDocument>[] = []
+    const subscription = source.pipe(groupTransactionEvents()).subscribe((e) => received.push(e))
+
+    const partial = createMutationEvent({
+      transactionId: 'txn-incomplete',
+      documentId: 'drafts.doc1',
+      transactionTotalEvents: 2,
+    })
+
+    source.next(partial)
+    source.next(reconnectEvent)
+    expect(received).toEqual([partial, reconnectEvent])
+
+    subscription.unsubscribe()
+  })
+
+  it('flushes an incomplete transaction and its held events after the deadline', () => {
+    vi.useFakeTimers()
+    const source = new Subject<ListenEvent<SanityDocument>>()
+    const received: ListenEvent<SanityDocument>[] = []
+    const subscription = source
+      .pipe(groupTransactionEvents({flushDeadline: 500}))
+      .subscribe((e) => received.push(e))
+
+    const partial = createMutationEvent({
+      transactionId: 'txn-incomplete',
+      documentId: 'drafts.doc1',
+      transactionTotalEvents: 2,
+    })
+    const heldBehind = createMutationEvent({transactionId: 'txn-held', documentId: 'doc9'})
+
+    source.next(partial)
+    source.next(heldBehind)
+    expect(received).toEqual([])
+
+    vi.advanceTimersByTime(500)
+    expect(received).toEqual([partial, heldBehind])
+
+    subscription.unsubscribe()
+  })
+
+  it('flushes buffered events on completion', async () => {
+    const partial = createMutationEvent({
+      transactionId: 'txn-incomplete',
+      documentId: 'drafts.doc1',
+      transactionTotalEvents: 2,
+    })
+    const events = await lastValueFrom(
+      listenEventsOf(partial).pipe(groupTransactionEvents(), toArray()),
+    )
+    expect(events).toEqual([partial])
+  })
+})

--- a/packages/core/src/document/listenerEventOperators.ts
+++ b/packages/core/src/document/listenerEventOperators.ts
@@ -1,0 +1,217 @@
+import {type ListenEvent, type MutationEvent} from '@sanity/client'
+import {type SanityDocument} from '@sanity/types'
+import {defer, filter, type MonoTypeOperatorFunction, Observable} from 'rxjs'
+
+import {setCleanupTimeout} from '../utils/setCleanupTimeout'
+
+const DEDUPE_TTL = 120_000
+const DEDUPE_MAX_ENTRIES = 1_000
+
+/**
+ * How long to hold an incomplete multi-document transaction (and the events
+ * held behind it) before releasing everything anyway. Only reached when part
+ * of a transaction is lost.
+ */
+const GROUP_FLUSH_DEADLINE = 30_000
+
+/**
+ * How many intervening events to hold behind an incomplete multi-document
+ * transaction before giving up on grouping and releasing everything in
+ * arrival order.
+ */
+const GROUP_MAX_HELD_EVENTS = 100
+
+interface DedupeOptions {
+  ttl?: number
+  maxEntries?: number
+}
+
+/**
+ * Drops mutation events that have already been observed, keyed by
+ * `transactionId#documentId`. With `enableResume`, the listener replays
+ * missed events after a reconnect on an at-least-once basis, so the same
+ * event can be delivered twice. A duplicate would never chain onto the
+ * current base revision and would clog the sequencing buffer until it
+ * overflows into an `OutOfSyncError`.
+ *
+ * Seen keys expire after `ttl` milliseconds and the cache is capped at
+ * `maxEntries`, evicting the oldest entries first.
+ *
+ * @internal
+ */
+export function dedupeListenerEvents(
+  options?: DedupeOptions,
+): MonoTypeOperatorFunction<ListenEvent<SanityDocument>> {
+  const {ttl = DEDUPE_TTL, maxEntries = DEDUPE_MAX_ENTRIES} = options ?? {}
+
+  return (source) =>
+    defer(() => {
+      // insertion-ordered map of dedupe key -> expiry timestamp
+      const seen = new Map<string, number>()
+
+      return source.pipe(
+        filter((event) => {
+          if (event.type !== 'mutation') return true
+
+          const key = `${event.transactionId}#${event.documentId}`
+          const now = Date.now()
+
+          const expiry = seen.get(key)
+          if (expiry !== undefined && expiry > now) return false
+
+          seen.delete(key)
+          seen.set(key, now + ttl)
+
+          for (const [existingKey, existingExpiry] of seen) {
+            if (seen.size <= maxEntries && existingExpiry > now) break
+            seen.delete(existingKey)
+          }
+
+          return true
+        }),
+      )
+    })
+}
+
+interface GroupTransactionEventsOptions {
+  flushDeadline?: number
+  maxHeldEvents?: number
+}
+
+/**
+ * Buffers the mutation events of multi-document transactions (e.g. a publish
+ * touching both the draft and the published document) until every event of
+ * the transaction has arrived, then emits them contiguously. Without this,
+ * a rebase can run between the two halves of a transaction and observe the
+ * dataset in a state that never existed on the server (draft deleted, but
+ * published not yet updated).
+ *
+ * The backend's streaming listener pipeline delivers a transaction's events
+ * contiguously and in order, but the legacy pipeline can interleave
+ * concurrent transactions. So while a multi-document transaction is
+ * incomplete, mutation events from other transactions are held (in arrival
+ * order) rather than emitted, and released right after the transaction
+ * completes; released events are re-processed so a held multi-document
+ * transaction is grouped too. Per-document `previousRev` sequencing
+ * downstream tolerates the reordering this introduces.
+ *
+ * Escape hatches so a lost event degrades to ungrouped delivery instead of
+ * stalling the stream: everything is released in arrival order when a
+ * non-mutation event (e.g. reconnect/welcome) arrives, when more than
+ * `maxHeldEvents` are held, or after `flushDeadline` milliseconds.
+ * Single-event transactions pass through untouched when nothing is buffered.
+ *
+ * @internal
+ */
+export function groupTransactionEvents(
+  options?: GroupTransactionEventsOptions,
+): MonoTypeOperatorFunction<ListenEvent<SanityDocument>> {
+  const {flushDeadline = GROUP_FLUSH_DEADLINE, maxHeldEvents = GROUP_MAX_HELD_EVENTS} =
+    options ?? {}
+
+  return (source) =>
+    new Observable<ListenEvent<SanityDocument>>((subscriber) => {
+      interface OpenTransaction {
+        transactionId: string
+        events: MutationEvent[]
+        total: number
+        timer: ReturnType<typeof setTimeout>
+      }
+
+      let open: OpenTransaction | null = null
+      let held: MutationEvent[] = []
+
+      // emits the open transaction's events (complete or not) without
+      // releasing the held queue; callers decide what happens to `held`
+      const closeOpen = () => {
+        if (!open) return
+        clearTimeout(open.timer)
+        const {events} = open
+        open = null
+        for (const event of events) subscriber.next(event)
+      }
+
+      // re-processes the held queue so a held multi-document transaction
+      // gets grouped in turn. processing may open a new transaction and top
+      // up a new held queue; each drain only touches its own snapshot, so
+      // this terminates
+      const releaseHeld = () => {
+        const queue = held
+        held = []
+        for (const event of queue) processEvent(event)
+      }
+
+      const releaseEverything = () => {
+        closeOpen()
+        const queue = held
+        held = []
+        for (const event of queue) subscriber.next(event)
+      }
+
+      const processEvent = (event: ListenEvent<SanityDocument>) => {
+        if (event.type !== 'mutation') {
+          // connection-level events (welcome/welcomeback/reset/reconnect)
+          // reset the world downstream; release everything before them
+          releaseEverything()
+          subscriber.next(event)
+          return
+        }
+
+        const isMultiDocument = (event.transactionTotalEvents ?? 0) > 1
+
+        if (!open) {
+          if (!isMultiDocument) {
+            subscriber.next(event)
+            return
+          }
+          // isMultiDocument guarantees total >= 2, so a freshly opened
+          // transaction is always incomplete; completion is checked when
+          // subsequent events of the same transaction arrive below
+          open = {
+            transactionId: event.transactionId,
+            events: [event],
+            total: event.transactionTotalEvents,
+            timer: setCleanupTimeout(() => {
+              closeOpen()
+              releaseHeld()
+            }, flushDeadline),
+          }
+          return
+        }
+
+        if (event.transactionId === open.transactionId) {
+          open.events.push(event)
+          if (open.events.length >= open.total) {
+            closeOpen()
+            releaseHeld()
+          }
+          return
+        }
+
+        // an event from another transaction while one is incomplete: hold it
+        // (legacy listener pipeline interleaving) instead of giving up on the
+        // open transaction
+        held.push(event)
+        if (held.length > maxHeldEvents) releaseEverything()
+      }
+
+      const subscription = source.subscribe({
+        next: processEvent,
+        error: (error) => {
+          releaseEverything()
+          subscriber.error(error)
+        },
+        complete: () => {
+          releaseEverything()
+          subscriber.complete()
+        },
+      })
+
+      return () => {
+        if (open) clearTimeout(open.timer)
+        open = null
+        held = []
+        subscription.unsubscribe()
+      }
+    })
+}

--- a/packages/core/src/document/sharedListener.test.ts
+++ b/packages/core/src/document/sharedListener.test.ts
@@ -49,7 +49,8 @@ describe('createSharedListener', () => {
       '*',
       {},
       {
-        events: ['mutation', 'welcome', 'reconnect'],
+        events: ['mutation', 'welcome', 'welcomeback', 'reconnect', 'reset'],
+        enableResume: true,
         includeResult: false,
         includeAllVersions: true,
         tag: 'document-listener',

--- a/packages/core/src/document/sharedListener.ts
+++ b/packages/core/src/document/sharedListener.ts
@@ -16,6 +16,7 @@ import {
 import {getClientState} from '../client/clientStore'
 import {type DocumentResource} from '../config/sanityConfig'
 import {type SanityInstance} from '../store/createSanityInstance'
+import {dedupeListenerEvents, groupTransactionEvents} from './listenerEventOperators'
 
 const API_VERSION = 'v2025-05-06'
 
@@ -41,7 +42,12 @@ export function createSharedListener(
         '*',
         {},
         {
-          events: ['mutation', 'welcome', 'reconnect'],
+          // with `enableResume`, a reconnect replays the events missed while
+          // offline (emitting `welcomeback`) instead of forcing a refetch of
+          // every subscribed document. when the backend cannot resume, it
+          // emits `welcome` or `reset`, both of which trigger a refetch
+          events: ['mutation', 'welcome', 'welcomeback', 'reconnect', 'reset'],
+          enableResume: true,
           includeResult: false,
           // the document store handles version documents, so we need to include all versions
           includeAllVersions: true,
@@ -53,6 +59,11 @@ export function createSharedListener(
         },
       ),
     ),
+    // resumed events are delivered at-least-once, so drop replayed duplicates
+    dedupeListenerEvents(),
+    // hold multi-document transactions (e.g. publish) until complete so
+    // per-document processing never observes half a transaction
+    groupTransactionEvents(),
     takeUntil(dispose$),
     share(),
   )


### PR DESCRIPTION
### Description

Three reliability improvements to how listener events are ingested, aimed at reconnects and multi-document transactions.

1. **Listener resume.** The shared listener now passes `enableResume: true` and subscribes to `welcomeback`/`reset`. A reconnect replays the events missed while offline instead of refetching every subscribed document. When the backend cannot resume, it emits `welcome` or `reset`; both trigger a snapshot refetch (the previous behavior). If the API host does not support resume at all, the client falls back to emitting `welcome` on reconnect, which is exactly the old refetch path.
2. **Dedupe and replay discard.** Resumed events are delivered at least once. A duplicate mutation event would never chain onto the current base revision, so it sat in the sequencing buffer until it overflowed into an `OutOfSyncError` (a full refetch plus backoff). Two layers now prevent that: a TTL dedupe cache keyed by `transactionId#documentId` in the shared listener, and chain-discard in `sortListenerEvents`, which orders buffered events into `previousRev`/`resultRev` chains and discards chains the freshly fetched snapshot already reflects (the same design as `@sanity/mutate`'s `sequentializeListenerEvents`; mutate does not export it from its published entry points, so the equivalent lives here).
3. **Multi-document transaction grouping.** The mutation events of one transaction touching several documents (a publish touches draft + published) are buffered until the transaction is complete, then emitted contiguously. Without this, a rebase can run between the two halves and observe a dataset state that never existed on the server (draft deleted, published not yet updated). While a transaction is incomplete, intervening mutation events from other transactions are held in arrival order and released right after it completes (matching Studio's `getPairListener` approach), because the legacy listener pipeline can interleave concurrent transactions; flushing on interleave would defeat grouping exactly where it is needed. Held events are re-processed on release, so a held multi-document transaction gets grouped too, and per-document `previousRev` sequencing downstream tolerates the reordering. Escape hatches keep a lost event from stalling the stream: everything is released in arrival order when a non-mutation event arrives, when the held queue exceeds 100 events, or after a 30s deadline.

**Backend verification (gradient):** resume is implemented in the streaming listener pipeline (`Last-Event-ID` token replay with a roughly 5 minute retention window; `reset` beyond that, which we refetch on). Replay is no-duplicates by design, so the dedupe here is insurance, plus protection on the legacy pipeline whose gap detector explicitly tolerates duplicates. The server also force-drops every listener connection after roughly 4 hours, so resume turns a guaranteed periodic refetch-everything into a seamless replay. Transaction-event contiguity is guaranteed by the streaming pipeline only; the legacy pipeline can interleave concurrent transactions, which is why the grouping buffer holds intervening events instead of giving up.

Stacked on #1057.

### What to review

- `packages/core/src/document/listenerEventOperators.ts` (new): the TTL cache eviction in `dedupeListenerEvents` and the buffer/flush lifecycle in `groupTransactionEvents` (including timer cleanup on unsubscribe).
- `sharedListener.ts`: the listen options (`enableResume`, event list) and where the two operators sit in the shared pipeline.
- `listen.ts`: `reset` now refetches like `welcome`, `welcomeback` deliberately does not; and the reworked `sortListenerEvents` scan body (`toOrderedChains` + `discardChainTo`). The error classes, buffer size, and deadline semantics are unchanged.

### Testing

- New unit tests in `listenerEventOperators.test.ts` (12 tests): dedupe uniqueness, per-document keys, TTL expiry, max-entry eviction, pass-through of non-mutation events; grouping hold/complete, holding intervening events until the open transaction completes, grouping a held multi-document transaction after release, held-queue overflow, flush before non-mutation events, deadline flush of the transaction and its held events, flush on completion.
- New `sortListenerEvents` tests for replay discard: single replayed event, partially replayed chain, and a multi-event replayed chain.
- `sharedListener.test.ts` updated for the new listen options.
- Full core suite (1068 tests), repo type check, and lint are green.
- Live gate: Snorre's Playwright concurrency harness (13 scenarios against a real dataset) run with this stack and with SDK `main` as baseline produced identical scores, confirming no regression on the wire-level behavior.

### Fun gif

![Reconnecting without losing anything](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWxvOGQ4cTZxNmdpOHV2cGQ3aGgwMTA0MTZuNTVsY25kemdxMjVxOCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0IxYD16t9PDEdg9q/giphy.gif)


