### PR TITLE
fix(react): allow `null` as fallback for `ResourceProvider`

### DIFF
--- a/packages/react/src/context/ResourceProvider.test.tsx
+++ b/packages/react/src/context/ResourceProvider.test.tsx
@@ -59,6 +59,27 @@ describe('ResourceProvider', () => {
     consoleSpy.mockRestore()
   })
 
+  it('renders nothing during loading when fallback is null', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const {promise, resolve} = promiseWithResolvers()
+    function SuspendingChild(): React.ReactNode {
+      throw promise
+    }
+
+    const {container} = render(
+      <ResourceProvider {...testConfig} fallback={null}>
+        <SuspendingChild />
+      </ResourceProvider>,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+    act(() => {
+      resolve()
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    consoleSpy.mockRestore()
+  })
+
   it('creates root instance when no parent context exists', async () => {
     const {promise, resolve} = promiseWithResolvers<SanityInstance | null>()
 

--- a/packages/react/src/context/ResourceProvider.tsx
+++ b/packages/react/src/context/ResourceProvider.tsx
@@ -130,7 +130,10 @@ export function ResourceProvider({
   }, [instance, parentInstance])
 
   return (
-    <SanityInstanceProvider instance={instance} fallback={fallback ?? DEFAULT_FALLBACK}>
+    <SanityInstanceProvider
+      instance={instance}
+      fallback={fallback === undefined ? DEFAULT_FALLBACK : fallback}
+    >
       <ResourceContext.Provider value={effectiveResource}>
         <ProjectContext.Provider value={effectiveProjectId}>
           <PerspectiveContext.Provider value={perspective ?? parentPerspective}>


### PR DESCRIPTION
### Description

`ResourceProvider` resolved its `fallback` with `??`, so `fallback={null}` — the idiomatic "render nothing" — landed on the built-in `DEFAULT_FALLBACK` and rendered `Warning: No fallback provided. Please supply a fallback prop…` in place of the suspended tree. 

I think it should be able to receive `null`, to render nothing, which is aligned with how `Suspense` works in React - otherwise I'd have to pass in a Fragment.

### Testing

Unit test: a suspending child under `fallback={null}` leaves the DOM empty.
