### PR TITLE
fix(core): keep in-flight outgoing visible on foreign rebase

### DIFF
--- a/packages/core/src/document/reducers.test.ts
+++ b/packages/core/src/document/reducers.test.ts
@@ -854,6 +854,220 @@ describe('applyRemoteDocument', () => {
     expect(newDocState?.local).toEqual(remote.document)
   })
 
+  /**
+   * Paste-loss H1 (duo-typing paste): when pastes sit only in `outgoing` (1s
+   * throttle) and a foreign mutation arrives with `applied` empty, rebase must
+   * still re-apply outgoing onto the new remote for local EDGE (mutator-style
+   * HEAD + submitted + pending) so in-flight paste text stays visible.
+   */
+  it('H1: rebase with empty applied retains outgoing paste text on local', () => {
+    const docId = getDraftId(DocumentId('doc1'))
+    const seedText = 'A: There is an armadillo in the restaurant and it wants a taco '
+    const pastePhrase = "I'm feeling pretty good honestly. "
+    const pastedText = `${seedText}${pastePhrase}${pastePhrase}${pastePhrase}`
+    const seedBlocks = [
+      {
+        _key: 'blockA',
+        _type: 'block',
+        children: [
+          {
+            _key: 'spanA',
+            _type: 'span',
+            text: seedText,
+            marks: [],
+          },
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _key: 'blockB',
+        _type: 'block',
+        children: [{_key: 'spanB', _type: 'span', text: 'B: peer', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+    const localWithPastes = {
+      ...exampleDoc,
+      _id: docId,
+      _rev: 'txnPasteOutgoing',
+      blocks: [
+        {
+          ...seedBlocks[0],
+          children: [
+            {
+              ...seedBlocks[0].children[0],
+              text: pastedText,
+            },
+          ],
+        },
+        seedBlocks[1],
+      ],
+    }
+    // Foreign peer typed in block B; remote has no paste copies yet.
+    const remoteWithoutPastes = {
+      ...exampleDoc,
+      _id: docId,
+      _rev: 'txnForeign',
+      blocks: [
+        seedBlocks[0],
+        {
+          ...seedBlocks[1],
+          children: [{_key: 'spanB', _type: 'span', text: 'B: peer typed', marks: []}],
+        },
+      ],
+    }
+
+    const seedDoc = {...exampleDoc, _id: docId, _rev: 'txn0', blocks: seedBlocks}
+    const outgoing = {
+      transactionId: 'txnPasteOutgoing',
+      actions: [
+        {
+          type: 'document.edit' as const,
+          documentId: 'doc1',
+          documentType: 'author',
+          patches: [
+            {
+              set: {
+                'blocks[_key=="blockA"].children[_key=="spanA"].text': pastedText,
+              },
+            },
+          ],
+          preserveOperations: true,
+        },
+      ],
+      working: {[docId]: localWithPastes},
+      previous: {[docId]: seedDoc},
+      base: {[docId]: seedDoc},
+      previousRevs: {[docId]: 'txn0'},
+      timestamp: '2025-02-06T00:08:00.000Z',
+      outgoingActions: [],
+      outgoingMutations: [],
+      disableBatching: false,
+      batchedTransactionIds: ['txnPasteOutgoing'],
+    }
+
+    const initialState: SyncTransactionState = {
+      queued: [],
+      applied: [],
+      outgoing,
+      grants,
+      documentStates: {
+        [docId]: {
+          id: docId,
+          subscriptions: ['sub-paste'],
+          local: localWithPastes,
+          remote: seedDoc,
+          unverifiedRevisions: {
+            txnPasteOutgoing: {
+              transactionId: 'txnPasteOutgoing',
+              documentId: docId,
+              previousRev: 'txn0',
+              timestamp: '2025-02-06T00:08:00.000Z',
+            },
+          },
+        },
+      },
+    }
+
+    const remote: RemoteDocument = {
+      type: 'mutation',
+      documentId: docId,
+      document: remoteWithoutPastes,
+      revision: 'txnForeign',
+      previousRev: 'txn0',
+      timestamp: '2025-02-06T00:08:01.000Z',
+      mutations: [],
+    }
+
+    const events = new Subject<DocumentEvent>()
+    const newState = applyRemoteDocument(initialState, remote, events)
+    const nextLocal = newState.documentStates[docId]?.local as {
+      blocks?: {children?: {text?: string}[]}[]
+    }
+    const blockTexts = (nextLocal?.blocks ?? []).map((block) =>
+      (block.children ?? []).map((child) => child.text ?? '').join(''),
+    )
+    const pasteCount = blockTexts.join('').split("I'm feeling").length - 1
+
+    expect(pasteCount).toBe(3)
+    expect(blockTexts[1]).toBe('B: peer typed')
+    expect(newState.outgoing?.transactionId).toBe('txnPasteOutgoing')
+    // Outgoing object itself is unchanged (already submitted).
+    expect(newState.outgoing).toBe(outgoing)
+  })
+
+  it('does not re-apply outgoing onto its own echo (avoids duplicated patches)', () => {
+    const docId = getDraftId(DocumentId('doc1'))
+    const seedDoc = {...exampleDoc, _id: docId, _rev: 'txn0', title: 'alpha bravo'}
+    const withOwnEdit = {...seedDoc, _rev: 'txnOwn', title: 'alpha oneA bravo'}
+    // Echo result already includes our edit; previousRev mismatch forces rebase.
+    const ownEchoWithPeer = {...seedDoc, _rev: 'txnOwn', title: 'alpha oneA bravo twoB'}
+
+    const outgoing = {
+      transactionId: 'txnOwn',
+      actions: [
+        {
+          type: 'document.edit' as const,
+          documentId: 'doc1',
+          documentType: 'author',
+          patches: [{set: {title: 'alpha oneA bravo'}}],
+          preserveOperations: true,
+        },
+      ],
+      working: {[docId]: withOwnEdit},
+      previous: {[docId]: seedDoc},
+      base: {[docId]: seedDoc},
+      previousRevs: {[docId]: 'txn0'},
+      timestamp: '2025-02-06T00:08:00.000Z',
+      outgoingActions: [],
+      outgoingMutations: [],
+      disableBatching: false,
+      batchedTransactionIds: ['txnOwn'],
+    }
+
+    const initialState: SyncTransactionState = {
+      queued: [],
+      applied: [],
+      outgoing,
+      grants,
+      documentStates: {
+        [docId]: {
+          id: docId,
+          subscriptions: ['sub-own'],
+          local: withOwnEdit,
+          remote: seedDoc,
+          unverifiedRevisions: {
+            txnOwn: {
+              transactionId: 'txnOwn',
+              documentId: docId,
+              previousRev: 'txn0',
+              timestamp: '2025-02-06T00:08:00.000Z',
+            },
+          },
+        },
+      },
+    }
+
+    const remote: RemoteDocument = {
+      type: 'mutation',
+      documentId: docId,
+      document: ownEchoWithPeer,
+      revision: 'txnOwn',
+      // Peer slipped in: stored previousRev was txn0 but server saw peer first.
+      previousRev: 'txnPeer',
+      timestamp: '2025-02-06T00:08:02.000Z',
+      mutations: [],
+    }
+
+    const newState = applyRemoteDocument(initialState, remote, new Subject<DocumentEvent>())
+    expect(newState.documentStates[docId]?.local).toEqual(ownEchoWithPeer)
+    expect((newState.documentStates[docId]?.local as {title?: string}).title).toBe(
+      'alpha oneA bravo twoB',
+    )
+  })
+
   // Test that a sync event removes outdated unverified revisions.
   it('removes outdated unverified revisions when a sync event is received', () => {
     const docId = getDraftId(DocumentId('doc1'))

--- a/packages/core/src/document/reducers.test.ts
+++ b/packages/core/src/document/reducers.test.ts
@@ -14,6 +14,7 @@ import {
   applyRemoteDocument,
   batchAppliedTransactions,
   cleanupOutgoingTransaction,
+  type OutgoingTransaction,
   type QueuedTransaction,
   queueTransaction,
   removeQueuedTransaction,
@@ -1068,6 +1069,108 @@ describe('applyRemoteDocument', () => {
     )
   })
 
+  it('does not re-apply outgoing when foreign revisions already include it', () => {
+    const docId = getDraftId(DocumentId('doc1'))
+    const seedDoc = {
+      ...exampleDoc,
+      _id: docId,
+      _rev: 'txn0',
+      items: [
+        {_key: 'a', value: 'first'},
+        {_key: 'b', value: 'second'},
+      ],
+    }
+    const withOwnInsert = {
+      ...seedDoc,
+      _rev: 'txnOwn',
+      items: [
+        {_key: 'a', value: 'first'},
+        {_key: 'c', value: 'from own transaction'},
+        {_key: 'b', value: 'second'},
+      ],
+    }
+    const remoteAlreadyIncludingOwn = {
+      ...seedDoc,
+      _rev: 'txnForeign',
+      items: [
+        {_key: 'a', value: 'first'},
+        {_key: 'c', value: 'from own transaction'},
+        {_key: 'b', value: 'second'},
+        {_key: 'd', value: 'from peer transaction'},
+      ],
+    }
+
+    const outgoing = {
+      transactionId: 'txnOwn',
+      actions: [
+        {
+          type: 'document.edit' as const,
+          documentId: 'doc1',
+          documentType: 'author',
+          patches: [
+            {
+              insert: {
+                after: 'items[_key=="a"]',
+                items: [{_key: 'c', value: 'from own transaction'}],
+              },
+            },
+          ],
+          preserveOperations: true,
+        },
+      ],
+      working: {[docId]: withOwnInsert},
+      previous: {[docId]: seedDoc},
+      base: {[docId]: seedDoc},
+      previousRevs: {[docId]: 'txn0'},
+      timestamp: '2025-02-06T00:08:00.000Z',
+      outgoingActions: [],
+      outgoingMutations: [],
+      disableBatching: false,
+      batchedTransactionIds: ['txnOwn'],
+    }
+
+    const initialState: SyncTransactionState = {
+      queued: [],
+      applied: [],
+      outgoing,
+      grants,
+      documentStates: {
+        [docId]: {
+          id: docId,
+          subscriptions: ['sub-own'],
+          local: withOwnInsert,
+          remote: seedDoc,
+          unverifiedRevisions: {
+            txnOwn: {
+              transactionId: 'txnOwn',
+              documentId: docId,
+              previousRev: 'txn0',
+              timestamp: '2025-02-06T00:08:00.000Z',
+            },
+          },
+        },
+      },
+    }
+
+    const remote: RemoteDocument = {
+      type: 'mutation',
+      documentId: docId,
+      document: remoteAlreadyIncludingOwn,
+      revision: 'txnForeign',
+      previousRev: 'txnOwn',
+      timestamp: '2025-02-06T00:08:02.000Z',
+      mutations: [],
+    }
+
+    const newState = applyRemoteDocument(initialState, remote, new Subject<DocumentEvent>())
+    expect(newState.documentStates[docId]?.local?.['items']).toEqual([
+      {_key: 'a', value: 'first'},
+      {_key: 'c', value: 'from own transaction'},
+      {_key: 'b', value: 'second'},
+      {_key: 'd', value: 'from peer transaction'},
+    ])
+  })
+
   // Test that a sync event removes outdated unverified revisions.
   it('removes outdated unverified revisions when a sync event is received', () => {
     const docId = getDraftId(DocumentId('doc1'))
@@ -1339,6 +1442,90 @@ describe('applyRemoteDocument', () => {
   })
 
   describe('rebase with preserved operations', () => {
+    it('emits rebase-error when outgoing re-apply fails', () => {
+      const docId = getDraftId(DocumentId('doc1'))
+      const originalDoc: SanityDocument = {
+        ...exampleDoc,
+        _id: docId,
+        _rev: 'rev1',
+        title: 'The quick brown fox',
+      }
+      const localDoc: SanityDocument = {
+        ...originalDoc,
+        _rev: 'txnLocal',
+        title: 'The quick brown cat',
+      }
+      const outgoing: OutgoingTransaction = {
+        transactionId: 'txnLocal',
+        actions: [
+          {
+            type: 'document.edit',
+            documentId: 'doc1',
+            documentType: 'author',
+            patches: [{diffMatchPatch: {title: '@@ -13,7 +13,7 @@\n own \n-fox\n+cat\n'}}],
+            preserveOperations: true,
+          },
+        ],
+        previous: {[docId]: originalDoc},
+        base: {[docId]: originalDoc},
+        working: {[docId]: localDoc},
+        previousRevs: {[docId]: 'rev1'},
+        timestamp: '2025-02-06T00:16:00.000Z',
+        outgoingActions: [],
+        outgoingMutations: [],
+        disableBatching: false,
+        batchedTransactionIds: ['txnLocal'],
+      }
+
+      const initialState: SyncTransactionState = {
+        queued: [],
+        applied: [],
+        outgoing,
+        grants,
+        documentStates: {
+          [docId]: {
+            id: docId,
+            subscriptions: ['sub1'],
+            local: localDoc,
+            remote: originalDoc,
+            unverifiedRevisions: {},
+          },
+        },
+      }
+
+      const remoteDoc: SanityDocument = {
+        ...originalDoc,
+        title: 42 as unknown as string,
+        _rev: 'txnForeign',
+      }
+      const remote: RemoteDocument = {
+        type: 'mutation',
+        documentId: docId,
+        document: remoteDoc,
+        revision: 'txnForeign',
+        previousRev: 'rev1',
+        timestamp: '2025-02-06T00:17:00.000Z',
+        mutations: [{patch: {id: docId, set: {title: 42}}}],
+      }
+
+      const events = new Subject<DocumentEvent>()
+      const received: DocumentEvent[] = []
+      events.subscribe((event) => received.push(event))
+
+      const newState = applyRemoteDocument(initialState, remote, events)
+      const rebaseErrors = received.filter((event) => event.type === 'rebase-error')
+
+      expect(rebaseErrors).toHaveLength(1)
+      expect(rebaseErrors[0]).toMatchObject({
+        type: 'rebase-error',
+        transactionId: 'txnLocal',
+        documentId: 'doc1',
+        message: expect.stringMatching(/Failed to apply patches to the working document/),
+      })
+      expect(newState.documentStates[docId]?.local).toEqual(remoteDoc)
+      expect(newState.documentStates[docId]?.remote).toEqual(remoteDoc)
+    })
+
     it('skips a preserved-operations transaction that fails to re-apply and emits rebase-error', () => {
       const docId = getDraftId(DocumentId('doc1'))
       const originalDoc: SanityDocument = {

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -469,6 +469,50 @@ function extractPatchOperations(
   })
 }
 
+// Opt-in sync diagnostics for concurrency investigations: set
+// `globalThis.__SDK_SYNC_DEBUG = true` before load (harness: SYNC_DEBUG=1).
+// Free when off.
+function syncDebugEnabled(): boolean {
+  return (globalThis as {__SDK_SYNC_DEBUG?: boolean}).__SDK_SYNC_DEBUG === true
+}
+
+type SyncDebugDigest = {
+  sample: string
+  chars: number
+  /** Count of the duo-paste harness phrase; useful for H1 outgoing-wipe traces. */
+  imFeeling: number
+}
+
+/** Compact digest of Portable-Text-shaped fields for `[sdk-sync]` trace lines. */
+function syncDebugTextDigest(doc: unknown): SyncDebugDigest {
+  if (!doc || typeof doc !== 'object') {
+    return {sample: '<none>', chars: 0, imFeeling: 0}
+  }
+  for (const field of ['blocks', 'content']) {
+    const value = (doc as Record<string, unknown>)[field]
+    if (!Array.isArray(value)) continue
+    const sample = value
+      .map((blockNode) => {
+        const children = (blockNode as {children?: {text?: string}[]}).children
+        if (!Array.isArray(children)) return ''
+        return children.map((child) => child.text ?? '').join('|')
+      })
+      .join(' ¶ ')
+    return {
+      sample: sample.length > 240 ? `${sample.slice(0, 240)}…` : sample,
+      chars: sample.length,
+      imFeeling: sample.split("I'm feeling").length - 1,
+    }
+  }
+  return {sample: '<no pte field>', chars: 0, imFeeling: 0}
+}
+
+function syncDebug(label: string, payload: Record<string, unknown>): void {
+  if (!syncDebugEnabled()) return
+  // eslint-disable-next-line no-console
+  console.debug(`[sdk-sync] ${label} ${JSON.stringify(payload)}`)
+}
+
 export function applyRemoteDocument(
   prev: SyncTransactionState,
   {document, documentId, previousRev, revision, timestamp, type, mutations}: RemoteDocument,
@@ -480,6 +524,22 @@ export function applyRemoteDocument(
   // document state is deleted when there are no more subscribers so we can
   // simply skip if there is no state
   if (!prevDocState) return prev
+
+  const prevLocalDigest = syncDebugTextDigest(prevDocState.local)
+  const remoteDigest = syncDebugTextDigest(document)
+  syncDebug('remote-in', {
+    documentId,
+    type,
+    revision,
+    previousRev,
+    own: Boolean(revision && prevDocState.unverifiedRevisions?.[revision]),
+    appliedTxs: prev.applied.map((transaction) => transaction.transactionId),
+    appliedCount: prev.applied.length,
+    outgoingTx: prev.outgoing?.transactionId ?? null,
+    outgoingPresent: Boolean(prev.outgoing),
+    remote: remoteDigest,
+    local: prevLocalDigest,
+  })
 
   // we send out transactions with IDs generated client-side to identify them
   // when they are observed through the listener. here we can check if this
@@ -562,6 +622,15 @@ export function applyRemoteDocument(
         ? document
         : prevDocState.local
 
+    const localDigest = syncDebugTextDigest(local)
+    syncDebug('fast-forward', {
+      documentId,
+      revision,
+      converged: nothingElsePending,
+      local: localDigest,
+      localLostImFeeling: localDigest.imFeeling < prevLocalDigest.imFeeling,
+    })
+
     return {
       ...prev,
       documentStates: {
@@ -587,14 +656,60 @@ export function applyRemoteDocument(
   let working = {...previous, [documentId]: document}
   const nextApplied: AppliedTransaction[] = []
 
+  // When pastes (or other edits) sit only in `outgoing` with an empty `applied`
+  // queue, re-apply that submitted transaction onto the new remote for local
+  // EDGE only. Mutator keeps submitted work on EDGE; without this, local snaps
+  // to remote and the plugin can repair away in-flight paste text. Do not mutate
+  // `outgoing` itself; `processActions`/`processMutations` mutate document sets
+  // in place, so clone `base`/`previous` before re-applying. Skip when `applied`
+  // is non-empty: those txns already sit on the outgoing optimistic chain, and
+  // replaying both double-applies.
+  if (
+    prev.outgoing &&
+    prev.grants &&
+    prev.outgoing.actions.length > 0 &&
+    prev.applied.length === 0 &&
+    // Own echo already includes this transaction's result; re-applying would
+    // duplicate inserts/DMP hunks (e.g. `oneA oneA`).
+    prev.outgoing.transactionId !== revision
+  ) {
+    try {
+      const next = processActions({
+        transactionId: prev.outgoing.transactionId,
+        actions: prev.outgoing.actions,
+        timestamp: prev.outgoing.timestamp,
+        base: structuredClone(prev.outgoing.base),
+        working: {
+          ...structuredClone(prev.outgoing.previous),
+          [documentId]: document,
+        },
+        grants: prev.grants,
+        identity: prev.identity,
+      })
+      working = next.working
+    } catch (error) {
+      if (error instanceof ActionError) {
+        syncDebug('outgoing-rebase-error', {
+          documentId: error.documentId,
+          transactionId: error.transactionId,
+          message: error.message,
+        })
+        events.next({
+          type: 'rebase-error',
+          transactionId: error.transactionId,
+          documentId: error.documentId,
+          message: error.message,
+          error,
+        })
+      } else {
+        throw error
+      }
+    }
+  }
+
   // now we can iterate through our applied (but not yet committed) transactions
   // starting with the updated working set and re-apply each transaction in
   // order creating a new set of applied transactions as we go.
-  //
-  // NOTE: we don't want to rebase over the outgoing transaction because that
-  // transaction is already on its way to the server. if an outgoing transaction
-  // needs to be rebased, then it eventually will be when we see that
-  // transaction again through the listener and this same flow will run then
   for (const curr of prev.applied) {
     try {
       const next = processActions({...curr, working, grants: prev.grants, identity: prev.identity})
@@ -608,6 +723,13 @@ export function applyRemoteDocument(
       // if processing the action ever throws a related error, we can skip this
       // local transaction and report the error to the user
       if (error instanceof ActionError) {
+        syncDebug('rebase-error', {
+          documentId: error.documentId,
+          transactionId: error.transactionId,
+          message: error.message,
+          outgoingPresent: Boolean(prev.outgoing),
+          appliedCount: prev.applied.length,
+        })
         events.next({
           type: 'rebase-error',
           transactionId: error.transactionId,
@@ -626,6 +748,22 @@ export function applyRemoteDocument(
   // reference so subscribers don't re-render for an identical value
   const nextLocal = working[documentId]
   const local = isDeepEqual(prevDocState.local, nextLocal) ? prevDocState.local : nextLocal
+
+  const localDigest = syncDebugTextDigest(local)
+  syncDebug('rebase', {
+    documentId,
+    revision,
+    outgoingPresent: Boolean(prev.outgoing),
+    outgoingTx: prev.outgoing?.transactionId ?? null,
+    appliedCountBefore: prev.applied.length,
+    replayedTxs: nextApplied.map((transaction) => transaction.transactionId),
+    // After Phase 1, outgoing is re-applied for local EDGE before this digest.
+    local: localDigest,
+    remote: remoteDigest,
+    prevLocal: prevLocalDigest,
+    localLostImFeeling: localDigest.imFeeling < prevLocalDigest.imFeeling,
+    localLostChars: localDigest.chars < prevLocalDigest.chars,
+  })
 
   return {
     ...prev,

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -1,5 +1,10 @@
 import {DocumentId, getDraftId, getPublishedId, getVersionId} from '@sanity/id-utils'
-import {type Mutation, type PatchOperations, type SanityDocumentLike} from '@sanity/types'
+import {
+  type Mutation,
+  type PatchOperations,
+  type SanityDocument,
+  type SanityDocumentLike,
+} from '@sanity/types'
 
 import {type DocumentHandle} from '../config/sanityConfig'
 import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
@@ -15,7 +20,9 @@ import {ActionError, processActions} from './processActions/processActions'
 import {getReleaseDocumentId, isReleaseAction} from './processActions/releaseUtil'
 import {type DocumentSet} from './processMutations'
 
-const EMPTY_REVISIONS: NonNullable<Required<DocumentState['unverifiedRevisions']>> = {}
+type UnverifiedRevisions = NonNullable<Required<DocumentState['unverifiedRevisions']>>
+
+const EMPTY_REVISIONS: UnverifiedRevisions = {}
 
 /**
  * How many of this client's own transaction IDs to remember per document for
@@ -469,48 +476,201 @@ function extractPatchOperations(
   })
 }
 
-// Opt-in sync diagnostics for concurrency investigations: set
-// `globalThis.__SDK_SYNC_DEBUG = true` before load (harness: SYNC_DEBUG=1).
-// Free when off.
-function syncDebugEnabled(): boolean {
-  return (globalThis as {__SDK_SYNC_DEBUG?: boolean}).__SDK_SYNC_DEBUG === true
+function emitRemotePatchesIfAny({
+  type,
+  revision,
+  previousRev,
+  timestamp,
+  mutations,
+  documentId,
+  revisionToVerify,
+  prevDocState,
+  events,
+}: {
+  type: RemoteDocument['type']
+  revision: string | undefined
+  previousRev: string | undefined
+  timestamp: string
+  mutations: Mutation[] | undefined
+  documentId: string
+  revisionToVerify: UnverifiedDocumentRevision | undefined
+  prevDocState: DocumentState
+  events: DocumentStoreState['events']
+}): void {
+  if (type !== 'mutation' || !revision) return
+
+  const patches = extractPatchOperations(mutations, documentId)
+  if (!patches.length) return
+
+  const isOwnTransaction =
+    Boolean(revisionToVerify) || (prevDocState.recentOwnTransactionIds?.includes(revision) ?? false)
+  events.next({
+    type: 'remote-patches',
+    documentId,
+    transactionId: revision,
+    previousRev,
+    timestamp,
+    patches,
+    origin: isOwnTransaction ? 'local' : 'remote',
+  })
 }
 
-type SyncDebugDigest = {
-  sample: string
-  chars: number
-  /** Count of the duo-paste harness phrase; useful for H1 outgoing-wipe traces. */
-  imFeeling: number
-}
+function pruneOutdatedUnverifiedRevisions(
+  unverifiedRevisions: UnverifiedRevisions,
+  timestamp: string,
+): UnverifiedRevisions {
+  const syncTime = new Date(timestamp).getTime()
+  const next: UnverifiedRevisions = {}
 
-/** Compact digest of Portable-Text-shaped fields for `[sdk-sync]` trace lines. */
-function syncDebugTextDigest(doc: unknown): SyncDebugDigest {
-  if (!doc || typeof doc !== 'object') {
-    return {sample: '<none>', chars: 0, imFeeling: 0}
-  }
-  for (const field of ['blocks', 'content']) {
-    const value = (doc as Record<string, unknown>)[field]
-    if (!Array.isArray(value)) continue
-    const sample = value
-      .map((blockNode) => {
-        const children = (blockNode as {children?: {text?: string}[]}).children
-        if (!Array.isArray(children)) return ''
-        return children.map((child) => child.text ?? '').join('|')
-      })
-      .join(' ¶ ')
-    return {
-      sample: sample.length > 240 ? `${sample.slice(0, 240)}…` : sample,
-      chars: sample.length,
-      imFeeling: sample.split("I'm feeling").length - 1,
+  for (const [transactionId, unverifiedRevision] of Object.entries(unverifiedRevisions)) {
+    if (!unverifiedRevision) continue
+    const revisionTime = new Date(unverifiedRevision.timestamp).getTime()
+    if (syncTime <= revisionTime) {
+      next[transactionId] = unverifiedRevision
     }
   }
-  return {sample: '<no pte field>', chars: 0, imFeeling: 0}
+
+  return next
 }
 
-function syncDebug(label: string, payload: Record<string, unknown>): void {
-  if (!syncDebugEnabled()) return
-  // eslint-disable-next-line no-console
-  console.debug(`[sdk-sync] ${label} ${JSON.stringify(payload)}`)
+function modifiesDocument(transaction: AppliedTransaction, documentId: string): boolean {
+  return transaction.working[documentId]?._rev !== transaction.previousRevs[documentId]
+}
+
+function shouldConvergeFastForwardLocal({
+  prev,
+  documentId,
+  revision,
+}: {
+  prev: SyncTransactionState
+  documentId: string
+  revision: string | undefined
+}): boolean {
+  if (prev.applied.some((transaction) => modifiesDocument(transaction, documentId))) {
+    return false
+  }
+  if (!prev.outgoing) return true
+  if (prev.outgoing.transactionId === revision) return true
+  return !modifiesDocument(prev.outgoing, documentId)
+}
+
+function shouldReapplyOutgoingForEdge({
+  prev,
+  documentId,
+  revision,
+  previousRev,
+}: {
+  prev: SyncTransactionState
+  documentId: string
+  revision: string | undefined
+  previousRev: string | undefined
+}): boolean {
+  const outgoing = prev.outgoing
+  if (!outgoing) return false
+  if (!prev.grants) return false
+  if (outgoing.actions.length === 0) return false
+  if (prev.applied.length > 0) return false
+  if (outgoing.transactionId === revision) return false
+  if (outgoing.transactionId === previousRev) return false
+  return modifiesDocument(outgoing, documentId)
+}
+
+function reapplyOutgoingForEdge({
+  prev,
+  document,
+  documentId,
+  revision,
+  previousRev,
+  working,
+  events,
+}: {
+  prev: SyncTransactionState
+  document: SanityDocument | null
+  documentId: string
+  revision: string | undefined
+  previousRev: string | undefined
+  working: DocumentSet
+  events: DocumentStoreState['events']
+}): DocumentSet {
+  if (!shouldReapplyOutgoingForEdge({prev, documentId, revision, previousRev})) {
+    return working
+  }
+
+  const outgoing = prev.outgoing
+  if (!outgoing || !prev.grants) return working
+
+  try {
+    const next = processActions({
+      transactionId: outgoing.transactionId,
+      actions: outgoing.actions,
+      timestamp: outgoing.timestamp,
+      base: structuredClone(outgoing.base),
+      working: {
+        ...structuredClone(outgoing.previous),
+        [documentId]: document,
+      },
+      grants: prev.grants,
+      identity: prev.identity,
+    })
+    return next.working
+  } catch (error) {
+    if (error instanceof ActionError) {
+      events.next({
+        type: 'rebase-error',
+        transactionId: error.transactionId,
+        documentId: error.documentId,
+        message: error.message,
+        error,
+      })
+      return working
+    }
+    throw error
+  }
+}
+
+function replayAppliedTransactions({
+  prev,
+  working,
+  events,
+}: {
+  prev: SyncTransactionState
+  working: DocumentSet
+  events: DocumentStoreState['events']
+}): {
+  working: DocumentSet
+  applied: AppliedTransaction[]
+} {
+  if (!prev.grants) return {working, applied: []}
+
+  let nextWorking = working
+  const nextApplied: AppliedTransaction[] = []
+
+  for (const transaction of prev.applied) {
+    try {
+      const next = processActions({
+        ...transaction,
+        working: nextWorking,
+        grants: prev.grants,
+        identity: prev.identity,
+      })
+      nextWorking = next.working
+      nextApplied.push({...transaction, ...next})
+    } catch (error) {
+      if (error instanceof ActionError) {
+        events.next({
+          type: 'rebase-error',
+          transactionId: error.transactionId,
+          documentId: error.documentId,
+          message: error.message,
+          error,
+        })
+        continue
+      }
+      throw error
+    }
+  }
+
+  return {working: nextWorking, applied: nextApplied}
 }
 
 export function applyRemoteDocument(
@@ -524,22 +684,6 @@ export function applyRemoteDocument(
   // document state is deleted when there are no more subscribers so we can
   // simply skip if there is no state
   if (!prevDocState) return prev
-
-  const prevLocalDigest = syncDebugTextDigest(prevDocState.local)
-  const remoteDigest = syncDebugTextDigest(document)
-  syncDebug('remote-in', {
-    documentId,
-    type,
-    revision,
-    previousRev,
-    own: Boolean(revision && prevDocState.unverifiedRevisions?.[revision]),
-    appliedTxs: prev.applied.map((transaction) => transaction.transactionId),
-    appliedCount: prev.applied.length,
-    outgoingTx: prev.outgoing?.transactionId ?? null,
-    outgoingPresent: Boolean(prev.outgoing),
-    remote: remoteDigest,
-    local: prevLocalDigest,
-  })
 
   // we send out transactions with IDs generated client-side to identify them
   // when they are observed through the listener. here we can check if this
@@ -555,26 +699,17 @@ export function applyRemoteDocument(
   // collapsed into the whole-document snapshot below. consumers that keep
   // their own state (e.g. collaborative text editors) rely on these to apply
   // remote changes without re-diffing document snapshots
-  if (type === 'mutation' && revision) {
-    const patches = extractPatchOperations(mutations, documentId)
-    if (patches.length) {
-      // `unverifiedRevisions` alone isn't a reliable origin marker: a sync
-      // event can prune an in-flight transaction's entry before its listener
-      // echo arrives. `recentOwnTransactionIds` survives that race
-      const isOwnTransaction =
-        Boolean(revisionToVerify) ||
-        (prevDocState.recentOwnTransactionIds?.includes(revision) ?? false)
-      events.next({
-        type: 'remote-patches',
-        documentId,
-        transactionId: revision,
-        previousRev,
-        timestamp,
-        patches,
-        origin: isOwnTransaction ? 'local' : 'remote',
-      })
-    }
-  }
+  emitRemotePatchesIfAny({
+    type,
+    revision,
+    previousRev,
+    timestamp,
+    mutations,
+    documentId,
+    revisionToVerify,
+    prevDocState,
+    events,
+  })
 
   // if this remote document is from a `'sync'` event (meaning that the whole
   // thing was just fetched and not re-created from mutations)
@@ -582,12 +717,7 @@ export function applyRemoteDocument(
     // then remove unverified revisions that are older than our sync time. we
     // don't need to verify them for a rebase any more because we synced and
     // grabbed the latest document
-    unverifiedRevisions = Object.fromEntries(
-      Object.entries(unverifiedRevisions).filter(([, unverifiedRevision]) => {
-        if (!unverifiedRevision) return false
-        return new Date(timestamp).getTime() <= new Date(unverifiedRevision.timestamp).getTime()
-      }),
-    )
+    unverifiedRevisions = pruneOutdatedUnverifiedRevisions(unverifiedRevisions, timestamp)
   }
 
   // if there is a revision to verify and the previous revision from remote
@@ -610,26 +740,11 @@ export function applyRemoteDocument(
     // set without changing it, so a presence check would block published-doc
     // convergence whenever a draft edit is pending. this is the same
     // modified-test `transitionAppliedTransactionsToOutgoing` uses
-    const modifiesDocument = (transaction: AppliedTransaction) =>
-      transaction.working[documentId]?._rev !== transaction.previousRevs[documentId]
-    const nothingElsePending =
-      !prev.applied.some(modifiesDocument) &&
-      (!prev.outgoing ||
-        prev.outgoing.transactionId === revision ||
-        !modifiesDocument(prev.outgoing))
+    const nothingElsePending = shouldConvergeFastForwardLocal({prev, documentId, revision})
     const local =
       nothingElsePending && !isDeepEqual(prevDocState.local, document)
         ? document
         : prevDocState.local
-
-    const localDigest = syncDebugTextDigest(local)
-    syncDebug('fast-forward', {
-      documentId,
-      revision,
-      converged: nothingElsePending,
-      local: localDigest,
-      localLostImFeeling: localDigest.imFeeling < prevLocalDigest.imFeeling,
-    })
 
     return {
       ...prev,
@@ -654,7 +769,6 @@ export function applyRemoteDocument(
   // our initial working set now is the state of the documents before any of our
   // local transactions plus the newly updated document from remote
   let working = {...previous, [documentId]: document}
-  const nextApplied: AppliedTransaction[] = []
 
   // When pastes (or other edits) sit only in `outgoing` with an empty `applied`
   // queue, re-apply that submitted transaction onto the new remote for local
@@ -664,84 +778,21 @@ export function applyRemoteDocument(
   // in place, so clone `base`/`previous` before re-applying. Skip when `applied`
   // is non-empty: those txns already sit on the outgoing optimistic chain, and
   // replaying both double-applies.
-  if (
-    prev.outgoing &&
-    prev.grants &&
-    prev.outgoing.actions.length > 0 &&
-    prev.applied.length === 0 &&
-    // Own echo already includes this transaction's result; re-applying would
-    // duplicate inserts/DMP hunks (e.g. `oneA oneA`).
-    prev.outgoing.transactionId !== revision
-  ) {
-    try {
-      const next = processActions({
-        transactionId: prev.outgoing.transactionId,
-        actions: prev.outgoing.actions,
-        timestamp: prev.outgoing.timestamp,
-        base: structuredClone(prev.outgoing.base),
-        working: {
-          ...structuredClone(prev.outgoing.previous),
-          [documentId]: document,
-        },
-        grants: prev.grants,
-        identity: prev.identity,
-      })
-      working = next.working
-    } catch (error) {
-      if (error instanceof ActionError) {
-        syncDebug('outgoing-rebase-error', {
-          documentId: error.documentId,
-          transactionId: error.transactionId,
-          message: error.message,
-        })
-        events.next({
-          type: 'rebase-error',
-          transactionId: error.transactionId,
-          documentId: error.documentId,
-          message: error.message,
-          error,
-        })
-      } else {
-        throw error
-      }
-    }
-  }
+  working = reapplyOutgoingForEdge({
+    prev,
+    document,
+    documentId,
+    revision,
+    previousRev,
+    working,
+    events,
+  })
 
   // now we can iterate through our applied (but not yet committed) transactions
   // starting with the updated working set and re-apply each transaction in
   // order creating a new set of applied transactions as we go.
-  for (const curr of prev.applied) {
-    try {
-      const next = processActions({...curr, working, grants: prev.grants, identity: prev.identity})
-      working = next.working
-      // next includes an updated `previous` set and `working` set and updates
-      // the `outgoingAction` and `outgoingMutations`. the `base` set from the
-      // original applied transaction gets put back into the updated transaction
-      // as-is to preserve the intended base for a 3-way merge
-      nextApplied.push({...curr, ...next})
-    } catch (error) {
-      // if processing the action ever throws a related error, we can skip this
-      // local transaction and report the error to the user
-      if (error instanceof ActionError) {
-        syncDebug('rebase-error', {
-          documentId: error.documentId,
-          transactionId: error.transactionId,
-          message: error.message,
-          outgoingPresent: Boolean(prev.outgoing),
-          appliedCount: prev.applied.length,
-        })
-        events.next({
-          type: 'rebase-error',
-          transactionId: error.transactionId,
-          documentId: error.documentId,
-          message: error.message,
-          error,
-        })
-        continue
-      }
-      throw error
-    }
-  }
+  const replayed = replayAppliedTransactions({prev, working, events})
+  working = replayed.working
 
   // when the recompute lands on a value deep-equal to the current local
   // (the common case for echoes of our own transactions), keep the previous
@@ -749,25 +800,9 @@ export function applyRemoteDocument(
   const nextLocal = working[documentId]
   const local = isDeepEqual(prevDocState.local, nextLocal) ? prevDocState.local : nextLocal
 
-  const localDigest = syncDebugTextDigest(local)
-  syncDebug('rebase', {
-    documentId,
-    revision,
-    outgoingPresent: Boolean(prev.outgoing),
-    outgoingTx: prev.outgoing?.transactionId ?? null,
-    appliedCountBefore: prev.applied.length,
-    replayedTxs: nextApplied.map((transaction) => transaction.transactionId),
-    // After Phase 1, outgoing is re-applied for local EDGE before this digest.
-    local: localDigest,
-    remote: remoteDigest,
-    prevLocal: prevLocalDigest,
-    localLostImFeeling: localDigest.imFeeling < prevLocalDigest.imFeeling,
-    localLostChars: localDigest.chars < prevLocalDigest.chars,
-  })
-
   return {
     ...prev,
-    applied: nextApplied,
+    applied: replayed.applied,
     documentStates: {
       ...prev.documentStates,
       [documentId]: {


### PR DESCRIPTION
## Summary
- When a peer mutation arrives while this client's edits sit only in `outgoing` (`applied` empty), re-apply that submitted transaction onto the new remote for **local EDGE** so optimistic paste/typing is not wiped from `local`.
- Clone `base`/`previous` before `processActions` (mutations mutate document sets in place).
- Skip re-apply when `revision === outgoing.transactionId` so own echoes do not double-apply patches.
- keeps the H1 unit pin for outgoing-empty rebase behavior (paste count and peer block text assertions), and removes debug-only tracing from core reducer code.
## Why
Duo paste under concurrent other-block typing could lose in-flight paste copies: rebase seeded `local` from remote alone and ignored `outgoing`, then plugin repair could persist the loss. Mutator keeps submitted work on EDGE; this matches that for the empty-`applied` window.

## Test plan
- [x] `pnpm exec vitest run src/document/reducers.test.ts src/document/documentStore.concurrency.test.ts` (75 passed)
- [ ] Harness: `duo-typing.mjs paste` + solo/blocks/format regression floor against local SDK build (follow-up; Vite dual-context blocked earlier run)