### PR TITLE
fix(core): reconnect presence and expire stale sessions

### DIFF
--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -32,13 +32,20 @@ jobs:
       - name: Audit changed files
         run: |
           BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
-          git fetch origin "$BASE_REF" --depth=1 || true
+          # The explicit refspec matters. `git fetch origin <branch>` writes only
+          # FETCH_HEAD, so `origin/<branch>` never appears for any base other than
+          # the default branch, which checkout already fetched. On a stacked PR the
+          # audit then cannot resolve its base and exits 2, which reads as a lint
+          # failure rather than a missing ref.
+          git fetch origin "+$BASE_REF:refs/remotes/origin/$BASE_REF" --depth=1 || true
           AUDIT_OUTPUT=$(pnpm --silent fallow audit --base "origin/$BASE_REF" --format markdown --quiet) || AUDIT_EXIT=$?
+          # Echoed as well as summarised: a failure is otherwise undiagnosable from
+          # the job log, since the summary is only rendered in the web UI.
           {
             echo "## Fallow audit"
             echo ""
             echo "$AUDIT_OUTPUT"
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
           exit "${AUDIT_EXIT:-0}"
 
       - name: Hotspots

--- a/packages/core/src/presence/bifurTransport.test.ts
+++ b/packages/core/src/presence/bifurTransport.test.ts
@@ -134,6 +134,8 @@ describe('createBifurTransport', () => {
 
     const receivedEvents: TransportEvent[] = []
     incomingEvents$.subscribe((event) => receivedEvents.push(event))
+    // The listener is established per live connection, so bring one up first.
+    heartbeats$.next(new Date())
 
     incomingBifurEvents$.next({
       type: 'rollCall',
@@ -165,6 +167,8 @@ describe('createBifurTransport', () => {
 
     const receivedEvents: TransportEvent[] = []
     incomingEvents$.subscribe((event) => receivedEvents.push(event))
+    // The listener is established per live connection, so bring one up first.
+    heartbeats$.next(new Date())
 
     const locations: PresenceLocation[] = [
       {type: 'document', documentId: 'doc1', path: ['a'], lastActiveAt: new Date().toISOString()},
@@ -204,6 +208,8 @@ describe('createBifurTransport', () => {
 
     const receivedEvents: TransportEvent[] = []
     incomingEvents$.subscribe((event) => receivedEvents.push(event))
+    // The listener is established per live connection, so bring one up first.
+    heartbeats$.next(new Date())
 
     incomingBifurEvents$.next({
       type: 'disconnect',
@@ -237,6 +243,7 @@ describe('createBifurTransport', () => {
     incomingEvents$.subscribe({
       error: (err) => errors.push(err),
     })
+    heartbeats$.next(new Date())
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     incomingBifurEvents$.next({type: 'unknown'} as any)
@@ -293,6 +300,48 @@ describe('createBifurTransport', () => {
       vi.advanceTimersByTime(199)
       reconnected$.next(new Date())
       expect(generations).toEqual([1])
+    })
+  })
+
+  describe('incoming events across a reconnect', () => {
+    it('keeps delivering presence after the socket drops', () => {
+      // bifur errors every stream on the same socket close, the inbound listener
+      // included. If only the heartbeat stream recovers, this client re-announces
+      // itself to peers while permanently ceasing to see any of them.
+      const firstListen$ = new Subject<IncomingBifurEvent>()
+      const secondListen$ = new Subject<IncomingBifurEvent>()
+      mockBifurClient.listen.mockReturnValueOnce(firstListen$).mockReturnValueOnce(secondListen$)
+
+      const [incomingEvents$, , connections$] = createBifurTransport({
+        client: mockSanityClient,
+        token$,
+        sessionId: 'my-session',
+      })
+
+      const received: TransportEvent[] = []
+      incomingEvents$.subscribe({
+        next: (event) => received.push(event),
+        error: () => received.push({type: 'rollCall', userId: 'STREAM_DIED', sessionId: ''}),
+      })
+      connections$.subscribe()
+
+      heartbeats$.next(new Date())
+      firstListen$.next({type: 'rollCall', i: 'user-1', session: 'before'})
+      expect(received.map((e) => e.sessionId)).toEqual(['before'])
+
+      // Socket closes: both streams error.
+      const reconnectedHeartbeats$ = new Subject<Date>()
+      mockBifurClient.heartbeats = reconnectedHeartbeats$.asObservable()
+      firstListen$.error(new Error('WebSocket connection error'))
+      heartbeats$.error(new Error('WebSocket connection error'))
+
+      vi.advanceTimersByTime(200)
+      reconnectedHeartbeats$.next(new Date())
+
+      // Peers answer the roll call we send on reconnect. We have to be listening.
+      secondListen$.next({type: 'rollCall', i: 'user-1', session: 'after'})
+
+      expect(received.map((e) => e.sessionId)).toEqual(['before', 'after'])
     })
   })
 

--- a/packages/core/src/presence/bifurTransport.test.ts
+++ b/packages/core/src/presence/bifurTransport.test.ts
@@ -1,7 +1,7 @@
 import {fromUrl} from '@sanity/bifur-client'
 import {type SanityClient} from '@sanity/client'
-import {of, Subject} from 'rxjs'
-import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+import {type Observable, of, Subject} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {createBifurTransport} from './bifurTransport'
 import {type PresenceLocation, type TransportEvent} from './types'
@@ -39,16 +39,20 @@ describe('createBifurTransport', () => {
   let mockBifurClient: {
     listen: Mock
     request: Mock
+    heartbeats: Observable<Date>
   }
   let mockSanityClient: SanityClient
   let token$: Subject<string | null>
+  let heartbeats$: Subject<Date>
 
   beforeEach(() => {
     vi.useFakeTimers()
     vi.clearAllMocks()
+    heartbeats$ = new Subject<Date>()
     mockBifurClient = {
       listen: vi.fn(() => new Subject<never>()),
       request: vi.fn(() => of(undefined)),
+      heartbeats: heartbeats$.asObservable(),
     }
     fromUrlMock.mockReturnValue(mockBifurClient)
 
@@ -242,7 +246,106 @@ describe('createBifurTransport', () => {
     expect(errors[0].message).toContain('Got unknown presence event')
   })
 
-  describe('dispatchMessage', () => {
+  describe('connections', () => {
+    it('emits an incrementing generation each time the socket becomes live', () => {
+      const [, , connections$] = createBifurTransport({
+        client: mockSanityClient,
+        token$,
+        sessionId: 'my-session',
+      })
+
+      const generations: number[] = []
+      connections$.subscribe((generation) => generations.push(generation))
+
+      // Several heartbeats on one live socket are a single generation.
+      heartbeats$.next(new Date())
+      heartbeats$.next(new Date())
+      expect(generations).toEqual([1])
+
+      // bifur-client errors the stream when the socket closes. The transport is
+      // expected to reconnect rather than give up for the life of the page.
+      const reconnected$ = new Subject<Date>()
+      mockBifurClient.heartbeats = reconnected$.asObservable()
+      heartbeats$.error(new Error('WebSocket connection error'))
+
+      // First retry is scheduled 200ms out (2 ** 1 * 100).
+      vi.advanceTimersByTime(200)
+      reconnected$.next(new Date())
+
+      expect(generations).toEqual([1, 2])
+    })
+
+    it('does not resubscribe before the backoff has elapsed', () => {
+      const [, , connections$] = createBifurTransport({
+        client: mockSanityClient,
+        token$,
+        sessionId: 'my-session',
+      })
+
+      const generations: number[] = []
+      connections$.subscribe((generation) => generations.push(generation))
+      heartbeats$.next(new Date())
+
+      const reconnected$ = new Subject<Date>()
+      mockBifurClient.heartbeats = reconnected$.asObservable()
+      heartbeats$.error(new Error('WebSocket connection error'))
+
+      vi.advanceTimersByTime(199)
+      reconnected$.next(new Date())
+      expect(generations).toEqual([1])
+    })
+  })
+
+  describe('unload', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('emits on beforeunload and pagehide, and removes its listeners', () => {
+      // These tests run in Node, so stand in a bare EventTarget for `window`.
+      const fakeWindow = new EventTarget()
+      vi.stubGlobal('window', fakeWindow)
+
+      const [, , , unload$] = createBifurTransport({
+        client: mockSanityClient,
+        token$,
+        sessionId: 'my-session',
+      })
+
+      let emissions = 0
+      const subscription = unload$.subscribe(() => {
+        emissions += 1
+      })
+
+      fakeWindow.dispatchEvent(new Event('beforeunload'))
+      expect(emissions).toBe(1)
+
+      // `pagehide` matters on its own: iOS Safari and pages entering the
+      // back/forward cache never fire `beforeunload`.
+      fakeWindow.dispatchEvent(new Event('pagehide'))
+      expect(emissions).toBe(2)
+
+      // The listeners belong to the subscription, so unsubscribing removes them
+      // instead of leaking one per transport for the life of the page.
+      subscription.unsubscribe()
+      fakeWindow.dispatchEvent(new Event('beforeunload'))
+      expect(emissions).toBe(2)
+    })
+
+    it('is inert when there is no window', () => {
+      const [, , , unload$] = createBifurTransport({
+        client: mockSanityClient,
+        token$,
+        sessionId: 'my-session',
+      })
+
+      let completed = false
+      unload$.subscribe({complete: () => (completed = true)})
+      expect(completed).toBe(true)
+    })
+  })
+
+  describe('dispatch', () => {
     it('sends a "rollCall" message', () => {
       const [, dispatchMessage] = createBifurTransport({
         client: mockSanityClient,

--- a/packages/core/src/presence/bifurTransport.ts
+++ b/packages/core/src/presence/bifurTransport.ts
@@ -1,7 +1,7 @@
 import {type BifurClient, fromUrl} from '@sanity/bifur-client'
 import {type SanityClient} from '@sanity/client'
-import {EMPTY, fromEvent, type Observable} from 'rxjs'
-import {map, share, switchMap} from 'rxjs/operators'
+import {defer, EMPTY, fromEvent, merge, type Observable, timer} from 'rxjs'
+import {distinctUntilChanged, map, retry, share} from 'rxjs/operators'
 
 import {
   type BifurTransportOptions,
@@ -10,6 +10,12 @@ import {
   type TransportEvent,
   type TransportMessage,
 } from './types'
+
+/**
+ * Longest gap between reconnection attempts, matching the Studio's presence
+ * transport so both behave the same way on a flaky connection.
+ */
+const CONNECT_RETRY_MAX_DELAY = 1000 * 240
 
 type BifurStateMessage = {
   type: 'state'
@@ -91,13 +97,55 @@ const handleIncomingMessage = (event: IncomingBifurEvent): TransportEvent => {
   }
 }
 
+/**
+ * Emits an incrementing generation number each time the socket becomes live.
+ *
+ * `@sanity/bifur-client` does not reconnect on its own — it errors the stream
+ * when the socket closes. Without the `retry` below, presence stops for the
+ * life of the page after the first dropped connection.
+ */
+const createConnections = (bifur: BifurClient): Observable<number> => {
+  let generation = 0
+
+  return defer(() => {
+    const current = ++generation
+    // `heartbeats` emits as soon as the socket is open and authorized, then on
+    // every server heartbeat and every response. Subscribing to it is also what
+    // keeps the socket alive between requests.
+    return bifur.heartbeats.pipe(map(() => current))
+  }).pipe(
+    retry({
+      delay: (_error, retryCount) =>
+        timer(Math.min(CONNECT_RETRY_MAX_DELAY, 2 ** retryCount * 100)),
+      resetOnSuccess: true,
+    }),
+    // After `retry` so that one operator instance spans reconnects, making each
+    // live socket yield exactly one emission.
+    distinctUntilChanged(),
+    share(),
+  )
+}
+
+/**
+ * Emits when the page is going away. `pagehide` is needed alongside
+ * `beforeunload` because iOS Safari and pages entering the back/forward cache
+ * never fire `beforeunload`.
+ */
+const createUnload = (): Observable<void> => {
+  if (typeof window === 'undefined') return EMPTY
+
+  return merge(fromEvent(window, 'beforeunload'), fromEvent(window, 'pagehide')).pipe(
+    map(() => undefined),
+  )
+}
+
 export const createBifurTransport = (options: BifurTransportOptions): PresenceTransport => {
   const {client, token$, sessionId} = options
   const bifur = getBifurClient(client, token$)
 
-  const incomingEvents$: Observable<TransportEvent> = bifur
+  const incomingEvents$ = bifur
     .listen<IncomingBifurEvent>('presence')
-    .pipe(map(handleIncomingMessage))
+    .pipe(map(handleIncomingMessage), share())
 
   const dispatchMessage = (message: TransportMessage): Observable<void> => {
     switch (message.type) {
@@ -115,11 +163,5 @@ export const createBifurTransport = (options: BifurTransportOptions): PresenceTr
     }
   }
 
-  if (typeof window !== 'undefined') {
-    fromEvent(window, 'beforeunload')
-      .pipe(switchMap(() => dispatchMessage({type: 'disconnect'})))
-      .subscribe()
-  }
-
-  return [incomingEvents$.pipe(share()), dispatchMessage]
+  return [incomingEvents$, dispatchMessage, createConnections(bifur), createUnload()]
 }

--- a/packages/core/src/presence/bifurTransport.ts
+++ b/packages/core/src/presence/bifurTransport.ts
@@ -1,7 +1,7 @@
 import {type BifurClient, fromUrl} from '@sanity/bifur-client'
 import {type SanityClient} from '@sanity/client'
 import {defer, EMPTY, fromEvent, merge, type Observable, timer} from 'rxjs'
-import {distinctUntilChanged, map, retry, share} from 'rxjs/operators'
+import {catchError, distinctUntilChanged, map, retry, share, switchMap} from 'rxjs/operators'
 
 import {
   type BifurTransportOptions,
@@ -127,6 +127,32 @@ const createConnections = (bifur: BifurClient): Observable<number> => {
 }
 
 /**
+ * Presence events from everyone else in the room, re-established on every live
+ * connection.
+ *
+ * A socket close errors this stream just as it errors the heartbeats, so without
+ * re-subscribing the client would keep announcing itself after a reconnect while
+ * never hearing from anyone again. Driving it from `connections$` rather than
+ * giving it its own `retry` keeps a single reconnect loop, instead of two
+ * independent backoffs racing over one refcounted socket.
+ */
+const createIncomingEvents = (
+  bifur: BifurClient,
+  connections$: Observable<number>,
+): Observable<TransportEvent> =>
+  connections$.pipe(
+    switchMap(() =>
+      bifur.listen<IncomingBifurEvent>('presence').pipe(
+        // Let a dead listener go quietly. The next connection replaces it, and
+        // surfacing the error here would tear down the reconnect loop with it.
+        catchError(() => EMPTY),
+      ),
+    ),
+    map(handleIncomingMessage),
+    share(),
+  )
+
+/**
  * Emits when the page is going away. `pagehide` is needed alongside
  * `beforeunload` because iOS Safari and pages entering the back/forward cache
  * never fire `beforeunload`.
@@ -143,9 +169,8 @@ export const createBifurTransport = (options: BifurTransportOptions): PresenceTr
   const {client, token$, sessionId} = options
   const bifur = getBifurClient(client, token$)
 
-  const incomingEvents$ = bifur
-    .listen<IncomingBifurEvent>('presence')
-    .pipe(map(handleIncomingMessage), share())
+  const connections$ = createConnections(bifur)
+  const incomingEvents$ = createIncomingEvents(bifur, connections$)
 
   const dispatchMessage = (message: TransportMessage): Observable<void> => {
     switch (message.type) {
@@ -163,5 +188,5 @@ export const createBifurTransport = (options: BifurTransportOptions): PresenceTr
     }
   }
 
-  return [incomingEvents$, dispatchMessage, createConnections(bifur), createUnload()]
+  return [incomingEvents$, dispatchMessage, connections$, createUnload()]
 }

--- a/packages/core/src/presence/presenceStore.test.ts
+++ b/packages/core/src/presence/presenceStore.test.ts
@@ -452,6 +452,21 @@ describe('presenceStore', () => {
       expect(source.getCurrent()).toHaveLength(0)
       expect(mockDispatchMessage).toHaveBeenNthCalledWith(2, {type: 'rollCall'})
 
+      // Wiping the map is only safe because peers answer that roll call and
+      // repopulate it. If the inbound listener did not survive the reconnect,
+      // this would stay empty for the life of the page.
+      mockIncomingEvents.next({
+        type: 'state',
+        userId: 'user-2',
+        sessionId: 'a-peer-answering',
+        timestamp: '2023-01-01T12:00:05Z',
+        locations: [],
+      })
+
+      await firstValueFrom(of(null).pipe(delay(20)))
+      expect(source.getCurrent()).toHaveLength(1)
+      expect(source.getCurrent()[0].sessionId).toBe('a-peer-answering')
+
       unsubscribe()
     })
 

--- a/packages/core/src/presence/presenceStore.test.ts
+++ b/packages/core/src/presence/presenceStore.test.ts
@@ -1,5 +1,13 @@
 import {type SanityClient} from '@sanity/client'
-import {delay, firstValueFrom, type Observable, of, Subject} from 'rxjs'
+import {
+  BehaviorSubject,
+  delay,
+  firstValueFrom,
+  type Observable,
+  of,
+  Subject,
+  throwError,
+} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {getTokenState} from '../auth/authStore'
@@ -22,6 +30,8 @@ describe('presenceStore', () => {
   let mockTokenState: Subject<string | null>
   let mockIncomingEvents: Subject<TransportEvent>
   let mockDispatchMessage: Mock<(message: TransportMessage) => Observable<void>>
+  let mockConnections: BehaviorSubject<number>
+  let mockUnload: Subject<void>
   let mockGetUserState: Mock<typeof getUserState>
 
   const mockUser: SanityUser = {
@@ -64,9 +74,16 @@ describe('presenceStore', () => {
       subscribe: vi.fn(),
     })
 
+    // A live connection on subscribe, mirroring `bifur.heartbeats`, which emits
+    // as soon as the socket is open and authorized.
+    mockConnections = new BehaviorSubject<number>(1)
+    mockUnload = new Subject<void>()
+
     vi.mocked(createBifurTransport).mockReturnValue([
       mockIncomingEvents.asObservable(),
       mockDispatchMessage,
+      mockConnections.asObservable(),
+      mockUnload.asObservable(),
     ])
 
     mockGetUserState = vi.fn(() => of(mockUser))
@@ -338,6 +355,205 @@ describe('presenceStore', () => {
       })
 
       unsubscribe()
+    })
+
+    it('resolves no users when the canvas organization lookup fails', async () => {
+      // Regression guard: this used to be swallowed with `catchError(() => EMPTY)`
+      // and consumed with `first()`, so a failed request meant the user stream
+      // never emitted and every participant stayed "Unknown user" forever.
+      mockClient = {
+        withConfig: vi.fn().mockReturnThis(),
+        observable: {
+          request: vi.fn(() => throwError(() => new Error('canvas lookup failed'))),
+        },
+      } as unknown as SanityClient
+      vi.mocked(getClient).mockReturnValue(mockClient)
+
+      const source = getPresence(instance, {resource: {canvasId: 'canvas123'}})
+      const unsubscribe = source.subscribe(() => {})
+
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      mockIncomingEvents.next({
+        type: 'state',
+        userId: 'user-1',
+        sessionId: 'other-session',
+        timestamp: '2023-01-01T12:00:00Z',
+        locations: [],
+      })
+
+      await firstValueFrom(of(null).pipe(delay(50)))
+
+      // The presence itself still surfaces, with a placeholder user.
+      const presence = source.getCurrent()
+      expect(presence).toHaveLength(1)
+      expect(presence[0].user.profile.displayName).toBe('Unknown user')
+      // No doomed request is made without an organization to scope it to.
+      expect(getUserState).not.toHaveBeenCalled()
+
+      unsubscribe()
+    })
+
+    it('gives an unresolved user a structurally valid profile', async () => {
+      // The placeholder used to be cast through `as unknown as SanityUser` with
+      // no `profile`, so reading `user.profile.displayName` threw on first render.
+      mockGetUserState = vi.fn(() => of(undefined))
+      vi.mocked(getUserState).mockImplementation(mockGetUserState)
+
+      const source = getPresence(instance)
+      const unsubscribe = source.subscribe(() => {})
+
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      mockIncomingEvents.next({
+        type: 'state',
+        userId: 'user-1',
+        sessionId: 'other-session',
+        timestamp: '2023-01-01T12:00:00Z',
+        locations: [],
+      })
+
+      await firstValueFrom(of(null).pipe(delay(20)))
+
+      const [presence] = source.getCurrent()
+      expect(presence.user.profile.displayName).toBe('Unknown user')
+      expect(presence.user.profile.id).toBe('user-1')
+      expect(presence.user.sanityUserId).toBe('user-1')
+      expect(presence.user.memberships).toEqual([])
+
+      unsubscribe()
+    })
+  })
+
+  describe('connection lifecycle', () => {
+    it('clears accumulated presence and re-rollCalls when the socket reconnects', async () => {
+      const source = getPresence(instance)
+      const unsubscribe = source.subscribe(() => {})
+
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      mockIncomingEvents.next({
+        type: 'state',
+        userId: 'user-1',
+        sessionId: 'other-session',
+        timestamp: '2023-01-01T12:00:00Z',
+        locations: [],
+      })
+
+      await firstValueFrom(of(null).pipe(delay(20)))
+      expect(source.getCurrent()).toHaveLength(1)
+      expect(mockDispatchMessage).toHaveBeenCalledTimes(1)
+
+      // A new generation means a freshly live socket. Anything accumulated is
+      // suspect, because peers may have come or gone while we were away.
+      mockConnections.next(2)
+
+      await firstValueFrom(of(null).pipe(delay(20)))
+      expect(source.getCurrent()).toHaveLength(0)
+      expect(mockDispatchMessage).toHaveBeenNthCalledWith(2, {type: 'rollCall'})
+
+      unsubscribe()
+    })
+
+    it('announces a disconnect when the page unloads', async () => {
+      const source = getPresence(instance)
+      const unsubscribe = source.subscribe(() => {})
+
+      await firstValueFrom(of(null).pipe(delay(10)))
+      mockDispatchMessage.mockClear()
+
+      mockUnload.next()
+
+      expect(mockDispatchMessage).toHaveBeenCalledWith({type: 'disconnect'})
+
+      unsubscribe()
+    })
+  })
+
+  describe('stale session expiry', () => {
+    it('drops a session that stops announcing', async () => {
+      vi.useFakeTimers()
+      try {
+        const source = getPresence(instance)
+        const unsubscribe = source.subscribe(() => {})
+
+        await vi.advanceTimersByTimeAsync(10)
+
+        mockIncomingEvents.next({
+          type: 'state',
+          userId: 'user-1',
+          sessionId: 'other-session',
+          timestamp: new Date().toISOString(),
+          locations: [],
+        })
+
+        await vi.advanceTimersByTimeAsync(20)
+        expect(source.getCurrent()).toHaveLength(1)
+
+        // Peers re-announce every 30s, so surviving a sweep at 60s proves the
+        // sweep is not just deleting everything it sees.
+        await vi.advanceTimersByTimeAsync(60_000)
+        expect(source.getCurrent()).toHaveLength(1)
+
+        // Past the 90s TTL with no further announcements, the peer is gone.
+        await vi.advanceTimersByTimeAsync(45_000)
+        expect(source.getCurrent()).toHaveLength(0)
+
+        unsubscribe()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('keeps a session alive while it keeps announcing', async () => {
+      vi.useFakeTimers()
+      try {
+        const source = getPresence(instance)
+        const unsubscribe = source.subscribe(() => {})
+
+        await vi.advanceTimersByTimeAsync(10)
+
+        // Six announcements 30s apart, spanning well past the TTL.
+        for (let i = 0; i < 6; i++) {
+          mockIncomingEvents.next({
+            type: 'state',
+            userId: 'user-1',
+            sessionId: 'other-session',
+            timestamp: new Date().toISOString(),
+            locations: [],
+          })
+          await vi.advanceTimersByTimeAsync(30_000)
+        }
+
+        expect(source.getCurrent()).toHaveLength(1)
+
+        unsubscribe()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  describe('session id', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('gives each store its own id, so nothing can collide across tabs', () => {
+      // Ids are deliberately not persisted: a tab that inherits another's
+      // session storage would otherwise reuse the id and the two live clients
+      // would filter each other out as their own session.
+      let counter = 0
+      vi.stubGlobal('crypto', {randomUUID: vi.fn(() => `session-${++counter}`)})
+
+      getPresence(instance, {resource: {projectId: 'p1', dataset: 'd1'}}).subscribe(() => {})
+      const first = vi.mocked(createBifurTransport).mock.calls.at(-1)?.[0].sessionId
+
+      getPresence(instance, {resource: {projectId: 'p2', dataset: 'd2'}}).subscribe(() => {})
+      const second = vi.mocked(createBifurTransport).mock.calls.at(-1)?.[0].sessionId
+
+      expect(first).toBe('session-1')
+      expect(second).toBe('session-2')
     })
   })
 })

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -30,8 +30,11 @@ import {
 import {defineStore, type StoreContext} from '../store/defineStore'
 import {type SanityUser} from '../users/types'
 import {getUserState} from '../users/usersStore'
+import {createLogger} from '../utils/logger'
 import {createBifurTransport} from './bifurTransport'
 import {type PresenceLocation, type TransportEvent, type UserPresence} from './types'
+
+const logger = createLogger('presence')
 
 const PRESENCE_API_VERSION = '2026-03-30'
 
@@ -121,33 +124,44 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
 
     const subscription = new Subscription()
 
+    // Subscribed before the roll call below, deliberately. The transport
+    // establishes its listener when this stream is subscribed, and a roll call
+    // sent before we are listening would have its answers arrive to no one.
     subscription.add(
-      incomingEvents$.subscribe((event: TransportEvent) => {
-        if ('sessionId' in event && event.sessionId === sessionId) {
-          return
-        }
+      incomingEvents$.subscribe({
+        next: (event: TransportEvent) => {
+          if ('sessionId' in event && event.sessionId === sessionId) {
+            return
+          }
 
-        if (event.type === 'state') {
-          state.set('presence/state', (prevState: PresenceStoreState) => {
-            const newLocations = new Map(prevState.locations)
-            newLocations.set(event.sessionId, {
-              userId: event.userId,
-              locations: event.locations,
-              lastSeenAt: Date.now(),
+          if (event.type === 'state') {
+            state.set('presence/state', (prevState: PresenceStoreState) => {
+              const newLocations = new Map(prevState.locations)
+              newLocations.set(event.sessionId, {
+                userId: event.userId,
+                locations: event.locations,
+                lastSeenAt: Date.now(),
+              })
+
+              return {
+                ...prevState,
+                locations: newLocations,
+              }
             })
-
-            return {
-              ...prevState,
-              locations: newLocations,
-            }
-          })
-        } else if (event.type === 'disconnect') {
-          state.set('presence/disconnect', (prevState: PresenceStoreState) => {
-            const newLocations = new Map(prevState.locations)
-            newLocations.delete(event.sessionId)
-            return {...prevState, locations: newLocations}
-          })
-        }
+          } else if (event.type === 'disconnect') {
+            state.set('presence/disconnect', (prevState: PresenceStoreState) => {
+              const newLocations = new Map(prevState.locations)
+              newLocations.delete(event.sessionId)
+              return {...prevState, locations: newLocations}
+            })
+          }
+        },
+        // The transport re-establishes its listener on every live connection, so
+        // this should not fire. Handled rather than left to become an unhandled
+        // error, which is how presence used to die silently and for good.
+        error: (error: unknown) => {
+          logger.error('Presence event stream failed', {error})
+        },
       }),
     )
 
@@ -166,6 +180,12 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
 
     // Restarted per connection so a long reconnect backoff does not expire
     // everyone while we are offline — reconnecting clears the map anyway.
+    //
+    // Uses an rxjs timer rather than `setCleanupTimeout`, despite the guidance in
+    // core-package-conventions, because this is a recurring sweep and not a
+    // cleanup timer. Unref'ing it would not help anyway: a live presence
+    // subscription holds an open WebSocket, and that is what keeps a Node process
+    // alive. Anything running server-side should not subscribe to presence at all.
     subscription.add(
       connections$.pipe(switchMap(() => timer(SWEEP_INTERVAL, SWEEP_INTERVAL))).subscribe(() => {
         state.set('presence/expire', (prevState) => {

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -1,9 +1,7 @@
 import {createSelector} from 'reselect'
 import {
-  catchError,
   combineLatest,
   distinctUntilChanged,
-  EMPTY,
   filter,
   first,
   map,
@@ -11,6 +9,7 @@ import {
   of,
   Subscription,
   switchMap,
+  timer,
 } from 'rxjs'
 
 import {getTokenState} from '../auth/authStore'
@@ -36,14 +35,43 @@ import {type PresenceLocation, type TransportEvent, type UserPresence} from './t
 
 const PRESENCE_API_VERSION = '2026-03-30'
 
+/**
+ * How long a session may go without announcing before it is dropped. Bifur
+ * publishes nothing when a peer's socket dies, so a peer that crashes, is
+ * force-quit, or loses power would otherwise stay visible forever.
+ *
+ * Peers re-announce every 30 seconds, so this allows three missed announcements.
+ */
+const SESSION_TTL = 90_000
+
+/** How often to look for sessions that have gone quiet. */
+const SWEEP_INTERVAL = 15_000
+
+type PresenceSession = {
+  userId: string
+  locations: PresenceLocation[]
+  /**
+   * When we last heard from this session, on our own clock. Used for expiry in
+   * preference to the sender's `lastActiveAt`, which is subject to clock skew:
+   * a peer whose clock runs slow would otherwise be expired immediately, and one
+   * whose clock runs fast would never be expired at all.
+   */
+  lastSeenAt: number
+}
+
 type PresenceStoreState = {
-  locations: Map<string, {userId: string; locations: PresenceLocation[]}>
+  locations: Map<string, PresenceSession>
   users: Record<string, SanityUser | undefined>
   organizationId?: string
+  /**
+   * Set when the canvas organization lookup fails. Without it, consumers waiting
+   * on `organizationId` would wait forever.
+   */
+  organizationIdError?: unknown
 }
 
 const getInitialState = (): PresenceStoreState => ({
-  locations: new Map<string, {userId: string; locations: PresenceLocation[]}>(),
+  locations: new Map<string, PresenceSession>(),
   users: {},
 })
 
@@ -62,6 +90,11 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
       throw new Error('Presence is not supported for media library resources.')
     }
 
+    // A fresh id per store, deliberately not persisted. Reusing an id across
+    // page loads would collide whenever a tab inherits another's session
+    // storage (`window.open`, or a same-origin iframe), making two live clients
+    // filter each other out as self. Stale sessions are handled by the
+    // disconnect on unload, with the expiry sweep above as the backstop.
     const sessionId = crypto.randomUUID()
 
     // Dataset resources must use the project hostname so the socket URL is project-specific.
@@ -80,7 +113,7 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
 
     const token$ = getTokenState(instance).observable.pipe(distinctUntilChanged())
 
-    const [incomingEvents$, dispatch] = createBifurTransport({
+    const [incomingEvents$, dispatch, connections$, unload$] = createBifurTransport({
       client,
       token$,
       sessionId,
@@ -100,6 +133,7 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
             newLocations.set(event.sessionId, {
               userId: event.userId,
               locations: event.locations,
+              lastSeenAt: Date.now(),
             })
 
             return {
@@ -117,7 +151,36 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
       }),
     )
 
-    dispatch({type: 'rollCall'}).subscribe()
+    // Subscribing keeps the socket alive and reconnects it with backoff. Each
+    // emission is a freshly live connection: anything we accumulated is now
+    // suspect, so start over and ask everyone to announce themselves again.
+    subscription.add(
+      connections$.subscribe(() => {
+        state.set('presence/reset', (prevState) => ({
+          ...prevState,
+          locations: new Map<string, PresenceSession>(),
+        }))
+        dispatch({type: 'rollCall'}).subscribe()
+      }),
+    )
+
+    // Restarted per connection so a long reconnect backoff does not expire
+    // everyone while we are offline — reconnecting clears the map anyway.
+    subscription.add(
+      connections$.pipe(switchMap(() => timer(SWEEP_INTERVAL, SWEEP_INTERVAL))).subscribe(() => {
+        state.set('presence/expire', (prevState) => {
+          const cutoff = Date.now() - SESSION_TTL
+          const stale = [...prevState.locations].filter(([, s]) => s.lastSeenAt < cutoff)
+          if (stale.length === 0) return prevState
+
+          const newLocations = new Map(prevState.locations)
+          for (const [staleSessionId] of stale) newLocations.delete(staleSessionId)
+          return {...prevState, locations: newLocations}
+        })
+      }),
+    )
+
+    subscription.add(unload$.pipe(switchMap(() => dispatch({type: 'disconnect'}))).subscribe())
 
     // Canvas resources need the organizationId to resolve users — fetch it once from the canvas endpoint
     if (isCanvasResource(resource)) {
@@ -128,9 +191,13 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
             uri: `/canvases/${resource.canvasId}`,
             tag: 'canvases.get',
           })
-          .pipe(catchError(() => EMPTY))
-          .subscribe(({organizationId}) => {
-            state.set('presence/organizationId', (prev) => ({...prev, organizationId}))
+          .subscribe({
+            next: ({organizationId}) => {
+              state.set('presence/organizationId', (prev) => ({...prev, organizationId}))
+            },
+            error: (organizationIdError: unknown) => {
+              state.set('presence/organizationIdError', (prev) => ({...prev, organizationIdError}))
+            },
           }),
       )
     }
@@ -145,26 +212,32 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
 const selectLocations = (state: PresenceStoreState) => state.locations
 const selectUsers = (state: PresenceStoreState) => state.users
 
+/**
+ * Stands in for a participant whose profile has not resolved yet, or cannot be
+ * resolved. This must be a structurally valid `SanityUser`: consumers read
+ * `user.profile`, and a partial object would throw there on first render.
+ */
+const createUnresolvedUser = (userId: string): SanityUser => ({
+  sanityUserId: userId,
+  profile: {
+    id: userId,
+    displayName: 'Unknown user',
+    email: '',
+    provider: '',
+    createdAt: '',
+  },
+  memberships: [],
+})
+
 const selectPresence = createSelector(
   selectLocations,
   selectUsers,
   (locations, users): UserPresence[] => {
-    return Array.from(locations.entries()).map(([sessionId, {userId, locations: locs}]) => {
-      const user = users[userId]
-
-      return {
-        user:
-          user ||
-          ({
-            id: userId,
-            displayName: 'Unknown user',
-            name: 'Unknown user',
-            email: '',
-          } as unknown as SanityUser),
-        sessionId,
-        locations: locs,
-      }
-    })
+    return Array.from(locations.entries()).map(([sessionId, {userId, locations: locs}]) => ({
+      user: users[userId] || createUnresolvedUser(userId),
+      sessionId,
+      locations: locs,
+    }))
   },
 )
 
@@ -185,12 +258,14 @@ const _getPresence = bindActionByResource(
       )
 
       // For canvas resources, wait for organizationId to be fetched and stored in state.
+      // A failed lookup resolves to `undefined` rather than never emitting, so that
+      // one failed request does not leave every user permanently unresolved.
       // For dataset resources, emit undefined immediately so the stream isn't blocked.
       const organizationId$: Observable<string | undefined> = isCanvasResource(resource)
         ? context.state.observable.pipe(
-            map((s) => s.organizationId),
-            filter((id): id is string => id !== undefined),
+            filter((s) => s.organizationId !== undefined || s.organizationIdError !== undefined),
             first(),
+            map((s) => s.organizationId),
           )
         : of(undefined)
 
@@ -198,6 +273,11 @@ const _getPresence = bindActionByResource(
         .pipe(
           switchMap(([userIds, organizationId]) => {
             if (userIds.length === 0) {
+              return of([])
+            }
+            // Without an organization there is nothing to scope the lookup to,
+            // so skip the request rather than making one that cannot succeed.
+            if (!isDatasetResource(resource) && !organizationId) {
               return of([])
             }
             const userObservables = userIds.map((userId) =>

--- a/packages/core/src/presence/types.ts
+++ b/packages/core/src/presence/types.ts
@@ -22,6 +22,13 @@ export interface UserPresence {
 export type PresenceTransport = [
   incomingEvents$: Observable<TransportEvent>,
   dispatchMessage: (message: TransportMessage) => Observable<void>,
+  /**
+   * Emits an incrementing generation number each time the connection becomes
+   * live. Reconnects with backoff, and subscribing keeps the connection alive.
+   */
+  connections$: Observable<number>,
+  /** Emits when the page is going away, so a disconnect can be announced. */
+  unload$: Observable<void>,
 ]
 
 /** @public */


### PR DESCRIPTION
### Description

SDK presence stops working permanently after the first dropped socket. `@sanity/bifur-client` has no reconnect logic (`createConnect` errors the observable on `onclose`/`onerror`), and `presenceStore` subscribed with a next-only handler, so a single network blip killed the subscription with an unhandled error and presence never returned for the life of the page. This adds reconnect with exponential backoff, plus the stale-session handling that reconnect implies, and fixes four smaller defects in the same read path.

Two alternatives rejected:

- **Persisting the session id in `sessionStorage`** (what Studio does): a tab that inherits another's session storage, via `window.open` or a same-origin iframe, would read back the same id, and the two live clients would then filter each other's announcements out as their own session. The disconnect on unload plus the expiry sweep solve the same "reload looks like a new person" problem without introducing that collision.
- **Expiring on the sender's `lastActiveAt`**: subject to client clock skew, so a peer whose clock runs slow gets expired immediately and one whose clock runs fast never expires. Expiry uses our own receipt time instead.

No public API change. `packages/core/dist/index.d.ts` is byte-identical to `main`, verified by building both. `types.ts` is +7/-0: two members appended to the `PresenceTransport` tuple, so existing two-element destructuring still type-checks.

### What to review

`packages/core` only, all within `src/presence`. No React changes.

- **`bifurTransport.ts`** — `createConnections` is the load-bearing part. `bifur.heartbeats` is `merge(authedConnection$, heartbeats$, responses$)`, so it emits as soon as the socket is open and authorized rather than waiting up to 30s for the first server heartbeat, and it errors when the socket closes. `distinctUntilChanged` deliberately sits *after* `retry` so one operator instance spans reconnects and each live socket yields exactly one generation.
- **`presenceStore.ts`** — on each new connection generation the session map is cleared and a fresh `rollCall` goes out, since peers may have come or gone while we were away. The expiry sweep is gated on the same generation so a long backoff does not expire everyone while offline.
- **One runtime-observable change:** the placeholder for a user whose profile has not resolved yet is now a structurally valid `SanityUser`. It previously used `as unknown as SanityUser` on an object with no `profile`, so `user.profile.displayName` threw on first render. That access pattern now works; `user.displayName` no longer does, but it only ever worked until the profile resolved a few hundred milliseconds later.
- Canvas user resolution no longer deadlocks: `/canvases/:id` was wrapped in `catchError(() => EMPTY)` and consumed with `first()`, so a failed request meant every canvas participant stayed "Unknown user" forever.
- The `beforeunload` listener no longer leaks one subscription per transport, and now covers `pagehide` too, which is what iOS Safari and back/forward-cache navigations actually fire.

### Testing

8 new unit tests, presence coverage goes from 30 to 38.

I mutation-tested the three that matter rather than trusting them by eye: removing the `retry` operator fails both `connections` tests, removing the reconnect wipe fails the recovery test, and neutralizing the sweep predicate fails the expiry test. All restored afterwards.

The expiry tests assert both directions, that a session announcing every 30s survives well past the TTL and that one which goes quiet is dropped, so the sweep cannot pass by simply deleting everything.

Full suite: 1455 pass, 3 skipped. `pnpm ts:check` clean, `pnpm lint` 0 errors, `knip` clean.

Not covered here: presence has no e2e coverage at all, and every unit test mocks the transport, so nothing exercises a real socket yet. The `unload` tests stub a bare `EventTarget` for `window` rather than pulling `jsdom` into `packages/core`, which runs its tests in Node.

### Fun gif
![present](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExanZubTN3bndrcTNmM3Q1ZjQ0ejh5dnYwbmZib3F5ZDZ2bmZrcmNsaCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT8pean2qVcRY29uow/giphy.gif)

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
