### PR TITLE
fix: run release-rc against the dispatched branch

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -32,7 +32,9 @@ jobs:
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: rc
+          # Run against the branch the workflow was dispatched from, and push
+          # the version-bump commit back to it, rather than a hardcoded branch.
+          ref: ${{ github.ref_name }}
           token: ${{ steps.generate-token.outputs.token }}
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/scripts/release-rc.mts
+++ b/scripts/release-rc.mts
@@ -3,36 +3,101 @@ import 'zx/globals'
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 const isMajor = process.argv.includes('--major')
+// Any extra CLI args (e.g. `--dry-run`, `--otp=123456`) are forwarded to
+// `pnpm publish`. `--major` is consumed here, so it is not forwarded.
+const publishArgs = process.argv.slice(2).filter((arg) => arg !== '--major')
 
 const {packages} = await fs.readJson('./release-please-config.json')
-const workspaces = Object.keys(packages)
+const workspaces: string[] = Object.keys(packages)
 const manifest: Record<string, string> = await fs.readJson('./.release-please-manifest.json')
 
-echo`found ${chalk.blue(workspaces.length)} workspaces to publish ${isMajor ? 'major ' : ''}release candidates for`
-
-const prev = new Map()
-const next = new Map()
-
+// Collect the publishable (non-private) workspaces up front.
+const publishable: {workspace: string; name: string; version: string}[] = []
 for (const workspace of workspaces) {
   const {name, version, private: isPrivate} = await fs.readJson(`./${workspace}/package.json`)
-  if (!isPrivate) {
-    await spinner(`bumping ${chalk.blue(name)} from ${chalk.yellow(version)}`, async () => {
-      prev.set(name, version)
-      const stableVersion = manifest[workspace]
-      const [major, minor] = stableVersion.split('.').map(Number)
-      const targetVersion = isMajor ? `${major + 1}.0.0-rc.0` : `${major}.${minor + 1}.0-rc.0`
-      // `pnpm version` is really just an alias for `npm version` atm, so we have to jump through some hoops
-      await $`pnpm --filter="${name}" exec pnpm version --no-commit-hooks --no-git-tag-version ${targetVersion}`
-      next.set(name, (await fs.readJson(`./${workspace}/package.json`)).version)
-    })
-    echo`bumped ${chalk.blue(name)} from ${chalk.yellow(prev.get(name))} to ${chalk.green(next.get(name))}`
+  if (!isPrivate) publishable.push({workspace, name, version})
+}
+
+if (publishable.length === 0) throw new Error('no publishable workspaces found')
+
+// Returns the highest of a list of `major.minor.patch` versions.
+function maxStable(versions: string[]): string {
+  return versions.reduce((max, v) => {
+    const a = max.split('.').map(Number)
+    const b = v.split('.').map(Number)
+    for (let i = 0; i < 3; i++) {
+      if (b[i] !== a[i]) return b[i] > a[i] ? v : max
+    }
+    return max
+  })
+}
+
+// Looks up every version already published for a package. Returns an empty list
+// when the package has never been published (npm exits non-zero).
+async function publishedVersions(name: string): Promise<string[]> {
+  try {
+    const {stdout} = await $`npm view ${name} versions --json`.quiet()
+    const parsed = JSON.parse(stdout)
+    return Array.isArray(parsed) ? parsed : [parsed]
+  } catch {
+    return []
   }
+}
+
+const existing = (await Promise.all(publishable.map(({name}) => publishedVersions(name)))).flat()
+
+// The base `major.minor.patch` we want to cut an rc for. Versions are linked
+// across packages (see the `linked-versions` plugin in release-please-config.json),
+// so we derive a single shared base from the highest stable version in the manifest…
+const stableBase = maxStable(publishable.map(({workspace}) => manifest[workspace]))
+const [major, minor] = stableBase.split('.').map(Number)
+const manifestBase = isMajor ? `${major + 1}.0.0` : `${major}.${minor + 1}.0`
+
+// …but never go backwards: if a higher `x.y.z-rc.n` line is already published
+// (e.g. an in-progress `3.0.0-rc.*`), continue that line instead. This is what
+// stops a stale manifest from downgrading the rc tag.
+const publishedRcBases = existing
+  .map((v) => /^(\d+\.\d+\.\d+)-rc\.\d+$/.exec(v)?.[1])
+  .filter((v): v is string => v !== undefined)
+const base = maxStable([manifestBase, ...publishedRcBases])
+
+// Pick the next free rc number for that base rather than always colliding on
+// `-rc.0` (which pnpm then silently skips).
+const prefix = `${base}-rc.`
+const usedRcNumbers = existing
+  .filter((v) => v.startsWith(prefix))
+  .map((v) => Number(v.slice(prefix.length)))
+  .filter((n) => Number.isInteger(n))
+const nextRc = usedRcNumbers.length > 0 ? Math.max(...usedRcNumbers) + 1 : 0
+const targetVersion = `${prefix}${nextRc}`
+
+echo`found ${chalk.blue(publishable.length)} workspace(s) to publish ${
+  isMajor ? 'major ' : ''
+}release candidate ${chalk.green(targetVersion)} for`
+
+for (const {name, version} of publishable) {
+  await spinner(`bumping ${chalk.blue(name)} from ${chalk.yellow(version)}`, async () => {
+    // `pnpm version` is really just an alias for `npm version` atm, so we have to jump through some hoops
+    await $`pnpm --filter="${name}" exec pnpm version --no-commit-hooks --no-git-tag-version ${targetVersion}`
+  })
+  echo`bumped ${chalk.blue(name)} from ${chalk.yellow(version)} to ${chalk.green(targetVersion)}`
 }
 
 await $`pnpm build --output-logs=errors-only`.pipe(process.stdout)
 
-for (const name of next.keys()) {
-  await $`pnpm --filter="${name}" publish --tag rc --no-git-checks`.pipe(process.stdout)
+for (const {name} of publishable) {
+  // Capture (rather than stream) the output so we can detect pnpm's silent skip.
+  const {stdout} = await $`pnpm --filter="${name}" publish --tag rc --no-git-checks ${publishArgs}`
+  process.stdout.write(stdout)
+  // A filtered/recursive `pnpm publish` exits 0 with this message when the
+  // target version already exists on the registry. Treat it as a hard failure
+  // so a release can never be reported as successful without actually publishing.
+  if (stdout.includes('There are no new packages that should be published')) {
+    throw new Error(
+      `${name}@${targetVersion} was not published — pnpm reported nothing to publish, ` +
+        `so this version likely already exists on the registry.`,
+    )
+  }
 }
 
-echo`published release candidates for ${chalk.blue(workspaces.length)} workspaces`
+echo`published release candidates for ${chalk.blue(publishable.length)} workspace(s)`

--- a/scripts/release-rc.mts
+++ b/scripts/release-rc.mts
@@ -36,7 +36,9 @@ function maxStable(versions: string[]): string {
 // when the package has never been published (npm exits non-zero).
 async function publishedVersions(name: string): Promise<string[]> {
   try {
-    const {stdout} = await $`npm view ${name} versions --json`.quiet()
+    // Pass args as an array so the interpolation is the final token — a trailing
+    // bare word like `versions` here trips knip's binary detection (depcheck).
+    const {stdout} = await $`npm view ${[name, 'versions', '--json']}`.quiet()
     const parsed = JSON.parse(stdout)
     return Array.isArray(parsed) ? parsed : [parsed]
   } catch {


### PR DESCRIPTION
The release-rc workflow hardcoded `ref: rc`, so it always ran the `rc` branch's script and manifest no matter which branch was dispatched. It now checks out and pushes back to the branch the workflow was dispatched from.

The rc versioning also derived the target purely from the release-please manifest with a fixed `-rc.0` suffix. That could downgrade the rc line (e.g. `3.0.0-rc.0` → `2.9.0-rc.0`) and silently no-op when the version already existed. The script now resolves the next rc from the highest published version so it never goes backwards, and fails loudly instead of reporting a false success.