### PR TITLE
fix(core): stop fabricating array items for unresolvable keyed set paths

### DIFF
--- a/packages/core/src/document/patchOperations.test.ts
+++ b/packages/core/src/document/patchOperations.test.ts
@@ -274,10 +274,51 @@ describe('set', () => {
     expect(output).toEqual({a: 1, nonexistent: {path: 999}})
   })
 
-  it('creates an item from a key constraint if the key is not present', () => {
+  // Content Lake never creates array items when setting: a keyed or indexed
+  // segment that does not resolve is a silent no-op server-side. The applier
+  // used to append a degenerate item (without the key, even), which
+  // fabricated array items locally that would never exist on the server.
+  it('does not create an item from a key constraint if the key is not present', () => {
     const input = {items: [{_key: 'item1'}]}
     const output = set(input, {'items[_key=="item2"]': {_key: 'item2'}})
-    expect(output).toEqual({items: [{_key: 'item1'}, {_key: 'item2'}]})
+    expect(output).toEqual({items: [{_key: 'item1'}]})
+  })
+
+  it('does not create an item when setting a property under an unresolvable key constraint', () => {
+    const input = {
+      blocks: [
+        {
+          _key: 'b1',
+          children: [{_key: 's1', _type: 'span', text: 'hello', marks: []}],
+        },
+      ],
+    }
+    const output = set(input, {'blocks[_key=="b1"].children[_key=="missing"].marks': ['mark1']})
+    expect(output).toEqual(input)
+  })
+
+  it('does not create an item when setting through an out-of-bounds index', () => {
+    const input = {items: [{_key: 'item1', value: 1}]}
+    const output = set(input, {'items[3].value': 99})
+    expect(output).toEqual(input)
+  })
+
+  it('still sets a missing property on an existing keyed item', () => {
+    const input = {items: [{_key: 'item1'}]}
+    const output = set(input, {'items[_key=="item1"].value': 42})
+    expect(output).toEqual({items: [{_key: 'item1', value: 42}]})
+  })
+
+  it('does not create anything when an array-addressing segment targets a non-array', () => {
+    const input = {items: {nested: true}}
+    const output = set(input, {'items[_key=="item1"].value': 42})
+    expect(output).toEqual(input)
+  })
+
+  it('does not create an item when setting through a negative out-of-bounds index', () => {
+    const input = {items: [{_key: 'item1', value: 1}]}
+    const output = set(input, {'items[-5].value': 99})
+    expect(output).toEqual(input)
   })
 })
 
@@ -298,6 +339,12 @@ describe('setIfMissing', () => {
     const input = {a: {b: 1}}
     const output = setIfMissing(input, {'a.b': 42})
     expect(output).toEqual({a: {b: 1}})
+  })
+
+  it('does not create an item under an unresolvable key constraint', () => {
+    const input = {items: [{_key: 'item1'}]}
+    const output = setIfMissing(input, {'items[_key=="missing"].value': 1})
+    expect(output).toEqual(input)
   })
 })
 

--- a/packages/core/src/document/patchOperations.ts
+++ b/packages/core/src/document/patchOperations.ts
@@ -176,6 +176,54 @@ export const ensureArrayKeysDeep = memoize(<R>(input: R): R => {
 })
 
 /**
+ * Whether every array-addressing segment (keyed `[_key=="…"]` or numeric
+ * index) in the given match path resolves to an existing array item.
+ *
+ * This mirrors Content Lake, which auto-creates missing *object* properties
+ * when setting but never creates *array items*:
+ *
+ * ```js
+ * // object properties are created, even nested ones:
+ * set({}, {'meta.author.name': 'Ada'})
+ * // -> {meta: {author: {name: 'Ada'}}}                    (applies)
+ *
+ * // array items are not:
+ * set({items: [{_key: 'a'}]}, {'items[_key=="b"].title': 'x'})
+ * // -> {items: [{_key: 'a'}]}                             (no-op)
+ * ```
+ *
+ * Without this filter, the second example fabricated a degenerate item
+ * (`{title: 'x'}`, no `_key`) that would never exist on the server, which
+ * is how concurrent Portable Text edits grew phantom span-less children.
+ */
+function resolvesArraySegments(input: unknown, path: SingleValuePath): boolean {
+  let current: unknown = input
+  for (const segment of path) {
+    if (typeof segment === 'string') {
+      // missing object properties (nested ones included) are created
+      // server-side, so a string segment may descend into undefined
+      current =
+        typeof current === 'object' && current !== null && !Array.isArray(current)
+          ? (current as Record<string, unknown>)[segment]
+          : undefined
+      continue
+    }
+    // keyed and numeric segments address array items, which are never created
+    if (!Array.isArray(current)) return false
+    if (isKeySegment(segment)) {
+      const index = getIndexForKey(current, segment._key)
+      if (index === undefined) return false
+      current = current[index]
+    } else {
+      const index = segment < 0 ? current.length + segment : segment
+      if (!(index in current)) return false
+      current = current[index]
+    }
+  }
+  return true
+}
+
+/**
  * Given an input object and a record of path expressions to values, this
  * function will set each match with the given value.
  *
@@ -198,6 +246,7 @@ export function set(input: unknown, pathExpressionValues: Record<string, unknown
         replacementValue,
       })),
     )
+    .filter(({path}) => resolvesArraySegments(input, path))
     .reduce((acc, {path, replacementValue}) => setDeep(acc, path, replacementValue), input)
 
   return ensureArrayKeysDeep(result)
@@ -231,6 +280,7 @@ export function setIfMissing(
       }))
     })
     .filter((matchEntry) => matchEntry.value === null || matchEntry.value === undefined)
+    .filter(({path}) => resolvesArraySegments(input, path))
     .reduce((acc, {path, replacementValue}) => setDeep(acc, path, replacementValue), input)
 
   return ensureArrayKeysDeep(result)


### PR DESCRIPTION
### Description

Fixes the client-side patch applier fabricating array items the server never creates, which turned out to be the root cause of the `Unexpected node type` crashes in the concurrent Portable Text editing harness.

Content Lake never creates array items when applying a `set`: a keyed (`[_key=="…"]`) or indexed segment that does not resolve is a silent no-op server-side (verified against gradient's jsonpath matcher, which only auto-creates missing object properties, `pkg/documents/mutation/jsonpath`). The SDK's local applier instead appended a degenerate item, without even the key from the constraint:

```js
set(doc, {'blocks[_key=="b1"].children[_key=="missing"].marks': ['m1']})
// before: children grows a phantom {marks: ['m1']} item (no _key, _type, or text)
// after:  no-op, matching the server
```

Under concurrent editing this was a crash factory: client A formats a span that client B's concurrent split already replaced, the `set` targets a `_key` that no longer exists, and every receiving client's local snapshot grows a phantom span-less child. The server stays valid (it no-ops), but the PT plugin's repair sync faithfully converges the editor to the corrupted local snapshot and the editor render layer throws `Uncaught Error: Unexpected node type` (`use-children.tsx`). This was captured directly with crash forensics in the harness: the malformed `{marks: []}` child and the exact patch that fabricated it.

`set` and `setIfMissing` now skip matches whose array-addressing segments do not resolve. Missing object properties (nested included) are still auto-created, matching the server.

Stacked on #1058.

### What to review

- `resolvesArraySegments` in `packages/core/src/document/patchOperations.ts` and its use in `set`/`setIfMissing`. `unset`, `insert`, `inc`/`dec`, and `diffMatchPatch` already no-op on unresolvable targets.
- The flipped expectation in `patchOperations.test.ts`: the old test asserting that an unmatched key constraint creates the item is replaced by the server-parity no-op, plus new cases (unresolvable keyed property path, out-of-bounds index, missing property on an existing keyed item still created).
- Note this applier backs both optimistic local application and the listener echo reconstruction (`processMutations`), so the fix stops phantom items in all local snapshots.

### Testing

- New/updated unit tests in `patchOperations.test.ts`; full core suite (1080 tests), repo type check, and lint green.
- Harness (Snorre's concurrency rig, local editor build with the #2977 fixes + this SDK build): before the fix, `bold-overlap-range` and `link-overlap-range` crashed in roughly 1 of 3 trials with `Unexpected node type`; after the fix, 0 crashes across 10 focused trials plus a full 13-scenario matrix at 2 trials each. The remaining SILENT-LOSS scores are convergence-timing divergences with identical text on both clients and the server (see PR discussion), not data loss or corruption.

### Fun gif

![No more phantoms](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHgwZzc4anprYzMxbHJveXJjNjgwbHVzeDJtd2dzaGJkbjhtazFweSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xVikRWcBqfV8xiR4E9/giphy.gif)
