### PR TITLE
feat(core): report presence at document, field, and cursor level

### DIFF
--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -193,10 +193,13 @@ export {
   type OrganizationsOptions,
   resolveOrganizations,
 } from '../organizations/organizations'
-export {getPresence} from '../presence/presenceStore'
+export {getPresence, reportPresence} from '../presence/presenceStore'
 export type {
   DisconnectEvent,
   PresenceLocation,
+  PresenceSelection,
+  PresenceSelectionPoint,
+  ReportPresenceOptions,
   RollCallEvent,
   StateEvent,
   TransportEvent,

--- a/packages/core/src/presence/presenceStore.test.ts
+++ b/packages/core/src/presence/presenceStore.test.ts
@@ -826,6 +826,31 @@ describe('presenceStore', () => {
       }
     })
 
+    it('keeps announcing when a trigger source fails', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        reportPresence(instance, {locations: [{documentId: 'doc-1'}]})
+        await flush()
+        expect(stateCalls()).toHaveLength(1)
+
+        // The three announce triggers are combined with `merge`, which propagates
+        // an error from any one of them. The inbound stream feeds the roll-call
+        // trigger, so a failure there would otherwise take the heartbeat and the
+        // reconnect re-announce down with it.
+        mockIncomingEvents.error(new Error('inbound stream failed'))
+
+        await vi.advanceTimersByTimeAsync(30_000)
+        expect(stateCalls()).toHaveLength(2)
+
+        mockConnections.next(2)
+        await flush()
+        expect(stateCalls()).toHaveLength(3)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('re-announces after a reconnect', async () => {
       vi.useFakeTimers()
       try {

--- a/packages/core/src/presence/presenceStore.test.ts
+++ b/packages/core/src/presence/presenceStore.test.ts
@@ -16,7 +16,7 @@ import {createSanityInstance, type SanityInstance} from '../store/createSanityIn
 import {type SanityUser} from '../users/types'
 import {getUserState} from '../users/usersStore'
 import {createBifurTransport} from './bifurTransport'
-import {getPresence} from './presenceStore'
+import {getPresence, reportPresence} from './presenceStore'
 import {type PresenceLocation, type TransportEvent, type TransportMessage} from './types'
 
 vi.mock('../auth/authStore')
@@ -470,6 +470,26 @@ describe('presenceStore', () => {
       unsubscribe()
     })
 
+    it('still announces a disconnect if an earlier one failed', async () => {
+      const source = getPresence(instance)
+      const unsubscribe = source.subscribe(() => {})
+
+      await firstValueFrom(of(null).pipe(delay(10)))
+      mockDispatchMessage.mockClear()
+
+      // `pagehide` can fire more than once: a page restored from the back/forward
+      // cache will fire it again. A failure on the first must not kill the stream.
+      mockDispatchMessage.mockReturnValueOnce(throwError(() => new Error('socket closed')))
+      mockUnload.next()
+      mockUnload.next()
+
+      expect(mockDispatchMessage.mock.calls.filter(([m]) => m.type === 'disconnect')).toHaveLength(
+        2,
+      )
+
+      unsubscribe()
+    })
+
     it('announces a disconnect when the page unloads', async () => {
       const source = getPresence(instance)
       const unsubscribe = source.subscribe(() => {})
@@ -543,6 +563,282 @@ describe('presenceStore', () => {
         expect(source.getCurrent()).toHaveLength(1)
 
         unsubscribe()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  describe('reportPresence', () => {
+    /** Drains the audit window so a pending announcement is flushed. */
+    const flush = () => vi.advanceTimersByTimeAsync(250)
+
+    const stateCalls = () =>
+      mockDispatchMessage.mock.calls
+        .map(([message]) => message)
+        .filter(
+          (message): message is Extract<TransportMessage, {type: 'state'}> =>
+            message.type === 'state',
+        )
+
+    it('stays silent until the app reports, so reading never broadcasts', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        await flush()
+        await vi.advanceTimersByTimeAsync(60_000)
+
+        // A rollCall goes out on connect, but never a state announcement.
+        expect(mockDispatchMessage).toHaveBeenCalledWith({type: 'rollCall'})
+        expect(stateCalls()).toEqual([])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('announces a document-level location', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-30T12:00:00.000Z'))
+      try {
+        getPresence(instance)
+        reportPresence(instance, {locations: [{documentId: 'doc-1'}]})
+        await flush()
+
+        expect(stateCalls()).toEqual([
+          {
+            type: 'state',
+            locations: [
+              {
+                type: 'document',
+                documentId: 'doc-1',
+                path: [],
+                lastActiveAt: '2026-07-30T12:00:00.000Z',
+              },
+            ],
+          },
+        ])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('carries keyed path segments and a Portable Text selection', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        // The shape the Studio expects: keyed segments for array items and spans.
+        reportPresence(instance, {
+          locations: [
+            {
+              documentId: 'doc-1',
+              path: ['body', {_key: 'block-1'}, 'children', {_key: 'span-1'}, 'text'],
+              selection: {
+                anchor: {path: [{_key: 'block-1'}, 'children', {_key: 'span-1'}], offset: 3},
+                focus: {path: [{_key: 'block-1'}, 'children', {_key: 'span-1'}], offset: 7},
+                backward: false,
+              },
+            },
+          ],
+        })
+        await flush()
+
+        const [announced] = stateCalls()
+        expect(announced.locations[0].path).toEqual([
+          'body',
+          {_key: 'block-1'},
+          'children',
+          {_key: 'span-1'},
+          'text',
+        ])
+        expect(announced.locations[0].selection).toEqual({
+          anchor: {path: [{_key: 'block-1'}, 'children', {_key: 'span-1'}], offset: 3},
+          focus: {path: [{_key: 'block-1'}, 'children', {_key: 'span-1'}], offset: 7},
+          backward: false,
+        })
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('omits selection entirely when none was reported', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        reportPresence(instance, {locations: [{documentId: 'doc-1', path: ['title']}]})
+        await flush()
+
+        expect('selection' in stateCalls()[0].locations[0]).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('announces an empty location list as present but nowhere', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        reportPresence(instance, {locations: []})
+        await flush()
+
+        expect(stateCalls()).toEqual([{type: 'state', locations: []}])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('collapses reports spread across the audit window into one announcement', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+
+        // Deliberately spaced out. Reports made in the same tick are collapsed by
+        // `switchMap` alone, so stepping the clock between them is what actually
+        // exercises the audit window - which is the case that matters, since a
+        // user typing produces focus changes tens of milliseconds apart.
+        reportPresence(instance, {locations: [{documentId: 'doc-1', path: ['a']}]})
+        await vi.advanceTimersByTimeAsync(50)
+        reportPresence(instance, {locations: [{documentId: 'doc-1', path: ['b']}]})
+        await vi.advanceTimersByTimeAsync(50)
+        reportPresence(instance, {locations: [{documentId: 'doc-1', path: ['c']}]})
+        await flush()
+
+        const announced = stateCalls()
+        expect(announced).toHaveLength(1)
+        expect(announced[0].locations[0].path).toEqual(['c'])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('does not re-announce when only lastActiveAt would differ', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        reportPresence(instance, {locations: [{documentId: 'doc-1', path: ['title']}]})
+        await flush()
+        expect(stateCalls()).toHaveLength(1)
+
+        // Same place, reported again. `lastActiveAt` is regenerated, but nothing
+        // moved, so this must not restart the heartbeat.
+        await vi.advanceTimersByTimeAsync(5_000)
+        reportPresence(instance, {locations: [{documentId: 'doc-1', path: ['title']}]})
+        await flush()
+
+        expect(stateCalls()).toHaveLength(1)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('re-announces every 30s while idle, so peers do not expire it', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        reportPresence(instance, {locations: [{documentId: 'doc-1'}]})
+        await flush()
+        expect(stateCalls()).toHaveLength(1)
+
+        await vi.advanceTimersByTimeAsync(30_000)
+        expect(stateCalls()).toHaveLength(2)
+
+        await vi.advanceTimersByTimeAsync(30_000)
+        expect(stateCalls()).toHaveLength(3)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it("answers another client's roll call", async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        reportPresence(instance, {locations: [{documentId: 'doc-1'}]})
+        await flush()
+        expect(stateCalls()).toHaveLength(1)
+
+        mockIncomingEvents.next({
+          type: 'rollCall',
+          userId: 'user-2',
+          sessionId: 'their-session',
+        })
+        await flush()
+
+        expect(stateCalls()).toHaveLength(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('ignores the echo of its own roll call', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        reportPresence(instance, {locations: [{documentId: 'doc-1'}]})
+        await flush()
+        expect(stateCalls()).toHaveLength(1)
+
+        // Bifur publishes to the topic we are subscribed to, so our own roll call
+        // comes straight back. Answering it would be a pointless round trip.
+        mockIncomingEvents.next({
+          type: 'rollCall',
+          userId: 'user-1',
+          sessionId: 'test-session-id',
+        })
+        await flush()
+
+        expect(stateCalls()).toHaveLength(1)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('keeps announcing after a failed announcement', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        reportPresence(instance, {locations: [{documentId: 'doc-1'}]})
+        await flush()
+        expect(stateCalls()).toHaveLength(1)
+
+        // A dropped socket errors the in-flight request. If that error reaches the
+        // announce stream it kills every trigger at once, because the heartbeat,
+        // roll-call responses, and reconnect re-announce all share this chain.
+        mockDispatchMessage.mockReturnValueOnce(throwError(() => new Error('socket closed')))
+        await vi.advanceTimersByTimeAsync(30_000)
+        expect(stateCalls()).toHaveLength(2)
+
+        // The heartbeat must survive the failure.
+        await vi.advanceTimersByTimeAsync(30_000)
+        expect(stateCalls()).toHaveLength(3)
+
+        // So must roll-call responses.
+        mockIncomingEvents.next({type: 'rollCall', userId: 'user-2', sessionId: 'their-session'})
+        await flush()
+        expect(stateCalls()).toHaveLength(4)
+
+        // And so must the re-announce on reconnect, which is the path that matters
+        // most: the failure and the reconnect have the same root cause.
+        mockConnections.next(2)
+        await flush()
+        expect(stateCalls()).toHaveLength(5)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('re-announces after a reconnect', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+        reportPresence(instance, {locations: [{documentId: 'doc-1'}]})
+        await flush()
+        expect(stateCalls()).toHaveLength(1)
+
+        mockConnections.next(2)
+        await flush()
+
+        // Peers cleared their view of us when we dropped, so we have to speak up.
+        expect(stateCalls()).toHaveLength(2)
       } finally {
         vi.useRealTimers()
       }

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -136,6 +136,24 @@ const sendSafely = (
     }),
   )
 
+/**
+ * Reduces a stream to a bare trigger that cannot fail.
+ *
+ * The announce pipeline combines three inputs with `merge`, which propagates an
+ * error from any one of them. Since that one pipeline carries the idle heartbeat,
+ * roll-call responses, and the re-announce on reconnect, a single failing input
+ * would silence this client for good. Losing one trigger is survivable; losing
+ * all three is not.
+ */
+const asTrigger = (source$: Observable<unknown>, name: string): Observable<void> =>
+  source$.pipe(
+    map(() => undefined),
+    catchError((error: unknown) => {
+      logger.error('Presence announce trigger failed', {trigger: name, error})
+      return EMPTY
+    }),
+  )
+
 /** Ignores `lastActiveAt`, which changes on every report even when nothing moved. */
 const locationKey = ({documentId, path, selection}: WirePresenceLocation) =>
   JSON.stringify([documentId, path, selection ?? null])
@@ -298,7 +316,11 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
     )
 
     subscription.add(
-      merge(localLocations$, rollCallRequests$, connections$)
+      merge(
+        asTrigger(localLocations$, 'locationChange'),
+        asTrigger(rollCallRequests$, 'rollCall'),
+        asTrigger(connections$, 'connection'),
+      )
         .pipe(
           switchMap(() => timer(0, REPORT_MIN_INTERVAL)),
           withLatestFrom(localLocations$),

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -1,15 +1,20 @@
 import {createSelector} from 'reselect'
 import {
+  auditTime,
+  catchError,
   combineLatest,
   distinctUntilChanged,
+  EMPTY,
   filter,
   first,
   map,
+  merge,
   type Observable,
   of,
   Subscription,
   switchMap,
   timer,
+  withLatestFrom,
 } from 'rxjs'
 
 import {getTokenState} from '../auth/authStore'
@@ -32,11 +37,33 @@ import {type SanityUser} from '../users/types'
 import {getUserState} from '../users/usersStore'
 import {createLogger} from '../utils/logger'
 import {createBifurTransport} from './bifurTransport'
-import {type PresenceLocation, type TransportEvent, type UserPresence} from './types'
+import {
+  type PresenceLocation,
+  type ReportPresenceOptions,
+  type TransportEvent,
+  type TransportMessage,
+  type UserPresence,
+  type WirePresenceLocation,
+} from './types'
 
 const logger = createLogger('presence')
 
+/**
+ * Used for the canvas organization lookup only. The socket itself is pinned to
+ * `2022-06-30` in `bifurTransport`, because that is the version Bifur compares
+ * against when deciding whether a connection may authenticate over RPC rather
+ * than requiring a JWT at upgrade. Do not align these two.
+ */
 const PRESENCE_API_VERSION = '2026-03-30'
+
+/**
+ * How often the current user re-announces while idle. Matches the Studio so the
+ * two agree on how long a quiet peer should be trusted.
+ */
+const REPORT_MIN_INTERVAL = 30_000
+
+/** Collapses a burst of focus changes into a single announcement. */
+const REPORT_AUDIT_TIME = 200
 
 /**
  * How long a session may go without announcing before it is dropped. Bifur
@@ -71,12 +98,61 @@ type PresenceStoreState = {
    * on `organizationId` would wait forever.
    */
   organizationIdError?: unknown
+  /**
+   * Where this client says it is. `undefined` means the app has never reported,
+   * which keeps it silent: reading presence must not make an app start
+   * broadcasting. An empty array is different, and means "here, but not in any
+   * particular document".
+   */
+  localLocations?: WirePresenceLocation[]
 }
 
 const getInitialState = (): PresenceStoreState => ({
   locations: new Map<string, PresenceSession>(),
   users: {},
 })
+
+/**
+ * Sends a message without letting a failure tear down the stream it was sent on.
+ *
+ * This matters most for the announce pipeline, which carries the idle heartbeat,
+ * roll-call responses, and the re-announce on reconnect. Those share one chain, so
+ * an unhandled error from a single rejected RPC would silence this client
+ * permanently while it carried on reading presence normally. A dropped socket
+ * errors the in-flight request, which is exactly the case where staying alive
+ * matters, since the reconnect that follows is what makes us visible again.
+ *
+ * No retry is needed here. The 30 second heartbeat sends again on its own, and a
+ * recovered connection triggers an immediate re-announce.
+ */
+const sendSafely = (
+  dispatch: (message: TransportMessage) => Observable<void>,
+  message: TransportMessage,
+): Observable<void> =>
+  dispatch(message).pipe(
+    catchError((error: unknown) => {
+      logger.warn('Failed to send presence message', {messageType: message.type, error})
+      return EMPTY
+    }),
+  )
+
+/** Ignores `lastActiveAt`, which changes on every report even when nothing moved. */
+const locationKey = ({documentId, path, selection}: WirePresenceLocation) =>
+  JSON.stringify([documentId, path, selection ?? null])
+
+/**
+ * Compares reported locations by value. Key order within a caller-supplied
+ * `selection` could in principle differ and read as a change, which costs one
+ * extra announcement and nothing else.
+ */
+function isEqualLocations(
+  a: WirePresenceLocation[] | undefined,
+  b: WirePresenceLocation[] | undefined,
+): boolean {
+  if (a === b) return true
+  if (!a || !b || a.length !== b.length) return false
+  return a.every((location, index) => locationKey(location) === locationKey(b[index]))
+}
 
 /** @public */
 export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
@@ -174,7 +250,7 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
           ...prevState,
           locations: new Map<string, PresenceSession>(),
         }))
-        dispatch({type: 'rollCall'}).subscribe()
+        sendSafely(dispatch, {type: 'rollCall'}).subscribe()
       }),
     )
 
@@ -200,7 +276,40 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
       }),
     )
 
-    subscription.add(unload$.pipe(switchMap(() => dispatch({type: 'disconnect'}))).subscribe())
+    subscription.add(
+      unload$.pipe(switchMap(() => sendSafely(dispatch, {type: 'disconnect'}))).subscribe(),
+    )
+
+    // Announce where we are. A location change, a peer asking for a roll call, or
+    // a reconnect all restart `timer(0, ...)`, so we announce immediately and then
+    // every 30s while idle. That idle tick is what tells peers we are still here,
+    // and is what their expiry sweep measures against.
+    const localLocations$ = state.observable.pipe(
+      map((s) => s.localLocations),
+      // Compared by value, not by reference. The Studio compares by reference and
+      // so never dedupes, because its form rebuilds the array on every call.
+      distinctUntilChanged(isEqualLocations),
+    )
+
+    const rollCallRequests$ = incomingEvents$.pipe(
+      // Bifur echoes our own roll call back to us, since we are subscribed to the
+      // same topic we published to. Answering it would be a pointless round trip.
+      filter((event) => event.type === 'rollCall' && event.sessionId !== sessionId),
+    )
+
+    subscription.add(
+      merge(localLocations$, rollCallRequests$, connections$)
+        .pipe(
+          switchMap(() => timer(0, REPORT_MIN_INTERVAL)),
+          withLatestFrom(localLocations$),
+          map(([, locations]) => locations),
+          // Stay silent until the app has reported at least once.
+          filter((locations): locations is WirePresenceLocation[] => locations !== undefined),
+          auditTime(REPORT_AUDIT_TIME),
+          switchMap((locations) => sendSafely(dispatch, {type: 'state', locations})),
+        )
+        .subscribe(),
+    )
 
     // Canvas resources need the organizationId to resolve users — fetch it once from the canvas endpoint
     if (isCanvasResource(resource)) {
@@ -223,7 +332,7 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
     }
 
     return () => {
-      dispatch({type: 'disconnect'}).subscribe()
+      sendSafely(dispatch, {type: 'disconnect'}).subscribe()
       subscription.unsubscribe()
     }
   },
@@ -338,4 +447,49 @@ export function getPresence(
   // bit of a hack to support the old bound action by dataset
   // in reality, this will always be passed a resource
   return _getPresence(instance, params ?? {})
+}
+
+const _reportPresence = bindActionByResource(
+  presenceStore,
+  (
+    {state}: StoreContext<PresenceStoreState, BoundResourceKey>,
+    {locations}: {resource?: DocumentResource; locations: ReportPresenceOptions[]},
+  ) => {
+    const lastActiveAt = new Date().toISOString()
+    const wireLocations: WirePresenceLocation[] = locations.map(
+      ({documentId, path = [], selection}) => ({
+        type: 'document',
+        documentId,
+        path,
+        lastActiveAt,
+        ...(selection === undefined ? {} : {selection}),
+      }),
+    )
+
+    state.set('presence/report', (prevState) => ({...prevState, localLocations: wireLocations}))
+  },
+)
+
+/**
+ * Announces where the current user is, so other clients in the same project and
+ * dataset can show them. Reading presence never announces anything, so this is
+ * the only way an app becomes visible to others.
+ *
+ * Call it again whenever the user moves. Announcements are collapsed over a short
+ * window and then repeated every 30 seconds while idle, which is what tells peers
+ * the session is still alive.
+ *
+ * @param instance - the Sanity instance
+ * @param params - the resource to announce on, plus the locations to report.
+ *   Pass one location with a `documentId` for document-level presence, add a
+ *   `path` for field-level presence, and pass an empty array to appear present
+ *   without being in any document.
+ *
+ * @beta
+ */
+export function reportPresence(
+  instance: SanityInstance,
+  params: {resource?: DocumentResource; locations: ReportPresenceOptions[]},
+): void {
+  return _reportPresence(instance, params)
 }

--- a/packages/core/src/presence/types.ts
+++ b/packages/core/src/presence/types.ts
@@ -1,14 +1,87 @@
 import {type SanityClient} from '@sanity/client'
+import {type Path} from '@sanity/types'
 import {type Observable} from 'rxjs'
 
 import {type SanityUser} from '../users/types'
+
+/**
+ * One end of a text selection: a Portable Text path plus a character offset
+ * within the span it addresses.
+ * @public
+ */
+export interface PresenceSelectionPoint {
+  path: Path
+  offset: number
+}
+
+/**
+ * A Portable Text caret or selected range, as exchanged with the Studio.
+ *
+ * Structurally identical to `EditorSelection` from `@portabletext/editor`, and
+ * declared here rather than imported so that `@sanity/sdk` stays free of React
+ * dependencies. The two are asserted to be mutually assignable in the React
+ * package, where the editor is already a peer dependency.
+ * @public
+ */
+export type PresenceSelection = {
+  anchor: PresenceSelectionPoint
+  focus: PresenceSelectionPoint
+  backward?: boolean
+} | null
 
 /** @public */
 export interface PresenceLocation {
   type: 'document'
   documentId: string
+  /**
+   * The focused field path.
+   *
+   * Note that this under-describes what actually arrives: path segments may be
+   * keyed (`{_key}`) or numeric when the focus is inside an array or a Portable
+   * Text field, because that is what the Studio sends. Narrowing to `string[]`
+   * predates that discovery, and widening it to `Path` is a breaking change to a
+   * published type, so it is deferred to the next major. Use
+   * {@link ReportPresenceOptions.path} when reporting, which is typed correctly.
+   */
   path: string[]
   lastActiveAt: string
+  /** A Portable Text caret, when the focused field is a Portable Text field. */
+  selection?: PresenceSelection
+}
+
+/**
+ * A location as it travels over the wire. Identical in shape to
+ * {@link PresenceLocation}, except `path` is a full `Path`, which is what is
+ * really exchanged. See the note on {@link PresenceLocation.path}.
+ *
+ * Internal: nothing in the public API accepts or returns this. Apps describe
+ * where they are with {@link ReportPresenceOptions} and read presence as
+ * {@link PresenceLocation}.
+ * @internal
+ */
+export interface WirePresenceLocation extends Omit<PresenceLocation, 'path'> {
+  path: Path
+}
+
+/**
+ * What an app reports about where the current user is.
+ *
+ * Omit `path` for document-level presence, or pass one for field-level presence.
+ * @public
+ */
+export interface ReportPresenceOptions {
+  /**
+   * The specific document id the user is in: a draft, published, or version id,
+   * whichever matches the perspective they are editing.
+   */
+  documentId: string
+  /**
+   * The focused field path. Supports keyed and numeric segments, so array items
+   * and Portable Text spans can be addressed.
+   */
+  path?: Path
+  /** A Portable Text caret, when the focused field is a Portable Text field. */
+  selection?: PresenceSelection
 }
 
 /** @public */
@@ -61,7 +134,7 @@ export interface DisconnectEvent {
 /** @public */
 export type TransportMessage =
   | {type: 'rollCall'}
-  | {type: 'state'; locations: PresenceLocation[]}
+  | {type: 'state'; locations: WirePresenceLocation[]}
   | {type: 'disconnect'}
 
 /** @public */


### PR DESCRIPTION
### Description

SDK presence has been read-only: `bifurTransport` implements `presence_announce`, but nothing ever called it, and the store discarded incoming `rollCall` events. So an SDK app could see Studio users while remaining invisible to them, and two SDK apps could never see each other. This adds the write half.

Announcing is opt-in. `localLocations` starts `undefined` and the publish pipeline filters on it, so calling `usePresence` never causes an app to start broadcasting. Reporting `[]` is deliberately distinct from never reporting, and means "present, but not in any document".

The cadence deliberately matches the Studio (`presence-store.ts:152`): a location change, a peer's roll call, or a reconnect restarts `timer(0, 30_000)`, through a 200ms audit window. That is not cosmetic. Studio clients share the NATS room `bifur.presence.<projectId>-<dataset>` and announce every 30s, and #1079 added a 90s expiry sweep, so the TTL has to stay a comfortable multiple of the slowest peer's announce interval. A shorter TTL would expire live Studio users between their announcements.

On `path` typing, one alternative rejected: widening `PresenceLocation.path` from `string[]` to `Path`. That would be correct, since keyed segments already arrive whenever a Studio user focuses an array item or a Portable Text span, but it is a breaking change to a published type and would force a major. Instead the read type is left alone with a doc comment recording that it under-describes reality, and the new `ReportPresenceOptions.path` is typed as a full `Path` so array items and Portable Text spans can be addressed. An internal `WirePresenceLocation` carries the accurate type between store and transport.

Stacked on #1079, so review that first and expect this diff to shrink once it merges.

### What to review

`packages/core` only. No React changes, so no hooks yet: that will come later, along with Portable Text cursor rendering and e2e.

- **`presenceStore.ts`, the publish pipeline.** `merge(localLocations$, rollCallRequests$, connections$)` into `switchMap(() => timer(0, REPORT_MIN_INTERVAL))`. The `filter` on `undefined` after `withLatestFrom` is what makes announcing opt-in. Roll-call echoes of our own session are dropped, since Bifur publishes back to the topic we subscribe to.
- **`sendSafely`, and why every dispatch goes through it.** `switchMap` propagates an inner error to the outer stream, and the heartbeat, roll-call responses, and reconnect re-announce all share that one chain. So a single rejected `presence_announce` would have silenced this client permanently while it carried on reading presence normally. The likeliest trigger is the worst one: a dropped socket errors the in-flight request, so the failure and the reconnect share a root cause, and the announce stream would die just before `connections$` recovered. `sendSafely` catches, logs to the `presence` logger namespace, and continues. No retry, because the 30s heartbeat and the reconnect re-announce already cover recovery.
- **`isEqualLocations`** compares by value and ignores `lastActiveAt`, which is regenerated on every report. Comparing by reference (as the Studio does, where the form rebuilds the array each call) would make every repeated report look like a move and restart the heartbeat.
- **`types.ts`.** `PresenceSelection` is declared structurally rather than imported from `@portabletext/editor`, so `packages/core` stays free of React dependencies per AGENTS.md. It is structurally identical to `EditorSelection`; the assignability assertion belongs in `packages/react`, where the editor becomes an optional peer in PR 3, and the doc comment says so.
- `WirePresenceLocation` is `@internal` and absent from the barrel, since nothing in the public API accepts or returns it.

### Testing

13 new unit tests, presence coverage 38 to 51. Full suite 1468 pass, `ts:check` clean, `lint` 0 errors, `knip` clean.

I mutation-tested every new behaviour rather than trusting a green run: dropping the silence guard, the audit window, the roll-call trigger, the roll-call self-filter, value-based location comparison, the 30s interval, and `sendSafely` on both the announce and unload paths each fail exactly the intended test.

Two of those tests came out of review questions rather than being written up front, and both found real problems:

The announce-failure test asserts that a failed send leaves the heartbeat, roll-call responses, and reconnect re-announce all working. It failed before `sendSafely` existed. The unload-failure test covers `pagehide` firing twice, which happens on a back/forward-cache restore, so a failure on the first must not kill the stream.

One bad test of mine also worth flagging, since the trap is easy to fall into again: my first "collapses a burst" test still passed with `auditTime` removed, because `switchMap` already discards reports made in the same tick, so it was really testing cancellation. It now steps the clock 50ms between reports, which is the case that matters, since a typing user produces focus changes tens of milliseconds apart.

Not covered here: nothing exercises a real socket yet, since every test mocks the transport.

### Fun gif
![im here](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExajh2cmhhOGs1dDB4d3M2ZGhpcmdzMmtmaXZ1bTVjejB3cG40N3dwciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3ohhwMgUhd0jaubsas/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
