### PR TITLE
fix(deps): bump groq-js to ^2.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: 3.88.1-typegen-experimental.0
       version: 3.88.1-typegen-experimental.0
     groq-js:
-      specifier: ^1.30.3
-      version: 1.30.3
+      specifier: ^2.0.0
+      version: 2.0.0
     lodash-es:
       specifier: ^4.18.1
       version: 4.18.1
@@ -525,7 +525,7 @@ importers:
         version: 3.88.1-typegen-experimental.0
       groq-js:
         specifier: 'catalog:'
-        version: 1.30.3
+        version: 2.0.0
       reselect:
         specifier: ^5.1.1
         version: 5.2.0
@@ -662,7 +662,7 @@ importers:
         version: 10.6.0(jiti@2.7.0)
       groq-js:
         specifier: 'catalog:'
-        version: 1.30.3
+        version: 2.0.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.0.1)
@@ -5650,6 +5650,10 @@ packages:
   groq-js@1.30.3:
     resolution: {integrity: sha512-X3Zppy8KO/mDLSu5RylcO9zON+IwxV6y6aeIWsfNNBz0PaRboUmsTVgk3Zndqp9TgWCTFvCk+Z2W0uu0R3i5DA==}
     engines: {node: '>= 14'}
+
+  groq-js@2.0.0:
+    resolution: {integrity: sha512-kj56ZjnOFbgDt91zYwQ10jsVUtVGJqAKfRbAir0EvTK84O5ZsSyc0rDEm2P3jmAJkxs4X1DOG8vtaYJQIA/XCA==}
+    engines: {node: '>=22.12'}
 
   groq@3.88.1-typegen-experimental.0:
     resolution: {integrity: sha512-6TZD6H1y3P7zk0BQharjFa7BOivV9nFL6KKVZbRZRH0yOSSyu2xHglTO48b1/2mCEdYoBQpvE7rjCDUf6XmQYQ==}
@@ -13875,6 +13879,10 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  groq-js@2.0.0:
+    dependencies:
+      obug: 2.1.3
 
   groq@3.88.1-typegen-experimental.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ catalog:
   '@vitest/coverage-v8': '^4.1.10'
   eslint: '^10.6.0'
   groq: '3.88.1-typegen-experimental.0'
-  groq-js: '^1.30.3'
+  groq-js: '^2.0.0'
   lodash-es: '^4.18.1'
   oxfmt: '^0.58.0'
   react: '^19.2.7'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps the pnpm catalog `groq-js` range from `^1.30.3` to `^2.0.0` so `@sanity/sdk` and `@sanity/sdk-react` resolve to v2.

Part of [SDK-2124](https://linear.app/sanity/issue/SDK-2124/bump-groq-js-to-v2-in-sanitysdk) / parent [SDK-2123](https://linear.app/sanity/issue/SDK-2123/eliminate-duplicate-groq-js-majors-by-bumping-satellite-packages-to-v2).

## Why

The `sanity` monorepo already depends on `groq-js@^2.0.0`, but published `@sanity/sdk` still declared `^1.30.3`, so consumers got both majors side by side.

## Notes

- `groq-js@2` public parse/evaluate APIs are unchanged
- Breaking changes in v2: ESM-only, Node `>=22.12` (already satisfied by this repo)
- Commit type is `fix(deps)` so release-please will cut a patch release after merge (catalog non-`@sanity` bumps normally land as `chore` and would not publish)
- Remaining `groq-js@1.x` in this lockfile comes from transitive `sanity` / CLI / codegen / migrate packages — covered by sibling bumps in SDK-2123

## Test plan

- [x] `pnpm --filter @sanity/sdk --filter @sanity/sdk-react test`
- [x] `pnpm --filter @sanity/sdk --filter @sanity/sdk-react ts:check`
- [x] Confirmed catalog + package importers resolve `groq-js@2.0.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SDK-2124](https://linear.app/sanity/issue/SDK-2124/bump-groq-js-to-v2-in-sanitysdk)

<div><a href="https://cursor.com/agents/bc-ecb9a4f5-35ff-4c91-8323-f32e2d7dfec7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecb9a4f5-35ff-4c91-8323-f32e2d7dfec7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

