### PR TITLE
chore: add pnpm flag to pkg-pr-new workflow

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -49,6 +49,7 @@ jobs:
             'packages/core' \
             'packages/react' \
             --comment=update \
-            --compact
+            --compact \
+            --pnpm
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Description
According to this `pkg-pr-preview` Github issue, this is the way to get our previews working with a `pnpm: catalog`. I don't think this should be high impact -- it just changes from an `npm pack` to `pnpm pack` -- but targeting the v3 branch for this anyway so impact should be low.

### What to review
I hopefully did not mistype 4 letters.

### Testing
I didn't test this locally, but we can validate in CI very quickly and revert if needed. 

### Fun gif
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWYyOW9mZnNvM2M4cmZqNzhybjE0OXZjcDN2a3A4MGsycng2cGp2OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1zmFgkvNxhf49Ry3Jk/giphy.gif)