### PR TITLE
feat(react): add presence reporting and per-document presence hooks

### DIFF
--- a/apps/kitchensink-react/e2e/presence.spec.ts
+++ b/apps/kitchensink-react/e2e/presence.spec.ts
@@ -1,0 +1,139 @@
+import {expect, test} from '@repo/e2e'
+
+/**
+ * Presence is exercised across two browser contexts rather than two panes on one
+ * page.
+ *
+ * Presence stores are keyed by project and dataset and held in a module-level
+ * registry, so two `SanityInstance`s in the same JavaScript realm share one store,
+ * one socket, and one session id. Two panes would therefore be a single
+ * participant, and every assertion here would pass without proving anything.
+ * Separate contexts are separate realms, so they are genuinely separate sessions
+ * talking over a real Bifur room.
+ *
+ * Both contexts are the same user, which is the ordinary "one person, two tabs"
+ * case. Participants are counted by session, not by user.
+ */
+test.describe('Presence', () => {
+  test('two sessions see each other in a document, down to the focused field', async ({
+    page,
+    browser,
+    createDocuments,
+    getPageContext,
+  }) => {
+    const {documentIds} = await createDocuments([{_type: 'author', name: 'Presence Subject'}], {
+      asDraft: false,
+    })
+    const documentId = documentIds[0]
+    const url = `./presence?documentId=${documentId}`
+
+    await page.goto(url)
+    const first = await getPageContext(page)
+    await expect(first.getByTestId('presence-document-id')).toHaveText(documentId)
+
+    // Alone to begin with: a client never sees its own session reported back.
+    await expect(first.getByTestId('presence-document-empty')).toBeVisible()
+
+    // A second context, authenticated as the same user from the same storage state
+    // the project set up, so this is a second session rather than a second person.
+    const secondContext = await browser.newContext({
+      storageState: await page.context().storageState(),
+    })
+    const secondPage = await secondContext.newPage()
+
+    try {
+      await secondPage.goto(url)
+      const second = await getPageContext(secondPage)
+
+      // Each announces on mount, and each answers the other's roll call.
+      await expect(first.getByTestId('presence-document')).toHaveAttribute('data-count', '1')
+      await expect(second.getByTestId('presence-document')).toHaveAttribute('data-count', '1')
+
+      // At the document root until a field is focused.
+      await expect(first.getByTestId('presence-document-participant')).toContainText(
+        'at the document root',
+      )
+
+      // Field level: the second session focuses a field, the first sees it against
+      // that field and not against the other one.
+      await second.getByTestId('presence-input-name').focus()
+      await expect(first.getByTestId('presence-field-name')).toHaveAttribute('data-count', '1')
+      await expect(first.getByTestId('presence-field-role')).toHaveAttribute('data-count', '0')
+
+      // Moving between fields moves the indicator rather than accumulating.
+      await second.getByTestId('presence-input-role').focus()
+      await expect(first.getByTestId('presence-field-role')).toHaveAttribute('data-count', '1')
+      await expect(first.getByTestId('presence-field-name')).toHaveAttribute('data-count', '0')
+
+      // Still in the document, just no longer in a field.
+      await second.getByTestId('presence-blur').click()
+      await expect(first.getByTestId('presence-field-role')).toHaveAttribute('data-count', '0')
+      await expect(first.getByTestId('presence-document')).toHaveAttribute('data-count', '1')
+    } finally {
+      await secondContext.close()
+    }
+
+    // Closing the tab fires the disconnect on unload, so the peer goes away
+    // promptly rather than lingering until the expiry sweep.
+    await expect(first.getByTestId('presence-document-empty')).toBeVisible()
+  })
+
+  test('reading presence does not announce anything', async ({
+    page,
+    browser,
+    createDocuments,
+    getPageContext,
+  }) => {
+    const {documentIds} = await createDocuments([{_type: 'author', name: 'Reader Only'}], {
+      asDraft: false,
+    })
+    const url = `./presence?documentId=${documentIds[0]}`
+
+    await page.goto(url)
+    const first = await getPageContext(page)
+
+    // Reading without writing, which is how an app that only displays presence
+    // behaves. Announcing is opt-in, so switching it off must make this session
+    // invisible while it carries on receiving everyone else.
+    //
+    // Clicked via the label rather than the input, because @sanity/ui hides the
+    // real checkbox under a styled overlay and Playwright's actionability check
+    // on the input itself is unreliable.
+    await first.getByTestId('presence-announcing-label').click()
+    await expect(first.getByTestId('presence-announcing')).not.toBeChecked()
+
+    const secondContext = await browser.newContext({
+      storageState: await page.context().storageState(),
+    })
+    const secondPage = await secondContext.newPage()
+
+    try {
+      await secondPage.goto(url)
+      const second = await getPageContext(secondPage)
+
+      // The reader still sees the announcer.
+      await expect(first.getByTestId('presence-document')).toHaveAttribute('data-count', '1')
+
+      // The announcer never sees the reader.
+      await expect(second.getByTestId('presence-document-empty')).toBeVisible()
+    } finally {
+      await secondContext.close()
+    }
+  })
+
+  test('defaults to a document without needing a query parameter', async ({
+    page,
+    createDocuments,
+    getPageContext,
+  }) => {
+    await createDocuments([{_type: 'author', name: 'Default Target'}], {asDraft: false})
+
+    await page.goto('./presence')
+    const context = await getPageContext(page)
+
+    // Opening the route bare has to land on a real document, otherwise poking at
+    // presence by hand means looking up an id first.
+    await expect(context.getByTestId('presence-document-id')).not.toBeEmpty()
+    await expect(context.getByTestId('presence-document')).toBeVisible()
+  })
+})

--- a/apps/kitchensink-react/e2e/presence.spec.ts
+++ b/apps/kitchensink-react/e2e/presence.spec.ts
@@ -1,4 +1,58 @@
+import {type Page} from '@playwright/test'
 import {expect, test} from '@repo/e2e'
+
+/**
+ * Reports what the presence socket actually did, so a failure says which of three
+ * things went wrong: the socket never opened, it opened and was rejected, or it
+ * connected and no peer was ever heard from.
+ *
+ * Without this, a failed assertion only says "nobody showed up", which is the same
+ * symptom for all three.
+ */
+function tracePresenceSocket(page: Page, label: string): void {
+  page.on('websocket', (ws) => {
+    const url = ws.url()
+    if (!url.includes('/socket/')) return
+
+    // eslint-disable-next-line no-console
+    console.log(`[${label}] socket open ${url}`)
+    ws.on('socketerror', (error) => {
+      // eslint-disable-next-line no-console
+      console.log(`[${label}] socket error ${error}`)
+    })
+    ws.on('close', () => {
+      // eslint-disable-next-line no-console
+      console.log(`[${label}] socket closed`)
+    })
+    ws.on('framesent', ({payload}) => {
+      const text = String(payload)
+      if (text.includes('presence_')) {
+        // eslint-disable-next-line no-console
+        console.log(`[${label}] sent ${text.slice(0, 200)}`)
+      }
+    })
+    ws.on('framereceived', ({payload}) => {
+      const text = String(payload)
+      // Skip the heartbeat, which is a bare U+2665 and would drown the log.
+      if (text.length > 1 && !text.includes('welcome')) {
+        // eslint-disable-next-line no-console
+        console.log(`[${label}] recv ${text.slice(0, 200)}`)
+      }
+    })
+  })
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      // eslint-disable-next-line no-console
+      console.log(`[${label}] console error ${message.text().slice(0, 300)}`)
+    }
+  })
+
+  page.on('pageerror', (error) => {
+    // eslint-disable-next-line no-console
+    console.log(`[${label}] page error ${error.message.slice(0, 300)}`)
+  })
+}
 
 /**
  * Presence is exercised across two browser contexts rather than two panes on one
@@ -27,6 +81,7 @@ test.describe('Presence', () => {
     const documentId = documentIds[0]
     const url = `./presence?documentId=${documentId}`
 
+    tracePresenceSocket(page, 'first')
     await page.goto(url)
     const first = await getPageContext(page)
     await expect(first.getByTestId('presence-document-id')).toHaveText(documentId)
@@ -40,10 +95,20 @@ test.describe('Presence', () => {
       storageState: await page.context().storageState(),
     })
     const secondPage = await secondContext.newPage()
+    tracePresenceSocket(secondPage, 'second')
 
     try {
       await secondPage.goto(url)
       const second = await getPageContext(secondPage)
+
+      // Both should be reporting the same specific id, or they will not see each
+      // other for the same reason the Studio's field indicators would not.
+      await expect(first.getByTestId('presence-reported-id')).toHaveText(
+        `Reporting as drafts.${documentId}`,
+      )
+      await expect(second.getByTestId('presence-reported-id')).toHaveText(
+        `Reporting as drafts.${documentId}`,
+      )
 
       // Each announces on mount, and each answers the other's roll call.
       await expect(first.getByTestId('presence-document')).toHaveAttribute('data-count', '1')
@@ -89,6 +154,7 @@ test.describe('Presence', () => {
     })
     const url = `./presence?documentId=${documentIds[0]}`
 
+    tracePresenceSocket(page, 'reader')
     await page.goto(url)
     const first = await getPageContext(page)
 
@@ -106,6 +172,7 @@ test.describe('Presence', () => {
       storageState: await page.context().storageState(),
     })
     const secondPage = await secondContext.newPage()
+    tracePresenceSocket(secondPage, 'announcer')
 
     try {
       await secondPage.goto(url)

--- a/apps/kitchensink-react/e2e/presence.spec.ts
+++ b/apps/kitchensink-react/e2e/presence.spec.ts
@@ -41,11 +41,15 @@ function tracePresenceSocket(page: Page, label: string): void {
     })
   })
 
+  // The dashboard emits a steady stream of font, Sentry, and CORS errors of its own,
+  // which drown anything useful. Kept out so a real error is visible.
+  const noise = /studio-static|sentry|Replay|bridge\.js|Failed to load resource/
   page.on('console', (message) => {
-    if (message.type() === 'error') {
-      // eslint-disable-next-line no-console
-      console.log(`[${label}] console error ${message.text().slice(0, 300)}`)
-    }
+    if (message.type() !== 'error') return
+    const text = message.text()
+    if (noise.test(text)) return
+    // eslint-disable-next-line no-console
+    console.log(`[${label}] console error ${text.slice(0, 300)}`)
   })
 
   page.on('pageerror', (error) => {
@@ -55,23 +59,21 @@ function tracePresenceSocket(page: Page, label: string): void {
 }
 
 /**
- * Presence is exercised across two browser contexts rather than two panes on one
- * page.
+ * Presence is exercised across two browser tabs rather than two panes on one page.
  *
  * Presence stores are keyed by project and dataset and held in a module-level
  * registry, so two `SanityInstance`s in the same JavaScript realm share one store,
  * one socket, and one session id. Two panes would therefore be a single
  * participant, and every assertion here would pass without proving anything.
- * Separate contexts are separate realms, so they are genuinely separate sessions
- * talking over a real Bifur room.
+ * Separate tabs are separate realms, so they are genuinely separate sessions talking
+ * over a real Bifur room.
  *
- * Both contexts are the same user, which is the ordinary "one person, two tabs"
- * case. Participants are counted by session, not by user.
+ * Both tabs are the same user, which is the ordinary "one person, two tabs" case.
+ * Participants are counted by session, not by user.
  */
 test.describe('Presence', () => {
   test('two sessions see each other in a document, down to the focused field', async ({
     page,
-    browser,
     createDocuments,
     getPageContext,
   }) => {
@@ -89,12 +91,14 @@ test.describe('Presence', () => {
     // Alone to begin with: a client never sees its own session reported back.
     await expect(first.getByTestId('presence-document-empty')).toBeVisible()
 
-    // A second context, authenticated as the same user from the same storage state
-    // the project set up, so this is a second session rather than a second person.
-    const secondContext = await browser.newContext({
-      storageState: await page.context().storageState(),
-    })
-    const secondPage = await secondContext.newPage()
+    // A second tab in the same context, which is a separate JavaScript realm and so
+    // a separate presence store, socket, and session id. Same user, second session.
+    //
+    // Deliberately not `browser.newContext()`: a manually created context does not
+    // inherit the project's `use` options, and without the `x-vercel-protection-bypass`
+    // headers the dashboard's app iframe stays sandboxed, scripts never execute, and
+    // the app never renders at all.
+    const secondPage = await page.context().newPage()
     tracePresenceSocket(secondPage, 'second')
 
     try {
@@ -135,7 +139,7 @@ test.describe('Presence', () => {
       await expect(first.getByTestId('presence-field-role')).toHaveAttribute('data-count', '0')
       await expect(first.getByTestId('presence-document')).toHaveAttribute('data-count', '1')
     } finally {
-      await secondContext.close()
+      await secondPage.close()
     }
 
     // Closing the tab fires the disconnect on unload, so the peer goes away
@@ -145,7 +149,6 @@ test.describe('Presence', () => {
 
   test('reading presence does not announce anything', async ({
     page,
-    browser,
     createDocuments,
     getPageContext,
   }) => {
@@ -168,10 +171,7 @@ test.describe('Presence', () => {
     await first.getByTestId('presence-announcing-label').click()
     await expect(first.getByTestId('presence-announcing')).not.toBeChecked()
 
-    const secondContext = await browser.newContext({
-      storageState: await page.context().storageState(),
-    })
-    const secondPage = await secondContext.newPage()
+    const secondPage = await page.context().newPage()
     tracePresenceSocket(secondPage, 'announcer')
 
     try {
@@ -184,7 +184,7 @@ test.describe('Presence', () => {
       // The announcer never sees the reader.
       await expect(second.getByTestId('presence-document-empty')).toBeVisible()
     } finally {
-      await secondContext.close()
+      await secondPage.close()
     }
   })
 

--- a/apps/kitchensink-react/e2e/presence.spec.ts
+++ b/apps/kitchensink-react/e2e/presence.spec.ts
@@ -105,14 +105,11 @@ test.describe('Presence', () => {
       await secondPage.goto(url)
       const second = await getPageContext(secondPage)
 
-      // Both resolve the default `drafts` perspective to the same specific id. If
-      // they diverged they would not see each other, for the same reason the
-      // Studio's field indicators would not.
-      await expect(first.getByTestId('presence-reported-id')).toHaveText(
-        `Reporting as drafts.${documentId}`,
-      )
-      await expect(second.getByTestId('presence-reported-id')).toHaveText(
-        `Reporting as drafts.${documentId}`,
+      // Asserted on the peer's own reported id, which is what actually went over the
+      // wire and came back, rather than on either tab's local display. Under the
+      // default `drafts` perspective the SDK resolves to the draft.
+      await expect(first.getByTestId('presence-participant-document-id')).toHaveText(
+        `drafts.${documentId}`,
       )
 
       // Each announces on mount, and each answers the other's roll call.

--- a/apps/kitchensink-react/e2e/presence.spec.ts
+++ b/apps/kitchensink-react/e2e/presence.spec.ts
@@ -105,8 +105,9 @@ test.describe('Presence', () => {
       await secondPage.goto(url)
       const second = await getPageContext(secondPage)
 
-      // Both should be reporting the same specific id, or they will not see each
-      // other for the same reason the Studio's field indicators would not.
+      // Both resolve the default `drafts` perspective to the same specific id. If
+      // they diverged they would not see each other, for the same reason the
+      // Studio's field indicators would not.
       await expect(first.getByTestId('presence-reported-id')).toHaveText(
         `Reporting as drafts.${documentId}`,
       )

--- a/apps/kitchensink-react/src/Presence/PresenceRoute.tsx
+++ b/apps/kitchensink-react/src/Presence/PresenceRoute.tsx
@@ -1,4 +1,3 @@
-import {getEditingDocumentId} from '@sanity/sdk'
 import {
   type DocumentPresence,
   useDocumentProjection,
@@ -153,13 +152,11 @@ function ScopeText(): JSX.Element | null {
 
 function DocumentCard({
   documentId,
-  reportedId,
   perspective,
   onPerspectiveChange,
   studioUrl,
 }: {
   documentId: string
-  reportedId: string
   perspective: Perspective
   onPerspectiveChange: (next: Perspective) => void
   studioUrl: string
@@ -181,9 +178,6 @@ function DocumentCard({
             {documentId}
           </Code>
           <PerspectiveSelect perspective={perspective} onChange={onPerspectiveChange} />
-          <Text size={1} muted data-testid="presence-reported-id">
-            Reporting as {reportedId}
-          </Text>
           <ScopeText />
         </Stack>
         <Button
@@ -240,6 +234,9 @@ function Participant({participant}: {participant: DocumentPresence}): JSX.Elemen
   return (
     <Flex align="center" gap={2} data-testid="presence-document-participant">
       <Badge tone="primary">{participant.user.profile.displayName}</Badge>
+      <Code size={0} data-testid="presence-participant-document-id">
+        {participant.documentId}
+      </Code>
       {/* Plain text rather than `Code`, which renders as a block and would stack
           the words vertically. */}
       <Text size={1} muted>
@@ -371,13 +368,12 @@ function PresenceDemo({documentId}: {documentId: string}): JSX.Element {
   const [focusedField, setFocusedField] = useState<string | undefined>(undefined)
   const [announcing, setAnnouncing] = useState(true)
 
-  // The perspective is all the app has to supply. The hooks resolve it to the
-  // specific document being edited, which is what other clients compare against:
-  // the draft under `drafts`, the published document under `published`. Getting that
-  // wrong is why presence can appear in the Studio at document level while never
-  // lighting up a field.
+  // The perspective is all the app supplies. The SDK resolves it to the specific
+  // document being edited, which is what other clients compare against: the draft
+  // under `drafts`, the published document under `published`. Getting that wrong is
+  // why presence can appear in the Studio at document level while never lighting up
+  // a field.
   const [perspective, setPerspective] = useState<Perspective>('drafts')
-  const reportedId = getEditingDocumentId({documentId, perspective})
 
   const studioBase = (searchParams.get('studio') ?? DEFAULT_STUDIO_BASE_URL).replace(/\/+$/, '')
   // An intent link rather than a structure path, so the Studio resolves it with
@@ -399,7 +395,6 @@ function PresenceDemo({documentId}: {documentId: string}): JSX.Element {
 
       <DocumentCard
         documentId={documentId}
-        reportedId={reportedId}
         perspective={perspective}
         onPerspectiveChange={setPerspective}
         studioUrl={studioUrl}

--- a/apps/kitchensink-react/src/Presence/PresenceRoute.tsx
+++ b/apps/kitchensink-react/src/Presence/PresenceRoute.tsx
@@ -1,47 +1,369 @@
-import {usePresence, useProject} from '@sanity/sdk-react'
-import {JSX} from 'react'
+import {
+  useDocumentProjection,
+  useDocuments,
+  usePresenceForDocument,
+  useReportPresence,
+  useResource,
+} from '@sanity/sdk-react'
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Code,
+  Flex,
+  Inline,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+} from '@sanity/ui'
+import {JSX, useState} from 'react'
+import {useSearchParams} from 'react-router'
 
-function PresenceSecondProject(): JSX.Element {
-  const project = useProject({projectId: 'vo1ysemo'})
-  const {locations} = usePresence({resource: {projectId: 'vo1ysemo', dataset: 'production'}})
+import {PageLayout} from '../components/PageLayout'
+
+const DOCUMENT_TYPE = 'author'
+
+/**
+ * The Studio that serves the kitchensink's default resource, `ppsg7ml5` / `test`.
+ * Override with `?studio=<baseUrl>` when pointing at any other one.
+ */
+const DEFAULT_STUDIO_BASE_URL = 'https://test-studio.sanity.build/test'
+
+/**
+ * The fields that report field-level presence when focused.
+ *
+ * Both exist on the `author` schema in the Studio, which matters: presence is
+ * reported against a path whether or not a field is in the schema, but a Studio
+ * with no input for that path has nowhere to draw the indicator. Picking real
+ * fields is what makes the Studio interop check work in both directions.
+ */
+const FIELDS = [
+  {name: 'name', label: 'Name'},
+  // Mirrors the schema, where `role` is a list of these three values.
+  {name: 'role', label: 'Role', options: ['developer', 'designer', 'ops']},
+] as const
+
+/**
+ * Who else is focused at or below one field.
+ *
+ * `excludeVersions` is on deliberately: a field indicator should show only people
+ * in the same document you are looking at, not someone in a release version of it.
+ */
+function FieldPresence({
+  documentId,
+  path,
+  testId,
+}: {
+  documentId: string
+  path: string[]
+  testId: string
+}): JSX.Element {
+  const {presence} = usePresenceForDocument({
+    documentId,
+    documentType: DOCUMENT_TYPE,
+    path,
+    excludeVersions: true,
+  })
 
   return (
-    <div>
-      <p>Project: {project?.id}</p>
-      <pre>{JSON.stringify(locations, null, 2)}</pre>
-    </div>
+    <Inline space={2} data-testid={`presence-field-${testId}`} data-count={presence.length}>
+      {presence.map((participant) => (
+        <Badge
+          key={participant.sessionId}
+          tone="primary"
+          data-testid={`presence-field-${testId}-avatar`}
+        >
+          {participant.user.profile.displayName}
+        </Badge>
+      ))}
+    </Inline>
   )
 }
 
-function PresenceCanvas(): JSX.Element {
-  const canvasId = 'cag5gSK37IGV'
-  const {locations} = usePresence({resource: {canvasId}})
+/**
+ * Announces the current user, and nothing else.
+ *
+ * Split out so announcing can be switched off by not rendering it, rather than by
+ * conditionally calling a hook. Unmounting clears the reported location, which is
+ * what `useReportPresence` does on cleanup.
+ */
+function PresenceReporter({
+  documentId,
+  focusedField,
+}: {
+  documentId: string
+  focusedField?: string
+}): null {
+  useReportPresence({
+    documentId,
+    documentType: DOCUMENT_TYPE,
+    ...(focusedField ? {path: [focusedField]} : {}),
+  })
+  return null
+}
+
+/**
+ * Announces the current user and shows everyone else in the same document.
+ *
+ * Two browser tabs are what this route is built to demonstrate. Presence stores
+ * are keyed by project and dataset and shared across `SanityInstance`s in one
+ * JavaScript realm, so two panes on this page would be a single participant with a
+ * single session. Separate tabs are separate realms, hence separate sessions.
+ */
+function PresenceDemo({documentId}: {documentId: string}): JSX.Element {
+  const [searchParams] = useSearchParams()
+  const [focusedField, setFocusedField] = useState<string | undefined>(undefined)
+  const [announcing, setAnnouncing] = useState(true)
+
+  // Which exact document id to be present in, and it matters more than it looks.
+  //
+  // The Studio scopes presence differently per surface. Its navbar and document
+  // lists compare published ids, so they match whichever of these you pick. Its
+  // form field indicators use the id it is actually editing with an exact
+  // comparison, and while editing in the default perspective that is the draft.
+  // So reporting the published id shows up in the Studio at document level while
+  // never lighting up a single field.
+  //
+  // Defaults to the draft for that reason. `drafts.` is the stable convention for
+  // draft ids; the SDK does not re-export an id helper for this.
+  const [reportAs, setReportAs] = useState<'draft' | 'published'>('draft')
+  const reportedId = reportAs === 'draft' ? `drafts.${documentId}` : documentId
+
+  const resource = useResource()
+  const studioBaseUrl = (searchParams.get('studio') ?? DEFAULT_STUDIO_BASE_URL).replace(/\/+$/, '')
+  // An intent link rather than a structure path, so the Studio resolves it with
+  // whichever tool handles editing rather than us guessing its structure.
+  const studioUrl = `${studioBaseUrl}/intent/edit/id=${encodeURIComponent(documentId)};type=${DOCUMENT_TYPE}`
+
+  const {presence} = usePresenceForDocument({documentId: reportedId, documentType: DOCUMENT_TYPE})
+  const {data} = useDocumentProjection<{name: string | null}>({
+    documentId,
+    documentType: DOCUMENT_TYPE,
+    projection: `{name}`,
+  })
 
   return (
-    <div>
-      <p>Canvas: {canvasId}</p>
-      <pre>{JSON.stringify(locations, null, 2)}</pre>
-    </div>
+    <PageLayout
+      title="Presence"
+      subtitle="Open this page in a second tab to see presence. Both tabs are you, as two separate sessions, which is what the Studio shows too."
+    >
+      {announcing ? <PresenceReporter documentId={reportedId} focusedField={focusedField} /> : null}
+
+      <Card padding={3} radius={2} tone="transparent">
+        <Flex align="flex-start" gap={3}>
+          <Stack space={3} flex={1}>
+            <Text size={1} weight="medium">
+              {data?.name ?? 'Untitled'}
+            </Text>
+            <Code size={0} data-testid="presence-document-id">
+              {documentId}
+            </Code>
+            <Flex align="center" gap={2}>
+              <Text size={1} muted>
+                Present in the
+              </Text>
+              <Select
+                data-testid="presence-report-as"
+                value={reportAs}
+                onChange={(event) =>
+                  setReportAs(event.currentTarget.value === 'draft' ? 'draft' : 'published')
+                }
+              >
+                <option value="draft">draft</option>
+                <option value="published">published document</option>
+              </Select>
+            </Flex>
+            <Text size={1} muted data-testid="presence-reported-id">
+              Reporting as {reportedId}
+            </Text>
+            <Text size={1} muted>
+              {resource && 'projectId' in resource
+                ? `Project ${resource.projectId} · dataset ${resource.dataset}`
+                : null}
+            </Text>
+          </Stack>
+          <Button
+            as="a"
+            href={studioUrl}
+            target="_blank"
+            rel="noreferrer"
+            mode="ghost"
+            text="Open in Studio"
+            data-testid="presence-studio-link"
+          />
+        </Flex>
+      </Card>
+
+      <Stack space={2}>
+        <Text size={1} muted>
+          Opening the same document in a Studio checks that presence works between the two: they
+          share one room per project and dataset, so each should see the other. The link assumes
+          that Studio serves the project and dataset above.
+        </Text>
+        <Text size={1} muted>
+          The Studio compares published ids in its navbar and document lists, but its field
+          indicators compare the exact id it is editing, which while editing is the draft. So
+          reporting the published document appears in the Studio at document level yet never lights
+          up a field. That is what the selector above is for.
+        </Text>
+        <Text size={1} muted>
+          Defaults to the most recently created {DOCUMENT_TYPE} document. Add ?documentId=&lt;id&gt;
+          to the URL to pick a different one, or ?studio=&lt;baseUrl&gt; to point the link at
+          another Studio.
+        </Text>
+      </Stack>
+
+      <Card padding={3} radius={2} tone="transparent">
+        <Flex align="flex-start" gap={3}>
+          <Checkbox
+            id="presence-announcing"
+            data-testid="presence-announcing"
+            checked={announcing}
+            onChange={(event) => setAnnouncing(event.currentTarget.checked)}
+          />
+          <Stack space={2} flex={1}>
+            <Text
+              as="label"
+              htmlFor="presence-announcing"
+              size={1}
+              weight="medium"
+              data-testid="presence-announcing-label"
+            >
+              Announce my presence
+            </Text>
+            <Text size={1} muted>
+              Turn this off to read presence without appearing to anyone else, which is how an app
+              that only displays presence behaves.
+            </Text>
+          </Stack>
+        </Flex>
+      </Card>
+
+      <Stack space={3}>
+        <Text size={1} weight="semibold">
+          Others in this document
+        </Text>
+        <Card
+          padding={3}
+          radius={2}
+          border
+          data-testid="presence-document"
+          data-count={presence.length}
+        >
+          {presence.length === 0 ? (
+            <Text size={1} muted data-testid="presence-document-empty">
+              Nobody else is here
+            </Text>
+          ) : (
+            <Stack space={3}>
+              {presence.map((participant) => (
+                <Flex
+                  key={participant.sessionId}
+                  align="center"
+                  gap={2}
+                  data-testid="presence-document-participant"
+                >
+                  <Badge tone="primary">{participant.user.profile.displayName}</Badge>
+                  {/* Plain text rather than `Code`, which renders as a block and
+                      would stack the words vertically. */}
+                  <Text size={1} muted>
+                    {participant.path.length > 0
+                      ? `in ${participant.path.join('.')}`
+                      : 'at the document root'}
+                  </Text>
+                </Flex>
+              ))}
+            </Stack>
+          )}
+        </Card>
+      </Stack>
+
+      <Stack space={3}>
+        <Text size={1} weight="semibold">
+          Fields
+        </Text>
+        <Text size={1} muted>
+          Focus a field to report presence there. The other tab shows a badge beside it.
+        </Text>
+        {FIELDS.map((field) => (
+          <Stack key={field.name} space={2}>
+            <Flex align="center" gap={2}>
+              <Text size={1} weight="medium">
+                {field.label}
+              </Text>
+              <FieldPresence documentId={reportedId} path={[field.name]} testId={field.name} />
+            </Flex>
+            {'options' in field ? (
+              <Select
+                data-testid={`presence-input-${field.name}`}
+                onFocus={() => setFocusedField(field.name)}
+                onBlur={() => setFocusedField(undefined)}
+              >
+                <option value="">Focus to be present in {field.name}</option>
+                {field.options.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </Select>
+            ) : (
+              <TextInput
+                data-testid={`presence-input-${field.name}`}
+                placeholder={`Focus to be present in ${field.name}`}
+                onFocus={() => setFocusedField(field.name)}
+                onBlur={() => setFocusedField(undefined)}
+              />
+            )}
+          </Stack>
+        ))}
+        <Box>
+          <Button
+            data-testid="presence-blur"
+            mode="ghost"
+            text="Clear focus"
+            onClick={() => setFocusedField(undefined)}
+          />
+        </Box>
+      </Stack>
+    </PageLayout>
   )
 }
 
 export function PresenceRoute(): JSX.Element {
-  const project = useProject()
-  const {locations} = usePresence()
+  const [searchParams] = useSearchParams()
+  const documentIdParam = searchParams.get('documentId')
 
-  return (
-    <div>
-      <h1>Presence for {project?.id}</h1>
-      <p>
-        <a href={`https://test-studio.sanity.build/test/structure/`} target={project?.id}>
-          View in Studio →
-        </a>
-      </p>
-      <pre>{JSON.stringify(locations, null, 2)}</pre>
-      <h1>Second Project Presence</h1>
-      <PresenceSecondProject />
-      <h1>Canvas Presence</h1>
-      <PresenceCanvas />
-    </div>
-  )
+  // Defaults to a real document so the route is useful the moment you open it,
+  // with no id to look up first. Ordered explicitly rather than relying on the
+  // API's default, because every tab has to land on the same document for presence
+  // to mean anything.
+  const {data} = useDocuments({
+    documentType: DOCUMENT_TYPE,
+    batchSize: 1,
+    orderings: [{field: '_createdAt', direction: 'desc'}],
+    ...(documentIdParam
+      ? {filter: '_id == $documentId', params: {documentId: documentIdParam}}
+      : {}),
+  })
+
+  const documentId = data[0]?.documentId
+
+  if (!documentId) {
+    return (
+      <PageLayout title="Presence" subtitle="Nothing to be present in">
+        <Card padding={3} radius={2} tone="caution">
+          <Text size={1} data-testid="presence-no-documents">
+            {documentIdParam
+              ? `No ${DOCUMENT_TYPE} document with id ${documentIdParam}.`
+              : `No ${DOCUMENT_TYPE} documents in this dataset.`}
+          </Text>
+        </Card>
+      </PageLayout>
+    )
+  }
+
+  return <PresenceDemo documentId={documentId} />
 }

--- a/apps/kitchensink-react/src/Presence/PresenceRoute.tsx
+++ b/apps/kitchensink-react/src/Presence/PresenceRoute.tsx
@@ -1,3 +1,4 @@
+import {getEditingDocumentId} from '@sanity/sdk'
 import {
   type DocumentPresence,
   useDocumentProjection,
@@ -47,15 +48,18 @@ const FIELDS = [
   {name: 'role', label: 'Role', options: ['developer', 'designer', 'ops']},
 ] as const
 
-type ReportAs = 'draft' | 'published'
+/** The perspectives this route can be present in. Mirrors what the Studio offers. */
+type Perspective = 'drafts' | 'published'
 
 /** Who else is focused at or below one field. */
 function FieldPresence({
   documentId,
+  perspective,
   path,
   testId,
 }: {
   documentId: string
+  perspective: Perspective
   path: string[]
   testId: string
 }): JSX.Element {
@@ -64,6 +68,7 @@ function FieldPresence({
   const {presence} = usePresenceForDocument({
     documentId,
     documentType: DOCUMENT_TYPE,
+    perspective,
     path,
     excludeVersions: true,
   })
@@ -92,40 +97,43 @@ function FieldPresence({
  */
 function PresenceReporter({
   documentId,
+  perspective,
   focusedField,
 }: {
   documentId: string
+  perspective: Perspective
   focusedField?: string
 }): null {
   useReportPresence({
     documentId,
     documentType: DOCUMENT_TYPE,
+    perspective,
     ...(focusedField ? {path: [focusedField]} : {}),
   })
   return null
 }
 
-function ReportAsSelect({
-  reportAs,
+function PerspectiveSelect({
+  perspective,
   onChange,
 }: {
-  reportAs: ReportAs
-  onChange: (next: ReportAs) => void
+  perspective: Perspective
+  onChange: (next: Perspective) => void
 }): JSX.Element {
   return (
     <Flex align="center" gap={2}>
       <Text size={1} muted>
-        Present in the
+        Perspective
       </Text>
       <Select
-        data-testid="presence-report-as"
-        value={reportAs}
+        data-testid="presence-perspective"
+        value={perspective}
         onChange={(event) =>
-          onChange(event.currentTarget.value === 'published' ? 'published' : 'draft')
+          onChange(event.currentTarget.value === 'published' ? 'published' : 'drafts')
         }
       >
-        <option value="draft">draft</option>
-        <option value="published">published document</option>
+        <option value="drafts">drafts</option>
+        <option value="published">published</option>
       </Select>
     </Flex>
   )
@@ -146,14 +154,14 @@ function ScopeText(): JSX.Element | null {
 function DocumentCard({
   documentId,
   reportedId,
-  reportAs,
-  onReportAsChange,
+  perspective,
+  onPerspectiveChange,
   studioUrl,
 }: {
   documentId: string
   reportedId: string
-  reportAs: ReportAs
-  onReportAsChange: (next: ReportAs) => void
+  perspective: Perspective
+  onPerspectiveChange: (next: Perspective) => void
   studioUrl: string
 }): JSX.Element {
   const {data} = useDocumentProjection<{name: string | null}>({
@@ -172,7 +180,7 @@ function DocumentCard({
           <Code size={0} data-testid="presence-document-id">
             {documentId}
           </Code>
-          <ReportAsSelect reportAs={reportAs} onChange={onReportAsChange} />
+          <PerspectiveSelect perspective={perspective} onChange={onPerspectiveChange} />
           <Text size={1} muted data-testid="presence-reported-id">
             Reporting as {reportedId}
           </Text>
@@ -241,8 +249,14 @@ function Participant({participant}: {participant: DocumentPresence}): JSX.Elemen
   )
 }
 
-function ParticipantList({documentId}: {documentId: string}): JSX.Element {
-  const {presence} = usePresenceForDocument({documentId, documentType: DOCUMENT_TYPE})
+function ParticipantList({
+  documentId,
+  perspective,
+}: {
+  documentId: string
+  perspective: Perspective
+}): JSX.Element {
+  const {presence} = usePresenceForDocument({documentId, documentType: DOCUMENT_TYPE, perspective})
 
   return (
     <Stack space={3}>
@@ -275,11 +289,13 @@ function ParticipantList({documentId}: {documentId: string}): JSX.Element {
 function FieldRow({
   field,
   documentId,
+  perspective,
   onFocus,
   onBlur,
 }: {
   field: (typeof FIELDS)[number]
   documentId: string
+  perspective: Perspective
   onFocus: () => void
   onBlur: () => void
 }): JSX.Element {
@@ -291,7 +307,12 @@ function FieldRow({
         <Text size={1} weight="medium">
           {field.label}
         </Text>
-        <FieldPresence documentId={documentId} path={[field.name]} testId={field.name} />
+        <FieldPresence
+          documentId={documentId}
+          perspective={perspective}
+          path={[field.name]}
+          testId={field.name}
+        />
       </Flex>
       {'options' in field ? (
         <Select data-testid={testId} onFocus={onFocus} onBlur={onBlur}>
@@ -323,10 +344,10 @@ function Notes(): JSX.Element {
         serves the project and dataset above.
       </Text>
       <Text size={1} muted>
-        The Studio compares published ids in its navbar and document lists, but its field indicators
-        compare the exact id it is editing, which while editing is the draft. So reporting the
-        published document appears in the Studio at document level yet never lights up a field. That
-        is what the selector above is for.
+        The perspective is the only thing an app supplies; the hooks resolve it to the specific
+        document being edited. That matters because the Studio compares published ids in its navbar
+        and document lists but compares the exact id its form is on for field indicators, so
+        reporting the wrong one appears at document level yet never lights up a field.
       </Text>
       <Text size={1} muted>
         Defaults to the most recently created {DOCUMENT_TYPE} document. Add ?documentId=&lt;id&gt;
@@ -350,15 +371,13 @@ function PresenceDemo({documentId}: {documentId: string}): JSX.Element {
   const [focusedField, setFocusedField] = useState<string | undefined>(undefined)
   const [announcing, setAnnouncing] = useState(true)
 
-  // Which exact document id to be present in, and it matters more than it looks.
-  // The Studio's field indicators compare the id it is editing, exactly, and while
-  // editing in the default perspective that is the draft. Reporting the published
-  // id therefore shows up at document level while never lighting up a field.
-  //
-  // `drafts.` is the stable convention for draft ids; the SDK does not re-export an
-  // id helper for this.
-  const [reportAs, setReportAs] = useState<ReportAs>('draft')
-  const reportedId = reportAs === 'draft' ? `drafts.${documentId}` : documentId
+  // The perspective is all the app has to supply. The hooks resolve it to the
+  // specific document being edited, which is what other clients compare against:
+  // the draft under `drafts`, the published document under `published`. Getting that
+  // wrong is why presence can appear in the Studio at document level while never
+  // lighting up a field.
+  const [perspective, setPerspective] = useState<Perspective>('drafts')
+  const reportedId = getEditingDocumentId({documentId, perspective})
 
   const studioBase = (searchParams.get('studio') ?? DEFAULT_STUDIO_BASE_URL).replace(/\/+$/, '')
   // An intent link rather than a structure path, so the Studio resolves it with
@@ -370,18 +389,24 @@ function PresenceDemo({documentId}: {documentId: string}): JSX.Element {
       title="Presence"
       subtitle="Open this page in a second tab to see presence. Both tabs are you, as two separate sessions, which is what the Studio shows too."
     >
-      {announcing ? <PresenceReporter documentId={reportedId} focusedField={focusedField} /> : null}
+      {announcing ? (
+        <PresenceReporter
+          documentId={documentId}
+          perspective={perspective}
+          focusedField={focusedField}
+        />
+      ) : null}
 
       <DocumentCard
         documentId={documentId}
         reportedId={reportedId}
-        reportAs={reportAs}
-        onReportAsChange={setReportAs}
+        perspective={perspective}
+        onPerspectiveChange={setPerspective}
         studioUrl={studioUrl}
       />
       <Notes />
       <AnnounceToggle announcing={announcing} onChange={setAnnouncing} />
-      <ParticipantList documentId={reportedId} />
+      <ParticipantList documentId={documentId} perspective={perspective} />
 
       <Stack space={3}>
         <Text size={1} weight="semibold">
@@ -394,7 +419,8 @@ function PresenceDemo({documentId}: {documentId: string}): JSX.Element {
           <FieldRow
             key={field.name}
             field={field}
-            documentId={reportedId}
+            documentId={documentId}
+            perspective={perspective}
             onFocus={() => setFocusedField(field.name)}
             onBlur={() => setFocusedField(undefined)}
           />

--- a/apps/kitchensink-react/src/Presence/PresenceRoute.tsx
+++ b/apps/kitchensink-react/src/Presence/PresenceRoute.tsx
@@ -1,4 +1,5 @@
 import {
+  type DocumentPresence,
   useDocumentProjection,
   useDocuments,
   usePresenceForDocument,
@@ -46,12 +47,9 @@ const FIELDS = [
   {name: 'role', label: 'Role', options: ['developer', 'designer', 'ops']},
 ] as const
 
-/**
- * Who else is focused at or below one field.
- *
- * `excludeVersions` is on deliberately: a field indicator should show only people
- * in the same document you are looking at, not someone in a release version of it.
- */
+type ReportAs = 'draft' | 'published'
+
+/** Who else is focused at or below one field. */
 function FieldPresence({
   documentId,
   path,
@@ -61,6 +59,8 @@ function FieldPresence({
   path: string[]
   testId: string
 }): JSX.Element {
+  // `excludeVersions` deliberately: a field indicator should show only people in
+  // the same document you are looking at, not someone in a release version of it.
   const {presence} = usePresenceForDocument({
     documentId,
     documentType: DOCUMENT_TYPE,
@@ -105,6 +105,238 @@ function PresenceReporter({
   return null
 }
 
+function ReportAsSelect({
+  reportAs,
+  onChange,
+}: {
+  reportAs: ReportAs
+  onChange: (next: ReportAs) => void
+}): JSX.Element {
+  return (
+    <Flex align="center" gap={2}>
+      <Text size={1} muted>
+        Present in the
+      </Text>
+      <Select
+        data-testid="presence-report-as"
+        value={reportAs}
+        onChange={(event) =>
+          onChange(event.currentTarget.value === 'published' ? 'published' : 'draft')
+        }
+      >
+        <option value="draft">draft</option>
+        <option value="published">published document</option>
+      </Select>
+    </Flex>
+  )
+}
+
+/** The project and dataset in play, so a mismatch with the Studio link is visible. */
+function ScopeText(): JSX.Element | null {
+  const resource = useResource()
+  if (!resource || !('projectId' in resource)) return null
+
+  return (
+    <Text size={1} muted>
+      {`Project ${resource.projectId} · dataset ${resource.dataset}`}
+    </Text>
+  )
+}
+
+function DocumentCard({
+  documentId,
+  reportedId,
+  reportAs,
+  onReportAsChange,
+  studioUrl,
+}: {
+  documentId: string
+  reportedId: string
+  reportAs: ReportAs
+  onReportAsChange: (next: ReportAs) => void
+  studioUrl: string
+}): JSX.Element {
+  const {data} = useDocumentProjection<{name: string | null}>({
+    documentId,
+    documentType: DOCUMENT_TYPE,
+    projection: `{name}`,
+  })
+
+  return (
+    <Card padding={3} radius={2} tone="transparent">
+      <Flex align="flex-start" gap={3}>
+        <Stack space={3} flex={1}>
+          <Text size={1} weight="medium">
+            {data?.name ?? 'Untitled'}
+          </Text>
+          <Code size={0} data-testid="presence-document-id">
+            {documentId}
+          </Code>
+          <ReportAsSelect reportAs={reportAs} onChange={onReportAsChange} />
+          <Text size={1} muted data-testid="presence-reported-id">
+            Reporting as {reportedId}
+          </Text>
+          <ScopeText />
+        </Stack>
+        <Button
+          as="a"
+          href={studioUrl}
+          target="_blank"
+          rel="noreferrer"
+          mode="ghost"
+          text="Open in Studio"
+          data-testid="presence-studio-link"
+        />
+      </Flex>
+    </Card>
+  )
+}
+
+function AnnounceToggle({
+  announcing,
+  onChange,
+}: {
+  announcing: boolean
+  onChange: (next: boolean) => void
+}): JSX.Element {
+  return (
+    <Card padding={3} radius={2} tone="transparent">
+      <Flex align="flex-start" gap={3}>
+        <Checkbox
+          id="presence-announcing"
+          data-testid="presence-announcing"
+          checked={announcing}
+          onChange={(event) => onChange(event.currentTarget.checked)}
+        />
+        <Stack space={2} flex={1}>
+          <Text
+            as="label"
+            htmlFor="presence-announcing"
+            size={1}
+            weight="medium"
+            data-testid="presence-announcing-label"
+          >
+            Announce my presence
+          </Text>
+          <Text size={1} muted>
+            Turn this off to read presence without appearing to anyone else, which is how an app
+            that only displays presence behaves.
+          </Text>
+        </Stack>
+      </Flex>
+    </Card>
+  )
+}
+
+function Participant({participant}: {participant: DocumentPresence}): JSX.Element {
+  return (
+    <Flex align="center" gap={2} data-testid="presence-document-participant">
+      <Badge tone="primary">{participant.user.profile.displayName}</Badge>
+      {/* Plain text rather than `Code`, which renders as a block and would stack
+          the words vertically. */}
+      <Text size={1} muted>
+        {participant.path.length > 0 ? `in ${participant.path.join('.')}` : 'at the document root'}
+      </Text>
+    </Flex>
+  )
+}
+
+function ParticipantList({documentId}: {documentId: string}): JSX.Element {
+  const {presence} = usePresenceForDocument({documentId, documentType: DOCUMENT_TYPE})
+
+  return (
+    <Stack space={3}>
+      <Text size={1} weight="semibold">
+        Others in this document
+      </Text>
+      <Card
+        padding={3}
+        radius={2}
+        border
+        data-testid="presence-document"
+        data-count={presence.length}
+      >
+        {presence.length === 0 ? (
+          <Text size={1} muted data-testid="presence-document-empty">
+            Nobody else is here
+          </Text>
+        ) : (
+          <Stack space={3}>
+            {presence.map((participant) => (
+              <Participant key={participant.sessionId} participant={participant} />
+            ))}
+          </Stack>
+        )}
+      </Card>
+    </Stack>
+  )
+}
+
+function FieldRow({
+  field,
+  documentId,
+  onFocus,
+  onBlur,
+}: {
+  field: (typeof FIELDS)[number]
+  documentId: string
+  onFocus: () => void
+  onBlur: () => void
+}): JSX.Element {
+  const testId = `presence-input-${field.name}`
+
+  return (
+    <Stack space={2}>
+      <Flex align="center" gap={2}>
+        <Text size={1} weight="medium">
+          {field.label}
+        </Text>
+        <FieldPresence documentId={documentId} path={[field.name]} testId={field.name} />
+      </Flex>
+      {'options' in field ? (
+        <Select data-testid={testId} onFocus={onFocus} onBlur={onBlur}>
+          <option value="">Focus to be present in {field.name}</option>
+          {field.options.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </Select>
+      ) : (
+        <TextInput
+          data-testid={testId}
+          placeholder={`Focus to be present in ${field.name}`}
+          onFocus={onFocus}
+          onBlur={onBlur}
+        />
+      )}
+    </Stack>
+  )
+}
+
+function Notes(): JSX.Element {
+  return (
+    <Stack space={2}>
+      <Text size={1} muted>
+        Opening the same document in a Studio checks that presence works between the two: they share
+        one room per project and dataset, so each should see the other. The link assumes that Studio
+        serves the project and dataset above.
+      </Text>
+      <Text size={1} muted>
+        The Studio compares published ids in its navbar and document lists, but its field indicators
+        compare the exact id it is editing, which while editing is the draft. So reporting the
+        published document appears in the Studio at document level yet never lights up a field. That
+        is what the selector above is for.
+      </Text>
+      <Text size={1} muted>
+        Defaults to the most recently created {DOCUMENT_TYPE} document. Add ?documentId=&lt;id&gt;
+        to the URL to pick a different one, or ?studio=&lt;baseUrl&gt; to point the link at another
+        Studio.
+      </Text>
+    </Stack>
+  )
+}
+
 /**
  * Announces the current user and shows everyone else in the same document.
  *
@@ -119,31 +351,19 @@ function PresenceDemo({documentId}: {documentId: string}): JSX.Element {
   const [announcing, setAnnouncing] = useState(true)
 
   // Which exact document id to be present in, and it matters more than it looks.
+  // The Studio's field indicators compare the id it is editing, exactly, and while
+  // editing in the default perspective that is the draft. Reporting the published
+  // id therefore shows up at document level while never lighting up a field.
   //
-  // The Studio scopes presence differently per surface. Its navbar and document
-  // lists compare published ids, so they match whichever of these you pick. Its
-  // form field indicators use the id it is actually editing with an exact
-  // comparison, and while editing in the default perspective that is the draft.
-  // So reporting the published id shows up in the Studio at document level while
-  // never lighting up a single field.
-  //
-  // Defaults to the draft for that reason. `drafts.` is the stable convention for
-  // draft ids; the SDK does not re-export an id helper for this.
-  const [reportAs, setReportAs] = useState<'draft' | 'published'>('draft')
+  // `drafts.` is the stable convention for draft ids; the SDK does not re-export an
+  // id helper for this.
+  const [reportAs, setReportAs] = useState<ReportAs>('draft')
   const reportedId = reportAs === 'draft' ? `drafts.${documentId}` : documentId
 
-  const resource = useResource()
-  const studioBaseUrl = (searchParams.get('studio') ?? DEFAULT_STUDIO_BASE_URL).replace(/\/+$/, '')
+  const studioBase = (searchParams.get('studio') ?? DEFAULT_STUDIO_BASE_URL).replace(/\/+$/, '')
   // An intent link rather than a structure path, so the Studio resolves it with
   // whichever tool handles editing rather than us guessing its structure.
-  const studioUrl = `${studioBaseUrl}/intent/edit/id=${encodeURIComponent(documentId)};type=${DOCUMENT_TYPE}`
-
-  const {presence} = usePresenceForDocument({documentId: reportedId, documentType: DOCUMENT_TYPE})
-  const {data} = useDocumentProjection<{name: string | null}>({
-    documentId,
-    documentType: DOCUMENT_TYPE,
-    projection: `{name}`,
-  })
+  const studioUrl = `${studioBase}/intent/edit/id=${encodeURIComponent(documentId)};type=${DOCUMENT_TYPE}`
 
   return (
     <PageLayout
@@ -152,134 +372,16 @@ function PresenceDemo({documentId}: {documentId: string}): JSX.Element {
     >
       {announcing ? <PresenceReporter documentId={reportedId} focusedField={focusedField} /> : null}
 
-      <Card padding={3} radius={2} tone="transparent">
-        <Flex align="flex-start" gap={3}>
-          <Stack space={3} flex={1}>
-            <Text size={1} weight="medium">
-              {data?.name ?? 'Untitled'}
-            </Text>
-            <Code size={0} data-testid="presence-document-id">
-              {documentId}
-            </Code>
-            <Flex align="center" gap={2}>
-              <Text size={1} muted>
-                Present in the
-              </Text>
-              <Select
-                data-testid="presence-report-as"
-                value={reportAs}
-                onChange={(event) =>
-                  setReportAs(event.currentTarget.value === 'draft' ? 'draft' : 'published')
-                }
-              >
-                <option value="draft">draft</option>
-                <option value="published">published document</option>
-              </Select>
-            </Flex>
-            <Text size={1} muted data-testid="presence-reported-id">
-              Reporting as {reportedId}
-            </Text>
-            <Text size={1} muted>
-              {resource && 'projectId' in resource
-                ? `Project ${resource.projectId} · dataset ${resource.dataset}`
-                : null}
-            </Text>
-          </Stack>
-          <Button
-            as="a"
-            href={studioUrl}
-            target="_blank"
-            rel="noreferrer"
-            mode="ghost"
-            text="Open in Studio"
-            data-testid="presence-studio-link"
-          />
-        </Flex>
-      </Card>
-
-      <Stack space={2}>
-        <Text size={1} muted>
-          Opening the same document in a Studio checks that presence works between the two: they
-          share one room per project and dataset, so each should see the other. The link assumes
-          that Studio serves the project and dataset above.
-        </Text>
-        <Text size={1} muted>
-          The Studio compares published ids in its navbar and document lists, but its field
-          indicators compare the exact id it is editing, which while editing is the draft. So
-          reporting the published document appears in the Studio at document level yet never lights
-          up a field. That is what the selector above is for.
-        </Text>
-        <Text size={1} muted>
-          Defaults to the most recently created {DOCUMENT_TYPE} document. Add ?documentId=&lt;id&gt;
-          to the URL to pick a different one, or ?studio=&lt;baseUrl&gt; to point the link at
-          another Studio.
-        </Text>
-      </Stack>
-
-      <Card padding={3} radius={2} tone="transparent">
-        <Flex align="flex-start" gap={3}>
-          <Checkbox
-            id="presence-announcing"
-            data-testid="presence-announcing"
-            checked={announcing}
-            onChange={(event) => setAnnouncing(event.currentTarget.checked)}
-          />
-          <Stack space={2} flex={1}>
-            <Text
-              as="label"
-              htmlFor="presence-announcing"
-              size={1}
-              weight="medium"
-              data-testid="presence-announcing-label"
-            >
-              Announce my presence
-            </Text>
-            <Text size={1} muted>
-              Turn this off to read presence without appearing to anyone else, which is how an app
-              that only displays presence behaves.
-            </Text>
-          </Stack>
-        </Flex>
-      </Card>
-
-      <Stack space={3}>
-        <Text size={1} weight="semibold">
-          Others in this document
-        </Text>
-        <Card
-          padding={3}
-          radius={2}
-          border
-          data-testid="presence-document"
-          data-count={presence.length}
-        >
-          {presence.length === 0 ? (
-            <Text size={1} muted data-testid="presence-document-empty">
-              Nobody else is here
-            </Text>
-          ) : (
-            <Stack space={3}>
-              {presence.map((participant) => (
-                <Flex
-                  key={participant.sessionId}
-                  align="center"
-                  gap={2}
-                  data-testid="presence-document-participant"
-                >
-                  <Badge tone="primary">{participant.user.profile.displayName}</Badge>
-                  {/* Plain text rather than `Code`, which renders as a block and
-                      would stack the words vertically. */}
-                  <Text size={1} muted>
-                    {participant.path.length > 0
-                      ? `in ${participant.path.join('.')}`
-                      : 'at the document root'}
-                  </Text>
-                </Flex>
-              ))}
-            </Stack>
-          )}
-        </Card>
-      </Stack>
+      <DocumentCard
+        documentId={documentId}
+        reportedId={reportedId}
+        reportAs={reportAs}
+        onReportAsChange={setReportAs}
+        studioUrl={studioUrl}
+      />
+      <Notes />
+      <AnnounceToggle announcing={announcing} onChange={setAnnouncing} />
+      <ParticipantList documentId={reportedId} />
 
       <Stack space={3}>
         <Text size={1} weight="semibold">
@@ -289,35 +391,13 @@ function PresenceDemo({documentId}: {documentId: string}): JSX.Element {
           Focus a field to report presence there. The other tab shows a badge beside it.
         </Text>
         {FIELDS.map((field) => (
-          <Stack key={field.name} space={2}>
-            <Flex align="center" gap={2}>
-              <Text size={1} weight="medium">
-                {field.label}
-              </Text>
-              <FieldPresence documentId={reportedId} path={[field.name]} testId={field.name} />
-            </Flex>
-            {'options' in field ? (
-              <Select
-                data-testid={`presence-input-${field.name}`}
-                onFocus={() => setFocusedField(field.name)}
-                onBlur={() => setFocusedField(undefined)}
-              >
-                <option value="">Focus to be present in {field.name}</option>
-                {field.options.map((option) => (
-                  <option key={option} value={option}>
-                    {option}
-                  </option>
-                ))}
-              </Select>
-            ) : (
-              <TextInput
-                data-testid={`presence-input-${field.name}`}
-                placeholder={`Focus to be present in ${field.name}`}
-                onFocus={() => setFocusedField(field.name)}
-                onBlur={() => setFocusedField(undefined)}
-              />
-            )}
-          </Stack>
+          <FieldRow
+            key={field.name}
+            field={field}
+            documentId={reportedId}
+            onFocus={() => setFocusedField(field.name)}
+            onBlur={() => setFocusedField(undefined)}
+          />
         ))}
         <Box>
           <Button
@@ -328,6 +408,22 @@ function PresenceDemo({documentId}: {documentId: string}): JSX.Element {
           />
         </Box>
       </Stack>
+    </PageLayout>
+  )
+}
+
+function NoDocuments({documentIdParam}: {documentIdParam: string | null}): JSX.Element {
+  const detail = documentIdParam
+    ? `No ${DOCUMENT_TYPE} document with id ${documentIdParam}.`
+    : `No ${DOCUMENT_TYPE} documents in this dataset.`
+
+  return (
+    <PageLayout title="Presence" subtitle="Nothing to be present in">
+      <Card padding={3} radius={2} tone="caution">
+        <Text size={1} data-testid="presence-no-documents">
+          {detail}
+        </Text>
+      </Card>
     </PageLayout>
   )
 }
@@ -350,20 +446,7 @@ export function PresenceRoute(): JSX.Element {
   })
 
   const documentId = data[0]?.documentId
-
-  if (!documentId) {
-    return (
-      <PageLayout title="Presence" subtitle="Nothing to be present in">
-        <Card padding={3} radius={2} tone="caution">
-          <Text size={1} data-testid="presence-no-documents">
-            {documentIdParam
-              ? `No ${DOCUMENT_TYPE} document with id ${documentIdParam}.`
-              : `No ${DOCUMENT_TYPE} documents in this dataset.`}
-          </Text>
-        </Card>
-      </PageLayout>
-    )
-  }
+  if (!documentId) return <NoDocuments documentIdParam={documentIdParam} />
 
   return <PresenceDemo documentId={documentId} />
 }

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -199,6 +199,7 @@ export type {
   DocumentPresence,
   DocumentPresenceOptions,
   PresenceLocation,
+  PresencePerspectiveOptions,
   PresenceSelection,
   PresenceSelectionPoint,
   ReportPresenceOptions,

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -177,7 +177,6 @@ export {
 export {type JsonMatch} from '../document/patchOperations'
 export {type DocumentPermissionsResult, type PermissionDeniedReason} from '../document/permissions'
 export {getReleaseDocumentId} from '../document/processActions/releaseUtil'
-export {getEditingDocumentId} from '../document/util'
 export type {FavoriteStatusResponse} from '../favorites/favorites'
 export {getFavoritesState, resolveFavoritesState} from '../favorites/favorites'
 export {

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -193,9 +193,11 @@ export {
   type OrganizationsOptions,
   resolveOrganizations,
 } from '../organizations/organizations'
-export {getPresence, reportPresence} from '../presence/presenceStore'
+export {getDocumentPresence, getPresence, reportPresence} from '../presence/presenceStore'
 export type {
   DisconnectEvent,
+  DocumentPresence,
+  DocumentPresenceOptions,
   PresenceLocation,
   PresenceSelection,
   PresenceSelectionPoint,

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -177,6 +177,7 @@ export {
 export {type JsonMatch} from '../document/patchOperations'
 export {type DocumentPermissionsResult, type PermissionDeniedReason} from '../document/permissions'
 export {getReleaseDocumentId} from '../document/processActions/releaseUtil'
+export {getEditingDocumentId} from '../document/util'
 export type {FavoriteStatusResponse} from '../favorites/favorites'
 export {getFavoritesState, resolveFavoritesState} from '../favorites/favorites'
 export {

--- a/packages/core/src/document/util.test.ts
+++ b/packages/core/src/document/util.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it} from 'vitest'
+
+import {getEditingDocumentId, getEffectiveDocumentId} from './util'
+
+const PUBLISHED = 'movie-1'
+const DRAFT = 'drafts.movie-1'
+const VERSION = 'versions.autumn.movie-1'
+
+describe('getEditingDocumentId', () => {
+  it('resolves the draft by default, which is what the Studio edits', () => {
+    expect(getEditingDocumentId({documentId: PUBLISHED})).toBe(DRAFT)
+  })
+
+  it("resolves the draft under the 'drafts' perspective", () => {
+    expect(getEditingDocumentId({documentId: PUBLISHED, perspective: 'drafts'})).toBe(DRAFT)
+  })
+
+  it("resolves the published document under the 'published' perspective", () => {
+    expect(getEditingDocumentId({documentId: PUBLISHED, perspective: 'published'})).toBe(PUBLISHED)
+  })
+
+  it('resolves the version under a release perspective', () => {
+    expect(
+      getEditingDocumentId({documentId: PUBLISHED, perspective: {releaseName: 'autumn'}}),
+    ).toBe(VERSION)
+  })
+
+  it('resolves the published document for live edit, which has no draft', () => {
+    expect(getEditingDocumentId({documentId: PUBLISHED, liveEdit: true})).toBe(PUBLISHED)
+  })
+
+  it('is idempotent when handed an already-specific id', () => {
+    expect(getEditingDocumentId({documentId: DRAFT})).toBe(DRAFT)
+    expect(getEditingDocumentId({documentId: VERSION, perspective: 'published'})).toBe(PUBLISHED)
+    expect(getEditingDocumentId({documentId: DRAFT, perspective: {releaseName: 'autumn'}})).toBe(
+      VERSION,
+    )
+  })
+
+  it('differs from getEffectiveDocumentId precisely where it has to', () => {
+    // The canonical key collapses a draft onto its published id, which is right for
+    // storing state and wrong for anything comparing exact ids.
+    expect(getEffectiveDocumentId({documentId: DRAFT, documentType: 'movie'})).toBe(PUBLISHED)
+    expect(getEditingDocumentId({documentId: DRAFT})).toBe(DRAFT)
+  })
+})

--- a/packages/core/src/document/util.ts
+++ b/packages/core/src/document/util.ts
@@ -1,7 +1,43 @@
-import {DocumentId, getPublishedId, getVersionId} from '@sanity/id-utils'
+import {DocumentId, getDraftId, getPublishedId, getVersionId} from '@sanity/id-utils'
 
 import {type DocumentHandle} from '../config/sanityConfig'
 import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
+
+/**
+ * The id of the specific document a user is editing under a given perspective:
+ * the draft, the published document, or a release version.
+ *
+ * Distinct from {@link getEffectiveDocumentId}, which resolves the canonical key a
+ * document's state is stored under and so collapses a draft onto its published id.
+ * This one keeps them apart, because some things compare the exact id. Presence is
+ * the motivating case: the Studio's field indicators match the id its form is on,
+ * exactly, so an app reporting the published id shows up in the Studio at document
+ * level while never lighting up a single field.
+ *
+ * @remarks
+ * Resolved from the handle alone, which is right whenever a draft or version
+ * exists, so for any document actually being edited. The Studio additionally falls
+ * back to whichever document exists, so for a published document nobody has edited
+ * yet its form sits on the published id where this returns the draft id. Matching
+ * that would mean reading document state, which presence deliberately does not
+ * depend on.
+ *
+ * @beta
+ */
+export function getEditingDocumentId(
+  doc: Pick<DocumentHandle, 'documentId' | 'liveEdit' | 'perspective'>,
+): string {
+  if (doc.liveEdit) {
+    return getPublishedId(DocumentId(doc.documentId))
+  }
+  if (isReleasePerspective(doc.perspective)) {
+    return getVersionId(DocumentId(doc.documentId), doc.perspective.releaseName)
+  }
+  if (doc.perspective === 'published') {
+    return getPublishedId(DocumentId(doc.documentId))
+  }
+  return getDraftId(DocumentId(doc.documentId))
+}
 
 export function getEffectiveDocumentId(doc: DocumentHandle): string {
   if (doc.liveEdit) {

--- a/packages/core/src/document/util.ts
+++ b/packages/core/src/document/util.ts
@@ -22,7 +22,7 @@ import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
  * that would mean reading document state, which presence deliberately does not
  * depend on.
  *
- * @beta
+ * @internal
  */
 export function getEditingDocumentId(
   doc: Pick<DocumentHandle, 'documentId' | 'liveEdit' | 'perspective'>,

--- a/packages/core/src/presence/paths.test.ts
+++ b/packages/core/src/presence/paths.test.ts
@@ -1,0 +1,70 @@
+import {type Path} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {startsWithPath} from './paths'
+
+describe('startsWithPath', () => {
+  it('treats the empty path as a prefix of everything, which is the document root', () => {
+    expect(startsWithPath([], ['title'])).toBe(true)
+    expect(startsWithPath([], [])).toBe(true)
+  })
+
+  it('matches a path against itself', () => {
+    expect(startsWithPath(['title'], ['title'])).toBe(true)
+  })
+
+  it('matches a descendant', () => {
+    expect(startsWithPath(['body'], ['body', 'children'])).toBe(true)
+  })
+
+  it('does not match an ancestor, since a longer prefix cannot fit', () => {
+    expect(startsWithPath(['body', 'children'], ['body'])).toBe(false)
+  })
+
+  it('does not match a sibling', () => {
+    expect(startsWithPath(['title'], ['subtitle'])).toBe(false)
+  })
+
+  it('does not match a partial segment name', () => {
+    // `title` must not be treated as a prefix of `titleImage`.
+    expect(startsWithPath(['title'], ['titleImage'])).toBe(false)
+  })
+
+  it('compares keyed segments by key rather than by identity', () => {
+    // Distinct objects with the same key, which is what arrives over the wire.
+    expect(startsWithPath(['cast', {_key: 'a'}], ['cast', {_key: 'a'}, 'name'])).toBe(true)
+    expect(startsWithPath(['cast', {_key: 'a'}], ['cast', {_key: 'b'}, 'name'])).toBe(false)
+  })
+
+  it('does not confuse a keyed segment with a string or a number', () => {
+    expect(startsWithPath([{_key: 'a'}], ['a'])).toBe(false)
+    expect(startsWithPath(['a'], [{_key: 'a'}])).toBe(false)
+    expect(startsWithPath([{_key: '0'}], [0])).toBe(false)
+  })
+
+  it('compares numeric indexes', () => {
+    expect(startsWithPath(['awards', 0], ['awards', 0])).toBe(true)
+    expect(startsWithPath(['awards', 0], ['awards', 1])).toBe(false)
+  })
+
+  it('compares index tuples structurally', () => {
+    const prefix: Path = ['body', [0, 2]]
+    expect(startsWithPath(prefix, ['body', [0, 2], 'children'])).toBe(true)
+    expect(startsWithPath(prefix, ['body', [0, 3]])).toBe(false)
+    expect(startsWithPath(prefix, ['body', [0, '']])).toBe(false)
+  })
+
+  it('does not confuse a tuple with a keyed segment', () => {
+    expect(startsWithPath([[0, 2]], [{_key: 'a'}])).toBe(false)
+    expect(startsWithPath([{_key: 'a'}], [[0, 2]])).toBe(false)
+  })
+
+  it('handles a realistic Portable Text span path', () => {
+    const field: Path = ['body']
+    const span: Path = ['body', {_key: 'block-1'}, 'children', {_key: 'span-1'}, 'text']
+
+    expect(startsWithPath(field, span)).toBe(true)
+    expect(startsWithPath(['title'], span)).toBe(false)
+    expect(startsWithPath(['body', {_key: 'block-2'}], span)).toBe(false)
+  })
+})

--- a/packages/core/src/presence/paths.ts
+++ b/packages/core/src/presence/paths.ts
@@ -1,26 +1,29 @@
-import {type Path, type PathSegment} from '@sanity/types'
+import {type IndexTuple, type KeyedSegment, type Path, type PathSegment} from '@sanity/types'
 
 /**
- * Compares two path segments.
- *
  * Segments are not always strings, despite what `PresenceLocation.path` declares.
  * Array items arrive as `{_key}` and Portable Text spans as a mix of keys and
- * property names, because that is what the Studio sends. See the note on
- * {@link PresenceLocation.path}.
+ * property names, because that is what the Studio sends.
  */
+function isKeyedSegment(segment: PathSegment): segment is KeyedSegment {
+  return (
+    typeof segment === 'object' && segment !== null && !Array.isArray(segment) && '_key' in segment
+  )
+}
+
+/**
+ * Index tuples (`[from, to]`) only occur in slice selections, which presence never
+ * reports. Compared structurally rather than assumed absent.
+ */
+function isEqualTuple(a: IndexTuple, b: IndexTuple): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index])
+}
+
+/** Compares two path segments, whatever shape they arrive in. */
 function isEqualSegment(a: PathSegment, b: PathSegment): boolean {
   if (a === b) return true
-
-  const aKeyed = typeof a === 'object' && a !== null && !Array.isArray(a) && '_key' in a
-  const bKeyed = typeof b === 'object' && b !== null && !Array.isArray(b) && '_key' in b
-  if (aKeyed && bKeyed) return a._key === b._key
-
-  // Index tuples (`[from, to]`) only occur in slice selections, which presence
-  // never reports. Compared structurally rather than assumed absent.
-  if (Array.isArray(a) && Array.isArray(b)) {
-    return a.length === b.length && a.every((value, index) => value === b[index])
-  }
-
+  if (isKeyedSegment(a) && isKeyedSegment(b)) return a._key === b._key
+  if (Array.isArray(a) && Array.isArray(b)) return isEqualTuple(a, b)
   return false
 }
 

--- a/packages/core/src/presence/paths.ts
+++ b/packages/core/src/presence/paths.ts
@@ -1,0 +1,38 @@
+import {type Path, type PathSegment} from '@sanity/types'
+
+/**
+ * Compares two path segments.
+ *
+ * Segments are not always strings, despite what `PresenceLocation.path` declares.
+ * Array items arrive as `{_key}` and Portable Text spans as a mix of keys and
+ * property names, because that is what the Studio sends. See the note on
+ * {@link PresenceLocation.path}.
+ */
+function isEqualSegment(a: PathSegment, b: PathSegment): boolean {
+  if (a === b) return true
+
+  const aKeyed = typeof a === 'object' && a !== null && !Array.isArray(a) && '_key' in a
+  const bKeyed = typeof b === 'object' && b !== null && !Array.isArray(b) && '_key' in b
+  if (aKeyed && bKeyed) return a._key === b._key
+
+  // Index tuples (`[from, to]`) only occur in slice selections, which presence
+  // never reports. Compared structurally rather than assumed absent.
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((value, index) => value === b[index])
+  }
+
+  return false
+}
+
+/**
+ * True when `candidate` is at or below `prefix` in the document tree.
+ *
+ * Equivalent to `startsWith` from the Studio's `@sanity/util/paths`, which is not
+ * an SDK dependency.
+ *
+ * @internal
+ */
+export function startsWithPath(prefix: Path, candidate: Path): boolean {
+  if (prefix.length > candidate.length) return false
+  return prefix.every((segment, index) => isEqualSegment(segment, candidate[index]))
+}

--- a/packages/core/src/presence/presenceStore.test.ts
+++ b/packages/core/src/presence/presenceStore.test.ts
@@ -16,7 +16,7 @@ import {createSanityInstance, type SanityInstance} from '../store/createSanityIn
 import {type SanityUser} from '../users/types'
 import {getUserState} from '../users/usersStore'
 import {createBifurTransport} from './bifurTransport'
-import {getPresence, reportPresence} from './presenceStore'
+import {getDocumentPresence, getPresence, reportPresence} from './presenceStore'
 import {type PresenceLocation, type TransportEvent, type TransportMessage} from './types'
 
 vi.mock('../auth/authStore')
@@ -420,6 +420,223 @@ describe('presenceStore', () => {
       expect(presence.user.profile.id).toBe('user-1')
       expect(presence.user.sanityUserId).toBe('user-1')
       expect(presence.user.memberships).toEqual([])
+
+      unsubscribe()
+    })
+  })
+
+  describe('getDocumentPresence', () => {
+    /** Puts a peer in a document at the given paths. */
+    const peerAt = async (
+      sessionId: string,
+      locations: {documentId: string; path?: unknown[]; selection?: unknown}[],
+    ) => {
+      mockIncomingEvents.next({
+        type: 'state',
+        userId: 'user-1',
+        sessionId,
+        timestamp: '2026-07-30T12:00:00Z',
+        locations: locations.map((l) => ({
+          type: 'document',
+          documentId: l.documentId,
+          path: (l.path ?? []) as string[],
+          lastActiveAt: '2026-07-30T12:00:00Z',
+          ...(l.selection === undefined ? {} : {selection: l.selection}),
+        })) as never,
+      })
+      await firstValueFrom(of(null).pipe(delay(20)))
+    }
+
+    it('flattens one entry per participant per location', async () => {
+      const source = getDocumentPresence(instance, {documentId: 'movie-1'})
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [
+        {documentId: 'movie-1', path: ['title']},
+        {documentId: 'movie-1', path: ['body']},
+      ])
+
+      const presence = source.getCurrent()
+      expect(presence).toHaveLength(2)
+      expect(presence.map((p) => p.path)).toEqual([['title'], ['body']])
+      expect(presence.every((p) => p.sessionId === 'peer-a')).toBe(true)
+
+      unsubscribe()
+    })
+
+    it('treats a draft, its published version, and a release version as one document', async () => {
+      const source = getDocumentPresence(instance, {documentId: 'movie-1'})
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [{documentId: 'drafts.movie-1'}])
+      await peerAt('peer-b', [{documentId: 'versions.r1.movie-1'}])
+      await peerAt('peer-c', [{documentId: 'movie-1'}])
+
+      // What a document list wants: someone is in this document, wherever exactly.
+      expect(source.getCurrent()).toHaveLength(3)
+
+      unsubscribe()
+    })
+
+    it('compares ids exactly when excludeVersions is set', async () => {
+      const source = getDocumentPresence(instance, {
+        documentId: 'drafts.movie-1',
+        excludeVersions: true,
+      })
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [{documentId: 'drafts.movie-1'}])
+      await peerAt('peer-b', [{documentId: 'versions.r1.movie-1'}])
+
+      // What a field indicator wants: a release version must not bleed into the
+      // draft the user is actually looking at.
+      const presence = source.getCurrent()
+      expect(presence).toHaveLength(1)
+      expect(presence[0].documentId).toBe('drafts.movie-1')
+
+      unsubscribe()
+    })
+
+    it('narrows to a field subtree, including the field itself', async () => {
+      const source = getDocumentPresence(instance, {documentId: 'movie-1', path: ['body']})
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [
+        {documentId: 'movie-1', path: ['title']},
+        {documentId: 'movie-1', path: ['body']},
+        {documentId: 'movie-1', path: ['body', {_key: 'b1'}, 'children']},
+      ])
+
+      const presence = source.getCurrent()
+      expect(presence).toHaveLength(2)
+      expect(presence.map((p) => p.path)).toEqual([['body'], ['body', {_key: 'b1'}, 'children']])
+
+      unsubscribe()
+    })
+
+    it('matches keyed path segments by key, not by identity', async () => {
+      const source = getDocumentPresence(instance, {
+        documentId: 'movie-1',
+        // A different object with the same key, which is what arrives over the wire.
+        path: ['cast', {_key: 'member-2'}],
+      })
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [
+        {documentId: 'movie-1', path: ['cast', {_key: 'member-1'}, 'name']},
+        {documentId: 'movie-1', path: ['cast', {_key: 'member-2'}, 'name']},
+      ])
+
+      const presence = source.getCurrent()
+      expect(presence).toHaveLength(1)
+      expect(presence[0].path).toEqual(['cast', {_key: 'member-2'}, 'name'])
+
+      unsubscribe()
+    })
+
+    it('preserves a Portable Text selection', async () => {
+      const selection = {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 2},
+        focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 9},
+        backward: false,
+      }
+
+      const source = getDocumentPresence(instance, {documentId: 'movie-1'})
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [{documentId: 'movie-1', path: ['body'], selection}])
+
+      expect(source.getCurrent()[0].selection).toEqual(selection)
+
+      unsubscribe()
+    })
+
+    it('omits selection when the participant did not report one', async () => {
+      const source = getDocumentPresence(instance, {documentId: 'movie-1'})
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [{documentId: 'movie-1', path: ['title']}])
+
+      expect('selection' in source.getCurrent()[0]).toBe(false)
+
+      unsubscribe()
+    })
+
+    it('returns a referentially stable snapshot', async () => {
+      const source = getDocumentPresence(instance, {documentId: 'movie-1'})
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+      await peerAt('peer-a', [{documentId: 'movie-1', path: ['title']}])
+
+      // React calls `getCurrent` as its `useSyncExternalStore` snapshot on every
+      // render. Returning a fresh array each call sends it into an infinite
+      // render loop, so this is load-bearing rather than a micro-optimisation.
+      expect(source.getCurrent()).toBe(source.getCurrent())
+
+      unsubscribe()
+    })
+
+    it('keeps separate snapshots per query, so callers do not evict each other', async () => {
+      const movie = getDocumentPresence(instance, {documentId: 'movie-1'})
+      const other = getDocumentPresence(instance, {documentId: 'movie-2'})
+      const titleOnly = getDocumentPresence(instance, {documentId: 'movie-1', path: ['title']})
+      const subs = [movie, other, titleOnly].map((s) => s.subscribe(() => {}))
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [
+        {documentId: 'movie-1', path: ['title']},
+        {documentId: 'movie-1', path: ['body']},
+      ])
+
+      // Interleaved reads, which is what concurrent components do.
+      const movieFirst = movie.getCurrent()
+      const titleFirst = titleOnly.getCurrent()
+      expect(movie.getCurrent()).toBe(movieFirst)
+      expect(titleOnly.getCurrent()).toBe(titleFirst)
+
+      expect(movieFirst).toHaveLength(2)
+      expect(titleFirst).toHaveLength(1)
+      expect(other.getCurrent()).toEqual([])
+
+      subs.forEach((unsubscribe) => unsubscribe())
+    })
+
+    it('resolves display names without anything else subscribing first', async () => {
+      // Regression guard: user resolution used to hang off `getPresence`'s
+      // `onSubscribe`, so reading presence any other way showed only
+      // "Unknown user". It belongs to the store, not to one state source.
+      const source = getDocumentPresence(instance, {documentId: 'movie-1'})
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [{documentId: 'movie-1', path: ['title']}])
+      await firstValueFrom(of(null).pipe(delay(50)))
+
+      expect(getUserState).toHaveBeenCalledWith(instance, {
+        userId: 'user-1',
+        resourceType: 'project',
+        projectId: 'test-project',
+      })
+      expect(source.getCurrent()[0].user.profile.displayName).toBe('Test User')
+
+      unsubscribe()
+    })
+
+    it('ignores other documents entirely', async () => {
+      const source = getDocumentPresence(instance, {documentId: 'movie-1'})
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [{documentId: 'movie-2', path: ['title']}])
+
+      expect(source.getCurrent()).toEqual([])
 
       unsubscribe()
     })

--- a/packages/core/src/presence/presenceStore.test.ts
+++ b/packages/core/src/presence/presenceStore.test.ts
@@ -500,6 +500,27 @@ describe('presenceStore', () => {
       unsubscribe()
     })
 
+    it('matches a peer in the draft when queried with a published id and excludeVersions', async () => {
+      // The field-indicator case, and the one that only works if the read side
+      // resolves the perspective exactly as the write side does. `excludeVersions`
+      // turns off published-id normalization, so an unresolved query for `movie-1`
+      // would never match a peer reporting `drafts.movie-1`.
+      const source = getDocumentPresence(instance, {
+        documentId: 'movie-1',
+        excludeVersions: true,
+      })
+      const unsubscribe = source.subscribe(() => {})
+      await firstValueFrom(of(null).pipe(delay(10)))
+
+      await peerAt('peer-a', [{documentId: 'drafts.movie-1', path: ['title']}])
+
+      const presence = source.getCurrent()
+      expect(presence).toHaveLength(1)
+      expect(presence[0].documentId).toBe('drafts.movie-1')
+
+      unsubscribe()
+    })
+
     it('narrows to a field subtree, including the field itself', async () => {
       const source = getDocumentPresence(instance, {documentId: 'movie-1', path: ['body']})
       const unsubscribe = source.subscribe(() => {})
@@ -813,6 +834,35 @@ describe('presenceStore', () => {
       }
     })
 
+    it('resolves the reported id from the perspective', async () => {
+      vi.useFakeTimers()
+      try {
+        getPresence(instance)
+
+        // Default: the draft, which is what the Studio's form is on and therefore
+        // what its field indicators compare against.
+        reportPresence(instance, {locations: [{documentId: 'movie-1'}]})
+        await flush()
+        expect(stateCalls().at(-1)!.locations[0].documentId).toBe('drafts.movie-1')
+
+        reportPresence(instance, {locations: [{documentId: 'movie-1', perspective: 'published'}]})
+        await flush()
+        expect(stateCalls().at(-1)!.locations[0].documentId).toBe('movie-1')
+
+        reportPresence(instance, {
+          locations: [{documentId: 'movie-1', perspective: {releaseName: 'autumn'}}],
+        })
+        await flush()
+        expect(stateCalls().at(-1)!.locations[0].documentId).toBe('versions.autumn.movie-1')
+
+        reportPresence(instance, {locations: [{documentId: 'movie-1', liveEdit: true}]})
+        await flush()
+        expect(stateCalls().at(-1)!.locations[0].documentId).toBe('movie-1')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('announces a document-level location', async () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-07-30T12:00:00.000Z'))
@@ -827,7 +877,8 @@ describe('presenceStore', () => {
             locations: [
               {
                 type: 'document',
-                documentId: 'doc-1',
+                // Resolved to the draft, which is the default perspective.
+                documentId: 'drafts.doc-1',
                 path: [],
                 lastActiveAt: '2026-07-30T12:00:00.000Z',
               },

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -1,3 +1,5 @@
+import {DocumentId, getPublishedId} from '@sanity/id-utils'
+import {type Path} from '@sanity/types'
 import {createSelector} from 'reselect'
 import {
   auditTime,
@@ -37,7 +39,10 @@ import {type SanityUser} from '../users/types'
 import {getUserState} from '../users/usersStore'
 import {createLogger} from '../utils/logger'
 import {createBifurTransport} from './bifurTransport'
+import {startsWithPath} from './paths'
 import {
+  type DocumentPresence,
+  type DocumentPresenceOptions,
   type PresenceLocation,
   type ReportPresenceOptions,
   type TransportEvent,
@@ -333,6 +338,72 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
         .subscribe(),
     )
 
+    // Resolve display names for everyone we can see.
+    //
+    // This belongs to the store rather than to one state source: it is driven by
+    // which user ids are in state, and every selector needs it. It used to hang off
+    // `getPresence`'s `onSubscribe`, which meant anything reading presence another
+    // way saw only "Unknown user".
+    const userIds$ = state.observable.pipe(
+      map((s) =>
+        Array.from(s.locations.values())
+          .map((l) => l.userId)
+          .filter((id): id is string => !!id),
+      ),
+      distinctUntilChanged((a, b) => a.length === b.length && a.every((v, i) => v === b[i])),
+    )
+
+    // For canvas resources, wait for the organizationId to arrive. A failed lookup
+    // resolves to `undefined` rather than never emitting, so one failed request
+    // does not leave every user permanently unresolved. Dataset resources emit
+    // immediately so the stream is never blocked.
+    const organizationId$: Observable<string | undefined> = isCanvasResource(resource)
+      ? state.observable.pipe(
+          filter((s) => s.organizationId !== undefined || s.organizationIdError !== undefined),
+          first(),
+          map((s) => s.organizationId),
+        )
+      : of(undefined)
+
+    subscription.add(
+      combineLatest([userIds$, organizationId$])
+        .pipe(
+          switchMap(([userIds, organizationId]) => {
+            if (userIds.length === 0) {
+              return of([])
+            }
+            // Without an organization there is nothing to scope the lookup to, so
+            // skip the request rather than making one that cannot succeed.
+            if (!isDatasetResource(resource) && !organizationId) {
+              return of([])
+            }
+            const userObservables = userIds.map((userId) =>
+              getUserState(instance, {
+                userId,
+                ...(isDatasetResource(resource)
+                  ? {resourceType: 'project', projectId: resource.projectId}
+                  : {resourceType: 'organization', organizationId}),
+              }).pipe(filter((v): v is NonNullable<typeof v> => !!v)),
+            )
+            return combineLatest(userObservables)
+          }),
+        )
+        .subscribe((users) => {
+          state.set('presence/users', (prevState) => ({
+            ...prevState,
+            users: {
+              ...prevState.users,
+              ...users.reduce<Record<string, SanityUser>>((acc, user) => {
+                if (user) {
+                  acc[user.profile.id] = user
+                }
+                return acc
+              }, {}),
+            },
+          }))
+        }),
+    )
+
     // Canvas resources need the organizationId to resolve users — fetch it once from the canvas endpoint
     if (isCanvasResource(resource)) {
       const globalClient = getClient(instance, {apiVersion: PRESENCE_API_VERSION})
@@ -392,72 +463,83 @@ const selectPresence = createSelector(
   },
 )
 
+/**
+ * Results per state object, then per query.
+ *
+ * `createStateSourceAction` runs its selector afresh on every `getCurrent()`, and
+ * `getCurrent` is what React's `useSyncExternalStore` calls as its snapshot. A
+ * selector that builds a new array each call therefore sends React into an
+ * infinite render loop, which is why the store docs point at memoized selectors.
+ *
+ * A single `reselect` memo slot is not enough here, because the selector is
+ * parameterised per document and callers watching different documents would
+ * evict each other. Keyed on the state object, which is replaced on every change,
+ * so entries are collected once that state is unreachable.
+ */
+const documentPresenceCache = new WeakMap<PresenceStoreState, Map<string, DocumentPresence[]>>()
+
+/** Flattens the session map down to one document. */
+function selectDocumentPresence(
+  state: PresenceStoreState,
+  options: DocumentPresenceOptions,
+): DocumentPresence[] {
+  const cacheKey = JSON.stringify([
+    options.documentId,
+    options.path ?? null,
+    options.excludeVersions ?? false,
+  ])
+
+  let perState = documentPresenceCache.get(state)
+  if (!perState) {
+    perState = new Map<string, DocumentPresence[]>()
+    documentPresenceCache.set(state, perState)
+  }
+
+  const cached = perState.get(cacheKey)
+  if (cached) return cached
+
+  const computed = computeDocumentPresence(state, options)
+  perState.set(cacheKey, computed)
+  return computed
+}
+
+function computeDocumentPresence(
+  state: PresenceStoreState,
+  {documentId, path, excludeVersions}: DocumentPresenceOptions,
+): DocumentPresence[] {
+  const target = excludeVersions ? documentId : getPublishedId(DocumentId(documentId))
+
+  const results: DocumentPresence[] = []
+  for (const [sessionId, session] of state.locations) {
+    for (const location of session.locations) {
+      const candidate = excludeVersions
+        ? location.documentId
+        : getPublishedId(DocumentId(location.documentId))
+      if (candidate !== target) continue
+
+      // Declared `string[]`, actually a `Path`. See the note on
+      // `PresenceLocation.path`; `DocumentPresence.path` reports it honestly.
+      const locationPath = location.path as unknown as Path
+      if (path && !startsWithPath(path, locationPath)) continue
+
+      results.push({
+        user: state.users[session.userId] || createUnresolvedUser(session.userId),
+        sessionId,
+        documentId: location.documentId,
+        path: locationPath,
+        lastActiveAt: location.lastActiveAt,
+        ...(location.selection === undefined ? {} : {selection: location.selection}),
+      })
+    }
+  }
+  return results
+}
+
 const _getPresence = bindActionByResource(
   presenceStore,
   createStateSourceAction({
     selector: (context: SelectorContext<PresenceStoreState>): UserPresence[] =>
       selectPresence(context.state),
-    onSubscribe: (context: StoreContext<PresenceStoreState, BoundResourceKey>) => {
-      const resource = context.key.resource
-      const userIds$ = context.state.observable.pipe(
-        map((state) =>
-          Array.from(state.locations.values())
-            .map((l) => l.userId)
-            .filter((id): id is string => !!id),
-        ),
-        distinctUntilChanged((a, b) => a.length === b.length && a.every((v, i) => v === b[i])),
-      )
-
-      // For canvas resources, wait for organizationId to be fetched and stored in state.
-      // A failed lookup resolves to `undefined` rather than never emitting, so that
-      // one failed request does not leave every user permanently unresolved.
-      // For dataset resources, emit undefined immediately so the stream isn't blocked.
-      const organizationId$: Observable<string | undefined> = isCanvasResource(resource)
-        ? context.state.observable.pipe(
-            filter((s) => s.organizationId !== undefined || s.organizationIdError !== undefined),
-            first(),
-            map((s) => s.organizationId),
-          )
-        : of(undefined)
-
-      const subscription = combineLatest([userIds$, organizationId$])
-        .pipe(
-          switchMap(([userIds, organizationId]) => {
-            if (userIds.length === 0) {
-              return of([])
-            }
-            // Without an organization there is nothing to scope the lookup to,
-            // so skip the request rather than making one that cannot succeed.
-            if (!isDatasetResource(resource) && !organizationId) {
-              return of([])
-            }
-            const userObservables = userIds.map((userId) =>
-              getUserState(context.instance, {
-                userId,
-                ...(isDatasetResource(resource)
-                  ? {resourceType: 'project', projectId: resource.projectId}
-                  : {resourceType: 'organization', organizationId}),
-              }).pipe(filter((v): v is NonNullable<typeof v> => !!v)),
-            )
-            return combineLatest(userObservables)
-          }),
-        )
-        .subscribe((users) => {
-          context.state.set('presence/users', (prevState) => ({
-            ...prevState,
-            users: {
-              ...prevState.users,
-              ...users.reduce<Record<string, SanityUser>>((acc, user) => {
-                if (user) {
-                  acc[user.profile.id] = user
-                }
-                return acc
-              }, {}),
-            },
-          }))
-        })
-      return () => subscription.unsubscribe()
-    },
   }),
 )
 
@@ -469,6 +551,36 @@ export function getPresence(
   // bit of a hack to support the old bound action by dataset
   // in reality, this will always be passed a resource
   return _getPresence(instance, params ?? {})
+}
+
+const _getDocumentPresence = bindActionByResource(
+  presenceStore,
+  createStateSourceAction({
+    selector: (
+      {state}: SelectorContext<PresenceStoreState>,
+      options: {resource?: DocumentResource} & DocumentPresenceOptions,
+    ): DocumentPresence[] => selectDocumentPresence(state, options),
+  }),
+)
+
+/**
+ * Presence within a single document, flattened to one entry per participant per
+ * location so it can be rendered directly against a field.
+ *
+ * Reading presence never announces anything. Use `reportPresence` to make the
+ * current user visible to others.
+ *
+ * @param instance - the Sanity instance
+ * @param params - the document to look at, an optional `path` to narrow to a
+ *   field subtree, and `excludeVersions` to compare document ids exactly
+ *
+ * @beta
+ */
+export function getDocumentPresence(
+  instance: SanityInstance,
+  params: {resource?: DocumentResource} & DocumentPresenceOptions,
+): StateSource<DocumentPresence[]> {
+  return _getDocumentPresence(instance, params)
 }
 
 const _reportPresence = bindActionByResource(

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -594,8 +594,8 @@ const _getDocumentPresence = bindActionByResource(
  * current user visible to others.
  *
  * @param instance - the Sanity instance
- * @param params - the document to look at, an optional `path` to narrow to a
- *   field subtree, and `excludeVersions` to compare document ids exactly
+ * @param params - the document to look at, its perspective, an optional `path` to
+ *   narrow to a field subtree, and `excludeVersions` to compare document ids exactly
  *
  * @beta
  */
@@ -635,6 +635,11 @@ const _reportPresence = bindActionByResource(
  * Call it again whenever the user moves. Announcements are collapsed over a short
  * window and then repeated every 30 seconds while idle, which is what tells peers
  * the session is still alive.
+ *
+ * Which specific document each location resolves to depends on its perspective, and
+ * that matters for interoperability: other clients, the Studio included, compare
+ * exact document ids for field-level presence. Pass the perspective you are editing
+ * under rather than building a draft or version id yourself.
  *
  * @param instance - the Sanity instance
  * @param params - the resource to announce on, plus the locations to report.

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -27,6 +27,7 @@ import {
   isDatasetResource,
   isMediaLibraryResource,
 } from '../config/sanityConfig'
+import {getEditingDocumentId} from '../document/util'
 import {bindActionByResource, type BoundResourceKey} from '../store/createActionBinder'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {
@@ -484,7 +485,7 @@ function selectDocumentPresence(
   options: DocumentPresenceOptions,
 ): DocumentPresence[] {
   const cacheKey = JSON.stringify([
-    options.documentId,
+    getEditingDocumentId(options),
     options.path ?? null,
     options.excludeVersions ?? false,
   ])
@@ -546,7 +547,9 @@ function computeDocumentPresence(
   state: PresenceStoreState,
   options: DocumentPresenceOptions,
 ): DocumentPresence[] {
-  const target = scopeId(options.documentId, options.excludeVersions)
+  // Resolved before scoping, and identically to the write side, or a query for a
+  // document would not match the client reporting it.
+  const target = scopeId(getEditingDocumentId(options), options.excludeVersions)
 
   return Array.from(state.locations).flatMap(([sessionId, session]) =>
     session.locations
@@ -610,15 +613,15 @@ const _reportPresence = bindActionByResource(
     {locations}: {resource?: DocumentResource; locations: ReportPresenceOptions[]},
   ) => {
     const lastActiveAt = new Date().toISOString()
-    const wireLocations: WirePresenceLocation[] = locations.map(
-      ({documentId, path = [], selection}) => ({
-        type: 'document',
-        documentId,
-        path,
-        lastActiveAt,
-        ...(selection === undefined ? {} : {selection}),
-      }),
-    )
+    const wireLocations: WirePresenceLocation[] = locations.map((location) => ({
+      type: 'document',
+      // The specific document being edited, not the canonical id. Other clients,
+      // the Studio included, compare exact ids for field-level presence.
+      documentId: getEditingDocumentId(location),
+      path: location.path ?? [],
+      lastActiveAt,
+      ...(location.selection === undefined ? {} : {selection: location.selection}),
+    }))
 
     state.set('presence/report', (prevState) => ({...prevState, localLocations: wireLocations}))
   },

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -503,36 +503,56 @@ function selectDocumentPresence(
   return computed
 }
 
+/**
+ * The id a query and a location are compared on. Exact when `excludeVersions` is
+ * set, otherwise normalized so a draft, its published version, and any release
+ * version count as one document.
+ */
+const scopeId = (documentId: string, excludeVersions: boolean | undefined): string =>
+  excludeVersions ? documentId : getPublishedId(DocumentId(documentId))
+
+/**
+ * Declared `string[]`, actually a `Path`. See the note on
+ * {@link PresenceLocation.path}; `DocumentPresence.path` reports it honestly.
+ */
+const pathOf = (location: PresenceLocation): Path => location.path as unknown as Path
+
+function matchesQuery(
+  location: PresenceLocation,
+  target: string,
+  {path, excludeVersions}: DocumentPresenceOptions,
+): boolean {
+  if (scopeId(location.documentId, excludeVersions) !== target) return false
+  return !path || startsWithPath(path, pathOf(location))
+}
+
+function toDocumentPresence(
+  users: PresenceStoreState['users'],
+  sessionId: string,
+  userId: string,
+  location: PresenceLocation,
+): DocumentPresence {
+  return {
+    user: users[userId] || createUnresolvedUser(userId),
+    sessionId,
+    documentId: location.documentId,
+    path: pathOf(location),
+    lastActiveAt: location.lastActiveAt,
+    ...(location.selection === undefined ? {} : {selection: location.selection}),
+  }
+}
+
 function computeDocumentPresence(
   state: PresenceStoreState,
-  {documentId, path, excludeVersions}: DocumentPresenceOptions,
+  options: DocumentPresenceOptions,
 ): DocumentPresence[] {
-  const target = excludeVersions ? documentId : getPublishedId(DocumentId(documentId))
+  const target = scopeId(options.documentId, options.excludeVersions)
 
-  const results: DocumentPresence[] = []
-  for (const [sessionId, session] of state.locations) {
-    for (const location of session.locations) {
-      const candidate = excludeVersions
-        ? location.documentId
-        : getPublishedId(DocumentId(location.documentId))
-      if (candidate !== target) continue
-
-      // Declared `string[]`, actually a `Path`. See the note on
-      // `PresenceLocation.path`; `DocumentPresence.path` reports it honestly.
-      const locationPath = location.path as unknown as Path
-      if (path && !startsWithPath(path, locationPath)) continue
-
-      results.push({
-        user: state.users[session.userId] || createUnresolvedUser(session.userId),
-        sessionId,
-        documentId: location.documentId,
-        path: locationPath,
-        lastActiveAt: location.lastActiveAt,
-        ...(location.selection === undefined ? {} : {selection: location.selection}),
-      })
-    }
-  }
-  return results
+  return Array.from(state.locations).flatMap(([sessionId, session]) =>
+    session.locations
+      .filter((location) => matchesQuery(location, target, options))
+      .map((location) => toDocumentPresence(state.users, sessionId, session.userId, location)),
+  )
 }
 
 const _getPresence = bindActionByResource(

--- a/packages/core/src/presence/types.ts
+++ b/packages/core/src/presence/types.ts
@@ -19,9 +19,10 @@ export interface PresenceSelectionPoint {
  * A Portable Text caret or selected range, as exchanged with the Studio.
  *
  * Structurally identical to `EditorSelection` from `@portabletext/editor`, and
- * declared here rather than imported so that `@sanity/sdk` stays free of React
- * dependencies. The two are asserted to be mutually assignable in the React
- * package, where the editor is already a peer dependency.
+ * declared separately so that `@sanity/sdk` stays free of React dependencies. A
+ * value from the editor can be passed straight through, and vice versa.
+ *
+ * `offset` is a character offset within the span that `path` addresses.
  * @public
  */
 export type PresenceSelection = {
@@ -30,21 +31,38 @@ export type PresenceSelection = {
   backward?: boolean
 } | null
 
-/** @public */
+/**
+ * Somewhere a participant is, as it arrives over the wire.
+ *
+ * Prefer {@link DocumentPresence} from `getDocumentPresence`, which is scoped to one
+ * document, flattened for rendering, and types `path` accurately.
+ * @public
+ */
 export interface PresenceLocation {
   type: 'document'
+  /**
+   * The specific document the participant is in, so a draft, published, or version
+   * id rather than a bare document id.
+   */
   documentId: string
   /**
-   * The focused field path.
+   * The focused field path, empty when they are in the document but not a field.
    *
-   * Note that this under-describes what actually arrives: path segments may be
-   * keyed (`{_key}`) or numeric when the focus is inside an array or a Portable
-   * Text field, because that is what the Studio sends. Narrowing to `string[]`
-   * predates that discovery, and widening it to `Path` is a breaking change to a
-   * published type, so it is deferred to the next major. Use
-   * {@link ReportPresenceOptions.path} when reporting, which is typed correctly.
+   * Declared as `string[]`, but segments can also be numbers or `{_key: string}`
+   * objects when the focus is inside an array or a Portable Text field, because
+   * that is what other clients send. Guard for those rather than assuming strings.
+   * Widening the declared type is a breaking change, so it waits for the next major;
+   * {@link DocumentPresence.path} is typed correctly today.
    */
   path: string[]
+  /**
+   * When the participant said they were last active, on *their* clock.
+   *
+   * Fine for display, unreliable for deciding whether someone is still here: it is
+   * subject to clock skew between machines. Presence already drops participants that
+   * stop announcing, so a session appearing here is one the SDK still considers
+   * live.
+   */
   lastActiveAt: string
   /** A Portable Text caret, when the focused field is a Portable Text field. */
   selection?: PresenceSelection
@@ -86,8 +104,11 @@ export interface PresencePerspectiveOptions extends PerspectiveHandle {
  */
 export interface ReportPresenceOptions extends PresencePerspectiveOptions {
   /**
-   * The specific document id the user is in: a draft, published, or version id,
-   * whichever matches the perspective they are editing.
+   * The document the user is in.
+   *
+   * Pass the plain document id; the perspective decides which specific document that
+   * resolves to. An already-specific id is accepted and re-resolved, so passing
+   * `drafts.abc` while the perspective is `published` reports the published document.
    */
   documentId: string
   /**
@@ -99,10 +120,17 @@ export interface ReportPresenceOptions extends PresencePerspectiveOptions {
   selection?: PresenceSelection
 }
 
-/** @public */
+/**
+ * One participant's session and everywhere it currently is.
+ *
+ * Keyed by session, not by user: the same person in two tabs is two entries with
+ * the same `user`.
+ * @public
+ */
 export interface UserPresence {
   user: SanityUser
   locations: PresenceLocation[]
+  /** Identifies one tab. Stable while that tab is open, and not reused. */
   sessionId: string
 }
 
@@ -110,12 +138,13 @@ export interface UserPresence {
  * One participant at one location within a single document, flattened so it can
  * be rendered directly against a field.
  *
- * `path` is a full `Path` here, unlike {@link PresenceLocation.path}, because this
- * type is new and can describe the keyed segments that actually arrive.
+ * Unlike {@link PresenceLocation.path}, `path` here is typed as a full `Path`, so
+ * keyed and numeric segments are described rather than cast away.
  * @beta
  */
 export interface DocumentPresence {
   user: SanityUser
+  /** Identifies one tab, so the same person in two tabs appears twice. */
   sessionId: string
   /**
    * The specific document id this participant is in: a draft, published, or
@@ -124,6 +153,10 @@ export interface DocumentPresence {
   documentId: string
   /** The focused field path. Empty when they are in the document but no field. */
   path: Path
+  /**
+   * When they said they were last active, on *their* clock. Fine for display,
+   * unreliable for liveness. See {@link PresenceLocation.lastActiveAt}.
+   */
   lastActiveAt: string
   /** The Portable Text caret, when they are focused in a Portable Text field. */
   selection?: PresenceSelection
@@ -131,6 +164,10 @@ export interface DocumentPresence {
 
 /** @beta */
 export interface DocumentPresenceOptions extends PresencePerspectiveOptions {
+  /**
+   * The document to look at. Resolved through the perspective exactly as
+   * {@link ReportPresenceOptions.documentId} is, so reads match writes.
+   */
   documentId: string
   /**
    * Narrows to participants at or below this field path. Omit it for everyone in

--- a/packages/core/src/presence/types.ts
+++ b/packages/core/src/presence/types.ts
@@ -91,6 +91,46 @@ export interface UserPresence {
   sessionId: string
 }
 
+/**
+ * One participant at one location within a single document, flattened so it can
+ * be rendered directly against a field.
+ *
+ * `path` is a full `Path` here, unlike {@link PresenceLocation.path}, because this
+ * type is new and can describe the keyed segments that actually arrive.
+ * @beta
+ */
+export interface DocumentPresence {
+  user: SanityUser
+  sessionId: string
+  /**
+   * The specific document id this participant is in: a draft, published, or
+   * version id, depending on which perspective they are editing.
+   */
+  documentId: string
+  /** The focused field path. Empty when they are in the document but no field. */
+  path: Path
+  lastActiveAt: string
+  /** The Portable Text caret, when they are focused in a Portable Text field. */
+  selection?: PresenceSelection
+}
+
+/** @beta */
+export interface DocumentPresenceOptions {
+  documentId: string
+  /**
+   * Narrows to participants at or below this field path. Omit it for everyone in
+   * the document.
+   */
+  path?: Path
+  /**
+   * By default a draft, its published version, and any release versions are
+   * treated as the same document, which is what document lists want. Set this to
+   * compare ids exactly, which is what field-level indicators want so that a
+   * draft and a release version do not bleed into each other.
+   */
+  excludeVersions?: boolean
+}
+
 /** @public */
 export type PresenceTransport = [
   incomingEvents$: Observable<TransportEvent>,

--- a/packages/core/src/presence/types.ts
+++ b/packages/core/src/presence/types.ts
@@ -2,6 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {type Path} from '@sanity/types'
 import {type Observable} from 'rxjs'
 
+import {type PerspectiveHandle} from '../config/sanityConfig'
 import {type SanityUser} from '../users/types'
 
 /**
@@ -64,12 +65,26 @@ export interface WirePresenceLocation extends Omit<PresenceLocation, 'path'> {
 }
 
 /**
+ * Which specific document a presence id resolves to.
+ *
+ * Presence compares exact document ids, so a client in a draft and a client in the
+ * published document are in different places even for the same `documentId`. Pass
+ * the perspective you are editing under and the SDK resolves it; the React hooks
+ * take it from `ResourceProvider` when you do not pass one.
+ * @public
+ */
+export interface PresencePerspectiveOptions extends PerspectiveHandle {
+  /** Live-edit documents have no draft, so presence resolves to the published id. */
+  liveEdit?: boolean
+}
+
+/**
  * What an app reports about where the current user is.
  *
  * Omit `path` for document-level presence, or pass one for field-level presence.
  * @public
  */
-export interface ReportPresenceOptions {
+export interface ReportPresenceOptions extends PresencePerspectiveOptions {
   /**
    * The specific document id the user is in: a draft, published, or version id,
    * whichever matches the perspective they are editing.
@@ -115,7 +130,7 @@ export interface DocumentPresence {
 }
 
 /** @beta */
-export interface DocumentPresenceOptions {
+export interface DocumentPresenceOptions extends PresencePerspectiveOptions {
   documentId: string
   /**
    * Narrows to participants at or below this field path. Omit it for everyone in

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -79,6 +79,11 @@ export {
 } from '../hooks/paginatedDocuments/usePaginatedDocuments'
 export {usePresence} from '../hooks/presence/usePresence'
 export {
+  usePresenceForDocument,
+  type UsePresenceForDocumentOptions,
+} from '../hooks/presence/usePresenceForDocument'
+export {useReportPresence, type UseReportPresenceOptions} from '../hooks/presence/useReportPresence'
+export {
   useDocumentPreview,
   type useDocumentPreviewOptions,
   type useDocumentPreviewResults,

--- a/packages/react/src/hooks/presence/usePresence.ts
+++ b/packages/react/src/hooks/presence/usePresence.ts
@@ -7,7 +7,20 @@ import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOpti
 import {trackHookUsage} from '../helpers/useTrackHookUsage'
 
 /**
- * A hook for subscribing to presence information for the current project or Canvas.
+ * Every participant in the current project and dataset, or Canvas.
+ *
+ * Reading presence never announces anything. Call `useReportPresence` to make the
+ * current user visible to others, including to the Studio, which shares the same
+ * presence room.
+ *
+ * This returns everyone in the whole resource and leaves the filtering to you.
+ * Prefer `usePresenceForDocument` when you care about one document: it scopes and
+ * flattens the result for rendering. Note that participants are counted by session,
+ * so one person in two tabs appears twice.
+ *
+ * Presence is scoped to a single project and dataset. It is not a list of everyone
+ * signed in to your organization.
+ *
  * @public
  */
 export function usePresence(options: ResourceHandle = {}): {

--- a/packages/react/src/hooks/presence/usePresenceForDocument.test.tsx
+++ b/packages/react/src/hooks/presence/usePresenceForDocument.test.tsx
@@ -80,10 +80,26 @@ describe('usePresenceForDocument', () => {
       {wrapper},
     )
 
+    // Already a draft id, so resolution leaves it alone.
     expect(vi.mocked(getDocumentPresence).mock.calls[0][1]).toMatchObject({
       documentId: 'drafts.movie-1',
       path: ['cast', {_key: 'm1'}],
       excludeVersions: true,
+    })
+  })
+
+  it('reads the same id useReportPresence writes, or reads never match writes', () => {
+    const {source} = createSource([])
+    vi.mocked(getDocumentPresence).mockReturnValue(source as never)
+
+    // A published id in, the draft it resolves to out. If this diverged from
+    // `useReportPresence`, field-level presence would silently never match.
+    renderHook(() => usePresenceForDocument({documentId: 'movie-1', documentType: 'movie'}), {
+      wrapper,
+    })
+
+    expect(vi.mocked(getDocumentPresence).mock.calls[0][1]).toMatchObject({
+      documentId: 'drafts.movie-1',
     })
   })
 

--- a/packages/react/src/hooks/presence/usePresenceForDocument.test.tsx
+++ b/packages/react/src/hooks/presence/usePresenceForDocument.test.tsx
@@ -92,14 +92,22 @@ describe('usePresenceForDocument', () => {
     const {source} = createSource([])
     vi.mocked(getDocumentPresence).mockReturnValue(source as never)
 
-    // A published id in, the draft it resolves to out. If this diverged from
-    // `useReportPresence`, field-level presence would silently never match.
-    renderHook(() => usePresenceForDocument({documentId: 'movie-1', documentType: 'movie'}), {
-      wrapper,
-    })
+    // Forwarded unresolved, exactly as `useReportPresence` forwards it, so core
+    // resolves both the same way. If these diverged, field-level presence would
+    // silently never match.
+    renderHook(
+      () =>
+        usePresenceForDocument({
+          documentId: 'movie-1',
+          documentType: 'movie',
+          perspective: 'published',
+        }),
+      {wrapper},
+    )
 
     expect(vi.mocked(getDocumentPresence).mock.calls[0][1]).toMatchObject({
-      documentId: 'drafts.movie-1',
+      documentId: 'movie-1',
+      perspective: 'published',
     })
   })
 

--- a/packages/react/src/hooks/presence/usePresenceForDocument.test.tsx
+++ b/packages/react/src/hooks/presence/usePresenceForDocument.test.tsx
@@ -1,0 +1,117 @@
+import {type DocumentPresence, getDocumentPresence} from '@sanity/sdk'
+import {act, renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {ResourceProvider} from '../../context/ResourceProvider'
+import {usePresenceForDocument} from './usePresenceForDocument'
+
+vi.mock('@sanity/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/sdk')>()
+  return {...actual, getDocumentPresence: vi.fn()}
+})
+
+const entry = (sessionId: string): DocumentPresence =>
+  ({
+    sessionId,
+    documentId: 'movie-1',
+    path: ['title'],
+    lastActiveAt: '2026-07-30T12:00:00Z',
+    user: {sanityUserId: 'u1', profile: {id: 'u1'}, memberships: []},
+  }) as unknown as DocumentPresence
+
+/** A minimal StateSource stand-in whose value can be pushed. */
+function createSource(initial: DocumentPresence[]) {
+  let current = initial
+  const listeners = new Set<() => void>()
+  return {
+    source: {
+      getCurrent: () => current,
+      subscribe: (cb: () => void) => {
+        listeners.add(cb)
+        return () => listeners.delete(cb)
+      },
+    },
+    push: (next: DocumentPresence[]) => {
+      current = next
+      listeners.forEach((cb) => cb())
+    },
+  }
+}
+
+const wrapper = ({children}: {children: React.ReactNode}) => (
+  <ResourceProvider projectId="p" dataset="d" fallback={null}>
+    {children}
+  </ResourceProvider>
+)
+
+describe('usePresenceForDocument', () => {
+  beforeEach(() => {
+    // Without this, `mock.calls[0]` is whatever the previous test did.
+    vi.clearAllMocks()
+  })
+
+  it('returns presence and updates when the store changes', () => {
+    const {source, push} = createSource([entry('s1')])
+    vi.mocked(getDocumentPresence).mockReturnValue(source as never)
+
+    const {result} = renderHook(
+      () => usePresenceForDocument({documentId: 'movie-1', documentType: 'movie'}),
+      {wrapper},
+    )
+
+    expect(result.current.presence).toHaveLength(1)
+
+    act(() => push([entry('s1'), entry('s2')]))
+    expect(result.current.presence).toHaveLength(2)
+  })
+
+  it('passes the document, path, and excludeVersions through', () => {
+    const {source} = createSource([])
+    vi.mocked(getDocumentPresence).mockReturnValue(source as never)
+
+    renderHook(
+      () =>
+        usePresenceForDocument({
+          documentId: 'drafts.movie-1',
+          documentType: 'movie',
+          path: ['cast', {_key: 'm1'}],
+          excludeVersions: true,
+        }),
+      {wrapper},
+    )
+
+    expect(vi.mocked(getDocumentPresence).mock.calls[0][1]).toMatchObject({
+      documentId: 'drafts.movie-1',
+      path: ['cast', {_key: 'm1'}],
+      excludeVersions: true,
+    })
+  })
+
+  it('does not rebuild the source when a caller passes a fresh path each render', () => {
+    const {source} = createSource([])
+    vi.mocked(getDocumentPresence).mockReturnValue(source as never)
+
+    const {rerender} = renderHook(
+      // A new array identity every render, which is what real callers write.
+      () => usePresenceForDocument({documentId: 'movie-1', documentType: 'movie', path: ['title']}),
+      {wrapper},
+    )
+
+    rerender()
+    rerender()
+
+    expect(vi.mocked(getDocumentPresence)).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns an empty array rather than undefined before anything arrives', () => {
+    const {source} = createSource(undefined as unknown as DocumentPresence[])
+    vi.mocked(getDocumentPresence).mockReturnValue(source as never)
+
+    const {result} = renderHook(
+      () => usePresenceForDocument({documentId: 'movie-1', documentType: 'movie'}),
+      {wrapper},
+    )
+
+    expect(result.current.presence).toEqual([])
+  })
+})

--- a/packages/react/src/hooks/presence/usePresenceForDocument.ts
+++ b/packages/react/src/hooks/presence/usePresenceForDocument.ts
@@ -1,4 +1,9 @@
-import {type DocumentPresence, getDocumentPresence, isMediaLibraryResource} from '@sanity/sdk'
+import {
+  type DocumentPresence,
+  getDocumentPresence,
+  getEditingDocumentId,
+  isMediaLibraryResource,
+} from '@sanity/sdk'
 import {type Path} from '@sanity/types'
 import {useCallback, useMemo, useSyncExternalStore} from 'react'
 
@@ -55,7 +60,12 @@ export interface UsePresenceForDocumentOptions extends DocumentHandle {
 export function usePresenceForDocument(options: UsePresenceForDocumentOptions): {
   presence: DocumentPresence[]
 } {
-  const {documentId, path, excludeVersions, ...handle} = options
+  const {path, excludeVersions, ...handle} = options
+
+  // Resolved the same way `useReportPresence` resolves it, or reads would not match
+  // writes: a client reporting `drafts.<id>` is invisible to a query for `<id>` once
+  // `excludeVersions` turns off published-id normalization.
+  const documentId = getEditingDocumentId(options)
 
   const normalizedOptions = useNormalizedResourceOptions(handle)
   if (normalizedOptions.resource && isMediaLibraryResource(normalizedOptions.resource)) {

--- a/packages/react/src/hooks/presence/usePresenceForDocument.ts
+++ b/packages/react/src/hooks/presence/usePresenceForDocument.ts
@@ -1,9 +1,4 @@
-import {
-  type DocumentPresence,
-  getDocumentPresence,
-  getEditingDocumentId,
-  isMediaLibraryResource,
-} from '@sanity/sdk'
+import {type DocumentPresence, getDocumentPresence, isMediaLibraryResource} from '@sanity/sdk'
 import {type Path} from '@sanity/types'
 import {useCallback, useMemo, useSyncExternalStore} from 'react'
 
@@ -62,11 +57,6 @@ export function usePresenceForDocument(options: UsePresenceForDocumentOptions): 
 } {
   const {path, excludeVersions, ...handle} = options
 
-  // Resolved the same way `useReportPresence` resolves it, or reads would not match
-  // writes: a client reporting `drafts.<id>` is invisible to a query for `<id>` once
-  // `excludeVersions` turns off published-id normalization.
-  const documentId = getEditingDocumentId(options)
-
   const normalizedOptions = useNormalizedResourceOptions(handle)
   if (normalizedOptions.resource && isMediaLibraryResource(normalizedOptions.resource)) {
     throw new Error(
@@ -77,7 +67,9 @@ export function usePresenceForDocument(options: UsePresenceForDocumentOptions): 
   const sanityInstance = useSanityInstance()
   trackHookUsage(sanityInstance, 'usePresenceForDocument')
 
-  const {resource} = normalizedOptions
+  const {resource, perspective} = normalizedOptions
+  const {documentId, liveEdit} = options
+
   // Serialized so a caller passing a fresh `path` array each render does not
   // rebuild the state source every render.
   const pathKey = useMemo(() => JSON.stringify(path ?? null), [path])
@@ -87,10 +79,14 @@ export function usePresenceForDocument(options: UsePresenceForDocumentOptions): 
       getDocumentPresence(sanityInstance, {
         ...(resource ? {resource} : {}),
         documentId,
+        // Forwarded, not resolved here, so this matches what `useReportPresence`
+        // sends. Core owns turning a perspective into a specific document id.
+        ...(perspective ? {perspective} : {}),
+        ...(liveEdit ? {liveEdit} : {}),
         ...(pathKey === 'null' ? {} : {path: JSON.parse(pathKey) as Path}),
         ...(excludeVersions === undefined ? {} : {excludeVersions}),
       }),
-    [sanityInstance, resource, documentId, pathKey, excludeVersions],
+    [sanityInstance, resource, documentId, perspective, liveEdit, pathKey, excludeVersions],
   )
 
   const subscribe = useCallback((callback: () => void) => source.subscribe(callback), [source])

--- a/packages/react/src/hooks/presence/usePresenceForDocument.ts
+++ b/packages/react/src/hooks/presence/usePresenceForDocument.ts
@@ -31,8 +31,12 @@ export interface UsePresenceForDocumentOptions extends DocumentHandle {
  * current user visible to others.
  *
  * Prefer this over `usePresence` when you care about one document: `usePresence`
- * returns every participant in the whole project and dataset, leaving the
- * filtering to you.
+ * returns every participant in the whole project and dataset, leaving the filtering
+ * to you.
+ *
+ * Resolves the document through its perspective exactly as `useReportPresence` does,
+ * so reads match writes. Participants are counted by session, so one person in two
+ * tabs appears twice.
  *
  * @example Avatars on a document
  * ```tsx

--- a/packages/react/src/hooks/presence/usePresenceForDocument.ts
+++ b/packages/react/src/hooks/presence/usePresenceForDocument.ts
@@ -1,0 +1,94 @@
+import {type DocumentPresence, getDocumentPresence, isMediaLibraryResource} from '@sanity/sdk'
+import {type Path} from '@sanity/types'
+import {useCallback, useMemo, useSyncExternalStore} from 'react'
+
+import {type DocumentHandle} from '../../config/handles'
+import {useSanityInstance} from '../context/useSanityInstance'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
+import {trackHookUsage} from '../helpers/useTrackHookUsage'
+
+/** @beta */
+export interface UsePresenceForDocumentOptions extends DocumentHandle {
+  /**
+   * Narrows to participants at or below this field path, which is what a field
+   * indicator wants. Omit it for everyone in the document.
+   */
+  path?: Path
+
+  /**
+   * By default a draft, its published version, and any release versions count as
+   * the same document, which is what document lists want. Set this to compare ids
+   * exactly, so that a draft and a release version do not bleed into each other.
+   */
+  excludeVersions?: boolean
+}
+
+/**
+ * Who else is in a document, flattened to one entry per participant per location
+ * so it can be rendered straight against a field.
+ *
+ * Reading presence never announces anything. Use `useReportPresence` to make the
+ * current user visible to others.
+ *
+ * Prefer this over `usePresence` when you care about one document: `usePresence`
+ * returns every participant in the whole project and dataset, leaving the
+ * filtering to you.
+ *
+ * @example Avatars on a document
+ * ```tsx
+ * const {presence} = usePresenceForDocument({documentId, documentType})
+ * return presence.map((p) => <Avatar key={p.sessionId} user={p.user} />)
+ * ```
+ *
+ * @example Avatars on a single field
+ * ```tsx
+ * const {presence} = usePresenceForDocument({
+ *   documentId,
+ *   documentType,
+ *   path: ['title'],
+ *   excludeVersions: true,
+ * })
+ * ```
+ *
+ * @beta
+ */
+export function usePresenceForDocument(options: UsePresenceForDocumentOptions): {
+  presence: DocumentPresence[]
+} {
+  const {documentId, path, excludeVersions, ...handle} = options
+
+  const normalizedOptions = useNormalizedResourceOptions(handle)
+  if (normalizedOptions.resource && isMediaLibraryResource(normalizedOptions.resource)) {
+    throw new Error(
+      'usePresenceForDocument() does not support media library resources. Presence tracking requires a canvas or dataset resource.',
+    )
+  }
+
+  const sanityInstance = useSanityInstance()
+  trackHookUsage(sanityInstance, 'usePresenceForDocument')
+
+  const {resource} = normalizedOptions
+  // Serialized so a caller passing a fresh `path` array each render does not
+  // rebuild the state source every render.
+  const pathKey = useMemo(() => JSON.stringify(path ?? null), [path])
+
+  const source = useMemo(
+    () =>
+      getDocumentPresence(sanityInstance, {
+        ...(resource ? {resource} : {}),
+        documentId,
+        ...(pathKey === 'null' ? {} : {path: JSON.parse(pathKey) as Path}),
+        ...(excludeVersions === undefined ? {} : {excludeVersions}),
+      }),
+    [sanityInstance, resource, documentId, pathKey, excludeVersions],
+  )
+
+  const subscribe = useCallback((callback: () => void) => source.subscribe(callback), [source])
+  const presence = useSyncExternalStore(
+    subscribe,
+    () => source.getCurrent(),
+    () => source.getCurrent(),
+  )
+
+  return {presence: presence || []}
+}

--- a/packages/react/src/hooks/presence/useReportPresence.test.tsx
+++ b/packages/react/src/hooks/presence/useReportPresence.test.tsx
@@ -31,11 +31,44 @@ describe('useReportPresence', () => {
     vi.useRealTimers()
   })
 
-  it('announces the document on mount', () => {
+  it('announces the draft by default, which is what the Studio edits', () => {
     renderHook(() => useReportPresence({documentId: 'doc-1', documentType: 'movie'}), {wrapper})
 
     // No `path` or `selection` keys at all, rather than keys set to `undefined`.
-    expect(reported()).toEqual([[{documentId: 'doc-1'}]])
+    expect(reported()).toEqual([[{documentId: 'drafts.doc-1'}]])
+  })
+
+  it('announces the published document under the published perspective', () => {
+    renderHook(
+      () =>
+        useReportPresence({documentId: 'doc-1', documentType: 'movie', perspective: 'published'}),
+      {wrapper},
+    )
+
+    expect(reported()[0][0].documentId).toBe('doc-1')
+  })
+
+  it('announces the version under a release perspective', () => {
+    renderHook(
+      () =>
+        useReportPresence({
+          documentId: 'doc-1',
+          documentType: 'movie',
+          perspective: {releaseName: 'autumn'},
+        }),
+      {wrapper},
+    )
+
+    expect(reported()[0][0].documentId).toBe('versions.autumn.doc-1')
+  })
+
+  it('announces the published document for live edit, which has no draft', () => {
+    renderHook(
+      () => useReportPresence({documentId: 'doc-1', documentType: 'movie', liveEdit: true}),
+      {wrapper},
+    )
+
+    expect(reported()[0][0].documentId).toBe('doc-1')
   })
 
   it('announces a field path', () => {

--- a/packages/react/src/hooks/presence/useReportPresence.test.tsx
+++ b/packages/react/src/hooks/presence/useReportPresence.test.tsx
@@ -1,0 +1,158 @@
+import {reportPresence} from '@sanity/sdk'
+import {act, renderHook} from '@testing-library/react'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {ResourceProvider} from '../../context/ResourceProvider'
+import {useReportPresence} from './useReportPresence'
+
+vi.mock('@sanity/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sanity/sdk')>()
+  return {
+    ...actual,
+    reportPresence: vi.fn(),
+  }
+})
+
+const reported = () => vi.mocked(reportPresence).mock.calls.map(([, params]) => params.locations)
+
+const wrapper = ({children}: {children: React.ReactNode}) => (
+  <ResourceProvider projectId="p" dataset="d" fallback={null}>
+    {children}
+  </ResourceProvider>
+)
+
+describe('useReportPresence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('announces the document on mount', () => {
+    renderHook(() => useReportPresence({documentId: 'doc-1', documentType: 'movie'}), {wrapper})
+
+    // No `path` or `selection` keys at all, rather than keys set to `undefined`.
+    expect(reported()).toEqual([[{documentId: 'doc-1'}]])
+  })
+
+  it('announces a field path', () => {
+    renderHook(
+      () => useReportPresence({documentId: 'doc-1', documentType: 'movie', path: ['title']}),
+      {wrapper},
+    )
+
+    expect(reported()[0][0].path).toEqual(['title'])
+  })
+
+  it('carries keyed segments and a selection', () => {
+    const path = ['body', {_key: 'b1'}, 'children', {_key: 's1'}, 'text']
+    const selection = {
+      anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 1},
+      focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 4},
+    }
+
+    renderHook(
+      () => useReportPresence({documentId: 'doc-1', documentType: 'movie', path, selection}),
+      {wrapper},
+    )
+
+    expect(reported()[0][0].path).toEqual(path)
+    expect(reported()[0][0].selection).toEqual(selection)
+  })
+
+  it('does not re-announce when a caller passes fresh literals each render', () => {
+    const {rerender} = renderHook(
+      () =>
+        useReportPresence({
+          documentId: 'doc-1',
+          documentType: 'movie',
+          // A new array identity on every render, which is what real callers do.
+          path: ['title'],
+        }),
+      {wrapper},
+    )
+
+    rerender()
+    rerender()
+
+    expect(reported()).toHaveLength(1)
+  })
+
+  it('throttles a burst and announces the final position', () => {
+    const {rerender} = renderHook(
+      ({path}: {path: string[]}) =>
+        useReportPresence({documentId: 'doc-1', documentType: 'movie', path}),
+      {wrapper, initialProps: {path: ['a']}},
+    )
+
+    expect(reported()).toHaveLength(1)
+
+    rerender({path: ['b']})
+    rerender({path: ['c']})
+    expect(reported()).toHaveLength(1)
+
+    // Trailing edge, so the position the user actually settled on is the one sent.
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(reported()).toHaveLength(2)
+    expect(reported()[1][0].path).toEqual(['c'])
+  })
+
+  it('announces selections more often than field focus', () => {
+    const selectionAt = (offset: number) => ({
+      anchor: {path: [{_key: 'b1'}], offset},
+      focus: {path: [{_key: 'b1'}], offset},
+    })
+
+    const {rerender} = renderHook(
+      ({offset}: {offset: number}) =>
+        useReportPresence({
+          documentId: 'doc-1',
+          documentType: 'movie',
+          path: ['body'],
+          selection: selectionAt(offset),
+        }),
+      {wrapper, initialProps: {offset: 1}},
+    )
+
+    expect(reported()).toHaveLength(1)
+    rerender({offset: 2})
+
+    // Would still be pending at the 1000ms focus interval. A caret that lags a
+    // full second reads as broken, so selections use 250ms.
+    act(() => {
+      vi.advanceTimersByTime(250)
+    })
+    expect(reported()).toHaveLength(2)
+  })
+
+  it('clears its location on unmount, staying present but nowhere', () => {
+    const {unmount} = renderHook(
+      () => useReportPresence({documentId: 'doc-1', documentType: 'movie'}),
+      {wrapper},
+    )
+
+    unmount()
+
+    expect(reported().at(-1)).toEqual([])
+  })
+
+  it('does not clear on every location change, only on unmount', () => {
+    const {rerender} = renderHook(
+      ({path}: {path: string[]}) =>
+        useReportPresence({documentId: 'doc-1', documentType: 'movie', path}),
+      {wrapper, initialProps: {path: ['a']}},
+    )
+
+    rerender({path: ['b']})
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(reported().every((locations) => locations.length === 1)).toBe(true)
+  })
+})

--- a/packages/react/src/hooks/presence/useReportPresence.test.tsx
+++ b/packages/react/src/hooks/presence/useReportPresence.test.tsx
@@ -31,24 +31,16 @@ describe('useReportPresence', () => {
     vi.useRealTimers()
   })
 
-  it('announces the draft by default, which is what the Studio edits', () => {
+  it('reports the document with no path or selection keys when neither was given', () => {
     renderHook(() => useReportPresence({documentId: 'doc-1', documentType: 'movie'}), {wrapper})
 
-    // No `path` or `selection` keys at all, rather than keys set to `undefined`.
-    expect(reported()).toEqual([[{documentId: 'drafts.doc-1'}]])
+    // Keys absent rather than set to `undefined`. The id stays unresolved here:
+    // core turns a perspective into a specific document id, so the read and write
+    // sides cannot drift apart.
+    expect(reported()).toEqual([[{documentId: 'doc-1'}]])
   })
 
-  it('announces the published document under the published perspective', () => {
-    renderHook(
-      () =>
-        useReportPresence({documentId: 'doc-1', documentType: 'movie', perspective: 'published'}),
-      {wrapper},
-    )
-
-    expect(reported()[0][0].documentId).toBe('doc-1')
-  })
-
-  it('announces the version under a release perspective', () => {
+  it('forwards an explicit perspective for core to resolve', () => {
     renderHook(
       () =>
         useReportPresence({
@@ -59,16 +51,35 @@ describe('useReportPresence', () => {
       {wrapper},
     )
 
-    expect(reported()[0][0].documentId).toBe('versions.autumn.doc-1')
+    expect(reported()[0][0]).toMatchObject({
+      documentId: 'doc-1',
+      perspective: {releaseName: 'autumn'},
+    })
   })
 
-  it('announces the published document for live edit, which has no draft', () => {
+  it('forwards liveEdit, which core resolves to the published document', () => {
     renderHook(
       () => useReportPresence({documentId: 'doc-1', documentType: 'movie', liveEdit: true}),
       {wrapper},
     )
 
-    expect(reported()[0][0].documentId).toBe('doc-1')
+    expect(reported()[0][0]).toMatchObject({documentId: 'doc-1', liveEdit: true})
+  })
+
+  it('picks up an ambient perspective from the provider', () => {
+    // The whole point of resolving after normalization: a perspective set once on
+    // `ResourceProvider` has to reach presence without every call site passing it.
+    const ambient = ({children}: {children: React.ReactNode}) => (
+      <ResourceProvider projectId="p" dataset="d" perspective="published" fallback={null}>
+        {children}
+      </ResourceProvider>
+    )
+
+    renderHook(() => useReportPresence({documentId: 'doc-1', documentType: 'movie'}), {
+      wrapper: ambient,
+    })
+
+    expect(reported()[0][0]).toMatchObject({documentId: 'doc-1', perspective: 'published'})
   })
 
   it('announces a field path', () => {

--- a/packages/react/src/hooks/presence/useReportPresence.ts
+++ b/packages/react/src/hooks/presence/useReportPresence.ts
@@ -1,5 +1,4 @@
 import {
-  getEditingDocumentId,
   isMediaLibraryResource,
   type PresenceSelection,
   reportPresence,
@@ -81,12 +80,6 @@ export interface UseReportPresenceOptions extends DocumentHandle {
 export function useReportPresence(options: UseReportPresenceOptions): void {
   const {path, selection, throttleMs, ...handle} = options
 
-  // Resolved to the specific document the user is editing under this perspective,
-  // because that is what other clients compare against. The Studio's field
-  // indicators match its form's id exactly, so reporting the published id would
-  // appear at document level and never light up a field.
-  const documentId = getEditingDocumentId(options)
-
   const normalizedOptions = useNormalizedResourceOptions(handle)
   if (normalizedOptions.resource && isMediaLibraryResource(normalizedOptions.resource)) {
     throw new Error(
@@ -97,26 +90,31 @@ export function useReportPresence(options: UseReportPresenceOptions): void {
   const sanityInstance = useSanityInstance()
   trackHookUsage(sanityInstance, 'useReportPresence')
 
-  const {resource} = normalizedOptions
+  const {resource, perspective} = normalizedOptions
+  const {documentId, liveEdit} = options
+
   const interval = throttleMs ?? (selection ? SELECTION_THROTTLE_MS : FOCUS_THROTTLE_MS)
 
   // Compared by value, because callers write `path={['title']}` inline and a fresh
   // array identity every render must not mean a fresh announcement every render.
   const locationKey = useMemo(
-    () => JSON.stringify([documentId, path ?? [], selection ?? null]),
-    [documentId, path, selection],
+    () =>
+      JSON.stringify([documentId, path ?? [], selection ?? null, perspective ?? null, liveEdit]),
+    [documentId, path, selection, perspective, liveEdit],
   )
 
   // Rebuilt from the key rather than from the props, so the effect below can
   // depend on it honestly instead of suppressing the exhaustive-deps rule.
   const location = useMemo<ReportPresenceOptions>(() => {
-    const [id, parsedPath, parsedSelection] = JSON.parse(locationKey) as [
-      string,
-      Path,
-      PresenceSelection,
-    ]
+    const [id, parsedPath, parsedSelection, parsedPerspective, parsedLiveEdit] = JSON.parse(
+      locationKey,
+    ) as [string, Path, PresenceSelection, ReportPresenceOptions['perspective'] | null, boolean?]
     return {
       documentId: id,
+      // Forwarded rather than resolved here: core turns the perspective into the
+      // specific document id, so the read and write sides cannot drift apart.
+      ...(parsedPerspective ? {perspective: parsedPerspective} : {}),
+      ...(parsedLiveEdit ? {liveEdit: parsedLiveEdit} : {}),
       ...(parsedPath.length > 0 ? {path: parsedPath} : {}),
       ...(parsedSelection ? {selection: parsedSelection} : {}),
     }

--- a/packages/react/src/hooks/presence/useReportPresence.ts
+++ b/packages/react/src/hooks/presence/useReportPresence.ts
@@ -1,0 +1,152 @@
+import {
+  isMediaLibraryResource,
+  type PresenceSelection,
+  reportPresence,
+  type ReportPresenceOptions,
+} from '@sanity/sdk'
+import {type Path} from '@sanity/types'
+import {useEffect, useMemo, useRef} from 'react'
+
+import {type DocumentHandle} from '../../config/handles'
+import {useSanityInstance} from '../context/useSanityInstance'
+import {useNormalizedResourceOptions} from '../helpers/useNormalizedResourceOptions'
+import {trackHookUsage} from '../helpers/useTrackHookUsage'
+
+/**
+ * Field focus moves at human speed, so a second between announcements is plenty.
+ */
+const FOCUS_THROTTLE_MS = 1000
+
+/**
+ * A caret that trails a second behind reads as broken rather than as latency, so
+ * reporting a `selection` announces more often. The Studio uses a flat 1000ms for
+ * both, which is why its remote carets feel sluggish.
+ */
+const SELECTION_THROTTLE_MS = 250
+
+/** @beta */
+export interface UseReportPresenceOptions extends DocumentHandle {
+  /**
+   * The focused field path. Omit it for document-level presence. Keyed and numeric
+   * segments are supported, so array items and Portable Text spans can be
+   * addressed.
+   */
+  path?: Path
+
+  /** The Portable Text caret, when the focused field is a Portable Text field. */
+  selection?: PresenceSelection
+
+  /** Overrides the throttle interval. Mainly useful in tests. */
+  throttleMs?: number
+}
+
+/**
+ * Announces that the current user is in a document, so that other clients in the
+ * same project and dataset can show them.
+ *
+ * Writing presence is opt-in. Reading it with `usePresenceForDocument` or
+ * `usePresence` never announces anything, and this hook is the only thing that
+ * makes an app visible to others. That includes the Studio, which shares the same
+ * presence room and will show these users in its navbar and field indicators.
+ *
+ * Announcements are throttled, collapsed over a short window, and then repeated
+ * every 30 seconds while the user is idle. That repeat is what tells peers the
+ * session is still alive, so the intended usage is to mount this hook for as long
+ * as the user is in the document. On unmount the location is cleared, leaving the
+ * user present in the app but not in any particular document.
+ *
+ * Presence is scoped to a single project and dataset. It is not a list of everyone
+ * signed in to your organization.
+ *
+ * @example Document-level presence
+ * ```tsx
+ * function DocumentEditor({documentId, documentType}: DocumentHandle) {
+ *   useReportPresence({documentId, documentType})
+ *   return <Editor />
+ * }
+ * ```
+ *
+ * @example Field-level presence
+ * ```tsx
+ * function TitleField({documentId, documentType}: DocumentHandle) {
+ *   const [focused, setFocused] = useState(false)
+ *   useReportPresence({documentId, documentType, path: focused ? ['title'] : undefined})
+ *   return <input onFocus={() => setFocused(true)} onBlur={() => setFocused(false)} />
+ * }
+ * ```
+ *
+ * @beta
+ */
+export function useReportPresence(options: UseReportPresenceOptions): void {
+  const {documentId, path, selection, throttleMs, ...handle} = options
+
+  const normalizedOptions = useNormalizedResourceOptions(handle)
+  if (normalizedOptions.resource && isMediaLibraryResource(normalizedOptions.resource)) {
+    throw new Error(
+      'useReportPresence() does not support media library resources. Presence tracking requires a canvas or dataset resource.',
+    )
+  }
+
+  const sanityInstance = useSanityInstance()
+  trackHookUsage(sanityInstance, 'useReportPresence')
+
+  const {resource} = normalizedOptions
+  const interval = throttleMs ?? (selection ? SELECTION_THROTTLE_MS : FOCUS_THROTTLE_MS)
+
+  // Compared by value, because callers write `path={['title']}` inline and a fresh
+  // array identity every render must not mean a fresh announcement every render.
+  const locationKey = useMemo(
+    () => JSON.stringify([documentId, path ?? [], selection ?? null]),
+    [documentId, path, selection],
+  )
+
+  // Rebuilt from the key rather than from the props, so the effect below can
+  // depend on it honestly instead of suppressing the exhaustive-deps rule.
+  const location = useMemo<ReportPresenceOptions>(() => {
+    const [id, parsedPath, parsedSelection] = JSON.parse(locationKey) as [
+      string,
+      Path,
+      PresenceSelection,
+    ]
+    return {
+      documentId: id,
+      ...(parsedPath.length > 0 ? {path: parsedPath} : {}),
+      ...(parsedSelection ? {selection: parsedSelection} : {}),
+    }
+  }, [locationKey])
+
+  const lastSentAt = useRef(0)
+  const pending = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => {
+    // Captured in this effect's closure rather than read from a ref, so nothing is
+    // written during render. A newer location re-runs the effect, which clears the
+    // pending timeout below and schedules the newer value instead.
+    const send = () => {
+      lastSentAt.current = Date.now()
+      reportPresence(sanityInstance, {
+        ...(resource ? {resource} : {}),
+        locations: [location],
+      })
+    }
+
+    const elapsed = Date.now() - lastSentAt.current
+    if (elapsed >= interval) {
+      send()
+    } else {
+      // Trailing edge, so the position the user settled on is the one announced.
+      clearTimeout(pending.current)
+      pending.current = setTimeout(send, interval - elapsed)
+    }
+
+    return () => clearTimeout(pending.current)
+  }, [location, interval, sanityInstance, resource])
+
+  // Kept separate from the throttled effect so it runs on unmount only, rather
+  // than every time the reported location changes.
+  useEffect(() => {
+    return () => {
+      reportPresence(sanityInstance, {...(resource ? {resource} : {}), locations: []})
+    }
+  }, [sanityInstance, resource])
+}

--- a/packages/react/src/hooks/presence/useReportPresence.ts
+++ b/packages/react/src/hooks/presence/useReportPresence.ts
@@ -55,6 +55,13 @@ export interface UseReportPresenceOptions extends DocumentHandle {
  * as the user is in the document. On unmount the location is cleared, leaving the
  * user present in the app but not in any particular document.
  *
+ * The perspective decides which specific document is reported: the draft under
+ * `drafts`, the published document under `published`, a version under a release.
+ * It is taken from `ResourceProvider` unless you pass one on the handle. That
+ * matters for interoperability, because the Studio's field indicators compare the
+ * exact id its form is on, so a mismatch shows your user at document level while
+ * never lighting up a field.
+ *
  * Presence is scoped to a single project and dataset. It is not a list of everyone
  * signed in to your organization.
  *
@@ -64,6 +71,12 @@ export interface UseReportPresenceOptions extends DocumentHandle {
  *   useReportPresence({documentId, documentType})
  *   return <Editor />
  * }
+ * ```
+ *
+ * @example Presence in a release version
+ * ```tsx
+ * // The document id stays plain; the perspective selects the version.
+ * useReportPresence({documentId, documentType, perspective: {releaseName: 'autumn'}})
  * ```
  *
  * @example Field-level presence

--- a/packages/react/src/hooks/presence/useReportPresence.ts
+++ b/packages/react/src/hooks/presence/useReportPresence.ts
@@ -1,4 +1,5 @@
 import {
+  getEditingDocumentId,
   isMediaLibraryResource,
   type PresenceSelection,
   reportPresence,
@@ -78,7 +79,13 @@ export interface UseReportPresenceOptions extends DocumentHandle {
  * @beta
  */
 export function useReportPresence(options: UseReportPresenceOptions): void {
-  const {documentId, path, selection, throttleMs, ...handle} = options
+  const {path, selection, throttleMs, ...handle} = options
+
+  // Resolved to the specific document the user is editing under this perspective,
+  // because that is what other clients compare against. The Studio's field
+  // indicators match its form's id exactly, so reporting the published id would
+  // appear at document level and never light up a field.
+  const documentId = getEditingDocumentId(options)
 
   const normalizedOptions = useNormalizedResourceOptions(handle)
   if (normalizedOptions.resource && isMediaLibraryResource(normalizedOptions.resource)) {


### PR DESCRIPTION
### Description

Completes the presence work: #1079 fixed the read path, #1080 added the core write path, and this makes both usable from React.


https://github.com/user-attachments/assets/be600647-9ab8-4d31-8b41-34a7b06da623



`useReportPresence` is the opt-in write site, and `usePresenceForDocument` is a per-document read flattened to one entry per participant per location, so it can be rendered straight against a field. `usePresence` still returns every participant in the whole project and dataset and leaves the filtering to you.

Two deliberate departures from the plan:

- **`usePresenceCursors` is not here.** Returning `RangeDecoration[]` means naming a type from `@portabletext/editor`, and since `@portabletext/plugin-sdk-value` already declares `@sanity/sdk-react` as a peer, adding the reverse peer would make the two mutually peer-dependent and tie the SDK's release cadence to the editor's major version. The Portable Text cursor mapping belongs in a `@portabletext/plugin-sdk-presence` where the editor is already a peer. No new dependency in this PR.
- **Document filtering lives in core, not the hook.** Version matching needs `@sanity/id-utils`, which core already depends on and `packages/react` does not. Putting `getDocumentPresence` in core keeps the hook a thin binding, matches the core-owns-state pattern, and avoids a new dependency.

`DocumentPresence.path` is a proper `Path`, which is the payoff from #1080's decision to leave the published `PresenceLocation.path` as `string[]`. New type, so consumers get honest keyed segments without a breaking change to the old one.

Stacked on #1080 which is stacked on #1079.

### What to review

- **`packages/core/src/presence/presenceStore.ts`, the snapshot cache.** `createStateSourceAction` runs its selector uncached on every `getCurrent()`, and `getCurrent` is what React calls as its `useSyncExternalStore` snapshot, so a selector building a fresh array sends React into an infinite render loop. `usePresence` avoids this with `reselect`, but a single memo slot will not do here: the query is parameterised per document, so callers watching different documents would evict each other. Cached in a `WeakMap` keyed on the state object, then per query.
- **User resolution moved into the store's `initialize()`.** It used to hang off `getPresence`'s `onSubscribe`, so reading presence any other way resolved no profiles and every participant showed as "Unknown user". It is driven by which user ids are in state, which is store-level, and this also stops two selectors duplicating the same profile requests.
- **`useReportPresence` throttling.** 1000ms for field focus, 250ms when a `selection` is present, because a caret trailing a full second reads as broken rather than as latency. The reported location is rebuilt from its serialized key so the effect can depend on it honestly rather than suppressing `exhaustive-deps`, and nothing is written to a ref during render.
- **`packages/core/src/presence/paths.ts`.** A `Path` prefix comparison, because the exported path helpers come from `@sanity/json-match` and model paths as JSONMatch expressions, not `(string | number | {_key})[]`. Compares keyed segments by `_key`, which is what actually arrives.
- **The kitchensink route was rewritten rather than extended.** It was three `JSON.stringify` dumps against hardcoded project and canvas ids whose implicit workflow was "open a Studio in another tab", because the SDK could not announce. It now demonstrates presence on its own, defaults to a real document so there is no id to look up, and links to the same document in a Studio.

### Testing

19 new unit tests, presence coverage 53 to 72. Full suite 1493 pass, `ts:check` clean, `lint` 0 errors, `knip` clean.

Every new behaviour was mutation-tested rather than trusted on a green run: removing the snapshot cache, the published-id normalisation, the keyed-segment comparison, the path filter, and the profile write each fail exactly the intended test. Two of those tests exist only because the mutation exposed that nothing covered them.

One finding changed the e2e design. Presence stores are keyed by project and dataset and held in a module-level registry, so two `SanityInstance`s in the same JavaScript realm share one store, one socket, and one session id. I verified this rather than assumed it: two instances on the same resource create exactly one transport. A two-pane harness would therefore have been a single participant and the assertions would have passed while proving nothing, so `presence.spec.ts` drives two browser contexts, which are separate realms and so genuinely separate sessions over a real Bifur room.

Worth knowing: `apps/kitchensink-react/src/routes/PortableTextRoute.tsx` has a comment claiming its two panes "round-trip through the Content Lake listener instead of sharing a document store". By the same registry logic that looks untrue, so that route's concurrency test may be weaker than it claims. Untested and out of scope here.

### Fun gif
![im in](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExbDlkbjM0dm81Z2F1ejUwdmxzc3dwYThrOGVoeWZ6ajZlOHNjMW9uaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iKBAAfYNDu1dowhnEj/giphy.gif)

<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
