### PR TITLE
fix(core): unregister subscription ids when reverting outgoing transactions

### DIFF
--- a/packages/core/src/document/reducers.test.ts
+++ b/packages/core/src/document/reducers.test.ts
@@ -632,6 +632,60 @@ describe('revertOutgoingTransaction', () => {
     const docState = newState.documentStates[draftId]
     expect(docState?.unverifiedRevisions && docState.unverifiedRevisions['txnOut']).toBeUndefined()
   })
+
+  it('unregisters the reverted batch subscription ids, making documents with no other subscribers evictable', () => {
+    const draftId = getDraftId(DocumentId('doc1'))
+    const pubId = getPublishedId(DocumentId('doc1'))
+    const state: SyncTransactionState = {
+      queued: [],
+      applied: [],
+      outgoing: {
+        transactionId: 'txnRevert',
+        actions: [
+          {
+            type: 'document.edit',
+            documentId: 'doc1',
+            documentType: 'book',
+            patches: [{set: {foo: 'changed'}}],
+          },
+        ],
+        disableBatching: false,
+        batchedTransactionIds: ['txnRevert'],
+        outgoingActions: [],
+        outgoingMutations: [],
+        base: {},
+        working: {},
+        previous: {},
+        previousRevs: {},
+        timestamp: '2025-02-06T00:04:30.000Z',
+      },
+      grants,
+      documentStates: {
+        // only subscriber is the reverted transaction itself
+        [draftId]: {
+          id: draftId,
+          subscriptions: ['txnRevert'],
+          local: {...exampleDoc, _id: draftId, foo: 'changed', _rev: 'rev2'},
+          remote: {...exampleDoc, _id: draftId, foo: 'old', _rev: 'rev1'},
+        },
+        // also has a UI subscriber, so it should survive with only the
+        // transaction subscription removed
+        [pubId]: {
+          id: pubId,
+          subscriptions: ['txnRevert', 'sub-ui'],
+          local: {...exampleDoc, _id: pubId, foo: 'pub', _rev: 'revPub'},
+          remote: {...exampleDoc, _id: pubId, foo: 'pub', _rev: 'revPub'},
+        },
+      },
+    }
+    const newState = revertOutgoingTransaction(state)
+    expect(newState.outgoing).toBeUndefined()
+    // no subscribers remain, so the document state is evicted entirely
+    expect(newState.documentStates[draftId]).toBeUndefined()
+    // the UI subscription keeps the other document alive, but the reverted
+    // transaction id is gone from its subscriptions
+    expect(newState.documentStates[pubId]?.subscriptions).toEqual(['sub-ui'])
+  })
 })
 
 describe('applyRemoteDocument', () => {

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -406,8 +406,23 @@ export function cleanupOutgoingTransaction(prev: SyncTransactionState): SyncTran
 
 export function revertOutgoingTransaction(prev: SyncTransactionState): SyncTransactionState {
   if (!prev.grants) return prev
+
+  // unregister the reverted batch's transaction-held subscriptions, symmetric
+  // with `cleanupOutgoingTransaction` on ack and `removeQueuedTransaction` on
+  // apply failure. without this, a reverted document's subscription IDs are
+  // never released and it can never be evicted
+  let base = prev
+  if (prev.outgoing) {
+    const ids = getDocumentIdsFromHandleLikes(prev.outgoing.actions)
+    for (const transactionId of prev.outgoing.batchedTransactionIds) {
+      for (const documentId of ids) {
+        base = removeSubscriptionIdFromDocument(base, documentId, transactionId)
+      }
+    }
+  }
+
   let working = Object.fromEntries(
-    Object.entries(prev.documentStates).map(([documentId, documentState]) => [
+    Object.entries(base.documentStates).map(([documentId, documentState]) => [
       documentId,
       documentState?.remote,
     ]),
@@ -428,11 +443,11 @@ export function revertOutgoingTransaction(prev: SyncTransactionState): SyncTrans
   }
 
   return {
-    ...prev,
+    ...base,
     applied: nextApplied,
     outgoing: undefined,
     documentStates: Object.fromEntries(
-      Object.entries(prev.documentStates)
+      Object.entries(base.documentStates)
         .filter((e): e is [string, DocumentState] => !!e[1])
         .map(([documentId, {unverifiedRevisions = {}, local, ...documentState}]) => {
           const next: DocumentState = {


### PR DESCRIPTION
### Description

Reverting an outgoing transaction never released the transaction-held subscription IDs it registered at queue time, unlike the two paths that already do this correctly: `cleanupOutgoingTransaction` on ack, and `removeQueuedTransaction` on apply failure. A reverted document kept the dead transaction ID in its subscription list for the life of the store, so it could never be evicted even after every real subscriber left. Repeated revert cycles pile up more of these dead IDs.

`revertOutgoingTransaction` now unregisters the reverted batch's transaction IDs the same way the other two paths do, before rebuilding the working document set from the resulting state.

### What to review

- `revertOutgoingTransaction` in `packages/core/src/document/reducers.ts`: the new subscription cleanup runs before the existing rebase logic, and the rest of the function now operates on that cleaned-up state.
- Mixed case: a document with both a UI subscriber and the reverted transaction ID should keep only the UI subscription afterward, not get evicted.

### Testing

Added a unit test in `reducers.test.ts` covering two cases: a document whose only subscriber was the reverted transaction (now evicted) and one with an additional UI subscriber (survives, transaction ID removed). Full core suite (1088 tests), `tsc --noEmit`, and `oxfmt --check` all pass.

### Fun gif
![leak fix](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExMHVhamZ0Zno0MDJiemFodmQ4d2FnMHBjMHlrazlmNzRjdmt0enNkNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZfzM9TfogyASLRCGmS/giphy.gif)

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
