### PR TITLE
feat(kitchensink): expand portable text toolbar

### DIFF
--- a/apps/kitchensink-react/sanity.cli.ts
+++ b/apps/kitchensink-react/sanity.cli.ts
@@ -2,6 +2,15 @@ import {resolve} from 'node:path'
 
 import {defineCliConfig} from 'sanity/cli'
 
+// Point the Portable Text packages at a local build of the portabletext/editor
+// monorepo instead of the published npm versions:
+//   PTE_LOCAL_PKGS=/path/to/editor/packages pnpm dev
+// The aliases target the build output (editor -> lib/*, plugin -> dist/*), so
+// rebuild there (`pnpm build` in packages/editor and packages/plugin-sdk-value)
+// to pick up changes. Their own imports (react, @sanity/sdk-react) still hit
+// this config's aliases and dedupe, so context identity is preserved.
+const PTE_LOCAL_PKGS = process.env['PTE_LOCAL_PKGS'] || ''
+
 export default defineCliConfig({
   app: {
     // Use e2e organization ID if provided, otherwise use dev organization ID
@@ -27,12 +36,64 @@ export default defineCliConfig({
     envDir: resolve(import.meta.dirname, '../..'),
     resolve: {
       ...prev.resolve,
-      alias: {
-        ...prev.resolve?.alias,
-        '@sanity/sdk': resolve(import.meta.dirname, '../../packages/core/src/_exports'),
-        '@sanity/sdk-react': resolve(import.meta.dirname, '../../packages/react/src/_exports'),
-      },
+      alias: [
+        ...Object.entries({
+          ...prev.resolve?.alias,
+          '@sanity/sdk': resolve(import.meta.dirname, '../../packages/core/src/_exports'),
+          '@sanity/sdk-react': resolve(import.meta.dirname, '../../packages/react/src/_exports'),
+        }).map(([find, replacement]) => ({find, replacement: replacement as string})),
+        // Regex finds with $ anchors so subpath exports resolve precisely
+        // (a string find would rewrite `@portabletext/editor/selectors` into
+        // a path inside lib/index.js).
+        ...(PTE_LOCAL_PKGS
+          ? [
+              {
+                find: /^@portabletext\/editor\/plugins$/,
+                replacement: `${PTE_LOCAL_PKGS}/editor/lib/plugins/index.js`,
+              },
+              {
+                find: /^@portabletext\/editor\/behaviors$/,
+                replacement: `${PTE_LOCAL_PKGS}/editor/lib/behaviors/index.js`,
+              },
+              {
+                find: /^@portabletext\/editor\/selectors$/,
+                replacement: `${PTE_LOCAL_PKGS}/editor/lib/selectors/index.js`,
+              },
+              {
+                find: /^@portabletext\/editor$/,
+                replacement: `${PTE_LOCAL_PKGS}/editor/lib/index.js`,
+              },
+              {
+                find: /^@portabletext\/plugin-sdk-value$/,
+                replacement: `${PTE_LOCAL_PKGS}/plugin-sdk-value/dist/index.js`,
+              },
+            ]
+          : []),
+      ],
+      // The aliased build files resolve react from their own repo's
+      // node_modules; force this app's single copy so hooks and contexts
+      // stay shared.
+      ...(PTE_LOCAL_PKGS
+        ? {dedupe: [...(prev.resolve?.dedupe ?? []), 'react', 'react-dom', 'react-is']}
+        : {}),
     },
+    ...(PTE_LOCAL_PKGS
+      ? {
+          server: {
+            ...prev.server,
+            fs: {
+              ...prev.server?.fs,
+              // Explicit allow replaces Vite's default (the workspace root),
+              // so list both this monorepo and the aliased editor repo.
+              allow: [
+                ...(prev.server?.fs?.allow ?? []),
+                resolve(import.meta.dirname, '../..'),
+                resolve(PTE_LOCAL_PKGS, '..'),
+              ],
+            },
+          },
+        }
+      : {}),
     optimizeDeps: {
       ...prev.optimizeDeps,
       // Pre-bundling would inline a second copy of @sanity/sdk-react into the

--- a/apps/kitchensink-react/src/routes/PortableTextRoute.tsx
+++ b/apps/kitchensink-react/src/routes/PortableTextRoute.tsx
@@ -21,7 +21,15 @@ import {
   useResource,
 } from '@sanity/sdk-react'
 import {Badge, Box, Button, Card, Flex, Spinner, Stack, Text, TextInput} from '@sanity/ui'
-import {type JSX, type ReactNode, Suspense, useEffect, useMemo, useState} from 'react'
+import {
+  type ElementType,
+  type JSX,
+  type ReactNode,
+  Suspense,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 
 import {isE2E} from '../sanityConfigs'
 
@@ -34,10 +42,15 @@ const schemaDefinition = defineSchema({
   annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
 })
 
+const simpleDecoratorTags: Record<string, ElementType> = {
+  strong: 'strong',
+  em: 'em',
+  underline: 'u',
+}
+
 const renderDecorator: RenderDecoratorFunction = (props) => {
-  if (props.value === 'strong') return <strong>{props.children}</strong>
-  if (props.value === 'em') return <em>{props.children}</em>
-  if (props.value === 'underline') return <u>{props.children}</u>
+  const Tag = simpleDecoratorTags[props.value]
+  if (Tag) return <Tag>{props.children}</Tag>
   if (props.value === 'code') {
     return (
       <code

--- a/apps/kitchensink-react/src/routes/PortableTextRoute.tsx
+++ b/apps/kitchensink-react/src/routes/PortableTextRoute.tsx
@@ -4,6 +4,8 @@ import {
   PortableTextEditable,
   type RenderAnnotationFunction,
   type RenderDecoratorFunction,
+  type RenderListItemFunction,
+  type RenderStyleFunction,
   useEditor,
   useEditorSelector,
 } from '@portabletext/editor'
@@ -26,13 +28,31 @@ import {isE2E} from '../sanityConfigs'
 const PTE_FIELD_PATH = 'minimalBlock'
 
 const schemaDefinition = defineSchema({
-  decorators: [{name: 'strong'}, {name: 'em'}],
+  styles: [{name: 'normal'}, {name: 'h1'}, {name: 'h2'}, {name: 'blockquote'}],
+  lists: [{name: 'bullet'}, {name: 'number'}],
+  decorators: [{name: 'strong'}, {name: 'em'}, {name: 'underline'}, {name: 'code'}],
   annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
 })
 
 const renderDecorator: RenderDecoratorFunction = (props) => {
   if (props.value === 'strong') return <strong>{props.children}</strong>
   if (props.value === 'em') return <em>{props.children}</em>
+  if (props.value === 'underline') return <u>{props.children}</u>
+  if (props.value === 'code') {
+    return (
+      <code
+        style={{
+          background: 'var(--card-code-bg-color)',
+          borderRadius: 3,
+          fontFamily: 'monospace',
+          fontSize: '0.95em',
+          padding: '0.08em 0.25em',
+        }}
+      >
+        {props.children}
+      </code>
+    )
+  }
   return <>{props.children}</>
 }
 
@@ -41,6 +61,31 @@ const renderAnnotation: RenderAnnotationFunction = (props) => {
     return <span style={{textDecoration: 'underline', color: 'blue'}}>{props.children}</span>
   }
   return <>{props.children}</>
+}
+
+const renderStyle: RenderStyleFunction = (props) => {
+  if (props.value === 'h1') {
+    return <h1 style={{margin: 0, fontSize: '1.5rem'}}>{props.children}</h1>
+  }
+
+  if (props.value === 'h2') {
+    return <h2 style={{margin: 0, fontSize: '1.25rem'}}>{props.children}</h2>
+  }
+
+  if (props.value === 'blockquote') {
+    return (
+      <blockquote style={{borderLeft: '3px solid #6e7683', margin: 0, paddingLeft: '0.75rem'}}>
+        {props.children}
+      </blockquote>
+    )
+  }
+
+  return <>{props.children}</>
+}
+
+const renderListItem: RenderListItemFunction = (props) => {
+  const listStyleType = props.value === 'number' ? 'decimal' : 'disc'
+  return <li style={{listStyleType, margin: 0}}>{props.children}</li>
 }
 
 function ToolbarButton(props: {
@@ -56,6 +101,7 @@ function ToolbarButton(props: {
       text={props.label}
       fontSize={1}
       padding={2}
+      onMouseDown={(event) => event.preventDefault()}
       onClick={props.onClick}
       data-testid={props.testId}
     />
@@ -66,10 +112,41 @@ function Toolbar({testId}: {testId: string}) {
   const editor = useEditor()
   const strongActive = useEditorSelector(editor, selectors.isActiveDecorator('strong'))
   const emActive = useEditorSelector(editor, selectors.isActiveDecorator('em'))
+  const underlineActive = useEditorSelector(editor, selectors.isActiveDecorator('underline'))
+  const codeActive = useEditorSelector(editor, selectors.isActiveDecorator('code'))
+  const h1Active = useEditorSelector(editor, selectors.isActiveStyle('h1'))
+  const h2Active = useEditorSelector(editor, selectors.isActiveStyle('h2'))
+  const blockquoteActive = useEditorSelector(editor, selectors.isActiveStyle('blockquote'))
+  const bulletActive = useEditorSelector(editor, selectors.isActiveListItem('bullet'))
+  const numberActive = useEditorSelector(editor, selectors.isActiveListItem('number'))
   const linkActive = useEditorSelector(editor, selectors.isActiveAnnotation('link'))
 
   const toggleDecorator = (decorator: string) => {
     editor.send({type: 'decorator.toggle', decorator})
+    editor.send({type: 'focus'})
+  }
+
+  const toggleStyle = (style: string, active: boolean) => {
+    if (active) {
+      editor.send({type: 'style.remove', style})
+    } else {
+      editor.send({type: 'style.add', style})
+    }
+    editor.send({type: 'focus'})
+  }
+
+  const toggleList = (listItem: string) => {
+    editor.send({type: 'list item.toggle', listItem})
+    editor.send({type: 'focus'})
+  }
+
+  const undo = () => {
+    editor.send({type: 'history.undo'})
+    editor.send({type: 'focus'})
+  }
+
+  const redo = () => {
+    editor.send({type: 'history.redo'})
     editor.send({type: 'focus'})
   }
 
@@ -86,18 +163,60 @@ function Toolbar({testId}: {testId: string}) {
   }
 
   return (
-    <Flex gap={1}>
+    <Flex gap={1} style={{flexWrap: 'wrap'}}>
       <ToolbarButton
         active={strongActive}
-        label="Bold"
+        label="B"
         onClick={() => toggleDecorator('strong')}
         testId={`pte-bold-${testId}`}
       />
       <ToolbarButton
         active={emActive}
-        label="Italic"
+        label="I"
         onClick={() => toggleDecorator('em')}
         testId={`pte-italic-${testId}`}
+      />
+      <ToolbarButton
+        active={underlineActive}
+        label="U"
+        onClick={() => toggleDecorator('underline')}
+        testId={`pte-underline-${testId}`}
+      />
+      <ToolbarButton
+        active={codeActive}
+        label="Code"
+        onClick={() => toggleDecorator('code')}
+        testId={`pte-code-${testId}`}
+      />
+      <ToolbarButton
+        active={h1Active}
+        label="H1"
+        onClick={() => toggleStyle('h1', h1Active)}
+        testId={`pte-h1-${testId}`}
+      />
+      <ToolbarButton
+        active={h2Active}
+        label="H2"
+        onClick={() => toggleStyle('h2', h2Active)}
+        testId={`pte-h2-${testId}`}
+      />
+      <ToolbarButton
+        active={blockquoteActive}
+        label="Quote"
+        onClick={() => toggleStyle('blockquote', blockquoteActive)}
+        testId={`pte-quote-${testId}`}
+      />
+      <ToolbarButton
+        active={bulletActive}
+        label="UL"
+        onClick={() => toggleList('bullet')}
+        testId={`pte-ul-${testId}`}
+      />
+      <ToolbarButton
+        active={numberActive}
+        label="OL"
+        onClick={() => toggleList('number')}
+        testId={`pte-ol-${testId}`}
       />
       <ToolbarButton
         active={linkActive}
@@ -105,6 +224,8 @@ function Toolbar({testId}: {testId: string}) {
         onClick={toggleLink}
         testId={`pte-link-${testId}`}
       />
+      <ToolbarButton active={false} label="Undo" onClick={undo} testId={`pte-undo-${testId}`} />
+      <ToolbarButton active={false} label="Redo" onClick={redo} testId={`pte-redo-${testId}`} />
     </Flex>
   )
 }
@@ -149,6 +270,8 @@ function EditorPane({
               style={{minHeight: 120, outline: 'none'}}
               renderDecorator={renderDecorator}
               renderAnnotation={renderAnnotation}
+              renderListItem={renderListItem}
+              renderStyle={renderStyle}
               data-testid={`pte-editable-${testId}`}
             />
           </Card>
@@ -225,8 +348,9 @@ function ConcurrentEditors() {
             <Text size={1} muted>
               Both panes edit the <code>{PTE_FIELD_PATH}</code> field of the same author document,
               but the right pane runs on its own SanityInstance, so edits sync through the server
-              like two separate users. Type in both panes at once and toggle bold/italic/link
-              mid-typing: edits should interleave without overwriting each other.
+              like two separate users. Type in both panes at once and toggle toolbar formatting
+              (decorators, styles, lists, link, undo, redo) mid-typing: edits should interleave
+              without overwriting each other.
             </Text>
             <Flex gap={3} align="flex-end">
               <Box flex={1}>

--- a/turbo.json
+++ b/turbo.json
@@ -46,7 +46,7 @@
     "dev": {
       "persistent": true,
       "cache": false,
-      "env": ["SANITY_INTERNAL_ENV"]
+      "env": ["SANITY_INTERNAL_ENV", "PTE_LOCAL_PKGS"]
     },
     "docs": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
### Description

This PR expands the Portable Text kitchensink route into a fuller formatting demo and fixes missing formatting visibility for several controls.

- Adds a compact, wrap-friendly toolbar in `PortableTextRoute` with decorators (`B`, `I`, `U`, `Code`), styles (`H1`, `H2`, `Quote`), lists (`UL`, `OL`), link toggle, and undo/redo.
- Extends the route schema and rendering so all toolbar options visibly apply in the editor, including explicit `renderStyle` and `renderListItem` handlers plus stronger inline `code` styling.
- Keeps selection stable when clicking toolbar controls by preventing button `mousedown` from stealing focus.
- Adds `PTE_LOCAL_PKGS` support in `apps/kitchensink-react/sanity.cli.ts` so local `@portabletext/editor` and `@portabletext/plugin-sdk-value` builds can be used during `pnpm dev` (with aliasing, dedupe, and Vite fs allow updates when enabled).
- Adds `PTE_LOCAL_PKGS` to Turbo dev env passthrough in `turbo.json`.

### What to review

- `apps/kitchensink-react/src/routes/PortableTextRoute.tsx`
  - Toolbar control coverage and active states
  - Style/list/decorator rendering behavior
  - Undo/redo and focus handling
  - Two-pane concurrent editing flow still behaves as expected
- `apps/kitchensink-react/sanity.cli.ts`
  - `PTE_LOCAL_PKGS` conditional aliasing for editor/plugin subpaths
  - `react` dedupe and Vite `server.fs.allow` additions when local packages are enabled
  - No behavior change when `PTE_LOCAL_PKGS` is not set
- `turbo.json`
  - `dev.env` includes `PTE_LOCAL_PKGS`

### Testing

- Ran:
  - `pnpm --filter @sanity/kitchensink-react tsc`
- Manual checks in the Portable Text route:
  - Toggle `Code`, `UL`, `OL`, and `Quote` and confirm visible styling in editor and JSON preview
  - Verify undo/redo works per pane
  - Verify formatting changes still sync correctly across both concurrent editor panes

### Fun gif
![writing](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExemd5bjlwNXQycGtvM2J2eTIzNDZuOGpmaTluMjZhNGJrdnlzMm83bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/dCC35XnBDAyeDBcBsv/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
