### PR TITLE
fix: raise fallow crap ceiling for example apps to match cyclomatic gate

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -6,5 +6,14 @@
     "deadCodeBaseline": "fallow-baselines/dead-code.json",
     "healthBaseline": "fallow-baselines/health.json",
     "dupesBaseline": "fallow-baselines/dupes.json"
+  },
+  "health": {
+    "thresholdOverrides": [
+      {
+        "files": ["apps/**"],
+        "maxCrap": 110,
+        "reason": "The example apps ship no tests, so fallow estimates 0% coverage and CRAP collapses to cc + cc^2. The default ceiling of 30 would cap these apps at cyclomatic 5, stricter than the packages. 110 caps them at cyclomatic 10; cognitive and cyclomatic still gate normally."
+      }
+    ]
   }
 }


### PR DESCRIPTION
### Description

Fallow CI was failing on PRs that touch `apps/kitchensink-react`, most recently on [#1075](https://github.com/sanity-io/sdk/pull/1075). The gate is `fallow audit --gate new-only`, which only fails on newly introduced findings, so the report's dependency and duplication noise was a red herring. The actual failure was a single CRAP-score finding on a 4-branch `if` function.

CRAP is `cc + cc² × (1 - coverage)³`. Nothing in `.github/workflows/fallow.yml` passes `--coverage`, and no test root reaches the kitchensink app, so fallow estimates 0% coverage there and CRAP collapses to `cc + cc²`. That makes the default ceiling of 30 an effective cyclomatic limit of 5 for the apps, versus the intended limit of 20 for the packages, so a routine four-way `if` in a demo route was enough to fail CI.

This adds a per-path `health.thresholdOverrides` entry that raises the CRAP ceiling to 110 (`= 10 + 10²`) for `apps/**`, bringing the app's effective cyclomatic ceiling to 10. `packages/**` keeps the default ceiling of 30 (cyclomatic 5), and cyclomatic/cognitive complexity still gate normally everywhere.

Alternatives considered:
- Raising `maxCrap` globally would silently loosen the gate on `packages/core` and `packages/react`, the parts of the repo that actually ship to users.
- Refactoring the specific flagged function (`renderDecorator` in `PortableTextRoute.tsx`) only fixes this one PR; the next `if`-heavy example component hits the same wall.
- Wiring real coverage into the CI job would fix the estimate at the source, but is a bigger change and out of scope here.

### What to review

- The new `health.thresholdOverrides` block in `.fallowrc.json`. `files: ["apps/**"]` should only match the example apps, not `packages/**`.
- Whether 110 (cyclomatic ~10) is the right ceiling for demo/example code, versus a looser or tighter number.

### Testing

No automated test covers CI config directly, so I verified by running `fallow audit` locally in throwaway worktrees against real branch diffs:
- Reproduced the failure against PR #1075's diff (`renderDecorator`, CRAP 30, exit 1), then confirmed the override flips it to exit 0.
- Re-ran PR #1077's diff (a `packages/core` change that already passed CI) with the same config and confirmed `packages/core/src/document/reducers.ts:496` still reports against the unchanged `CRAP >= 30.0` threshold.
- Added a synthetic 12-branch function inside `apps/kitchensink-react` and confirmed it still fails the gate (CRAP 156), so this raises the app ceiling rather than disabling the check.

### Fun gif
![crap](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExcXRldGU2NW9qam1lODZzNGsxbGhjcXNrMDFub24zM2I4ZG1odHNqNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/U7rz8Q1ues8hDbDydS/giphy.gif)

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
