### PR TITLE
feat(core): add commenting store and write actions

### DIFF
--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -91,15 +91,11 @@ export {
   resolveCommentThreads,
 } from '../comments/commentsStore'
 export {
-  type CommentContext,
-  type CommentDocument,
+  type Comment,
   type CommentLocalState,
   type CommentMessage,
-  type CommentPath,
-  type CommentPostPayload,
-  type CommentReactionItem,
+  type CommentReaction,
   type CommentStatus,
-  type CommentTarget,
   type CommentTextSelection,
   type CommentTextSelectionItem,
   type CommentThread,

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -81,7 +81,6 @@ export {
   updateComment,
   type UpdateCommentOptions,
 } from '../comments/commentActions'
-export {toCommentFieldPath} from '../comments/commentFieldPath'
 export {
   type CommentsOptions,
   getCommentsState,

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -69,6 +69,41 @@ export {
   type RequestNewTokenMessage,
   type WindowMessage,
 } from '../comlink/types'
+export {
+  createComment,
+  type CreateCommentOptions,
+  removeComment,
+  type RemoveCommentOptions,
+  replyToComment,
+  type ReplyToCommentOptions,
+  setCommentStatus,
+  type SetCommentStatusOptions,
+  updateComment,
+  type UpdateCommentOptions,
+} from '../comments/commentActions'
+export {toCommentFieldPath} from '../comments/commentFieldPath'
+export {
+  type CommentsOptions,
+  getCommentsState,
+  getCommentThreadsState,
+  resolveComments,
+  type ResolveCommentsOptions,
+  resolveCommentThreads,
+} from '../comments/commentsStore'
+export {
+  type CommentContext,
+  type CommentDocument,
+  type CommentLocalState,
+  type CommentMessage,
+  type CommentPath,
+  type CommentPostPayload,
+  type CommentReactionItem,
+  type CommentStatus,
+  type CommentTarget,
+  type CommentTextSelection,
+  type CommentTextSelectionItem,
+  type CommentThread,
+} from '../comments/types'
 export {type AuthConfig, type AuthProvider} from '../config/authConfig'
 export {
   createDatasetHandle,

--- a/packages/core/src/comments/addonDatasetStore.test.ts
+++ b/packages/core/src/comments/addonDatasetStore.test.ts
@@ -1,0 +1,215 @@
+import {type SanityClient} from '@sanity/client'
+import {BehaviorSubject, firstValueFrom, NEVER, of, throwError} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getClient, getClientState} from '../client/clientStore'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {
+  getAddonDatasetState,
+  observeAddonDatasetClient,
+  provisionAddonDataset,
+} from './addonDatasetStore'
+
+vi.mock('../client/clientStore', () => ({
+  getClient: vi.fn(),
+  getClientState: vi.fn(),
+}))
+
+let instance: SanityInstance
+let observableRequest: ReturnType<typeof vi.fn>
+let request: ReturnType<typeof vi.fn>
+
+function mockClient() {
+  observableRequest = vi.fn()
+  request = vi.fn()
+  const client = {observable: {request: observableRequest}, request} as unknown as SanityClient
+
+  vi.mocked(getClient).mockReturnValue(client)
+  vi.mocked(getClientState).mockReturnValue({
+    observable: of(client),
+    getCurrent: () => client,
+    subscribe: () => () => {},
+  } as unknown as StateSource<SanityClient>)
+
+  return client
+}
+
+/** Waits for discovery, which runs asynchronously when the store initializes. */
+function resolvedAddonDataset() {
+  return firstValueFrom(getAddonDatasetState(instance, {}).observable.pipe())
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+  mockClient()
+})
+
+afterEach(() => {
+  instance.dispose()
+})
+
+describe('getAddonDatasetState', () => {
+  it('reports the dataset name once discovery answers', async () => {
+    observableRequest.mockReturnValue(of([{name: 'd-comments'}]))
+
+    await vi.waitFor(() =>
+      expect(getAddonDatasetState(instance, {}).getCurrent()).toBe('d-comments'),
+    )
+
+    expect(observableRequest).toHaveBeenCalledWith({
+      uri: '/projects/p/datasets?datasetProfile=comments&addonFor=d',
+      tag: 'comments.addon-dataset.list',
+    })
+  })
+
+  it('reports null when the project has no comments dataset', async () => {
+    observableRequest.mockReturnValue(of([]))
+
+    await vi.waitFor(() => expect(getAddonDatasetState(instance, {}).getCurrent()).toBe(null))
+  })
+
+  it('reports null rather than erroring when discovery is forbidden', async () => {
+    // A member without access to the addon dataset gets a 403. There is nothing
+    // for them to read, which is the same outcome as the dataset not existing.
+    observableRequest.mockReturnValue(throwError(() => ({statusCode: 403})))
+
+    await vi.waitFor(() => expect(getAddonDatasetState(instance, {}).getCurrent()).toBe(null))
+  })
+
+  it('recovers when a new authenticated client arrives after a transient failure', async () => {
+    const firstClient = {
+      observable: {request: vi.fn(() => throwError(() => ({statusCode: 500})))},
+    } as unknown as SanityClient
+    const secondClient = {
+      observable: {request: vi.fn(() => of([{name: 'd-comments'}]))},
+    } as unknown as SanityClient
+    const clients = new BehaviorSubject(firstClient)
+
+    vi.mocked(getClientState).mockReturnValue({
+      observable: clients,
+      getCurrent: () => clients.getValue(),
+      subscribe: () => () => {},
+    } as unknown as StateSource<SanityClient>)
+
+    const state = getAddonDatasetState(instance, {})
+    expect(state.getCurrent()).toBe(undefined)
+
+    clients.next(secondClient)
+
+    await vi.waitFor(() => expect(state.getCurrent()).toBe('d-comments'))
+  })
+
+  it('stays undefined while discovery is in flight', () => {
+    observableRequest.mockReturnValue(NEVER)
+    expect(getAddonDatasetState(instance, {}).getCurrent()).toBe(undefined)
+  })
+
+  it('throws for a resource that is not a dataset', () => {
+    expect(() => getAddonDatasetState(instance, {resource: {mediaLibraryId: 'ml-1'}})).toThrow(
+      /only supported for dataset resources/,
+    )
+  })
+})
+
+describe('provisionAddonDataset', () => {
+  it('returns the existing dataset without writing anything', async () => {
+    observableRequest.mockReturnValue(of([{name: 'd-comments'}]))
+    await resolvedAddonDataset()
+
+    await expect(provisionAddonDataset(instance, {})).resolves.toBe('d-comments')
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('re-checks before creating, and adopts a dataset another user just made', async () => {
+    // Discovery said missing when this client started, but someone else has
+    // provisioned it since. Creating it again would fail.
+    observableRequest.mockReturnValueOnce(of([])).mockReturnValueOnce(of([{name: 'd-comments'}]))
+    await resolvedAddonDataset()
+
+    await expect(provisionAddonDataset(instance, {})).resolves.toBe('d-comments')
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('creates the dataset when the re-check confirms it is missing', async () => {
+    observableRequest.mockReturnValue(of([]))
+    request.mockResolvedValue({datasetName: 'd-comments'})
+    await resolvedAddonDataset()
+
+    await expect(provisionAddonDataset(instance, {})).resolves.toBe('d-comments')
+    expect(request).toHaveBeenCalledWith({
+      uri: '/comments/d/setup',
+      method: 'POST',
+      tag: 'comments.addon-dataset.setup',
+    })
+    expect(getAddonDatasetState(instance, {}).getCurrent()).toBe('d-comments')
+  })
+
+  it('issues one POST for concurrent callers', async () => {
+    observableRequest.mockReturnValue(of([]))
+    request.mockResolvedValue({datasetName: 'd-comments'})
+    await resolvedAddonDataset()
+
+    const results = await Promise.all([
+      provisionAddonDataset(instance, {}),
+      provisionAddonDataset(instance, {}),
+      provisionAddonDataset(instance, {}),
+    ])
+
+    expect(results).toEqual(['d-comments', 'd-comments', 'd-comments'])
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when setup returns no dataset name', async () => {
+    observableRequest.mockReturnValue(of([]))
+    request.mockResolvedValue({})
+    await resolvedAddonDataset()
+
+    await expect(provisionAddonDataset(instance, {})).rejects.toThrow(/no dataset name/)
+  })
+
+  it('allows a retry after a failure', async () => {
+    observableRequest.mockReturnValue(of([]))
+    request.mockRejectedValueOnce(new Error('boom')).mockResolvedValue({datasetName: 'd-comments'})
+    await resolvedAddonDataset()
+
+    await expect(provisionAddonDataset(instance, {})).rejects.toThrow('boom')
+    await expect(provisionAddonDataset(instance, {})).resolves.toBe('d-comments')
+  })
+})
+
+describe('observeAddonDatasetClient', () => {
+  it('does not report a missing dataset while discovery is still in flight', () => {
+    observableRequest.mockReturnValue(NEVER)
+    const values: Array<SanityClient | null> = []
+
+    const subscription = observeAddonDatasetClient(instance, {}).subscribe((value) =>
+      values.push(value),
+    )
+
+    expect(values).toEqual([])
+    subscription.unsubscribe()
+  })
+
+  it('emits null while the project has no comments dataset', async () => {
+    observableRequest.mockReturnValue(of([]))
+
+    await expect(firstValueFrom(observeAddonDatasetClient(instance, {}))).resolves.toBe(null)
+  })
+
+  it('emits a client once the dataset is known', async () => {
+    const client = mockClient()
+    observableRequest.mockReturnValue(of([{name: 'd-comments'}]))
+
+    await vi.waitFor(async () =>
+      expect(await firstValueFrom(observeAddonDatasetClient(instance, {}))).toBe(client),
+    )
+
+    expect(getClientState).toHaveBeenCalledWith(instance, {
+      apiVersion: 'v2025-05-06',
+      projectId: 'p',
+      dataset: 'd-comments',
+    })
+  })
+})

--- a/packages/core/src/comments/addonDatasetStore.ts
+++ b/packages/core/src/comments/addonDatasetStore.ts
@@ -1,0 +1,249 @@
+import {type SanityClient} from '@sanity/client'
+import {
+  catchError,
+  distinctUntilChanged,
+  EMPTY,
+  filter,
+  firstValueFrom,
+  map,
+  type Observable,
+  of,
+  switchMap,
+  take,
+} from 'rxjs'
+
+import {getClient, getClientState} from '../client/clientStore'
+import {
+  type DatasetResource,
+  type DocumentResource,
+  isDatasetResource,
+} from '../config/sanityConfig'
+import {bindActionByResource, type BoundResourceKey} from '../store/createActionBinder'
+import {type SanityInstance} from '../store/createSanityInstance'
+import {createStateSourceAction, type StateSource} from '../store/createStateSourceAction'
+import {defineStore, type StoreContext} from '../store/defineStore'
+import {
+  ADDON_DATASET_API_VERSION,
+  ADDON_DATASET_PROFILE,
+  COMMENTS_API_VERSION,
+} from './commentsConstants'
+
+interface AddonDatasetStoreState {
+  /**
+   * `unknown` until discovery answers. `missing` means the project has no
+   * comments dataset yet, which is the normal state until someone writes a
+   * first comment.
+   */
+  status: 'unknown' | 'resolved' | 'missing'
+  datasetName?: string
+  /** In flight provisioning, so concurrent first comments issue one POST. */
+  provisioning?: Promise<string>
+}
+
+/**
+ * Comments need a project and a dataset. There is nowhere to put them for a
+ * media library or a canvas, and no Studio to interoperate with either.
+ *
+ * @internal
+ */
+export function assertDatasetResource(resource: DocumentResource): DatasetResource {
+  if (!isDatasetResource(resource)) {
+    throw new Error(
+      `Comments are only supported for dataset resources, received: ${JSON.stringify(resource)}`,
+    )
+  }
+  return resource
+}
+
+function isMissingOrForbidden(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('statusCode' in error)) return false
+  const {statusCode} = error as {statusCode?: unknown}
+  return statusCode === 403 || statusCode === 404
+}
+
+function requestAddonDataset(
+  client: SanityClient,
+  {projectId, dataset}: DatasetResource,
+): Observable<string | undefined> {
+  return client.observable
+    .request<{name: string}[] | undefined>({
+      uri: `/projects/${projectId}/datasets?datasetProfile=${ADDON_DATASET_PROFILE}&addonFor=${dataset}`,
+      tag: 'comments.addon-dataset.list',
+    })
+    .pipe(map((datasets) => datasets?.[0]?.name))
+}
+
+function discover(
+  instance: SanityInstance,
+  resource: DatasetResource,
+): Observable<string | undefined> {
+  return getClientState(instance, {
+    apiVersion: ADDON_DATASET_API_VERSION,
+    projectId: resource.projectId,
+    useProjectHostname: true,
+  }).observable.pipe(
+    switchMap((client) =>
+      requestAddonDataset(client, resource).pipe(
+        // A missing dataset and a dataset this user cannot see both mean there
+        // are no comments to read. Transient failures stay pending so a new
+        // authenticated client can retry discovery.
+        catchError((error: unknown) => (isMissingOrForbidden(error) ? of(undefined) : EMPTY)),
+      ),
+    ),
+  )
+}
+
+async function discoverOnce(
+  instance: SanityInstance,
+  resource: DatasetResource,
+): Promise<string | undefined> {
+  const client = await firstValueFrom(
+    getClientState(instance, {
+      apiVersion: ADDON_DATASET_API_VERSION,
+      projectId: resource.projectId,
+      useProjectHostname: true,
+    }).observable.pipe(take(1)),
+  )
+
+  try {
+    return await firstValueFrom(requestAddonDataset(client, resource))
+  } catch (error) {
+    if (isMissingOrForbidden(error)) return undefined
+    throw error
+  }
+}
+
+const addonDatasetStore = defineStore<AddonDatasetStoreState, BoundResourceKey>({
+  name: 'CommentsAddonDataset',
+  getInitialState: () => ({status: 'unknown'}),
+  initialize: ({instance, state, key}) => {
+    const resource = assertDatasetResource(key.resource)
+
+    const subscription = discover(instance, resource).subscribe((datasetName) =>
+      state.set(
+        'setAddonDataset',
+        datasetName ? {status: 'resolved', datasetName} : {status: 'missing'},
+      ),
+    )
+
+    return () => subscription.unsubscribe()
+  },
+})
+
+/**
+ * The addon dataset's name: `undefined` while discovery is in flight, `null`
+ * when the project has none yet.
+ *
+ * @internal
+ */
+export const getAddonDatasetState: (
+  instance: SanityInstance,
+  options: {resource?: DocumentResource},
+) => StateSource<string | null | undefined> = bindActionByResource(
+  addonDatasetStore,
+  createStateSourceAction(({state}: {state: AddonDatasetStoreState}) => {
+    if (state.status === 'unknown') return undefined
+    return state.datasetName ?? null
+  }),
+)
+
+/**
+ * Resolves the addon dataset, creating it if the project has none.
+ *
+ * Safe to call concurrently: the first call owns the request and later ones
+ * await the same promise. Provisioning is a one-time, project-wide side effect,
+ * so this is only called from the write path, when we know there is a comment
+ * to store.
+ *
+ * @internal
+ */
+export const provisionAddonDataset: (
+  instance: SanityInstance,
+  options: {resource?: DocumentResource},
+) => Promise<string> = bindActionByResource(
+  addonDatasetStore,
+  ({instance, state, key}: StoreContext<AddonDatasetStoreState, BoundResourceKey>) => {
+    const current = state.get()
+    if (current.datasetName) return Promise.resolve(current.datasetName)
+    if (current.provisioning) return current.provisioning
+
+    const resource = assertDatasetResource(key.resource)
+
+    const provisioning = (async () => {
+      // Another user may have provisioned it since this client started up, in
+      // which case creating it again would fail. Ask before writing.
+      const existing = await discoverOnce(instance, resource)
+      if (existing) return existing
+
+      const client = getClient(instance, {
+        apiVersion: ADDON_DATASET_API_VERSION,
+        projectId: resource.projectId,
+        useProjectHostname: true,
+      })
+
+      const response = await client.request<{datasetName?: string} | undefined>({
+        uri: `/comments/${resource.dataset}/setup`,
+        method: 'POST',
+        tag: 'comments.addon-dataset.setup',
+      })
+
+      if (!response?.datasetName) {
+        throw new Error('Creating the comments addon dataset returned no dataset name.')
+      }
+
+      return response.datasetName
+    })()
+      .then((datasetName) => {
+        state.set('setAddonDataset', {
+          status: 'resolved',
+          datasetName,
+          provisioning: undefined,
+        })
+        return datasetName
+      })
+      .catch((error: unknown) => {
+        // Clear the in-flight promise so a retry is not permanently stuck on
+        // this failure.
+        state.set('clearProvisioning', {provisioning: undefined})
+        throw error
+      })
+
+    state.set('startProvisioning', {provisioning})
+
+    return provisioning
+  },
+)
+
+/**
+ * A client pointed at the addon dataset, or `null` while the project has none.
+ *
+ * Emits again whenever the dataset is discovered or provisioned, and whenever
+ * the auth token changes. Long-lived readers must follow it rather than holding
+ * a client, because the client store drops every cached client on a token
+ * change.
+ *
+ * @internal
+ */
+export const observeAddonDatasetClient: (
+  instance: SanityInstance,
+  options: {resource?: DocumentResource},
+) => Observable<SanityClient | null> = bindActionByResource(
+  addonDatasetStore,
+  ({instance, key}: StoreContext<AddonDatasetStoreState, BoundResourceKey>) => {
+    const {projectId} = assertDatasetResource(key.resource)
+
+    return getAddonDatasetState(instance, {resource: key.resource}).observable.pipe(
+      distinctUntilChanged(),
+      filter((datasetName): datasetName is string | null => datasetName !== undefined),
+      switchMap((datasetName) =>
+        typeof datasetName === 'string'
+          ? getClientState(instance, {
+              apiVersion: COMMENTS_API_VERSION,
+              projectId,
+              dataset: datasetName,
+            }).observable
+          : of(null),
+      ),
+    )
+  },
+)

--- a/packages/core/src/comments/buildCommentThreads.test.ts
+++ b/packages/core/src/comments/buildCommentThreads.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from 'vitest'
+
+import {buildCommentThreads} from './buildCommentThreads'
+import {type CommentDocument} from './types'
+
+function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_id'>) {
+  return {
+    _type: 'comment',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _rev: 'rev',
+    authorId: 'user-1',
+    message: null,
+    threadId: 'thread-1',
+    status: 'open',
+    reactions: null,
+    target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
+    ...overrides,
+  } satisfies CommentDocument as CommentDocument
+}
+
+describe('buildCommentThreads', () => {
+  it('returns nothing for an empty list', () => {
+    expect(buildCommentThreads([])).toEqual([])
+  })
+
+  it('groups a parent with its replies, oldest reply first', () => {
+    const parent = comment({_id: 'a', _createdAt: '2026-01-01T00:00:00Z'})
+    const second = comment({_id: 'c', _createdAt: '2026-01-03T00:00:00Z', parentCommentId: 'a'})
+    const first = comment({_id: 'b', _createdAt: '2026-01-02T00:00:00Z', parentCommentId: 'a'})
+
+    expect(buildCommentThreads([second, first, parent])).toEqual([
+      {
+        threadId: 'thread-1',
+        fieldPath: '',
+        parentComment: parent,
+        replies: [first, second],
+        commentsCount: 3,
+        status: 'open',
+        lastActivityAt: '2026-01-03T00:00:00Z',
+      },
+    ])
+  })
+
+  it('takes fieldPath from the parent target', () => {
+    const parent = comment({
+      _id: 'a',
+      target: {
+        documentType: 'author',
+        path: {field: 'body[_key=="intro"].content'},
+        document: {_ref: 'doc-1', _type: 'reference', _weak: true},
+      },
+    })
+
+    expect(buildCommentThreads([parent])[0].fieldPath).toBe('body[_key=="intro"].content')
+  })
+
+  it('falls back to the parent createdAt when there are no replies', () => {
+    const parent = comment({_id: 'a', _createdAt: '2026-02-02T00:00:00Z'})
+
+    expect(buildCommentThreads([parent])[0]).toMatchObject({
+      commentsCount: 1,
+      lastActivityAt: '2026-02-02T00:00:00Z',
+      replies: [],
+    })
+  })
+
+  it('drops replies whose parent is missing', () => {
+    // Happens between a parent being deleted and its replies disappearing.
+    const orphan = comment({_id: 'b', parentCommentId: 'gone'})
+
+    expect(buildCommentThreads([orphan])).toEqual([])
+  })
+
+  it('keeps threads in the order their parents arrive', () => {
+    const newer = comment({_id: 'a', threadId: 'thread-a', _createdAt: '2026-01-05T00:00:00Z'})
+    const older = comment({_id: 'b', threadId: 'thread-b', _createdAt: '2026-01-01T00:00:00Z'})
+
+    expect(buildCommentThreads([newer, older]).map((thread) => thread.threadId)).toEqual([
+      'thread-a',
+      'thread-b',
+    ])
+  })
+
+  it('reports the parent status for the thread', () => {
+    const parent = comment({_id: 'a', status: 'resolved'})
+    const reply = comment({_id: 'b', parentCommentId: 'a', status: 'resolved'})
+
+    expect(buildCommentThreads([parent, reply])[0].status).toBe('resolved')
+  })
+})

--- a/packages/core/src/comments/buildCommentThreads.test.ts
+++ b/packages/core/src/comments/buildCommentThreads.test.ts
@@ -1,21 +1,21 @@
 import {describe, expect, it} from 'vitest'
 
 import {buildCommentThreads} from './buildCommentThreads'
-import {type CommentDocument} from './types'
+import {type Comment} from './types'
 
-function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_id'>) {
+function comment(overrides: Partial<Comment> & Pick<Comment, 'id'>): Comment {
   return {
-    _type: 'comment',
-    _createdAt: '2026-01-01T00:00:00Z',
-    _rev: 'rev',
+    createdAt: '2026-01-01T00:00:00Z',
     authorId: 'user-1',
     message: null,
     threadId: 'thread-1',
     status: 'open',
-    reactions: null,
-    target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
+    reactions: [],
+    documentId: 'doc-1',
+    documentType: 'author',
+    fieldPath: '',
     ...overrides,
-  } satisfies CommentDocument as CommentDocument
+  }
 }
 
 describe('buildCommentThreads', () => {
@@ -24,9 +24,9 @@ describe('buildCommentThreads', () => {
   })
 
   it('groups a parent with its replies, oldest reply first', () => {
-    const parent = comment({_id: 'a', _createdAt: '2026-01-01T00:00:00Z'})
-    const second = comment({_id: 'c', _createdAt: '2026-01-03T00:00:00Z', parentCommentId: 'a'})
-    const first = comment({_id: 'b', _createdAt: '2026-01-02T00:00:00Z', parentCommentId: 'a'})
+    const parent = comment({id: 'a', createdAt: '2026-01-01T00:00:00Z'})
+    const second = comment({id: 'c', createdAt: '2026-01-03T00:00:00Z', parentCommentId: 'a'})
+    const first = comment({id: 'b', createdAt: '2026-01-02T00:00:00Z', parentCommentId: 'a'})
 
     expect(buildCommentThreads([second, first, parent])).toEqual([
       {
@@ -41,21 +41,14 @@ describe('buildCommentThreads', () => {
     ])
   })
 
-  it('takes fieldPath from the parent target', () => {
-    const parent = comment({
-      _id: 'a',
-      target: {
-        documentType: 'author',
-        path: {field: 'body[_key=="intro"].content'},
-        document: {_ref: 'doc-1', _type: 'reference', _weak: true},
-      },
-    })
+  it('takes fieldPath from the parent', () => {
+    const parent = comment({id: 'a', fieldPath: 'body[_key=="intro"].content'})
 
     expect(buildCommentThreads([parent])[0].fieldPath).toBe('body[_key=="intro"].content')
   })
 
   it('falls back to the parent createdAt when there are no replies', () => {
-    const parent = comment({_id: 'a', _createdAt: '2026-02-02T00:00:00Z'})
+    const parent = comment({id: 'a', createdAt: '2026-02-02T00:00:00Z'})
 
     expect(buildCommentThreads([parent])[0]).toMatchObject({
       commentsCount: 1,
@@ -66,14 +59,14 @@ describe('buildCommentThreads', () => {
 
   it('drops replies whose parent is missing', () => {
     // Happens between a parent being deleted and its replies disappearing.
-    const orphan = comment({_id: 'b', parentCommentId: 'gone'})
+    const orphan = comment({id: 'b', parentCommentId: 'gone'})
 
     expect(buildCommentThreads([orphan])).toEqual([])
   })
 
   it('keeps threads in the order their parents arrive', () => {
-    const newer = comment({_id: 'a', threadId: 'thread-a', _createdAt: '2026-01-05T00:00:00Z'})
-    const older = comment({_id: 'b', threadId: 'thread-b', _createdAt: '2026-01-01T00:00:00Z'})
+    const newer = comment({id: 'a', threadId: 'thread-a', createdAt: '2026-01-05T00:00:00Z'})
+    const older = comment({id: 'b', threadId: 'thread-b', createdAt: '2026-01-01T00:00:00Z'})
 
     expect(buildCommentThreads([newer, older]).map((thread) => thread.threadId)).toEqual([
       'thread-a',
@@ -82,8 +75,8 @@ describe('buildCommentThreads', () => {
   })
 
   it('reports the parent status for the thread', () => {
-    const parent = comment({_id: 'a', status: 'resolved'})
-    const reply = comment({_id: 'b', parentCommentId: 'a', status: 'resolved'})
+    const parent = comment({id: 'a', status: 'resolved'})
+    const reply = comment({id: 'b', parentCommentId: 'a', status: 'resolved'})
 
     expect(buildCommentThreads([parent, reply])[0].status).toBe('resolved')
   })

--- a/packages/core/src/comments/buildCommentThreads.ts
+++ b/packages/core/src/comments/buildCommentThreads.ts
@@ -1,0 +1,54 @@
+import {type CommentDocument, type CommentThread} from './types'
+
+/**
+ * Groups a flat comment list into threads.
+ *
+ * A thread's parent is the comment with no `parentCommentId`; replies point at
+ * the parent's `_id`. Replies whose parent is missing from the input are
+ * dropped, which is what happens when a parent is deleted but its replies have
+ * not disappeared yet.
+ *
+ * Threads come back in the order their parents appear in `comments`, so passing
+ * the store's newest-first list gives newest-thread-first. Replies within a
+ * thread are always oldest first, since that is reading order.
+ *
+ * @internal
+ */
+export function buildCommentThreads(comments: CommentDocument[]): CommentThread[] {
+  const repliesByParent = new Map<string, CommentDocument[]>()
+
+  for (const comment of comments) {
+    if (!comment.parentCommentId) continue
+    const existing = repliesByParent.get(comment.parentCommentId)
+    if (existing) {
+      existing.push(comment)
+    } else {
+      repliesByParent.set(comment.parentCommentId, [comment])
+    }
+  }
+
+  const threads: CommentThread[] = []
+
+  for (const parentComment of comments) {
+    if (parentComment.parentCommentId) continue
+
+    // The array is built above and owned here, so sorting in place is safe.
+    const replies = (repliesByParent.get(parentComment._id) ?? []).sort((a, b) =>
+      a._createdAt.localeCompare(b._createdAt),
+    )
+
+    const lastReply = replies[replies.length - 1]
+
+    threads.push({
+      threadId: parentComment.threadId,
+      fieldPath: parentComment.target.path?.field ?? '',
+      parentComment,
+      replies,
+      commentsCount: replies.length + 1,
+      status: parentComment.status,
+      lastActivityAt: lastReply ? lastReply._createdAt : parentComment._createdAt,
+    })
+  }
+
+  return threads
+}

--- a/packages/core/src/comments/buildCommentThreads.ts
+++ b/packages/core/src/comments/buildCommentThreads.ts
@@ -1,10 +1,10 @@
-import {type CommentDocument, type CommentThread} from './types'
+import {type Comment, type CommentThread} from './types'
 
 /**
  * Groups a flat comment list into threads.
  *
  * A thread's parent is the comment with no `parentCommentId`; replies point at
- * the parent's `_id`. Replies whose parent is missing from the input are
+ * the parent's `id`. Replies whose parent is missing from the input are
  * dropped, which is what happens when a parent is deleted but its replies have
  * not disappeared yet.
  *
@@ -14,8 +14,8 @@ import {type CommentDocument, type CommentThread} from './types'
  *
  * @internal
  */
-export function buildCommentThreads(comments: CommentDocument[]): CommentThread[] {
-  const repliesByParent = new Map<string, CommentDocument[]>()
+export function buildCommentThreads(comments: Comment[]): CommentThread[] {
+  const repliesByParent = new Map<string, Comment[]>()
 
   for (const comment of comments) {
     if (!comment.parentCommentId) continue
@@ -33,20 +33,20 @@ export function buildCommentThreads(comments: CommentDocument[]): CommentThread[
     if (parentComment.parentCommentId) continue
 
     // The array is built above and owned here, so sorting in place is safe.
-    const replies = (repliesByParent.get(parentComment._id) ?? []).sort((a, b) =>
-      a._createdAt.localeCompare(b._createdAt),
+    const replies = (repliesByParent.get(parentComment.id) ?? []).sort((a, b) =>
+      a.createdAt.localeCompare(b.createdAt),
     )
 
     const lastReply = replies[replies.length - 1]
 
     threads.push({
       threadId: parentComment.threadId,
-      fieldPath: parentComment.target.path?.field ?? '',
+      fieldPath: parentComment.fieldPath,
       parentComment,
       replies,
       commentsCount: replies.length + 1,
       status: parentComment.status,
-      lastActivityAt: lastReply ? lastReply._createdAt : parentComment._createdAt,
+      lastActivityAt: lastReply ? lastReply.createdAt : parentComment.createdAt,
     })
   }
 

--- a/packages/core/src/comments/commentActions.test.ts
+++ b/packages/core/src/comments/commentActions.test.ts
@@ -32,6 +32,9 @@ vi.mock('./addonDatasetStore', async (importOriginal) => ({
 
 const HANDLE = {documentId: 'doc-1', documentType: 'author'}
 
+/** Creates always name a field, since a pathless comment is refused. */
+const CREATE = {...HANDLE, fieldPath: 'name'}
+
 function comment(overrides: Partial<StoredComment> & Pick<StoredComment, '_id'>) {
   return {
     _type: 'comment',
@@ -42,7 +45,12 @@ function comment(overrides: Partial<StoredComment> & Pick<StoredComment, '_id'>)
     threadId: 'thread-1',
     status: 'open',
     reactions: null,
-    target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
+    target: {
+      documentType: 'author',
+      // Every comment points at a field, so replies inherit a real path.
+      path: {field: 'name'},
+      document: {_ref: 'doc-1', _type: 'reference', _weak: true},
+    },
     ...overrides,
   } satisfies StoredComment as StoredComment
 }
@@ -170,14 +178,14 @@ describe('createComment', () => {
   })
 
   it('targets the published document from a draft id', async () => {
-    await createComment(instance, {...HANDLE, documentId: 'drafts.doc-1', message: null})
+    await createComment(instance, {...CREATE, documentId: 'drafts.doc-1', message: null})
 
     expect(client.createIfNotExists.mock.calls[0][0].target.document._ref).toBe('doc-1')
   })
 
   it('records the release when commenting on one', async () => {
     await createComment(instance, {
-      ...HANDLE,
+      ...CREATE,
       perspective: {releaseName: 'summer'},
       message: null,
     })
@@ -188,7 +196,7 @@ describe('createComment', () => {
   it('carries a text selection through untouched', async () => {
     const selection = {type: 'text' as const, value: [{_key: 'b1', text: 'marked'}]}
 
-    await createComment(instance, {...HANDLE, message: null, fieldPath: 'body', selection})
+    await createComment(instance, {...CREATE, message: null, fieldPath: 'body', selection})
 
     expect(client.createIfNotExists.mock.calls[0][0].target.path).toEqual({
       field: 'body',
@@ -198,7 +206,7 @@ describe('createComment', () => {
 
   it('weakens references in a content snapshot', async () => {
     await createComment(instance, {
-      ...HANDLE,
+      ...CREATE,
       message: null,
       contentSnapshot: {author: {_ref: 'other-doc', _type: 'reference'}},
     })
@@ -209,7 +217,7 @@ describe('createComment', () => {
   })
 
   it('provisions the addon dataset on the way', async () => {
-    await createComment(instance, {...HANDLE, message: null})
+    await createComment(instance, {...CREATE, message: null})
 
     expect(provisionAddonDataset).toHaveBeenCalled()
     expect(getClient).toHaveBeenCalledWith(instance, {
@@ -226,7 +234,7 @@ describe('createComment', () => {
     let resolveCreate: (value: unknown) => void = () => {}
     client.createIfNotExists.mockReturnValue(new Promise((resolve) => (resolveCreate = resolve)))
 
-    const pending = createComment(instance, {...HANDLE, commentId: 'c1', message: null})
+    const pending = createComment(instance, {...CREATE, commentId: 'c1', message: null})
 
     expect(source.getCurrent()!.map((c) => c.id)).toEqual(['c1'])
 
@@ -242,7 +250,7 @@ describe('createComment', () => {
     client.createIfNotExists.mockRejectedValue(new Error('nope'))
 
     await expect(
-      createComment(instance, {...HANDLE, commentId: 'c1', message: null}),
+      createComment(instance, {...CREATE, commentId: 'c1', message: null}),
     ).rejects.toThrow('nope')
 
     expect(source.getCurrent()![0].state).toEqual({type: 'createError', error: expect.any(Error)})
@@ -255,14 +263,14 @@ describe('createComment', () => {
     client.createIfNotExists.mockRejectedValueOnce(new Error('nope'))
 
     await expect(
-      createComment(instance, {...HANDLE, commentId: 'c1', message: null}),
+      createComment(instance, {...CREATE, commentId: 'c1', message: null}),
     ).rejects.toThrow('nope')
 
     let resolveRetry: (value: unknown) => void = () => {}
     client.create.mockReturnValue(new Promise((resolve) => (resolveRetry = resolve)))
     client.createIfNotExists.mockReturnValue(new Promise((resolve) => (resolveRetry = resolve)))
 
-    const retry = createComment(instance, {...HANDLE, commentId: 'c1', message: null})
+    const retry = createComment(instance, {...CREATE, commentId: 'c1', message: null})
 
     expect(source.getCurrent()![0].state).toEqual({type: 'createRetrying'})
 
@@ -277,9 +285,24 @@ describe('createComment', () => {
       subscribe: () => () => {},
     } as unknown as StateSource<CurrentUser | null>)
 
-    await expect(createComment(instance, {...HANDLE, message: null})).rejects.toThrow(
+    await expect(createComment(instance, {...CREATE, message: null})).rejects.toThrow(
       /requires a logged in user/,
     )
+  })
+
+  it('refuses a comment that points at no field', async () => {
+    // Not pedantry. The Studio's inspector calls `fromString` on the stored
+    // path and throws on `''`, so a pathless comment crashes the inspector for
+    // everyone viewing that document until someone deletes it.
+    await expect(
+      createComment(instance, {...HANDLE, fieldPath: '', message: null}),
+    ).rejects.toThrow(/needs a field path/)
+
+    await expect(
+      createComment(instance, {...HANDLE, fieldPath: [], message: null}),
+    ).rejects.toThrow(/needs a field path/)
+
+    expect(client.createIfNotExists).not.toHaveBeenCalled()
   })
 })
 
@@ -349,6 +372,8 @@ describe('replyToComment', () => {
       parentCommentId: 'unknown',
       threadId: 'thread-3',
       status: 'resolved',
+      // With no parent to inherit from, the field has to be named too.
+      fieldPath: 'name',
       message: null,
     })
 

--- a/packages/core/src/comments/commentActions.test.ts
+++ b/packages/core/src/comments/commentActions.test.ts
@@ -1,0 +1,515 @@
+import {type SanityClient} from '@sanity/client'
+import {type CurrentUser} from '@sanity/types'
+import {of} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getCurrentUserState} from '../auth/authStore'
+import {getClient} from '../client/clientStore'
+import {type DocumentResource} from '../config/sanityConfig'
+import {bindActionByResource} from '../store/createActionBinder'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {type StateSource} from '../store/createStateSourceAction'
+import {getAddonDatasetState, provisionAddonDataset} from './addonDatasetStore'
+import {
+  createComment,
+  removeComment,
+  replyToComment,
+  setCommentStatus,
+  updateComment,
+} from './commentActions'
+import {commentsStore, getCommentsState} from './commentsStore'
+import {addSubscriber, getCommentsKey, setComments} from './reducers'
+import {type CommentDocument} from './types'
+
+vi.mock('../auth/authStore', () => ({getCurrentUserState: vi.fn()}))
+vi.mock('../client/clientStore', () => ({getClient: vi.fn(), getClientState: vi.fn()}))
+vi.mock('./addonDatasetStore', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./addonDatasetStore')>()),
+  getAddonDatasetState: vi.fn(),
+  provisionAddonDataset: vi.fn(),
+  observeAddonDatasetClient: vi.fn(() => of(null)),
+}))
+
+const HANDLE = {documentId: 'doc-1', documentType: 'author'}
+
+function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_id'>) {
+  return {
+    _type: 'comment',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _rev: 'rev',
+    authorId: 'user-1',
+    message: null,
+    threadId: 'thread-1',
+    status: 'open',
+    reactions: null,
+    target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
+    ...overrides,
+  } satisfies CommentDocument as CommentDocument
+}
+
+/** Puts comments into the store without going through the listener. */
+const seedComments = bindActionByResource(
+  commentsStore,
+  (
+    {state},
+    options: {resource?: DocumentResource; documentId?: string; comments: CommentDocument[]},
+  ) => {
+    const key = getCommentsKey({documentId: options.documentId ?? 'doc-1'})
+    state.set('addSubscriber', addSubscriber(key, 'seed'))
+    state.set('setComments', setComments(key, options.comments))
+  },
+)
+
+const getCommentsStoreState = bindActionByResource(
+  commentsStore,
+  ({state}, _options: {resource?: DocumentResource}) => state.get(),
+)
+
+let instance: SanityInstance
+let client: {
+  create: ReturnType<typeof vi.fn>
+  createIfNotExists: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+  mutate: ReturnType<typeof vi.fn>
+  transaction: ReturnType<typeof vi.fn>
+}
+let patchCommit: ReturnType<typeof vi.fn>
+let transactionCommit: ReturnType<typeof vi.fn>
+let patchSet: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.resetAllMocks()
+
+  patchCommit = vi.fn().mockResolvedValue({})
+  transactionCommit = vi.fn().mockResolvedValue({})
+  patchSet = vi.fn(() => ({commit: patchCommit, set: patchSet}))
+
+  const patch = vi.fn(() => ({set: patchSet, commit: patchCommit}))
+  const transaction = vi.fn(() => {
+    const tx = {
+      transactionId: vi.fn(() => tx),
+      patch: vi.fn(() => tx),
+      commit: transactionCommit,
+    }
+    return tx
+  })
+
+  client = {
+    create: vi.fn(async (doc) => ({...doc, _createdAt: '2026-06-01T00:00:00Z', _rev: 'rev-1'})),
+    createIfNotExists: vi.fn(async (doc) => ({
+      ...doc,
+      _createdAt: '2026-06-01T00:00:00Z',
+      _rev: 'rev-1',
+    })),
+    patch,
+    delete: vi.fn().mockResolvedValue({}),
+    mutate: vi.fn().mockResolvedValue({}),
+    transaction,
+  }
+
+  vi.mocked(getClient).mockReturnValue(client as unknown as SanityClient)
+  vi.mocked(provisionAddonDataset).mockResolvedValue('d-comments')
+  vi.mocked(getAddonDatasetState).mockReturnValue({
+    observable: of('d-comments'),
+    getCurrent: () => 'd-comments',
+    subscribe: () => () => {},
+  } as unknown as StateSource<string | null | undefined>)
+  vi.mocked(getCurrentUserState).mockReturnValue({
+    observable: of({id: 'user-1'}),
+    getCurrent: () => ({id: 'user-1'}) as CurrentUser,
+    subscribe: () => () => {},
+  } as unknown as StateSource<CurrentUser | null>)
+
+  instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+})
+
+afterEach(() => {
+  instance.dispose()
+})
+
+describe('createComment', () => {
+  it('writes the document shape the Studio reads', async () => {
+    // Golden test. This object is the interop contract: the Studio filters on
+    // `target.document._ref` and groups on `target.path.field`, so a change
+    // here makes SDK comments invisible in the Studio without failing anything
+    // else.
+    await createComment(instance, {
+      ...HANDLE,
+      commentId: 'comment-1',
+      threadId: 'thread-1',
+      message: [{_type: 'block', _key: 'b1', children: [{_type: 'span', text: 'hi'}]}],
+      fieldPath: ['body', {_key: 'intro'}, 'content'],
+    })
+
+    expect(client.createIfNotExists).toHaveBeenCalledWith(
+      {
+        _id: 'comment-1',
+        _type: 'comment',
+        authorId: 'user-1',
+        message: [{_type: 'block', _key: 'b1', children: [{_type: 'span', text: 'hi'}]}],
+        threadId: 'thread-1',
+        status: 'open',
+        reactions: null,
+        context: {tool: ''},
+        target: {
+          documentRevisionId: '',
+          path: {field: 'body[_key=="intro"].content'},
+          document: {
+            _dataset: 'd',
+            _projectId: 'p',
+            _ref: 'doc-1',
+            _type: 'crossDatasetReference',
+            _weak: true,
+          },
+          documentType: 'author',
+        },
+      },
+      {tag: 'comments.create'},
+    )
+  })
+
+  it('targets the published document from a draft id', async () => {
+    await createComment(instance, {...HANDLE, documentId: 'drafts.doc-1', message: null})
+
+    expect(client.createIfNotExists.mock.calls[0][0].target.document._ref).toBe('doc-1')
+  })
+
+  it('records the release when commenting on one', async () => {
+    await createComment(instance, {
+      ...HANDLE,
+      perspective: {releaseName: 'summer'},
+      message: null,
+    })
+
+    expect(client.createIfNotExists.mock.calls[0][0].target.documentVersionId).toBe('summer')
+  })
+
+  it('carries a text selection through untouched', async () => {
+    const selection = {type: 'text' as const, value: [{_key: 'b1', text: 'marked'}]}
+
+    await createComment(instance, {...HANDLE, message: null, fieldPath: 'body', selection})
+
+    expect(client.createIfNotExists.mock.calls[0][0].target.path).toEqual({
+      field: 'body',
+      selection,
+    })
+  })
+
+  it('weakens references in a content snapshot', async () => {
+    await createComment(instance, {
+      ...HANDLE,
+      message: null,
+      contentSnapshot: {author: {_ref: 'other-doc', _type: 'reference'}},
+    })
+
+    expect(client.createIfNotExists.mock.calls[0][0].contentSnapshot).toEqual({
+      author: {_ref: 'other-doc', _type: 'reference', _weak: true},
+    })
+  })
+
+  it('provisions the addon dataset on the way', async () => {
+    await createComment(instance, {...HANDLE, message: null})
+
+    expect(provisionAddonDataset).toHaveBeenCalled()
+    expect(getClient).toHaveBeenCalledWith(instance, {
+      apiVersion: 'v2025-05-06',
+      projectId: 'p',
+      dataset: 'd-comments',
+    })
+  })
+
+  it('shows the comment before the server confirms it', async () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+
+    let resolveCreate: (value: unknown) => void = () => {}
+    client.createIfNotExists.mockReturnValue(new Promise((resolve) => (resolveCreate = resolve)))
+
+    const pending = createComment(instance, {...HANDLE, commentId: 'c1', message: null})
+
+    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['c1'])
+
+    resolveCreate({...comment({_id: 'c1'})})
+    await pending
+  })
+
+  it('leaves a failed comment in place carrying the error', async () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+
+    client.create.mockRejectedValue(new Error('nope'))
+    client.createIfNotExists.mockRejectedValue(new Error('nope'))
+
+    await expect(
+      createComment(instance, {...HANDLE, commentId: 'c1', message: null}),
+    ).rejects.toThrow('nope')
+
+    expect(source.getCurrent()![0]._state).toEqual({type: 'createError', error: expect.any(Error)})
+  })
+
+  it('marks a failed comment as retrying while the retry is in flight', async () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+    client.create.mockRejectedValueOnce(new Error('nope'))
+    client.createIfNotExists.mockRejectedValueOnce(new Error('nope'))
+
+    await expect(
+      createComment(instance, {...HANDLE, commentId: 'c1', message: null}),
+    ).rejects.toThrow('nope')
+
+    let resolveRetry: (value: unknown) => void = () => {}
+    client.create.mockReturnValue(new Promise((resolve) => (resolveRetry = resolve)))
+    client.createIfNotExists.mockReturnValue(new Promise((resolve) => (resolveRetry = resolve)))
+
+    const retry = createComment(instance, {...HANDLE, commentId: 'c1', message: null})
+
+    expect(source.getCurrent()![0]._state).toEqual({type: 'createRetrying'})
+
+    resolveRetry(comment({_id: 'c1'}))
+    await retry
+  })
+
+  it('refuses to write without a logged in user', async () => {
+    vi.mocked(getCurrentUserState).mockReturnValue({
+      getCurrent: () => null,
+      observable: of(null),
+      subscribe: () => () => {},
+    } as unknown as StateSource<CurrentUser | null>)
+
+    await expect(createComment(instance, {...HANDLE, message: null})).rejects.toThrow(
+      /requires a logged in user/,
+    )
+  })
+})
+
+describe('replyToComment', () => {
+  it('inherits thread, field, and status from the parent', async () => {
+    seedComments(instance, {
+      comments: [
+        comment({
+          _id: 'parent',
+          threadId: 'thread-9',
+          status: 'resolved',
+          target: {
+            documentType: 'author',
+            path: {field: 'title'},
+            document: {_ref: 'doc-1', _type: 'reference', _weak: true},
+          },
+        }),
+      ],
+    })
+
+    await replyToComment(instance, {
+      ...HANDLE,
+      parentCommentId: 'parent',
+      commentId: 'reply-1',
+      message: null,
+    })
+
+    expect(client.createIfNotExists.mock.calls[0][0]).toMatchObject({
+      parentCommentId: 'parent',
+      threadId: 'thread-9',
+      status: 'resolved',
+      target: {path: {field: 'title'}},
+    })
+  })
+
+  it('attaches a reply to a reply to the thread parent', async () => {
+    // The Studio's threads are one level deep; a nested reply would be orphaned.
+    seedComments(instance, {
+      comments: [comment({_id: 'parent'}), comment({_id: 'reply-1', parentCommentId: 'parent'})],
+    })
+
+    await replyToComment(instance, {...HANDLE, parentCommentId: 'reply-1', message: null})
+
+    expect(client.createIfNotExists.mock.calls[0][0].parentCommentId).toBe('parent')
+  })
+
+  it('explains itself when the parent is not loaded', async () => {
+    await expect(
+      replyToComment(instance, {...HANDLE, parentCommentId: 'unknown', message: null}),
+    ).rejects.toThrow(/pass its threadId/)
+  })
+
+  it('requires the status when the parent is not loaded', async () => {
+    await expect(
+      replyToComment(instance, {
+        ...HANDLE,
+        parentCommentId: 'unknown',
+        threadId: 'thread-3',
+        message: null,
+      }),
+    ).rejects.toThrow(/pass its status/)
+  })
+
+  it('accepts explicit thread details when the parent is not loaded', async () => {
+    await replyToComment(instance, {
+      ...HANDLE,
+      parentCommentId: 'unknown',
+      threadId: 'thread-3',
+      status: 'resolved',
+      message: null,
+    })
+
+    expect(client.createIfNotExists.mock.calls[0][0]).toMatchObject({
+      threadId: 'thread-3',
+      status: 'resolved',
+    })
+  })
+
+  it('does not reuse a parent loaded for another document', async () => {
+    seedComments(instance, {comments: [comment({_id: 'parent'})]})
+
+    await expect(
+      replyToComment(instance, {
+        ...HANDLE,
+        documentId: 'doc-2',
+        parentCommentId: 'parent',
+        message: null,
+      }),
+    ).rejects.toThrow(/not loaded/)
+  })
+})
+
+describe('updateComment', () => {
+  it('patches the message and stamps lastEditedAt in one transaction', async () => {
+    await updateComment(instance, {commentId: 'c1', message: null})
+
+    expect(client.transaction).toHaveBeenCalled()
+    expect(patchSet).toHaveBeenCalledWith({message: null, lastEditedAt: expect.any(String)})
+    expect(transactionCommit).toHaveBeenCalledWith({tag: 'comments.update'})
+  })
+
+  it('does not create a dataset just to edit a comment', async () => {
+    await updateComment(instance, {commentId: 'c1', message: null})
+
+    expect(provisionAddonDataset).not.toHaveBeenCalled()
+  })
+
+  it('does not retain a pending transaction when no comment is loaded', async () => {
+    await updateComment(instance, {commentId: 'c1', message: null})
+
+    expect(getCommentsStoreState(instance, {}).pendingTransactions).toEqual({})
+  })
+
+  it('restores the previous message when the write fails', async () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+    seedComments(instance, {comments: [comment({_id: 'c1', message: null})]})
+    transactionCommit.mockRejectedValue(new Error('nope'))
+    const message: CommentDocument['message'] = [
+      {_type: 'block', _key: 'block-1', children: [{_type: 'span', text: 'changed'}]},
+    ]
+
+    await expect(updateComment(instance, {commentId: 'c1', message})).rejects.toThrow('nope')
+
+    expect(source.getCurrent()![0].message).toBe(null)
+  })
+})
+
+describe('setCommentStatus', () => {
+  it('patches the parent and replies in one mutation', async () => {
+    await setCommentStatus(instance, {commentId: 'c1', status: 'resolved'})
+
+    expect(client.mutate).toHaveBeenCalledWith(
+      [
+        {patch: {id: 'c1', set: {status: 'resolved'}}},
+        {
+          patch: {
+            query: '*[_type == "comment" && parentCommentId == $commentId]',
+            params: {commentId: 'c1'},
+            set: {status: 'resolved'},
+          },
+        },
+      ],
+      {transactionId: expect.any(String), tag: 'comments.set-status'},
+    )
+  })
+
+  it('moves known replies immediately rather than waiting for the echo', async () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+    seedComments(instance, {
+      comments: [comment({_id: 'c1'}), comment({_id: 'r1', parentCommentId: 'c1'})],
+    })
+
+    await setCommentStatus(instance, {commentId: 'c1', status: 'resolved'})
+
+    expect(source.getCurrent()!.every((c) => c.status === 'resolved')).toBe(true)
+  })
+
+  it('restores the parent and replies when the write fails', async () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+    seedComments(instance, {
+      comments: [comment({_id: 'c1'}), comment({_id: 'r1', parentCommentId: 'c1'})],
+    })
+    client.mutate.mockRejectedValue(new Error('nope'))
+    transactionCommit.mockRejectedValue(new Error('nope'))
+
+    await expect(setCommentStatus(instance, {commentId: 'c1', status: 'resolved'})).rejects.toThrow(
+      'nope',
+    )
+
+    expect(source.getCurrent()!.every((c) => c.status === 'open')).toBe(true)
+  })
+})
+
+describe('removeComment', () => {
+  it('deletes the comment and its replies in one mutation', async () => {
+    await removeComment(instance, {commentId: 'c1'})
+
+    expect(client.mutate).toHaveBeenCalledWith(
+      [
+        {
+          delete: {
+            query: '*[_type == "comment" && parentCommentId == $commentId]',
+            params: {commentId: 'c1'},
+          },
+        },
+        {delete: {id: 'c1'}},
+      ],
+      {tag: 'comments.remove'},
+    )
+  })
+
+  it('drops the comment and its replies locally right away', async () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+    seedComments(instance, {
+      comments: [
+        comment({_id: 'c1'}),
+        comment({_id: 'r1', parentCommentId: 'c1'}),
+        comment({_id: 'other'}),
+      ],
+    })
+
+    await removeComment(instance, {commentId: 'c1'})
+
+    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['other'])
+  })
+
+  it('restores the comment and replies when the write fails', async () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+    seedComments(instance, {
+      comments: [
+        comment({_id: 'c1'}),
+        comment({_id: 'r1', parentCommentId: 'c1'}),
+        comment({_id: 'other'}),
+      ],
+    })
+    client.mutate.mockRejectedValue(new Error('nope'))
+    client.delete.mockRejectedValue(new Error('nope'))
+
+    await expect(removeComment(instance, {commentId: 'c1'})).rejects.toThrow('nope')
+
+    expect(
+      source
+        .getCurrent()!
+        .map((c) => c._id)
+        .sort(),
+    ).toEqual(['c1', 'other', 'r1'])
+  })
+})

--- a/packages/core/src/comments/commentActions.test.ts
+++ b/packages/core/src/comments/commentActions.test.ts
@@ -19,7 +19,7 @@ import {
 } from './commentActions'
 import {commentsStore, getCommentsState} from './commentsStore'
 import {addSubscriber, getCommentsKey, setComments} from './reducers'
-import {type CommentDocument} from './types'
+import {type StoredComment} from './types'
 
 vi.mock('../auth/authStore', () => ({getCurrentUserState: vi.fn()}))
 vi.mock('../client/clientStore', () => ({getClient: vi.fn(), getClientState: vi.fn()}))
@@ -32,7 +32,7 @@ vi.mock('./addonDatasetStore', async (importOriginal) => ({
 
 const HANDLE = {documentId: 'doc-1', documentType: 'author'}
 
-function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_id'>) {
+function comment(overrides: Partial<StoredComment> & Pick<StoredComment, '_id'>) {
   return {
     _type: 'comment',
     _createdAt: '2026-01-01T00:00:00Z',
@@ -44,7 +44,7 @@ function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_i
     reactions: null,
     target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
     ...overrides,
-  } satisfies CommentDocument as CommentDocument
+  } satisfies StoredComment as StoredComment
 }
 
 /** Puts comments into the store without going through the listener. */
@@ -52,7 +52,7 @@ const seedComments = bindActionByResource(
   commentsStore,
   (
     {state},
-    options: {resource?: DocumentResource; documentId?: string; comments: CommentDocument[]},
+    options: {resource?: DocumentResource; documentId?: string; comments: StoredComment[]},
   ) => {
     const key = getCommentsKey({documentId: options.documentId ?? 'doc-1'})
     state.set('addSubscriber', addSubscriber(key, 'seed'))
@@ -228,7 +228,7 @@ describe('createComment', () => {
 
     const pending = createComment(instance, {...HANDLE, commentId: 'c1', message: null})
 
-    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['c1'])
+    expect(source.getCurrent()!.map((c) => c.id)).toEqual(['c1'])
 
     resolveCreate({...comment({_id: 'c1'})})
     await pending
@@ -245,7 +245,7 @@ describe('createComment', () => {
       createComment(instance, {...HANDLE, commentId: 'c1', message: null}),
     ).rejects.toThrow('nope')
 
-    expect(source.getCurrent()![0]._state).toEqual({type: 'createError', error: expect.any(Error)})
+    expect(source.getCurrent()![0].state).toEqual({type: 'createError', error: expect.any(Error)})
   })
 
   it('marks a failed comment as retrying while the retry is in flight', async () => {
@@ -264,7 +264,7 @@ describe('createComment', () => {
 
     const retry = createComment(instance, {...HANDLE, commentId: 'c1', message: null})
 
-    expect(source.getCurrent()![0]._state).toEqual({type: 'createRetrying'})
+    expect(source.getCurrent()![0].state).toEqual({type: 'createRetrying'})
 
     resolveRetry(comment({_id: 'c1'}))
     await retry
@@ -398,7 +398,7 @@ describe('updateComment', () => {
     source.subscribe()
     seedComments(instance, {comments: [comment({_id: 'c1', message: null})]})
     transactionCommit.mockRejectedValue(new Error('nope'))
-    const message: CommentDocument['message'] = [
+    const message: StoredComment['message'] = [
       {_type: 'block', _key: 'block-1', children: [{_type: 'span', text: 'changed'}]},
     ]
 
@@ -487,7 +487,7 @@ describe('removeComment', () => {
 
     await removeComment(instance, {commentId: 'c1'})
 
-    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['other'])
+    expect(source.getCurrent()!.map((c) => c.id)).toEqual(['other'])
   })
 
   it('restores the comment and replies when the write fails', async () => {
@@ -508,7 +508,7 @@ describe('removeComment', () => {
     expect(
       source
         .getCurrent()!
-        .map((c) => c._id)
+        .map((c) => c.id)
         .sort(),
     ).toEqual(['c1', 'other', 'r1'])
   })

--- a/packages/core/src/comments/commentActions.ts
+++ b/packages/core/src/comments/commentActions.ts
@@ -1,0 +1,525 @@
+import {type SanityClient} from '@sanity/client'
+import {DocumentId, getPublishedId} from '@sanity/id-utils'
+import {type Path} from '@sanity/types'
+import {filter, firstValueFrom, take} from 'rxjs'
+
+import {getCurrentUserState} from '../auth/authStore'
+import {getClient} from '../client/clientStore'
+import {
+  type DatasetHandle,
+  type DatasetResource,
+  type DocumentHandle,
+  type DocumentResource,
+} from '../config/sanityConfig'
+import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
+import {bindActionByResource, type BoundResourceKey} from '../store/createActionBinder'
+import {type SanityInstance} from '../store/createSanityInstance'
+import {type StoreState} from '../store/createStoreState'
+import {type StoreContext} from '../store/defineStore'
+import {
+  assertDatasetResource,
+  getAddonDatasetState,
+  provisionAddonDataset,
+} from './addonDatasetStore'
+import {toCommentFieldPath} from './commentFieldPath'
+import {COMMENTS_API_VERSION} from './commentsConstants'
+import {type CommentsOptions, commentsStore, toCommentsKeyParts} from './commentsStore'
+import {
+  addComment,
+  applyCommentUpdate,
+  clearPendingTransaction,
+  type CommentsStoreState,
+  getCommentsKey,
+  receiveComment,
+  removeCommentById,
+  restoreComments,
+  rollbackCommentUpdate,
+  setCommentCreateError,
+  setPendingTransaction,
+} from './reducers'
+import {
+  type CommentContext,
+  type CommentDocument,
+  type CommentMessage,
+  type CommentPostPayload,
+  type CommentStatus,
+  type CommentTextSelection,
+} from './types'
+import {weakenReferencesInContentSnapshot} from './weakenReferences'
+
+/** @beta */
+export interface CreateCommentOptions extends DocumentHandle {
+  message: CommentMessage
+  /**
+   * Which field the thread hangs off. Omit, or pass `''`, for a thread about
+   * the document as a whole.
+   */
+  fieldPath?: string | Path
+  /**
+   * Anchors the comment to a run of text inside a Portable Text field. Building
+   * one needs a live editor, so this comes from
+   * `@portabletext/plugin-sdk-value` rather than being constructed by hand.
+   */
+  selection?: CommentTextSelection
+  /** Reuse the id of a failed comment to retry it. Defaults to a new id. */
+  commentId?: string
+  /** Defaults to a new id, which starts a new thread. */
+  threadId?: string
+  /** @defaultValue `'open'` */
+  status?: CommentStatus
+  /**
+   * The `_rev` of the document when the comment was written.
+   *
+   * Not filled in automatically: the SDK's local document revision is replaced
+   * by a transaction id while an edit is in flight, so it can name a revision
+   * that never reached the server. Nothing in the Studio reads this today.
+   */
+  documentRevisionId?: string
+  /**
+   * Merged over the defaults. The Studio writes `tool`, `payload`, `intent`,
+   * and `notification` here for its notification backend; the SDK has no source
+   * for any of them, so mentions in comments created this way do not send
+   * email unless you supply `notification` yourself.
+   */
+  context?: Partial<CommentContext>
+  /** A copy of the content being discussed. References in it are weakened. */
+  contentSnapshot?: unknown
+}
+
+/** @beta */
+export interface ReplyToCommentOptions extends DocumentHandle {
+  /** The comment being replied to. Replies to a reply join the same thread. */
+  parentCommentId: string
+  message: CommentMessage
+  commentId?: string
+  /** Only needed when the parent is not loaded, such as following a deep link. */
+  threadId?: string
+  /** Only needed when the parent is not loaded. */
+  fieldPath?: string | Path
+  /** Required when the parent is not loaded. */
+  status?: CommentStatus
+}
+
+/** @beta */
+export interface UpdateCommentOptions extends DatasetHandle {
+  commentId: string
+  message: CommentMessage
+}
+
+/** @beta */
+export interface SetCommentStatusOptions extends DatasetHandle {
+  /** The thread's first comment. Replies follow their parent. */
+  commentId: string
+  status: CommentStatus
+}
+
+/** @beta */
+export interface RemoveCommentOptions extends DatasetHandle {
+  commentId: string
+}
+
+function requireCurrentUserId(instance: SanityInstance): string {
+  const userId = getCurrentUserState(instance).getCurrent()?.id
+  if (!userId) {
+    throw new Error('Writing a comment requires a logged in user.')
+  }
+  return userId
+}
+
+/** Waits out discovery, then insists the addon dataset exists. */
+async function requireAddonDataset(
+  instance: SanityInstance,
+  resource: DocumentResource,
+): Promise<string> {
+  const datasetName = await firstValueFrom(
+    getAddonDatasetState(instance, {resource}).observable.pipe(
+      filter((value) => value !== undefined),
+      take(1),
+    ),
+  )
+
+  if (!datasetName) {
+    throw new Error('This project has no comments dataset, so there is no comment to change.')
+  }
+
+  return datasetName
+}
+
+async function getWritableClient(
+  instance: SanityInstance,
+  resource: DocumentResource,
+  {createIfMissing}: {createIfMissing: boolean},
+): Promise<SanityClient> {
+  const {projectId} = assertDatasetResource(resource)
+
+  // Provisioning is a project-wide side effect, so only the create path may
+  // trigger it. Editing or deleting a comment implies the dataset is there.
+  const dataset = createIfMissing
+    ? await provisionAddonDataset(instance, {resource})
+    : await requireAddonDataset(instance, resource)
+
+  return getClient(instance, {apiVersion: COMMENTS_API_VERSION, projectId, dataset})
+}
+
+function buildCommentPayload(options: {
+  authorId: string
+  commentId: string
+  contentSnapshot?: unknown
+  context?: Partial<CommentContext>
+  documentRevisionId?: string
+  handle: DocumentHandle
+  message: CommentMessage
+  parentCommentId?: string
+  resource: DatasetResource
+  fieldPath: string
+  selection?: CommentTextSelection
+  status: CommentStatus
+  threadId: string
+  documentVersionId?: string
+}): CommentPostPayload {
+  const {handle, resource} = options
+
+  return {
+    _id: options.commentId,
+    _type: 'comment',
+    authorId: options.authorId,
+    message: options.message,
+    threadId: options.threadId,
+    ...(options.parentCommentId ? {parentCommentId: options.parentCommentId} : {}),
+    status: options.status,
+    reactions: null,
+    // The Studio writes an empty tool name when no tool is active, and reads
+    // this nowhere in its UI.
+    context: {tool: '', ...options.context},
+    ...(options.contentSnapshot === undefined
+      ? {}
+      : {contentSnapshot: weakenReferencesInContentSnapshot(options.contentSnapshot)}),
+    target: {
+      documentRevisionId: options.documentRevisionId ?? '',
+      path: {
+        field: options.fieldPath,
+        ...(options.selection ? {selection: options.selection} : {}),
+      },
+      // The comment lives in the addon dataset, so this points across to the
+      // dataset holding the document. Weak, or Content Lake would refuse to
+      // delete a commented document.
+      document: {
+        _dataset: resource.dataset,
+        _projectId: resource.projectId,
+        _ref: getPublishedId(DocumentId(handle.documentId)),
+        _type: 'crossDatasetReference',
+        _weak: true,
+      },
+      documentType: handle.documentType,
+      ...(options.documentVersionId ? {documentVersionId: options.documentVersionId} : {}),
+    },
+  }
+}
+
+function findComment(
+  state: StoreState<CommentsStoreState>,
+  commentsKey: string,
+  commentId: string,
+): CommentDocument | undefined {
+  const comments = state.get().entries[commentsKey]?.comments
+  return comments && Object.hasOwn(comments, commentId) ? comments[commentId] : undefined
+}
+
+function findCommentById(
+  state: StoreState<CommentsStoreState>,
+  commentId: string,
+): CommentDocument | undefined {
+  for (const entry of Object.values(state.get().entries)) {
+    const comments = entry?.comments
+    const comment = comments && Object.hasOwn(comments, commentId) ? comments[commentId] : undefined
+    if (comment) return comment
+  }
+  return undefined
+}
+
+async function postComment(
+  context: StoreContext<CommentsStoreState, BoundResourceKey>,
+  handle: DocumentHandle & CommentsOptions,
+  payload: CommentPostPayload,
+): Promise<CommentDocument> {
+  const {state, instance, key} = context
+  const commentsKey = getCommentsKey(toCommentsKeyParts(instance, handle))
+
+  // Show it before the round trip, so a thread feels immediate.
+  state.set('addComment', addComment(commentsKey, payload))
+
+  try {
+    const client = await getWritableClient(instance, key.resource, {createIfMissing: true})
+    // `createIfNotExists` makes duplicate writes of the same id harmless, which
+    // covers both a retry after a lost response and two concurrent calls with
+    // the same comment id.
+    const created = await client.createIfNotExists(payload, {tag: 'comments.create'})
+    state.set('receiveComment', receiveComment(commentsKey, created))
+    return created
+  } catch (error) {
+    // Keep it on screen carrying the failure, so an app can offer a retry with
+    // the same id rather than silently losing what someone typed.
+    state.set(
+      'setCommentCreateError',
+      setCommentCreateError(payload._id, error instanceof Error ? error : new Error(String(error))),
+    )
+    throw error
+  }
+}
+
+/**
+ * Starts a thread on a document, or on one of its fields.
+ *
+ * Creates the project's comments dataset if this is the first comment anywhere
+ * in it. The comment appears locally before the server confirms it; if the
+ * write fails it stays, carrying `_state.createError`, and retrying with the
+ * same `commentId` replaces it.
+ *
+ * @beta
+ */
+export const createComment: (
+  instance: SanityInstance,
+  options: CreateCommentOptions,
+) => Promise<CommentDocument> = bindActionByResource(
+  commentsStore,
+  // `async` so a validation failure rejects rather than throwing at the call
+  // site, which would slip past a `.catch()`.
+  async (
+    context: StoreContext<CommentsStoreState, BoundResourceKey>,
+    options: CreateCommentOptions,
+  ) => {
+    const {instance, key} = context
+    const perspective = options.perspective ?? instance.config.perspective
+
+    return postComment(
+      context,
+      options,
+      buildCommentPayload({
+        authorId: requireCurrentUserId(instance),
+        commentId: options.commentId ?? crypto.randomUUID(),
+        contentSnapshot: options.contentSnapshot,
+        context: options.context,
+        documentRevisionId: options.documentRevisionId,
+        handle: options,
+        message: options.message,
+        resource: assertDatasetResource(key.resource),
+        fieldPath: toCommentFieldPath(options.fieldPath),
+        selection: options.selection,
+        status: options.status ?? 'open',
+        threadId: options.threadId ?? crypto.randomUUID(),
+        ...(isReleasePerspective(perspective) ? {documentVersionId: perspective.releaseName} : {}),
+      }),
+    )
+  },
+)
+
+/**
+ * Adds a reply to an existing thread.
+ *
+ * The thread and field are taken from the parent comment, so a reply always
+ * matches the same list as the comment it answers. Supply them only when the
+ * parent is not loaded.
+ *
+ * @beta
+ */
+export const replyToComment: (
+  instance: SanityInstance,
+  options: ReplyToCommentOptions,
+) => Promise<CommentDocument> = bindActionByResource(
+  commentsStore,
+  async (
+    context: StoreContext<CommentsStoreState, BoundResourceKey>,
+    options: ReplyToCommentOptions,
+  ) => {
+    const {instance, key, state} = context
+    const commentsKey = getCommentsKey(toCommentsKeyParts(instance, options))
+    const parent = findComment(state, commentsKey, options.parentCommentId)
+
+    const threadId = options.threadId ?? parent?.threadId
+    if (!threadId) {
+      throw new Error(
+        `Cannot reply to "${options.parentCommentId}": it is not loaded, so pass its threadId.`,
+      )
+    }
+
+    const status = parent?.status ?? options.status
+    if (!status) {
+      throw new Error(
+        `Cannot reply to "${options.parentCommentId}": it is not loaded, so pass its status.`,
+      )
+    }
+
+    const perspective = options.perspective ?? instance.config.perspective
+
+    return postComment(
+      context,
+      options,
+      buildCommentPayload({
+        authorId: requireCurrentUserId(instance),
+        commentId: options.commentId ?? crypto.randomUUID(),
+        handle: options,
+        message: options.message,
+        // Replies to a reply belong to the thread's first comment, matching how
+        // the Studio flattens threads.
+        parentCommentId: parent?.parentCommentId ?? options.parentCommentId,
+        resource: assertDatasetResource(key.resource),
+        fieldPath:
+          options.fieldPath === undefined
+            ? (parent?.target.path?.field ?? '')
+            : toCommentFieldPath(options.fieldPath),
+        // A reply into a resolved thread stays consistent with its parent.
+        status,
+        threadId,
+        ...(isReleasePerspective(perspective) ? {documentVersionId: perspective.releaseName} : {}),
+      }),
+    )
+  },
+)
+
+/**
+ * Rewrites a comment's message and stamps `lastEditedAt`.
+ * @beta
+ */
+export const updateComment: (
+  instance: SanityInstance,
+  options: UpdateCommentOptions,
+) => Promise<void> = bindActionByResource(
+  commentsStore,
+  async (
+    {state, instance, key}: StoreContext<CommentsStoreState, BoundResourceKey>,
+    {commentId, message}: UpdateCommentOptions,
+  ) => {
+    const lastEditedAt = new Date().toISOString()
+    const transactionId = crypto.randomUUID()
+    const previous = findCommentById(state, commentId)
+
+    if (previous) {
+      state.set('setPendingTransaction', setPendingTransaction(commentId, transactionId))
+      state.set('updateComment', applyCommentUpdate(commentId, {message, lastEditedAt}))
+    }
+
+    try {
+      const client = await getWritableClient(instance, key.resource, {createIfMissing: false})
+      await client
+        .transaction()
+        .transactionId(transactionId)
+        .patch(client.patch(commentId).set({message, lastEditedAt}))
+        .commit({tag: 'comments.update'})
+      if (previous) {
+        state.set('clearPendingTransaction', clearPendingTransaction(commentId))
+      }
+    } catch (error) {
+      if (previous) {
+        state.set(
+          'rollbackCommentUpdate',
+          rollbackCommentUpdate(commentId, transactionId, previous),
+        )
+      }
+      throw error
+    }
+  },
+)
+
+/**
+ * Resolves or reopens a thread.
+ *
+ * Pass the thread's first comment: replies follow it, patched server-side in
+ * one query so a reply created by someone else at the same moment is caught
+ * too.
+ *
+ * @beta
+ */
+export const setCommentStatus: (
+  instance: SanityInstance,
+  options: SetCommentStatusOptions,
+) => Promise<void> = bindActionByResource(
+  commentsStore,
+  async (
+    {state, instance, key}: StoreContext<CommentsStoreState, BoundResourceKey>,
+    {commentId, status}: SetCommentStatusOptions,
+  ) => {
+    const transactionId = crypto.randomUUID()
+    const previousComments: CommentDocument[] = []
+
+    for (const entry of Object.values(state.get().entries)) {
+      for (const candidate of Object.values(entry?.comments ?? {})) {
+        if (candidate._id !== commentId && candidate.parentCommentId !== commentId) continue
+        previousComments.push(candidate)
+        state.set('setPendingTransaction', setPendingTransaction(candidate._id, transactionId))
+        state.set('updateCommentStatus', applyCommentUpdate(candidate._id, {status}))
+      }
+    }
+
+    try {
+      const client = await getWritableClient(instance, key.resource, {createIfMissing: false})
+
+      await client.mutate(
+        [
+          {patch: {id: commentId, set: {status}}},
+          {
+            patch: {
+              query: '*[_type == "comment" && parentCommentId == $commentId]',
+              params: {commentId},
+              set: {status},
+            },
+          },
+        ],
+        {transactionId, tag: 'comments.set-status'},
+      )
+      for (const previous of previousComments) {
+        state.set('clearPendingTransaction', clearPendingTransaction(previous._id))
+      }
+    } catch (error) {
+      for (const previous of previousComments) {
+        state.set(
+          'rollbackCommentUpdate',
+          rollbackCommentUpdate(previous._id, transactionId, previous),
+        )
+      }
+      throw error
+    }
+  },
+)
+
+/**
+ * Deletes a comment, and its replies when it starts a thread.
+ * @beta
+ */
+export const removeComment: (
+  instance: SanityInstance,
+  options: RemoveCommentOptions,
+) => Promise<void> = bindActionByResource(
+  commentsStore,
+  async (
+    {state, instance, key}: StoreContext<CommentsStoreState, BoundResourceKey>,
+    {commentId}: RemoveCommentOptions,
+  ) => {
+    const removed = Object.entries(state.get().entries).flatMap(([entryKey, entry]) => {
+      const comments = Object.values(entry?.comments ?? {}).filter(
+        (comment) => comment._id === commentId || comment.parentCommentId === commentId,
+      )
+      return comments.length ? [{key: entryKey, comments}] : []
+    })
+
+    state.set('removeComment', removeCommentById(commentId))
+
+    try {
+      const client = await getWritableClient(instance, key.resource, {createIfMissing: false})
+      await client.mutate(
+        [
+          {
+            delete: {
+              query: '*[_type == "comment" && parentCommentId == $commentId]',
+              params: {commentId},
+            },
+          },
+          {delete: {id: commentId}},
+        ],
+        {tag: 'comments.remove'},
+      )
+    } catch (error) {
+      state.set('restoreComments', restoreComments(removed))
+      throw error
+    }
+  },
+)

--- a/packages/core/src/comments/commentActions.ts
+++ b/packages/core/src/comments/commentActions.ts
@@ -52,10 +52,16 @@ import {weakenReferencesInContentSnapshot} from './weakenReferences'
 export interface CreateCommentOptions extends DocumentHandle {
   message: CommentMessage
   /**
-   * Which field the thread hangs off. Omit, or pass `''`, for a thread about
-   * the document as a whole.
+   * Which field the thread hangs off, for example `title` or
+   * `body[_key=="intro"].content`.
+   *
+   * Required, and it has to resolve to a real path. There is no such thing as a
+   * comment on a document as a whole: the Studio only ever creates field
+   * comments, and its comment inspector throws on an empty path rather than
+   * ignoring it, so a pathless comment takes the inspector down for everyone
+   * looking at that document.
    */
-  fieldPath?: string | Path
+  fieldPath: string | Path
   /**
    * Anchors the comment to a run of text inside a Portable Text field. Building
    * one needs a live editor, so this comes from
@@ -120,6 +126,25 @@ export interface SetCommentStatusOptions extends DatasetHandle {
 /** @beta */
 export interface RemoveCommentOptions extends DatasetHandle {
   commentId: string
+}
+
+/**
+ * Refuses to write a comment that points at nothing.
+ *
+ * The type already requires `fieldPath`, but an empty string or an empty path
+ * array both survive that and normalise to `''`. Such a comment is not merely
+ * useless: the Studio's comment inspector calls `fromString` on the stored
+ * path, which throws on `''`, so the inspector crashes for everyone viewing
+ * that document until the comment is deleted. Cheaper to refuse the write.
+ */
+function requireFieldPath(fieldPath: string | Path): string {
+  const normalized = toCommentFieldPath(fieldPath)
+  if (!normalized) {
+    throw new Error(
+      'A comment needs a field path. Comments attach to a field, not to a document as a whole.',
+    )
+  }
+  return normalized
 }
 
 function requireCurrentUserId(instance: SanityInstance): string {
@@ -294,6 +319,7 @@ export const createComment: (
   ) => {
     const {instance, key} = context
     const perspective = options.perspective ?? instance.config.perspective
+    const fieldPath = requireFieldPath(options.fieldPath)
 
     return postComment(
       context,
@@ -307,7 +333,7 @@ export const createComment: (
         handle: options,
         message: options.message,
         resource: assertDatasetResource(key.resource),
-        fieldPath: toCommentFieldPath(options.fieldPath),
+        fieldPath,
         selection: options.selection,
         status: options.status ?? 'open',
         threadId: options.threadId ?? crypto.randomUUID(),
@@ -367,10 +393,10 @@ export const replyToComment: (
         // the Studio flattens threads.
         parentCommentId: parent?.parentCommentId ?? options.parentCommentId,
         resource: assertDatasetResource(key.resource),
-        fieldPath:
-          options.fieldPath === undefined
-            ? (parent?.target.path?.field ?? '')
-            : toCommentFieldPath(options.fieldPath),
+        // Inherited from the parent unless the caller names one, and checked
+        // either way: a reply with no path crashes the Studio inspector exactly
+        // as a pathless thread would.
+        fieldPath: requireFieldPath(options.fieldPath ?? parent?.target.path?.field ?? ''),
         // A reply into a resolved thread stays consistent with its parent.
         status,
         threadId,

--- a/packages/core/src/comments/commentActions.ts
+++ b/packages/core/src/comments/commentActions.ts
@@ -24,6 +24,7 @@ import {
 import {toCommentFieldPath} from './commentFieldPath'
 import {COMMENTS_API_VERSION} from './commentsConstants'
 import {type CommentsOptions, commentsStore, toCommentsKeyParts} from './commentsStore'
+import {normalizeComment} from './normalizeComment'
 import {
   addComment,
   applyCommentUpdate,
@@ -38,12 +39,12 @@ import {
   setPendingTransaction,
 } from './reducers'
 import {
-  type CommentContext,
-  type CommentDocument,
+  type Comment,
   type CommentMessage,
   type CommentPostPayload,
   type CommentStatus,
   type CommentTextSelection,
+  type StoredComment,
 } from './types'
 import {weakenReferencesInContentSnapshot} from './weakenReferences'
 
@@ -76,12 +77,15 @@ export interface CreateCommentOptions extends DocumentHandle {
    */
   documentRevisionId?: string
   /**
-   * Merged over the defaults. The Studio writes `tool`, `payload`, `intent`,
-   * and `notification` here for its notification backend; the SDK has no source
-   * for any of them, so mentions in comments created this way do not send
-   * email unless you supply `notification` yourself.
+   * Ambient information stored alongside the comment, merged over the defaults.
+   *
+   * The Studio writes `tool`, `payload`, `intent`, and `notification` here for
+   * its notification backend. The SDK has no source for any of them, so
+   * mentions in comments created this way do not send email unless you supply
+   * `notification` yourself. Deliberately loose: the organization-level store
+   * treats this as free-form, so no shape is worth promising.
    */
-  context?: Partial<CommentContext>
+  context?: Record<string, unknown>
   /** A copy of the content being discussed. References in it are weakened. */
   contentSnapshot?: unknown
 }
@@ -165,7 +169,7 @@ function buildCommentPayload(options: {
   authorId: string
   commentId: string
   contentSnapshot?: unknown
-  context?: Partial<CommentContext>
+  context?: Record<string, unknown>
   documentRevisionId?: string
   handle: DocumentHandle
   message: CommentMessage
@@ -220,7 +224,7 @@ function findComment(
   state: StoreState<CommentsStoreState>,
   commentsKey: string,
   commentId: string,
-): CommentDocument | undefined {
+): StoredComment | undefined {
   const comments = state.get().entries[commentsKey]?.comments
   return comments && Object.hasOwn(comments, commentId) ? comments[commentId] : undefined
 }
@@ -228,7 +232,7 @@ function findComment(
 function findCommentById(
   state: StoreState<CommentsStoreState>,
   commentId: string,
-): CommentDocument | undefined {
+): StoredComment | undefined {
   for (const entry of Object.values(state.get().entries)) {
     const comments = entry?.comments
     const comment = comments && Object.hasOwn(comments, commentId) ? comments[commentId] : undefined
@@ -241,7 +245,7 @@ async function postComment(
   context: StoreContext<CommentsStoreState, BoundResourceKey>,
   handle: DocumentHandle & CommentsOptions,
   payload: CommentPostPayload,
-): Promise<CommentDocument> {
+): Promise<Comment> {
   const {state, instance, key} = context
   const commentsKey = getCommentsKey(toCommentsKeyParts(instance, handle))
 
@@ -255,7 +259,7 @@ async function postComment(
     // the same comment id.
     const created = await client.createIfNotExists(payload, {tag: 'comments.create'})
     state.set('receiveComment', receiveComment(commentsKey, created))
-    return created
+    return normalizeComment(created)
   } catch (error) {
     // Keep it on screen carrying the failure, so an app can offer a retry with
     // the same id rather than silently losing what someone typed.
@@ -280,7 +284,7 @@ async function postComment(
 export const createComment: (
   instance: SanityInstance,
   options: CreateCommentOptions,
-) => Promise<CommentDocument> = bindActionByResource(
+) => Promise<Comment> = bindActionByResource(
   commentsStore,
   // `async` so a validation failure rejects rather than throwing at the call
   // site, which would slip past a `.catch()`.
@@ -325,7 +329,7 @@ export const createComment: (
 export const replyToComment: (
   instance: SanityInstance,
   options: ReplyToCommentOptions,
-) => Promise<CommentDocument> = bindActionByResource(
+) => Promise<Comment> = bindActionByResource(
   commentsStore,
   async (
     context: StoreContext<CommentsStoreState, BoundResourceKey>,
@@ -439,7 +443,7 @@ export const setCommentStatus: (
     {commentId, status}: SetCommentStatusOptions,
   ) => {
     const transactionId = crypto.randomUUID()
-    const previousComments: CommentDocument[] = []
+    const previousComments: StoredComment[] = []
 
     for (const entry of Object.values(state.get().entries)) {
       for (const candidate of Object.values(entry?.comments ?? {})) {

--- a/packages/core/src/comments/commentFieldPath.test.ts
+++ b/packages/core/src/comments/commentFieldPath.test.ts
@@ -1,0 +1,40 @@
+import {describe, expect, it} from 'vitest'
+
+import {toCommentFieldPath} from './commentFieldPath'
+
+describe('toCommentFieldPath', () => {
+  it('produces the strings the Studio writes', () => {
+    // Golden values. These are the interop contract: a comment the SDK writes is
+    // only visible in the Studio if `target.path.field` matches what the Studio
+    // would have written for the same field.
+    expect(toCommentFieldPath(['title'])).toBe('title')
+    expect(toCommentFieldPath(['body', {_key: 'intro'}, 'content'])).toBe(
+      'body[_key=="intro"].content',
+    )
+    expect(toCommentFieldPath(['arr', 0, 'field'])).toBe('arr[0].field')
+    expect(toCommentFieldPath(['a', {_key: 'b'}, 'c', 0, 'd'])).toBe('a[_key=="b"].c[0].d')
+  })
+
+  it('treats a missing or empty path as document level', () => {
+    expect(toCommentFieldPath()).toBe('')
+    expect(toCommentFieldPath([])).toBe('')
+    expect(toCommentFieldPath('')).toBe('')
+  })
+
+  it('canonicalises a string that is already a path', () => {
+    expect(toCommentFieldPath('body[_key=="intro"].content')).toBe('body[_key=="intro"].content')
+  })
+
+  it('quotes nested field names that GROQ treats as values', () => {
+    expect(toCommentFieldPath(['object', 'true'])).toBe('object["true"]')
+    expect(toCommentFieldPath(['object', 'false'])).toBe('object["false"]')
+    expect(toCommentFieldPath(['object', 'null'])).toBe('object["null"]')
+    expect(toCommentFieldPath('object.true')).toBe('object["true"]')
+  })
+
+  it('does not rewrite reserved words inside keyed segments', () => {
+    expect(toCommentFieldPath(['body', {_key: 'section.true.child'}, 'null'])).toBe(
+      'body[_key=="section.true.child"]["null"]',
+    )
+  })
+})

--- a/packages/core/src/comments/commentFieldPath.ts
+++ b/packages/core/src/comments/commentFieldPath.ts
@@ -37,7 +37,7 @@ function quoteReservedFieldSegments(path: string): string {
  * // ''
  * ```
  *
- * @beta
+ * @internal
  */
 export function toCommentFieldPath(path?: string | Path): string {
   return quoteReservedFieldSegments(stringifyPath(path))

--- a/packages/core/src/comments/commentFieldPath.ts
+++ b/packages/core/src/comments/commentFieldPath.ts
@@ -1,0 +1,44 @@
+import {stringifyPath} from '@sanity/json-match'
+import {type Path} from '@sanity/types'
+
+/** A dotted segment GROQ would read as a literal rather than a field name. */
+const RESERVED_SEGMENT = /\.(true|false|null)(?=$|[.[])/g
+
+/**
+ * One quoted string, or one run of text containing no quote at all. Splitting on
+ * this is what keeps the rewrite below out of `[_key=="..."]` values.
+ */
+const QUOTED_OR_PLAIN = /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^"']+/g
+
+function quoteReservedFieldSegments(path: string): string {
+  return path.replace(QUOTED_OR_PLAIN, (chunk) =>
+    chunk.startsWith('"') || chunk.startsWith("'")
+      ? chunk
+      : chunk.replace(RESERVED_SEGMENT, '["$1"]'),
+  )
+}
+
+/**
+ * Normalises a field path to the string form comments are stored in.
+ *
+ * Comments keep `target.path.field` as a string rather than a path array,
+ * because that is what the Studio writes and reading it back has to match
+ * exactly. A string given here is parsed and re-stringified, so both a path
+ * array and a hand-written string come out in the same canonical form.
+ *
+ * `undefined` and `[]` both produce `''`, which is how a document-level thread
+ * is addressed.
+ *
+ * @example
+ * ```ts
+ * toCommentFieldPath(['body', {_key: 'intro'}, 'content'])
+ * // 'body[_key=="intro"].content'
+ * toCommentFieldPath(undefined)
+ * // ''
+ * ```
+ *
+ * @beta
+ */
+export function toCommentFieldPath(path?: string | Path): string {
+  return quoteReservedFieldSegments(stringifyPath(path))
+}

--- a/packages/core/src/comments/commentFieldPath.ts
+++ b/packages/core/src/comments/commentFieldPath.ts
@@ -26,8 +26,8 @@ function quoteReservedFieldSegments(path: string): string {
  * exactly. A string given here is parsed and re-stringified, so both a path
  * array and a hand-written string come out in the same canonical form.
  *
- * `undefined` and `[]` both produce `''`, which is how a document-level thread
- * is addressed.
+ * `undefined` and `[]` both produce `''`. Callers writing a comment reject that
+ * rather than passing it on, since a comment has to point at a field.
  *
  * @example
  * ```ts

--- a/packages/core/src/comments/commentsConstants.ts
+++ b/packages/core/src/comments/commentsConstants.ts
@@ -1,0 +1,80 @@
+import {type ListenOptions} from '@sanity/client'
+
+/** Data API version used for reading and writing comments in the addon dataset. */
+export const COMMENTS_API_VERSION = 'v2025-05-06'
+
+/** Projects API version used to discover and provision the addon dataset. */
+export const ADDON_DATASET_API_VERSION = 'v2025-02-19'
+
+/**
+ * The dataset profile the Studio tags its comments dataset with. Discovery
+ * matches on it, so changing it stops the SDK and the Studio sharing comments.
+ */
+export const ADDON_DATASET_PROFILE = 'comments'
+
+/**
+ * How long a comment list outlives its last subscriber before being dropped.
+ *
+ * Long enough that navigating away from a document and straight back reuses the
+ * loaded list instead of refetching and re-suspending.
+ */
+export const COMMENTS_STATE_CLEAR_DELAY = 5000
+
+/**
+ * Kept identical to the Studio's own listener options
+ * (`packages/sanity/src/core/comments/store/useCommentsStore.ts:29-35`), apart
+ * from the request tag. `includeResult` is what lets a mutation event carry the
+ * changed comment, which is what makes per-comment reconciliation possible
+ * rather than refetching the list.
+ */
+export const LISTEN_OPTIONS: ListenOptions = {
+  events: ['welcome', 'mutation', 'reconnect'],
+  includeResult: true,
+  includeAllVersions: true,
+  visibility: 'query',
+  tag: 'comments.listen',
+}
+
+const QUERY_PROJECTION = `{
+  _createdAt,
+  _id,
+  _rev,
+  authorId,
+  contentSnapshot,
+  context,
+  lastEditedAt,
+  message,
+  parentCommentId,
+  reactions,
+  status,
+  target,
+  threadId
+}`
+
+const BASE_FILTERS = [`_type == "comment"`, `target.document._ref == $documentId`]
+const VERSION_FILTER = `target.documentVersionId == $documentVersionId`
+const NO_VERSION_FILTER = `!defined(target.documentVersionId)`
+
+/**
+ * Which comments belong to a document, matching the Studio's filter.
+ *
+ * A release's comments are kept apart from the default ones: asking for a
+ * release returns only that release's comments, and asking without one returns
+ * only comments with no version at all.
+ */
+function buildCommentsFilter(documentVersionId?: string): string {
+  return [...BASE_FILTERS, documentVersionId ? VERSION_FILTER : NO_VERSION_FILTER].join(' && ')
+}
+
+/** The snapshot query. Newest comment first, as the Studio orders it. */
+export function buildCommentsQuery(documentVersionId?: string): string {
+  return `*[${buildCommentsFilter(documentVersionId)}] ${QUERY_PROJECTION} | order(_createdAt desc)`
+}
+
+/**
+ * The listener query. Unprojected on purpose: mutation events carry the whole
+ * comment, so there is nothing to trim.
+ */
+export function buildCommentsListenQuery(documentVersionId?: string): string {
+  return `*[${buildCommentsFilter(documentVersionId)}]`
+}

--- a/packages/core/src/comments/commentsStore.test.ts
+++ b/packages/core/src/comments/commentsStore.test.ts
@@ -1,0 +1,368 @@
+import {type ListenEvent, type SanityClient} from '@sanity/client'
+import {BehaviorSubject, Subject} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type DocumentResource} from '../config/sanityConfig'
+import {bindActionByResource} from '../store/createActionBinder'
+import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
+import {observeAddonDatasetClient} from './addonDatasetStore'
+import {
+  commentsStore,
+  getCommentsState,
+  getCommentThreadsState,
+  resolveComments,
+} from './commentsStore'
+import {setPendingTransaction} from './reducers'
+import {type CommentDocument} from './types'
+
+vi.mock('./addonDatasetStore', () => ({
+  observeAddonDatasetClient: vi.fn(),
+}))
+
+function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_id'>) {
+  return {
+    _type: 'comment',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _rev: 'rev',
+    authorId: 'user-1',
+    message: null,
+    threadId: 'thread-1',
+    status: 'open',
+    reactions: null,
+    target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
+    ...overrides,
+  } satisfies CommentDocument as CommentDocument
+}
+
+const WELCOME = {type: 'welcome'} as ListenEvent<CommentDocument>
+
+/** Lets a test seed a pending transaction the way the write actions will. */
+const markPending = bindActionByResource(
+  commentsStore,
+  ({state}, options: {resource?: DocumentResource; commentId: string; transactionId: string}) =>
+    state.set(
+      'setPendingTransaction',
+      setPendingTransaction(options.commentId, options.transactionId),
+    ),
+)
+
+const HANDLE = {documentId: 'doc-1', documentType: 'author'}
+
+let instance: SanityInstance
+let listeners: Map<string, Subject<ListenEvent<CommentDocument>>>
+let fetches: Subject<CommentDocument[]>[]
+let client$: BehaviorSubject<SanityClient | null>
+let client: SanityClient
+
+/**
+ * Keyed on query *and* params: the document id travels as a parameter, so two
+ * documents share one query string but must not share a listener.
+ */
+function listenerFor(query: string, params: Record<string, unknown>) {
+  const key = `${query}|${JSON.stringify(params)}`
+  const existing = listeners.get(key)
+  if (existing) return existing
+  const subject = new Subject<ListenEvent<CommentDocument>>()
+  listeners.set(key, subject)
+  return subject
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  listeners = new Map()
+  fetches = []
+
+  client = {
+    observable: {
+      listen: vi.fn((query: string, params: Record<string, unknown>) => listenerFor(query, params)),
+      fetch: vi.fn(() => {
+        const fetch$ = new Subject<CommentDocument[]>()
+        fetches.push(fetch$)
+        return fetch$
+      }),
+    },
+  } as unknown as SanityClient
+
+  client$ = new BehaviorSubject<SanityClient | null>(client)
+  vi.mocked(observeAddonDatasetClient).mockReturnValue(client$)
+
+  instance = createSanityInstance({projectId: 'p', dataset: 'd'})
+})
+
+afterEach(() => {
+  instance.dispose()
+})
+
+describe('getCommentsState', () => {
+  it('is undefined until the first snapshot arrives', () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+
+    expect(source.getCurrent()).toBe(undefined)
+  })
+
+  it('loads a document’s comments once someone reads them', () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+
+    listeners.values().next().value!.next(WELCOME)
+    fetches[0].next([comment({_id: 'a'})])
+
+    expect(source.getCurrent()).toEqual([comment({_id: 'a'})])
+  })
+
+  it('sorts newest first', () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+
+    const older = comment({_id: 'a', _createdAt: '2026-01-01T00:00:00Z'})
+    const newer = comment({_id: 'b', _createdAt: '2026-02-01T00:00:00Z'})
+
+    listeners.values().next().value!.next(WELCOME)
+    fetches[0].next([older, newer])
+
+    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['b', 'a'])
+  })
+
+  it('settles on an empty list when the project has no comments dataset', () => {
+    // Leaving this unset would suspend readers forever on a project nobody has
+    // ever commented in.
+    client$.next(null)
+
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+
+    expect(source.getCurrent()).toEqual([])
+  })
+
+  it('filters by field path', () => {
+    const source = getCommentsState(instance, {...HANDLE, fieldPath: 'title'})
+    source.subscribe()
+
+    const onField = comment({
+      _id: 'a',
+      target: {
+        documentType: 'author',
+        path: {field: 'title'},
+        document: {_ref: 'doc-1', _type: 'reference', _weak: true},
+      },
+    })
+
+    listeners.values().next().value!.next(WELCOME)
+    fetches[0].next([onField, comment({_id: 'b'})])
+
+    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['a'])
+  })
+
+  it('selects document-level threads for an empty field path', () => {
+    const source = getCommentsState(instance, {...HANDLE, fieldPath: ''})
+    source.subscribe()
+
+    const onField = comment({
+      _id: 'a',
+      target: {
+        documentType: 'author',
+        path: {field: 'title'},
+        document: {_ref: 'doc-1', _type: 'reference', _weak: true},
+      },
+    })
+
+    listeners.values().next().value!.next(WELCOME)
+    fetches[0].next([onField, comment({_id: 'b'})])
+
+    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['b'])
+  })
+
+  it('filters by status', () => {
+    const source = getCommentsState(instance, {...HANDLE, status: 'resolved'})
+    source.subscribe()
+
+    listeners.values().next().value!.next(WELCOME)
+    fetches[0].next([comment({_id: 'a'}), comment({_id: 'b', status: 'resolved'})])
+
+    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['b'])
+  })
+
+  it('keeps a release’s comments apart from the default ones', () => {
+    const base = getCommentsState(instance, HANDLE)
+    const release = getCommentsState(instance, {
+      ...HANDLE,
+      perspective: {releaseName: 'summer'},
+    })
+    base.subscribe()
+    release.subscribe()
+
+    expect(listeners.size).toBe(2)
+
+    const [baseListener, releaseListener] = Array.from(listeners.values())
+    baseListener.next(WELCOME)
+    releaseListener.next(WELCOME)
+    fetches[0].next([comment({_id: 'a'})])
+    fetches[1].next([comment({_id: 'b'})])
+
+    expect(base.getCurrent()!.map((c) => c._id)).toEqual(['a'])
+    expect(release.getCurrent()!.map((c) => c._id)).toEqual(['b'])
+  })
+
+  it('shares one list between a draft and its published document', () => {
+    getCommentsState(instance, HANDLE).subscribe()
+    getCommentsState(instance, {...HANDLE, documentId: 'drafts.doc-1'}).subscribe()
+
+    expect(listeners.size).toBe(1)
+  })
+})
+
+describe('transaction reconciliation', () => {
+  function updateEvent(transactionId: string, status: CommentDocument['status']) {
+    return {
+      type: 'mutation',
+      transition: 'update',
+      documentId: 'a',
+      result: comment({_id: 'a', status}),
+      transactionId,
+    } as ListenEvent<CommentDocument>
+  }
+
+  function loaded() {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+    listeners.values().next().value!.next(WELCOME)
+    fetches[0].next([comment({_id: 'a'})])
+    return source
+  }
+
+  it('ignores an echo from a superseded transaction', () => {
+    const source = loaded()
+    markPending(instance, {commentId: 'a', transactionId: 'tx-2'})
+
+    listeners.values().next().value!.next(updateEvent('tx-1', 'resolved'))
+
+    expect(source.getCurrent()![0].status).toBe('open')
+  })
+
+  it('applies the echo we were waiting for', () => {
+    const source = loaded()
+    markPending(instance, {commentId: 'a', transactionId: 'tx-2'})
+
+    listeners.values().next().value!.next(updateEvent('tx-2', 'resolved'))
+
+    expect(source.getCurrent()![0].status).toBe('resolved')
+  })
+
+  it('applies updates from other clients when nothing is pending', () => {
+    const source = loaded()
+
+    listeners.values().next().value!.next(updateEvent('tx-elsewhere', 'resolved'))
+
+    expect(source.getCurrent()![0].status).toBe('resolved')
+  })
+})
+
+describe('getCommentThreadsState', () => {
+  it('groups comments into threads', () => {
+    const source = getCommentThreadsState(instance, HANDLE)
+    source.subscribe()
+
+    listeners.values().next().value!.next(WELCOME)
+    fetches[0].next([comment({_id: 'a'}), comment({_id: 'b', parentCommentId: 'a'})])
+
+    expect(source.getCurrent()).toMatchObject([{threadId: 'thread-1', commentsCount: 2}])
+  })
+
+  it('filters by the parent status without dropping replies', () => {
+    const source = getCommentThreadsState(instance, {...HANDLE, status: 'resolved'})
+    source.subscribe()
+
+    listeners.values().next().value!.next(WELCOME)
+    fetches[0].next([
+      comment({_id: 'parent', status: 'resolved'}),
+      comment({_id: 'reply', parentCommentId: 'parent', status: 'open'}),
+    ])
+
+    expect(source.getCurrent()).toMatchObject([
+      {
+        parentComment: {_id: 'parent'},
+        replies: [{_id: 'reply'}],
+        commentsCount: 2,
+      },
+    ])
+  })
+
+  it('returns the same array on repeated reads', () => {
+    // A fresh array from one read to the next would make useSyncExternalStore
+    // re-render without end.
+    const source = getCommentThreadsState(instance, HANDLE)
+    source.subscribe()
+
+    listeners.values().next().value!.next(WELCOME)
+    fetches[0].next([comment({_id: 'a'})])
+
+    expect(source.getCurrent()).toBe(source.getCurrent())
+  })
+
+  it('returns the same array when an unrelated document loads', () => {
+    // Every state change re-runs the selector, so without a cache keyed on the
+    // data, one document loading would re-render readers of every other one.
+    const source = getCommentThreadsState(instance, HANDLE)
+    source.subscribe()
+
+    const [ownListener] = Array.from(listeners.values())
+    ownListener.next(WELCOME)
+    fetches[0].next([comment({_id: 'a'})])
+    const before = source.getCurrent()
+
+    const other = getCommentThreadsState(instance, {...HANDLE, documentId: 'doc-2'})
+    other.subscribe()
+    Array.from(listeners.values())[1].next(WELCOME)
+    fetches[1].next([comment({_id: 'b'})])
+
+    expect(source.getCurrent()).toBe(before)
+  })
+})
+
+describe('resolveComments', () => {
+  it('starts loading and resolves with the snapshot', async () => {
+    const promise = resolveComments(instance, HANDLE)
+
+    await vi.waitFor(() => expect(listeners.size).toBe(1))
+    listeners.values().next().value!.next(WELCOME)
+    fetches[0].next([comment({_id: 'a'})])
+
+    await expect(promise).resolves.toEqual([comment({_id: 'a'})])
+  })
+
+  it('rejects when aborted', async () => {
+    const controller = new AbortController()
+    const promise = resolveComments(instance, {...HANDLE, signal: controller.signal})
+
+    controller.abort()
+
+    await expect(promise).rejects.toThrow(/aborted/)
+  })
+
+  it('tears the listener down when an abort leaves no readers', async () => {
+    const controller = new AbortController()
+    const promise = resolveComments(instance, {...HANDLE, signal: controller.signal})
+    await vi.waitFor(() => expect(listeners.size).toBe(1))
+
+    controller.abort()
+    await expect(promise).rejects.toThrow()
+
+    expect(listeners.values().next().value!.observed).toBe(false)
+  })
+})
+
+describe('listener recovery', () => {
+  it('starts listening again when the addon client changes after a listener error', () => {
+    const source = getCommentsState(instance, HANDLE)
+    source.subscribe()
+
+    const failedListener = listeners.values().next().value!
+    failedListener.error(new Error('connection failed'))
+    listeners.clear()
+
+    client$.next(client)
+
+    expect(listeners.size).toBe(1)
+  })
+})

--- a/packages/core/src/comments/commentsStore.test.ts
+++ b/packages/core/src/comments/commentsStore.test.ts
@@ -13,13 +13,13 @@ import {
   resolveComments,
 } from './commentsStore'
 import {setPendingTransaction} from './reducers'
-import {type CommentDocument} from './types'
+import {type StoredComment} from './types'
 
 vi.mock('./addonDatasetStore', () => ({
   observeAddonDatasetClient: vi.fn(),
 }))
 
-function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_id'>) {
+function comment(overrides: Partial<StoredComment> & Pick<StoredComment, '_id'>) {
   return {
     _type: 'comment',
     _createdAt: '2026-01-01T00:00:00Z',
@@ -31,10 +31,10 @@ function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_i
     reactions: null,
     target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
     ...overrides,
-  } satisfies CommentDocument as CommentDocument
+  } satisfies StoredComment as StoredComment
 }
 
-const WELCOME = {type: 'welcome'} as ListenEvent<CommentDocument>
+const WELCOME = {type: 'welcome'} as ListenEvent<StoredComment>
 
 /** Lets a test seed a pending transaction the way the write actions will. */
 const markPending = bindActionByResource(
@@ -49,8 +49,8 @@ const markPending = bindActionByResource(
 const HANDLE = {documentId: 'doc-1', documentType: 'author'}
 
 let instance: SanityInstance
-let listeners: Map<string, Subject<ListenEvent<CommentDocument>>>
-let fetches: Subject<CommentDocument[]>[]
+let listeners: Map<string, Subject<ListenEvent<StoredComment>>>
+let fetches: Subject<StoredComment[]>[]
 let client$: BehaviorSubject<SanityClient | null>
 let client: SanityClient
 
@@ -62,7 +62,7 @@ function listenerFor(query: string, params: Record<string, unknown>) {
   const key = `${query}|${JSON.stringify(params)}`
   const existing = listeners.get(key)
   if (existing) return existing
-  const subject = new Subject<ListenEvent<CommentDocument>>()
+  const subject = new Subject<ListenEvent<StoredComment>>()
   listeners.set(key, subject)
   return subject
 }
@@ -76,7 +76,7 @@ beforeEach(() => {
     observable: {
       listen: vi.fn((query: string, params: Record<string, unknown>) => listenerFor(query, params)),
       fetch: vi.fn(() => {
-        const fetch$ = new Subject<CommentDocument[]>()
+        const fetch$ = new Subject<StoredComment[]>()
         fetches.push(fetch$)
         return fetch$
       }),
@@ -108,7 +108,23 @@ describe('getCommentsState', () => {
     listeners.values().next().value!.next(WELCOME)
     fetches[0].next([comment({_id: 'a'})])
 
-    expect(source.getCurrent()).toEqual([comment({_id: 'a'})])
+    // Asserted in full rather than by id. This is the entire mapping from the
+    // stored document to what a consumer sees, and it is what has to stay put
+    // when comments move off the addon dataset.
+    expect(source.getCurrent()).toEqual([
+      {
+        id: 'a',
+        createdAt: '2026-01-01T00:00:00Z',
+        authorId: 'user-1',
+        message: null,
+        threadId: 'thread-1',
+        status: 'open',
+        documentId: 'doc-1',
+        documentType: 'author',
+        fieldPath: '',
+        reactions: [],
+      },
+    ])
   })
 
   it('sorts newest first', () => {
@@ -121,7 +137,7 @@ describe('getCommentsState', () => {
     listeners.values().next().value!.next(WELCOME)
     fetches[0].next([older, newer])
 
-    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['b', 'a'])
+    expect(source.getCurrent()!.map((c) => c.id)).toEqual(['b', 'a'])
   })
 
   it('settles on an empty list when the project has no comments dataset', () => {
@@ -151,7 +167,7 @@ describe('getCommentsState', () => {
     listeners.values().next().value!.next(WELCOME)
     fetches[0].next([onField, comment({_id: 'b'})])
 
-    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['a'])
+    expect(source.getCurrent()!.map((c) => c.id)).toEqual(['a'])
   })
 
   it('selects document-level threads for an empty field path', () => {
@@ -170,7 +186,7 @@ describe('getCommentsState', () => {
     listeners.values().next().value!.next(WELCOME)
     fetches[0].next([onField, comment({_id: 'b'})])
 
-    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['b'])
+    expect(source.getCurrent()!.map((c) => c.id)).toEqual(['b'])
   })
 
   it('filters by status', () => {
@@ -180,7 +196,7 @@ describe('getCommentsState', () => {
     listeners.values().next().value!.next(WELCOME)
     fetches[0].next([comment({_id: 'a'}), comment({_id: 'b', status: 'resolved'})])
 
-    expect(source.getCurrent()!.map((c) => c._id)).toEqual(['b'])
+    expect(source.getCurrent()!.map((c) => c.id)).toEqual(['b'])
   })
 
   it('keeps a release’s comments apart from the default ones', () => {
@@ -200,8 +216,8 @@ describe('getCommentsState', () => {
     fetches[0].next([comment({_id: 'a'})])
     fetches[1].next([comment({_id: 'b'})])
 
-    expect(base.getCurrent()!.map((c) => c._id)).toEqual(['a'])
-    expect(release.getCurrent()!.map((c) => c._id)).toEqual(['b'])
+    expect(base.getCurrent()!.map((c) => c.id)).toEqual(['a'])
+    expect(release.getCurrent()!.map((c) => c.id)).toEqual(['b'])
   })
 
   it('shares one list between a draft and its published document', () => {
@@ -213,14 +229,14 @@ describe('getCommentsState', () => {
 })
 
 describe('transaction reconciliation', () => {
-  function updateEvent(transactionId: string, status: CommentDocument['status']) {
+  function updateEvent(transactionId: string, status: StoredComment['status']) {
     return {
       type: 'mutation',
       transition: 'update',
       documentId: 'a',
       result: comment({_id: 'a', status}),
       transactionId,
-    } as ListenEvent<CommentDocument>
+    } as ListenEvent<StoredComment>
   }
 
   function loaded() {
@@ -281,8 +297,8 @@ describe('getCommentThreadsState', () => {
 
     expect(source.getCurrent()).toMatchObject([
       {
-        parentComment: {_id: 'parent'},
-        replies: [{_id: 'reply'}],
+        parentComment: {id: 'parent'},
+        replies: [{id: 'reply'}],
         commentsCount: 2,
       },
     ])
@@ -328,7 +344,7 @@ describe('resolveComments', () => {
     listeners.values().next().value!.next(WELCOME)
     fetches[0].next([comment({_id: 'a'})])
 
-    await expect(promise).resolves.toEqual([comment({_id: 'a'})])
+    await expect(promise).resolves.toMatchObject([{id: 'a'}])
   })
 
   it('rejects when aborted', async () => {

--- a/packages/core/src/comments/commentsStore.test.ts
+++ b/packages/core/src/comments/commentsStore.test.ts
@@ -170,7 +170,9 @@ describe('getCommentsState', () => {
     expect(source.getCurrent()!.map((c) => c.id)).toEqual(['a'])
   })
 
-  it('selects document-level threads for an empty field path', () => {
+  it('matches the field path exactly rather than by prefix', () => {
+    // Nothing writes an empty path any more, but the filter is still an exact
+    // match, so it must not sweep up every comment on the document.
     const source = getCommentsState(instance, {...HANDLE, fieldPath: ''})
     source.subscribe()
 

--- a/packages/core/src/comments/commentsStore.ts
+++ b/packages/core/src/comments/commentsStore.ts
@@ -1,0 +1,421 @@
+import {DocumentId, getPublishedId} from '@sanity/id-utils'
+import {type Path} from '@sanity/types'
+import {
+  catchError,
+  distinctUntilChanged,
+  EMPTY,
+  first,
+  firstValueFrom,
+  groupBy,
+  map,
+  mergeMap,
+  NEVER,
+  Observable,
+  pairwise,
+  race,
+  startWith,
+  switchMap,
+  tap,
+} from 'rxjs'
+
+import {type DocumentHandle} from '../config/sanityConfig'
+import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
+import {bindActionByResource, type BoundResourceKey} from '../store/createActionBinder'
+import {type SanityInstance} from '../store/createSanityInstance'
+import {
+  createStateSourceAction,
+  type SelectorContext,
+  type StateSource,
+} from '../store/createStateSourceAction'
+import {type StoreState} from '../store/createStoreState'
+import {defineStore, type StoreContext} from '../store/defineStore'
+import {insecureRandomId} from '../utils/ids'
+import {setCleanupTimeout} from '../utils/setCleanupTimeout'
+import {observeAddonDatasetClient} from './addonDatasetStore'
+import {buildCommentThreads} from './buildCommentThreads'
+import {toCommentFieldPath} from './commentFieldPath'
+import {COMMENTS_STATE_CLEAR_DELAY} from './commentsConstants'
+import {type CommentsEvent, observeComments} from './observeComments'
+import {
+  addSubscriber,
+  clearPendingTransaction,
+  type CommentsKeyParts,
+  type CommentsStoreState,
+  getCommentsKey,
+  parseCommentsKey,
+  receiveComment,
+  removeCommentById,
+  removeSubscriber,
+  setComments,
+  setCommentsError,
+} from './reducers'
+import {type CommentDocument, type CommentStatus, type CommentThread} from './types'
+
+/**
+ * Which comments to read.
+ * @beta
+ */
+export interface CommentsOptions extends DocumentHandle {
+  /**
+   * Narrow to one field. `''` selects document-level threads only. Omit to get
+   * every comment on the document.
+   */
+  fieldPath?: string | Path
+  /** Narrow to open or resolved threads. Omit for both. */
+  status?: CommentStatus
+}
+
+/** @beta */
+export interface ResolveCommentsOptions extends CommentsOptions {
+  signal?: AbortSignal
+}
+
+/**
+ * Which comment list an option set addresses.
+ *
+ * Comments hang off the published id, so a draft and its published document
+ * share one list. A release keeps its own.
+ */
+export function toCommentsKeyParts(
+  instance: SanityInstance,
+  options: CommentsOptions,
+): CommentsKeyParts {
+  const perspective = options.perspective ?? instance.config.perspective
+  return {
+    documentId: getPublishedId(DocumentId(options.documentId)),
+    ...(isReleasePerspective(perspective) ? {documentVersionId: perspective.releaseName} : {}),
+  }
+}
+
+function applyEvent(
+  state: StoreState<CommentsStoreState>,
+  key: string,
+  event: CommentsEvent,
+): void {
+  switch (event.type) {
+    case 'snapshot':
+      state.set('setComments', setComments(key, event.comments))
+      return
+    case 'appear':
+      state.set('receiveComment', receiveComment(key, event.comment))
+      return
+    case 'disappear':
+      state.set('removeComment', removeCommentById(event.commentId))
+      return
+    case 'error':
+      state.set('setCommentsError', setCommentsError(key, event.error))
+      return
+    case 'update': {
+      const pending = state.get().pendingTransactions[event.comment._id]
+
+      // Our own writes come back through the listener. When a later transaction
+      // is already in flight for this comment, an echo of an earlier one would
+      // undo it on screen, so drop it and wait for the one we are expecting.
+      if (pending && pending !== event.transactionId) return
+
+      state.set('receiveComment', receiveComment(key, event.comment))
+      if (pending) {
+        state.set('clearPendingTransaction', clearPendingTransaction(event.comment._id))
+      }
+    }
+  }
+}
+
+const watchSubscribedDocuments = ({
+  state,
+  instance,
+  key,
+}: StoreContext<CommentsStoreState, BoundResourceKey>) => {
+  const client$ = observeAddonDatasetClient(instance, {resource: key.resource})
+
+  return state.observable
+    .pipe(
+      map((current) => new Set(Object.keys(current.entries))),
+      distinctUntilChanged(
+        (a, b) => a.size === b.size && Array.from(b).every((entry) => a.has(entry)),
+      ),
+      startWith(new Set<string>()),
+      pairwise(),
+      mergeMap(([previous, current]) => [
+        ...Array.from(current)
+          .filter((entry) => !previous.has(entry))
+          .map((entry) => ({key: entry, added: true})),
+        ...Array.from(previous)
+          .filter((entry) => !current.has(entry))
+          .map((entry) => ({key: entry, added: false})),
+      ]),
+      groupBy((event) => event.key),
+      mergeMap((group$) =>
+        group$.pipe(
+          switchMap((event) => {
+            if (!event.added) return EMPTY
+
+            const {documentId, documentVersionId} = parseCommentsKey(group$.key)
+
+            return client$.pipe(
+              switchMap((client) => {
+                if (!client) {
+                  // A dataset that does not exist holds no comments. Settling on
+                  // an empty list matters: leaving it unset would suspend
+                  // readers forever on a project nobody has commented in.
+                  state.set('setComments', setComments(group$.key, []))
+                  return EMPTY
+                }
+
+                return observeComments({client, documentId, documentVersionId}).pipe(
+                  tap((commentsEvent) => applyEvent(state, group$.key, commentsEvent)),
+                  // Keep following the addon client after one listener fails.
+                  // A token refresh or reconnect can then supply a new client.
+                  catchError((error: unknown) => {
+                    state.set('setCommentsError', setCommentsError(group$.key, error))
+                    return EMPTY
+                  }),
+                )
+              }),
+            )
+          }),
+        ),
+      ),
+    )
+    .subscribe({error: (error: unknown) => state.set('setError', {error})})
+}
+
+export const commentsStore = defineStore<CommentsStoreState, BoundResourceKey>({
+  name: 'Comments',
+  getInitialState: () => ({
+    entries: {},
+    pendingCreates: {},
+    pendingTransactions: {},
+  }),
+  initialize: (context) => {
+    const subscription = watchSubscribedDocuments(context)
+    return () => subscription.unsubscribe()
+  },
+})
+
+/**
+ * Filtered lists and their threads, cached against the comment map they came
+ * from.
+ *
+ * Selectors run on every store change, and a fresh array each time would make
+ * `useSyncExternalStore` re-render whenever anything anywhere in the store
+ * moved. Keying on the comment map means a change to some other document, or
+ * to an unrelated part of the state, hands back the identical array. Entries
+ * die with the map they belong to.
+ */
+const filteredCache = new WeakMap<object, Map<string, CommentDocument[]>>()
+const threadCache = new WeakMap<object, Map<string, CommentThread[]>>()
+
+function filterComments(
+  commentsById: Record<string, CommentDocument>,
+  fieldPath: string | undefined,
+  status: CommentStatus | undefined,
+): CommentDocument[] {
+  let byFilter = filteredCache.get(commentsById)
+  if (!byFilter) {
+    byFilter = new Map()
+    filteredCache.set(commentsById, byFilter)
+  }
+
+  // `\0` stands in for "no field filter", which is not the same as `''`.
+  const cacheKey = `${fieldPath ?? '\0'}|${status ?? ''}`
+  const cached = byFilter.get(cacheKey)
+  if (cached) return cached
+
+  const filtered = Object.values(commentsById)
+    .filter((comment) => {
+      if (status && comment.status !== status) return false
+      if (fieldPath === undefined) return true
+      return (comment.target.path?.field ?? '') === fieldPath
+    })
+    // Newest first, matching the query's order. The store keys comments by id,
+    // so the order has to be reapplied here.
+    .sort((a, b) => b._createdAt.localeCompare(a._createdAt))
+
+  byFilter.set(cacheKey, filtered)
+  return filtered
+}
+
+function selectComments(
+  {state, instance}: SelectorContext<CommentsStoreState>,
+  options: CommentsOptions,
+): CommentDocument[] | undefined {
+  if (state.error) throw state.error
+
+  const entry = state.entries[getCommentsKey(toCommentsKeyParts(instance, options))]
+  if (entry?.error) throw entry.error
+  if (!entry?.comments) return undefined
+
+  return filterComments(
+    entry.comments,
+    options.fieldPath === undefined ? undefined : toCommentFieldPath(options.fieldPath),
+    options.status,
+  )
+}
+
+function selectCommentThreads(
+  context: SelectorContext<CommentsStoreState>,
+  options: CommentsOptions,
+): CommentThread[] | undefined {
+  const comments = selectComments(context, {...options, fieldPath: undefined, status: undefined})
+  if (comments === undefined) return undefined
+
+  let byFilter = threadCache.get(comments)
+  if (!byFilter) {
+    byFilter = new Map()
+    threadCache.set(comments, byFilter)
+  }
+
+  const fieldPath =
+    options.fieldPath === undefined ? undefined : toCommentFieldPath(options.fieldPath)
+  const cacheKey = `${fieldPath ?? '\0'}|${options.status ?? ''}`
+  const cached = byFilter.get(cacheKey)
+  if (cached) return cached
+
+  const threads = buildCommentThreads(comments).filter((thread) => {
+    if (options.status && thread.parentComment.status !== options.status) return false
+    if (fieldPath === undefined) return true
+    return thread.fieldPath === fieldPath
+  })
+  byFilter.set(cacheKey, threads)
+  return threads
+}
+
+/**
+ * Every comment on a document, newest first.
+ *
+ * `undefined` until the first snapshot arrives. Replies are included; use
+ * {@link getCommentThreadsState} to read them grouped.
+ *
+ * @beta
+ */
+export const getCommentsState: (
+  instance: SanityInstance,
+  options: CommentsOptions,
+) => StateSource<CommentDocument[] | undefined> = bindActionByResource(
+  commentsStore,
+  createStateSourceAction({
+    selector: selectComments,
+    onSubscribe: ({state, instance}, options: CommentsOptions) => {
+      const key = getCommentsKey(toCommentsKeyParts(instance, options))
+      const subscriptionId = insecureRandomId()
+      state.set('addSubscriber', addSubscriber(key, subscriptionId))
+
+      return () => {
+        setCleanupTimeout(
+          () => state.set('removeSubscriber', removeSubscriber(key, subscriptionId)),
+          COMMENTS_STATE_CLEAR_DELAY,
+        )
+      }
+    },
+  }),
+)
+
+/**
+ * Threads on a document, newest thread first, each with its replies oldest first.
+ *
+ * A thread's `status` and `fieldPath` come from its first comment, so filtering
+ * by either selects whole threads rather than individual replies.
+ *
+ * @beta
+ */
+export const getCommentThreadsState: (
+  instance: SanityInstance,
+  options: CommentsOptions,
+) => StateSource<CommentThread[] | undefined> = bindActionByResource(
+  commentsStore,
+  createStateSourceAction({
+    selector: selectCommentThreads,
+    onSubscribe: ({state, instance}, options: CommentsOptions) => {
+      const key = getCommentsKey(toCommentsKeyParts(instance, options))
+      const subscriptionId = insecureRandomId()
+      state.set('addSubscriber', addSubscriber(key, subscriptionId))
+
+      return () => {
+        setCleanupTimeout(
+          () => state.set('removeSubscriber', removeSubscriber(key, subscriptionId)),
+          COMMENTS_STATE_CLEAR_DELAY,
+        )
+      }
+    },
+  }),
+)
+
+/**
+ * Waits for a document's comments to load.
+ *
+ * Holds a subscriber only while resolving, so a component that suspends on this
+ * and then errors before mounting does not strand the list. Throw the promise
+ * for Suspense, then read through {@link getCommentsState}.
+ *
+ * @beta
+ */
+export const resolveComments: (
+  instance: SanityInstance,
+  options: ResolveCommentsOptions,
+) => Promise<CommentDocument[]> = bindActionByResource(
+  commentsStore,
+  (
+    {state, instance}: StoreContext<CommentsStoreState, BoundResourceKey>,
+    {signal, ...options}: ResolveCommentsOptions,
+  ) => resolveList(state, instance, options, signal, getCommentsState),
+)
+
+/**
+ * Waits for a document's comments to load, grouped into threads.
+ * @beta
+ */
+export const resolveCommentThreads: (
+  instance: SanityInstance,
+  options: ResolveCommentsOptions,
+) => Promise<CommentThread[]> = bindActionByResource(
+  commentsStore,
+  (
+    {state, instance}: StoreContext<CommentsStoreState, BoundResourceKey>,
+    {signal, ...options}: ResolveCommentsOptions,
+  ) => resolveList(state, instance, options, signal, getCommentThreadsState),
+)
+
+function resolveList<T>(
+  state: StoreState<CommentsStoreState>,
+  instance: SanityInstance,
+  options: CommentsOptions,
+  signal: AbortSignal | undefined,
+  getState: (i: SanityInstance, o: CommentsOptions) => StateSource<T | undefined>,
+): Promise<T> {
+  const key = getCommentsKey(toCommentsKeyParts(instance, options))
+  const {getCurrent} = getState(instance, options)
+
+  // Loading is driven by subscribers, so without one here nothing would ever
+  // fetch and this promise would never settle. Holding it only for the duration
+  // of the resolve also means a component that suspends and then errors before
+  // mounting does not leave a subscriber-less entry behind holding its error.
+  const subscriptionId = insecureRandomId()
+  state.set('addSubscriber', addSubscriber(key, subscriptionId))
+
+  const release = () => state.set('removeSubscriber', removeSubscriber(key, subscriptionId))
+
+  const aborted$ = signal
+    ? new Observable<never>((observer) => {
+        const listener = () => {
+          // Release now rather than after the delay: when this was the only
+          // reader, dropping the key tears down the listener immediately, which
+          // is the point of aborting.
+          release()
+          observer.error(new DOMException('The operation was aborted.', 'AbortError'))
+        }
+        signal.addEventListener('abort', listener)
+        return () => signal.removeEventListener('abort', listener)
+      })
+    : NEVER
+
+  const resolved$ = state.observable.pipe(
+    map(() => getCurrent()),
+    first((value): value is T => value !== undefined),
+  )
+
+  const promise = firstValueFrom(race([resolved$, aborted$]))
+  const releaseLater = () => setCleanupTimeout(release, COMMENTS_STATE_CLEAR_DELAY)
+  promise.then(releaseLater, releaseLater)
+  return promise
+}

--- a/packages/core/src/comments/commentsStore.ts
+++ b/packages/core/src/comments/commentsStore.ts
@@ -58,8 +58,7 @@ import {type Comment, type CommentStatus, type CommentThread, type StoredComment
  */
 export interface CommentsOptions extends DocumentHandle {
   /**
-   * Narrow to one field. `''` selects document-level threads only. Omit to get
-   * every comment on the document.
+   * Narrow to one field. Omit to get every comment on the document.
    */
   fieldPath?: string | Path
   /** Narrow to open or resolved threads. Omit for both. */

--- a/packages/core/src/comments/commentsStore.ts
+++ b/packages/core/src/comments/commentsStore.ts
@@ -35,6 +35,7 @@ import {observeAddonDatasetClient} from './addonDatasetStore'
 import {buildCommentThreads} from './buildCommentThreads'
 import {toCommentFieldPath} from './commentFieldPath'
 import {COMMENTS_STATE_CLEAR_DELAY} from './commentsConstants'
+import {normalizeComment} from './normalizeComment'
 import {type CommentsEvent, observeComments} from './observeComments'
 import {
   addSubscriber,
@@ -49,7 +50,7 @@ import {
   setComments,
   setCommentsError,
 } from './reducers'
-import {type CommentDocument, type CommentStatus, type CommentThread} from './types'
+import {type Comment, type CommentStatus, type CommentThread, type StoredComment} from './types'
 
 /**
  * Which comments to read.
@@ -203,18 +204,39 @@ export const commentsStore = defineStore<CommentsStoreState, BoundResourceKey>({
  * to an unrelated part of the state, hands back the identical array. Entries
  * die with the map they belong to.
  */
-const filteredCache = new WeakMap<object, Map<string, CommentDocument[]>>()
+const normalizedCache = new WeakMap<object, Comment[]>()
+const filteredCache = new WeakMap<object, Map<string, Comment[]>>()
 const threadCache = new WeakMap<object, Map<string, CommentThread[]>>()
 
+/**
+ * The stored map turned into what consumers see, newest first.
+ *
+ * Cached alongside the filters below rather than done per read, so the
+ * normalised objects keep their identity for as long as the stored map does.
+ */
+function normalizeAll(commentsById: Record<string, StoredComment>): Comment[] {
+  const cached = normalizedCache.get(commentsById)
+  if (cached) return cached
+
+  // Newest first, matching the query's order. The store keys comments by id, so
+  // the order has to be reapplied here.
+  const normalized = Object.values(commentsById)
+    .map(normalizeComment)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+
+  normalizedCache.set(commentsById, normalized)
+  return normalized
+}
+
 function filterComments(
-  commentsById: Record<string, CommentDocument>,
+  all: Comment[],
   fieldPath: string | undefined,
   status: CommentStatus | undefined,
-): CommentDocument[] {
-  let byFilter = filteredCache.get(commentsById)
+): Comment[] {
+  let byFilter = filteredCache.get(all)
   if (!byFilter) {
     byFilter = new Map()
-    filteredCache.set(commentsById, byFilter)
+    filteredCache.set(all, byFilter)
   }
 
   // `\0` stands in for "no field filter", which is not the same as `''`.
@@ -222,15 +244,11 @@ function filterComments(
   const cached = byFilter.get(cacheKey)
   if (cached) return cached
 
-  const filtered = Object.values(commentsById)
-    .filter((comment) => {
-      if (status && comment.status !== status) return false
-      if (fieldPath === undefined) return true
-      return (comment.target.path?.field ?? '') === fieldPath
-    })
-    // Newest first, matching the query's order. The store keys comments by id,
-    // so the order has to be reapplied here.
-    .sort((a, b) => b._createdAt.localeCompare(a._createdAt))
+  const filtered = all.filter((comment) => {
+    if (status && comment.status !== status) return false
+    if (fieldPath === undefined) return true
+    return comment.fieldPath === fieldPath
+  })
 
   byFilter.set(cacheKey, filtered)
   return filtered
@@ -239,7 +257,7 @@ function filterComments(
 function selectComments(
   {state, instance}: SelectorContext<CommentsStoreState>,
   options: CommentsOptions,
-): CommentDocument[] | undefined {
+): Comment[] | undefined {
   if (state.error) throw state.error
 
   const entry = state.entries[getCommentsKey(toCommentsKeyParts(instance, options))]
@@ -247,7 +265,7 @@ function selectComments(
   if (!entry?.comments) return undefined
 
   return filterComments(
-    entry.comments,
+    normalizeAll(entry.comments),
     options.fieldPath === undefined ? undefined : toCommentFieldPath(options.fieldPath),
     options.status,
   )
@@ -292,7 +310,7 @@ function selectCommentThreads(
 export const getCommentsState: (
   instance: SanityInstance,
   options: CommentsOptions,
-) => StateSource<CommentDocument[] | undefined> = bindActionByResource(
+) => StateSource<Comment[] | undefined> = bindActionByResource(
   commentsStore,
   createStateSourceAction({
     selector: selectComments,
@@ -353,7 +371,7 @@ export const getCommentThreadsState: (
 export const resolveComments: (
   instance: SanityInstance,
   options: ResolveCommentsOptions,
-) => Promise<CommentDocument[]> = bindActionByResource(
+) => Promise<Comment[]> = bindActionByResource(
   commentsStore,
   (
     {state, instance}: StoreContext<CommentsStoreState, BoundResourceKey>,

--- a/packages/core/src/comments/normalizeComment.test.ts
+++ b/packages/core/src/comments/normalizeComment.test.ts
@@ -93,6 +93,16 @@ describe('normalizeComment', () => {
     ])
   })
 
+  it('leaves the author out when the document does not carry one', () => {
+    // The organization store records identity server-side rather than on the
+    // document, and types it as doubly optional, so there are comments with no
+    // author to map. Emitting `''` would look like a user id.
+    const comment = stored()
+    delete (comment as {authorId?: string}).authorId
+
+    expect('authorId' in normalizeComment(comment)).toBe(false)
+  })
+
   it('carries the local create state through', () => {
     const error = new Error('nope')
     const comment = stored({_state: {type: 'createError', error}})

--- a/packages/core/src/comments/normalizeComment.test.ts
+++ b/packages/core/src/comments/normalizeComment.test.ts
@@ -1,0 +1,106 @@
+import {describe, expect, it} from 'vitest'
+
+import {normalizeComment} from './normalizeComment'
+import {type StoredComment} from './types'
+
+function stored(overrides: Partial<StoredComment> = {}): StoredComment {
+  return {
+    _type: 'comment',
+    _id: 'comment-1',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _rev: 'rev-1',
+    authorId: 'user-1',
+    message: null,
+    threadId: 'thread-1',
+    status: 'open',
+    reactions: null,
+    target: {
+      documentType: 'author',
+      document: {
+        _dataset: 'production',
+        _projectId: 'p',
+        _ref: 'doc-1',
+        _type: 'crossDatasetReference',
+        _weak: true,
+      },
+    },
+    ...overrides,
+  }
+}
+
+describe('normalizeComment', () => {
+  it('maps a stored comment to the public shape', () => {
+    // Asserted in full. This mapping is the seam that lets storage change
+    // without the public shape moving, so every field is deliberate.
+    expect(normalizeComment(stored())).toEqual({
+      id: 'comment-1',
+      createdAt: '2026-01-01T00:00:00Z',
+      authorId: 'user-1',
+      message: null,
+      threadId: 'thread-1',
+      status: 'open',
+      documentId: 'doc-1',
+      documentType: 'author',
+      fieldPath: '',
+      reactions: [],
+    })
+  })
+
+  it('leaves out what the stored comment does not have', () => {
+    const normalized = normalizeComment(stored())
+
+    // Absent rather than present-and-undefined, so a deep equality check in a
+    // consumer's test does not have to know about keys it never set.
+    expect('parentCommentId' in normalized).toBe(false)
+    expect('lastEditedAt' in normalized).toBe(false)
+    expect('selection' in normalized).toBe(false)
+    expect('contentSnapshot' in normalized).toBe(false)
+    expect('state' in normalized).toBe(false)
+  })
+
+  it('lifts the field path out of the target', () => {
+    const comment = stored({
+      target: {
+        documentType: 'author',
+        path: {field: 'body[_key=="intro"].content'},
+        document: {_ref: 'doc-1', _type: 'reference', _weak: true},
+      },
+    })
+
+    expect(normalizeComment(comment).fieldPath).toBe('body[_key=="intro"].content')
+  })
+
+  it('lifts a text selection out of the target', () => {
+    const selection = {type: 'text' as const, value: [{_key: 'b1', text: 'marked'}]}
+    const comment = stored({
+      target: {
+        documentType: 'author',
+        path: {field: 'body', selection},
+        document: {_ref: 'doc-1', _type: 'reference', _weak: true},
+      },
+    })
+
+    expect(normalizeComment(comment).selection).toEqual(selection)
+  })
+
+  it('drops the array key from reactions', () => {
+    const comment = stored({
+      reactions: [{_key: 'user-2-:+1:', shortName: ':+1:', userId: 'user-2', addedAt: 'then'}],
+    })
+
+    expect(normalizeComment(comment).reactions).toEqual([
+      {shortName: ':+1:', userId: 'user-2', addedAt: 'then'},
+    ])
+  })
+
+  it('carries the local create state through', () => {
+    const error = new Error('nope')
+    const comment = stored({_state: {type: 'createError', error}})
+
+    expect(normalizeComment(comment).state).toEqual({type: 'createError', error})
+  })
+
+  it('keeps replies pointed at their parent', () => {
+    expect(normalizeComment(stored({parentCommentId: 'parent-1'})).parentCommentId).toBe('parent-1')
+  })
+})

--- a/packages/core/src/comments/normalizeComment.ts
+++ b/packages/core/src/comments/normalizeComment.ts
@@ -1,0 +1,43 @@
+import {type Comment, type StoredComment} from './types'
+
+/**
+ * Turns a stored comment into the shape consumers see.
+ *
+ * This is the whole seam between the storage format and the public API. When
+ * comments move to the organization-level store, the three fields that differ
+ * are handled here and nothing downstream changes:
+ *
+ * - the author moves from `authorId` to `_system.createdBy`
+ * - `target.document` becomes a global document reference, so `documentId` is
+ *   parsed out of a `resourceType:resourceId:documentId` string rather than
+ *   read off `_ref`
+ * - `_type` goes from `comment` to `sanity.comment`, and stops being exposed
+ *
+ * @internal
+ */
+export function normalizeComment(stored: StoredComment): Comment {
+  const {target} = stored
+
+  return {
+    id: stored._id,
+    createdAt: stored._createdAt,
+    authorId: stored.authorId,
+    message: stored.message,
+    threadId: stored.threadId,
+    ...(stored.parentCommentId ? {parentCommentId: stored.parentCommentId} : {}),
+    status: stored.status,
+    ...(stored.lastEditedAt ? {lastEditedAt: stored.lastEditedAt} : {}),
+    documentId: target.document._ref,
+    documentType: target.documentType,
+    fieldPath: target.path?.field ?? '',
+    ...(target.path?.selection ? {selection: target.path.selection} : {}),
+    ...(stored.contentSnapshot === undefined ? {} : {contentSnapshot: stored.contentSnapshot}),
+    // Dropped: the stored `_key`, which only exists to address the array item.
+    reactions: (stored.reactions ?? []).map(({shortName, userId, addedAt}) => ({
+      shortName,
+      userId,
+      addedAt,
+    })),
+    ...(stored._state ? {state: stored._state} : {}),
+  }
+}

--- a/packages/core/src/comments/normalizeComment.ts
+++ b/packages/core/src/comments/normalizeComment.ts
@@ -21,7 +21,9 @@ export function normalizeComment(stored: StoredComment): Comment {
   return {
     id: stored._id,
     createdAt: stored._createdAt,
-    authorId: stored.authorId,
+    // Omitted rather than emptied when absent, so a consumer can tell "no
+    // author recorded" from a user whose id happens to be falsy.
+    ...(stored.authorId ? {authorId: stored.authorId} : {}),
     message: stored.message,
     threadId: stored.threadId,
     ...(stored.parentCommentId ? {parentCommentId: stored.parentCommentId} : {}),

--- a/packages/core/src/comments/observeComments.test.ts
+++ b/packages/core/src/comments/observeComments.test.ts
@@ -1,0 +1,193 @@
+import {type ListenEvent, type SanityClient} from '@sanity/client'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type CommentsEvent, observeComments} from './observeComments'
+import {type CommentDocument} from './types'
+
+function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_id'>) {
+  return {
+    _type: 'comment',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _rev: 'rev',
+    authorId: 'user-1',
+    message: null,
+    threadId: 'thread-1',
+    status: 'open',
+    reactions: null,
+    target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
+    ...overrides,
+  } satisfies CommentDocument as CommentDocument
+}
+
+const WELCOME = {type: 'welcome'} as ListenEvent<CommentDocument>
+
+let listen$: Subject<ListenEvent<CommentDocument>>
+let fetches: Subject<CommentDocument[]>[]
+let client: SanityClient
+
+beforeEach(() => {
+  listen$ = new Subject()
+  fetches = []
+  client = {
+    observable: {
+      listen: vi.fn(() => listen$),
+      fetch: vi.fn(() => {
+        const fetch$ = new Subject<CommentDocument[]>()
+        fetches.push(fetch$)
+        return fetch$
+      }),
+    },
+  } as unknown as SanityClient
+})
+
+function collect(documentVersionId?: string) {
+  const events: CommentsEvent[] = []
+  const subscription = observeComments({client, documentId: 'doc-1', documentVersionId}).subscribe(
+    (event) => events.push(event),
+  )
+  return {events, subscription}
+}
+
+describe('observeComments', () => {
+  it('fetches a snapshot when the listener connects', () => {
+    const {events} = collect()
+
+    listen$.next(WELCOME)
+    fetches[0].next([comment({_id: 'a'})])
+
+    expect(events).toEqual([{type: 'snapshot', comments: [comment({_id: 'a'})]}])
+    expect(client.observable.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('_type == "comment"'),
+      {documentId: 'doc-1'},
+      {tag: 'comments.list'},
+    )
+  })
+
+  it('passes the release id when reading a release', () => {
+    collect('summer')
+
+    expect(client.observable.listen).toHaveBeenCalledWith(
+      expect.stringContaining('target.documentVersionId == $documentVersionId'),
+      {documentId: 'doc-1', documentVersionId: 'summer'},
+      expect.objectContaining({tag: 'comments.listen'}),
+    )
+  })
+
+  it('maps appear, update, and disappear events', () => {
+    const {events} = collect()
+    listen$.next(WELCOME)
+    fetches[0].next([])
+    fetches[0].complete()
+
+    const created = comment({_id: 'a'})
+    const edited = comment({_id: 'a', status: 'resolved'})
+
+    listen$.next({
+      type: 'mutation',
+      transition: 'appear',
+      documentId: 'a',
+      result: created,
+      transactionId: 'tx-1',
+    } as ListenEvent<CommentDocument>)
+    listen$.next({
+      type: 'mutation',
+      transition: 'update',
+      documentId: 'a',
+      result: edited,
+      transactionId: 'tx-2',
+    } as ListenEvent<CommentDocument>)
+    listen$.next({
+      type: 'mutation',
+      transition: 'disappear',
+      documentId: 'a',
+    } as ListenEvent<CommentDocument>)
+
+    expect(events.slice(1)).toEqual([
+      {type: 'appear', comment: created},
+      {type: 'update', comment: edited, transactionId: 'tx-2'},
+      {type: 'disappear', commentId: 'a'},
+    ])
+  })
+
+  it('ignores a mutation that carries no document', () => {
+    const {events} = collect()
+    listen$.next(WELCOME)
+    fetches[0].next([])
+
+    listen$.next({
+      type: 'mutation',
+      transition: 'update',
+      documentId: 'a',
+      transactionId: 'tx-1',
+    } as ListenEvent<CommentDocument>)
+
+    expect(events).toHaveLength(1)
+  })
+
+  it('keeps a mutation that arrives while the snapshot is still loading', () => {
+    // The Studio loses this one: it awaits the fetch inside the event handler,
+    // so the older snapshot overwrites the newer comment.
+    const {events} = collect()
+    listen$.next(WELCOME)
+
+    const created = comment({_id: 'late'})
+    listen$.next({
+      type: 'mutation',
+      transition: 'appear',
+      documentId: 'late',
+      result: created,
+      transactionId: 'tx-1',
+    } as ListenEvent<CommentDocument>)
+
+    expect(events).toEqual([])
+
+    fetches[0].next([comment({_id: 'a'})])
+
+    expect(events).toEqual([
+      {type: 'snapshot', comments: [comment({_id: 'a'})]},
+      {type: 'appear', comment: created},
+    ])
+  })
+
+  it('abandons an in-flight fetch when the listener reconnects', () => {
+    const {events} = collect()
+    listen$.next(WELCOME)
+    expect(fetches).toHaveLength(1)
+
+    listen$.next(WELCOME)
+    expect(fetches).toHaveLength(2)
+
+    // The first connection's snapshot is stale by now and must not be applied.
+    expect(fetches[0].observed).toBe(false)
+
+    fetches[0].next([comment({_id: 'stale'})])
+    expect(events).toEqual([])
+
+    fetches[1].next([comment({_id: 'fresh'})])
+    expect(events).toEqual([{type: 'snapshot', comments: [comment({_id: 'fresh'})]}])
+  })
+
+  it('reports a failed snapshot without killing the stream', () => {
+    const {events} = collect()
+    listen$.next(WELCOME)
+
+    const error = new Error('boom')
+    fetches[0].error(error)
+
+    expect(events).toEqual([{type: 'error', error}])
+
+    // A later reconnect still recovers.
+    listen$.next(WELCOME)
+    fetches[1].next([])
+    expect(events).toHaveLength(2)
+  })
+
+  it('stops listening when unsubscribed', () => {
+    const {subscription} = collect()
+    listen$.next(WELCOME)
+    subscription.unsubscribe()
+
+    expect(listen$.observed).toBe(false)
+  })
+})

--- a/packages/core/src/comments/observeComments.test.ts
+++ b/packages/core/src/comments/observeComments.test.ts
@@ -3,9 +3,9 @@ import {Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {type CommentsEvent, observeComments} from './observeComments'
-import {type CommentDocument} from './types'
+import {type StoredComment} from './types'
 
-function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_id'>) {
+function comment(overrides: Partial<StoredComment> & Pick<StoredComment, '_id'>) {
   return {
     _type: 'comment',
     _createdAt: '2026-01-01T00:00:00Z',
@@ -17,13 +17,13 @@ function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_i
     reactions: null,
     target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
     ...overrides,
-  } satisfies CommentDocument as CommentDocument
+  } satisfies StoredComment as StoredComment
 }
 
-const WELCOME = {type: 'welcome'} as ListenEvent<CommentDocument>
+const WELCOME = {type: 'welcome'} as ListenEvent<StoredComment>
 
-let listen$: Subject<ListenEvent<CommentDocument>>
-let fetches: Subject<CommentDocument[]>[]
+let listen$: Subject<ListenEvent<StoredComment>>
+let fetches: Subject<StoredComment[]>[]
 let client: SanityClient
 
 beforeEach(() => {
@@ -33,7 +33,7 @@ beforeEach(() => {
     observable: {
       listen: vi.fn(() => listen$),
       fetch: vi.fn(() => {
-        const fetch$ = new Subject<CommentDocument[]>()
+        const fetch$ = new Subject<StoredComment[]>()
         fetches.push(fetch$)
         return fetch$
       }),
@@ -89,19 +89,19 @@ describe('observeComments', () => {
       documentId: 'a',
       result: created,
       transactionId: 'tx-1',
-    } as ListenEvent<CommentDocument>)
+    } as ListenEvent<StoredComment>)
     listen$.next({
       type: 'mutation',
       transition: 'update',
       documentId: 'a',
       result: edited,
       transactionId: 'tx-2',
-    } as ListenEvent<CommentDocument>)
+    } as ListenEvent<StoredComment>)
     listen$.next({
       type: 'mutation',
       transition: 'disappear',
       documentId: 'a',
-    } as ListenEvent<CommentDocument>)
+    } as ListenEvent<StoredComment>)
 
     expect(events.slice(1)).toEqual([
       {type: 'appear', comment: created},
@@ -120,7 +120,7 @@ describe('observeComments', () => {
       transition: 'update',
       documentId: 'a',
       transactionId: 'tx-1',
-    } as ListenEvent<CommentDocument>)
+    } as ListenEvent<StoredComment>)
 
     expect(events).toHaveLength(1)
   })
@@ -138,7 +138,7 @@ describe('observeComments', () => {
       documentId: 'late',
       result: created,
       transactionId: 'tx-1',
-    } as ListenEvent<CommentDocument>)
+    } as ListenEvent<StoredComment>)
 
     expect(events).toEqual([])
 

--- a/packages/core/src/comments/observeComments.ts
+++ b/packages/core/src/comments/observeComments.ts
@@ -2,17 +2,17 @@ import {type ListenEvent, type SanityClient} from '@sanity/client'
 import {filter, map, Observable, share, switchMap, take} from 'rxjs'
 
 import {buildCommentsListenQuery, buildCommentsQuery, LISTEN_OPTIONS} from './commentsConstants'
-import {type CommentDocument} from './types'
+import {type StoredComment} from './types'
 
 /** What the listener saw, in terms the store can apply. */
 export type CommentsEvent =
-  | {type: 'snapshot'; comments: CommentDocument[]}
-  | {type: 'appear'; comment: CommentDocument}
+  | {type: 'snapshot'; comments: StoredComment[]}
+  | {type: 'appear'; comment: StoredComment}
   | {type: 'disappear'; commentId: string}
-  | {type: 'update'; comment: CommentDocument; transactionId: string}
+  | {type: 'update'; comment: StoredComment; transactionId: string}
   | {type: 'error'; error: unknown}
 
-function toCommentsEvent(event: ListenEvent<CommentDocument>): CommentsEvent | undefined {
+function toCommentsEvent(event: ListenEvent<StoredComment>): CommentsEvent | undefined {
   if (event.type !== 'mutation') return undefined
 
   if (event.transition === 'disappear') {
@@ -58,7 +58,7 @@ export function observeComments(options: {
   }
 
   const events$ = client.observable
-    .listen<CommentDocument>(buildCommentsListenQuery(documentVersionId), params, LISTEN_OPTIONS)
+    .listen<StoredComment>(buildCommentsListenQuery(documentVersionId), params, LISTEN_OPTIONS)
     .pipe(share())
 
   const mutations$ = events$.pipe(
@@ -85,7 +85,7 @@ export function observeComments(options: {
           })
 
           const snapshotSubscription = client.observable
-            .fetch<CommentDocument[]>(buildCommentsQuery(documentVersionId), params, {
+            .fetch<StoredComment[]>(buildCommentsQuery(documentVersionId), params, {
               tag: 'comments.list',
             })
             .pipe(take(1))

--- a/packages/core/src/comments/observeComments.ts
+++ b/packages/core/src/comments/observeComments.ts
@@ -1,0 +1,113 @@
+import {type ListenEvent, type SanityClient} from '@sanity/client'
+import {filter, map, Observable, share, switchMap, take} from 'rxjs'
+
+import {buildCommentsListenQuery, buildCommentsQuery, LISTEN_OPTIONS} from './commentsConstants'
+import {type CommentDocument} from './types'
+
+/** What the listener saw, in terms the store can apply. */
+export type CommentsEvent =
+  | {type: 'snapshot'; comments: CommentDocument[]}
+  | {type: 'appear'; comment: CommentDocument}
+  | {type: 'disappear'; commentId: string}
+  | {type: 'update'; comment: CommentDocument; transactionId: string}
+  | {type: 'error'; error: unknown}
+
+function toCommentsEvent(event: ListenEvent<CommentDocument>): CommentsEvent | undefined {
+  if (event.type !== 'mutation') return undefined
+
+  if (event.transition === 'disappear') {
+    return {type: 'disappear', commentId: event.documentId}
+  }
+
+  // `includeResult` is on, so a create or update carries the whole comment. An
+  // event without one is nothing we can apply.
+  if (!event.result) return undefined
+
+  if (event.transition === 'appear') {
+    return {type: 'appear', comment: event.result}
+  }
+
+  return {type: 'update', comment: event.result, transactionId: event.transactionId}
+}
+
+/**
+ * Watches one document's comments: a snapshot on connect, then live changes.
+ *
+ * The Studio awaits its snapshot inside the event handler, which loses any
+ * mutation that arrives while the fetch is in flight, because the older
+ * snapshot overwrites it. Here the mutations that arrive during a fetch are
+ * held and replayed straight after the snapshot, so nothing is dropped.
+ *
+ * A reconnect produces a fresh `welcome`, which cancels any fetch still running
+ * and starts a new one. Reconnects emit nothing themselves: dropping the list
+ * while reconnecting would only make readers suspend again for data we still
+ * have.
+ *
+ * @internal
+ */
+export function observeComments(options: {
+  client: SanityClient
+  documentId: string
+  documentVersionId?: string
+}): Observable<CommentsEvent> {
+  const {client, documentId, documentVersionId} = options
+
+  const params = {
+    documentId,
+    ...(documentVersionId ? {documentVersionId} : {}),
+  }
+
+  const events$ = client.observable
+    .listen<CommentDocument>(buildCommentsListenQuery(documentVersionId), params, LISTEN_OPTIONS)
+    .pipe(share())
+
+  const mutations$ = events$.pipe(
+    map(toCommentsEvent),
+    filter((event): event is CommentsEvent => event !== undefined),
+  )
+
+  return events$.pipe(
+    filter((event) => event.type === 'welcome'),
+    switchMap(
+      () =>
+        new Observable<CommentsEvent>((observer) => {
+          // Subscribe before the fetch starts so nothing between the two is missed.
+          // The array only exists while the snapshot is in flight. Once flushed,
+          // live mutations pass through without retaining their history.
+          const buffered: CommentsEvent[] = []
+          let snapshotReceived = false
+          const mutationSubscription = mutations$.subscribe({
+            next: (event) => {
+              if (snapshotReceived) observer.next(event)
+              else buffered.push(event)
+            },
+            error: (error: unknown) => observer.error(error),
+          })
+
+          const snapshotSubscription = client.observable
+            .fetch<CommentDocument[]>(buildCommentsQuery(documentVersionId), params, {
+              tag: 'comments.list',
+            })
+            .pipe(take(1))
+            .subscribe({
+              next: (comments) => {
+                observer.next({type: 'snapshot', comments})
+                snapshotReceived = true
+                for (const event of buffered) observer.next(event)
+                buffered.length = 0
+              },
+              error: (error: unknown) => {
+                observer.next({type: 'error', error})
+                observer.complete()
+              },
+            })
+
+          return () => {
+            mutationSubscription.unsubscribe()
+            snapshotSubscription.unsubscribe()
+            buffered.length = 0
+          }
+        }),
+    ),
+  )
+}

--- a/packages/core/src/comments/reducers.test.ts
+++ b/packages/core/src/comments/reducers.test.ts
@@ -1,0 +1,277 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  addComment,
+  addSubscriber,
+  applyCommentUpdate,
+  clearPendingTransaction,
+  type CommentsStoreState,
+  getCommentsKey,
+  parseCommentsKey,
+  receiveComment,
+  removeCommentById,
+  removeSubscriber,
+  rollbackCommentUpdate,
+  setComments,
+  setCommentsError,
+  setPendingTransaction,
+} from './reducers'
+import {type CommentDocument} from './types'
+
+const KEY = getCommentsKey({documentId: 'doc-1'})
+
+function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_id'>) {
+  return {
+    _type: 'comment',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _rev: 'rev',
+    authorId: 'user-1',
+    message: null,
+    threadId: 'thread-1',
+    status: 'open',
+    reactions: null,
+    target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
+    ...overrides,
+  } satisfies CommentDocument as CommentDocument
+}
+
+function stateWith(comments: CommentDocument[]): CommentsStoreState {
+  const base: CommentsStoreState = {
+    entries: {[KEY]: {subscribers: ['sub-1']}},
+    pendingCreates: {},
+    pendingTransactions: {},
+  }
+  return setComments(KEY, comments)(base)
+}
+
+const emptyState = (): CommentsStoreState => ({
+  entries: {},
+  pendingCreates: {},
+  pendingTransactions: {},
+})
+
+describe('comment list keys', () => {
+  it('round-trips a document id', () => {
+    expect(parseCommentsKey(getCommentsKey({documentId: 'doc-1'}))).toEqual({documentId: 'doc-1'})
+  })
+
+  it('round-trips a release version', () => {
+    const key = getCommentsKey({documentId: 'doc-1', documentVersionId: 'summer'})
+    expect(parseCommentsKey(key)).toEqual({documentId: 'doc-1', documentVersionId: 'summer'})
+  })
+
+  it('separates a release from the default list', () => {
+    expect(getCommentsKey({documentId: 'doc-1'})).not.toBe(
+      getCommentsKey({documentId: 'doc-1', documentVersionId: 'summer'}),
+    )
+  })
+})
+
+describe('subscribers', () => {
+  const empty = emptyState()
+
+  it('creates an entry for the first subscriber', () => {
+    expect(addSubscriber(KEY, 'sub-1')(empty).entries[KEY]).toEqual({subscribers: ['sub-1']})
+  })
+
+  it('drops the entry when the last subscriber leaves', () => {
+    const one = addSubscriber(KEY, 'sub-1')(empty)
+    expect(removeSubscriber(KEY, 'sub-1')(one).entries).toEqual({})
+  })
+
+  it('keeps the entry while another subscriber remains', () => {
+    const two = addSubscriber(KEY, 'sub-2')(addSubscriber(KEY, 'sub-1')(empty))
+    expect(removeSubscriber(KEY, 'sub-1')(two).entries[KEY]).toEqual({subscribers: ['sub-2']})
+  })
+
+  it('drops reconciliation state when the last listener leaves', () => {
+    const before = {
+      ...stateWith([comment({_id: 'a'})]),
+      pendingCreates: {a: true as const},
+      pendingTransactions: {a: 'tx-1'},
+    }
+
+    const next = removeSubscriber(KEY, 'sub-1')(before)
+
+    expect(next.entries).toEqual({})
+    expect(next.pendingCreates).toEqual({})
+    expect(next.pendingTransactions).toEqual({})
+  })
+
+  it('ignores removal for an unknown key', () => {
+    expect(removeSubscriber('missing', 'sub-1')(empty)).toBe(empty)
+  })
+})
+
+describe('setComments', () => {
+  it('keys the snapshot by comment id and clears any previous error', () => {
+    const withError = setCommentsError(
+      KEY,
+      new Error('boom'),
+    )({...emptyState(), entries: {[KEY]: {subscribers: ['sub-1']}}})
+
+    const next = setComments(KEY, [comment({_id: 'a'})])(withError)
+
+    expect(Object.keys(next.entries[KEY]!.comments!)).toEqual(['a'])
+    expect(next.entries[KEY]!.error).toBe(undefined)
+  })
+
+  it('ignores a snapshot for an entry nobody is reading', () => {
+    const empty = emptyState()
+    expect(setComments(KEY, [comment({_id: 'a'})])(empty)).toBe(empty)
+  })
+
+  it('keeps a failed local create that is absent from the snapshot', () => {
+    const failed = comment({
+      _id: 'failed',
+      message: [{_type: 'block', _key: 'block-1', children: [{_type: 'span', text: 'unsent'}]}],
+      _state: {type: 'createError', error: new Error('nope')},
+    })
+
+    const next = setComments(KEY, [])(stateWith([failed]))
+
+    expect(next.entries[KEY]!.comments!['failed']).toBe(failed)
+  })
+
+  it('keeps an in-flight local create that is absent from the snapshot', () => {
+    const optimistic = addComment(KEY, {
+      _id: 'pending',
+      _type: 'comment',
+      authorId: 'user-1',
+      message: null,
+      threadId: 'thread-2',
+      status: 'open',
+      reactions: null,
+      target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
+    })(stateWith([]))
+
+    const next = setComments(KEY, [])(optimistic)
+
+    expect(next.entries[KEY]!.comments!['pending']).toBeDefined()
+  })
+
+  it('stores comment ids such as __proto__ as ordinary keys', () => {
+    const special = comment({_id: '__proto__'})
+    const next = setComments(KEY, [special])(stateWith([]))
+
+    expect(Object.values(next.entries[KEY]!.comments!)).toEqual([special])
+  })
+})
+
+describe('addComment', () => {
+  it('stands in a createdAt so an unconfirmed comment still sorts', () => {
+    const next = addComment(KEY, {
+      _id: 'new',
+      _type: 'comment',
+      authorId: 'user-1',
+      message: null,
+      threadId: 'thread-2',
+      status: 'open',
+      reactions: null,
+      target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
+    })(stateWith([]))
+
+    expect(next.entries[KEY]!.comments!['new']._createdAt).toEqual(expect.any(String))
+  })
+
+  it('keeps the server createdAt once there is one', () => {
+    const existing = comment({_id: 'a', _createdAt: '2026-03-03T00:00:00Z'})
+    const next = addComment(KEY, {...existing})(stateWith([existing]))
+
+    expect(next.entries[KEY]!.comments!['a']._createdAt).toBe('2026-03-03T00:00:00Z')
+  })
+
+  it('marks a failed comment as retrying when it is added again', () => {
+    const failed = comment({
+      _id: 'a',
+      _state: {type: 'createError', error: new Error('nope')},
+    })
+    const payload = {...failed}
+    delete payload._state
+
+    const next = addComment(KEY, payload)(stateWith([failed]))
+
+    expect(next.entries[KEY]!.comments!['a']._state).toEqual({type: 'createRetrying'})
+  })
+})
+
+describe('applyCommentUpdate', () => {
+  it('merges a patch into the comment', () => {
+    const next = applyCommentUpdate('a', {status: 'resolved'})(stateWith([comment({_id: 'a'})]))
+    expect(next.entries[KEY]!.comments!['a'].status).toBe('resolved')
+  })
+
+  it('leaves state untouched for an unknown comment', () => {
+    const before = stateWith([comment({_id: 'a'})])
+    expect(applyCommentUpdate('missing', {status: 'resolved'})(before)).toBe(before)
+  })
+})
+
+describe('removeCommentById', () => {
+  it('removes the comment and its replies', () => {
+    const before = stateWith([
+      comment({_id: 'a'}),
+      comment({_id: 'b', parentCommentId: 'a'}),
+      comment({_id: 'c'}),
+    ])
+
+    expect(Object.keys(removeCommentById('a')(before).entries[KEY]!.comments!)).toEqual(['c'])
+  })
+
+  it('removes a single reply without touching its siblings', () => {
+    const before = stateWith([
+      comment({_id: 'a'}),
+      comment({_id: 'b', parentCommentId: 'a'}),
+      comment({_id: 'c', parentCommentId: 'a'}),
+    ])
+
+    expect(Object.keys(removeCommentById('b')(before).entries[KEY]!.comments!)).toEqual(['a', 'c'])
+  })
+
+  it('leaves state untouched for an unknown comment', () => {
+    const before = stateWith([comment({_id: 'a'})])
+    expect(removeCommentById('missing')(before)).toBe(before)
+  })
+})
+
+describe('receiveComment', () => {
+  it('replaces what we held with the server copy', () => {
+    const before = stateWith([comment({_id: 'a', status: 'open'})])
+    const next = receiveComment(KEY, comment({_id: 'a', status: 'resolved'}))(before)
+
+    expect(next.entries[KEY]!.comments!['a'].status).toBe('resolved')
+  })
+
+  it('clears create reconciliation after the entry has been released', () => {
+    const before: CommentsStoreState = {...emptyState(), pendingCreates: {a: true}}
+
+    expect(receiveComment(KEY, comment({_id: 'a'}))(before).pendingCreates).toEqual({})
+  })
+})
+
+describe('pending transactions', () => {
+  it('records and clears the transaction for a comment', () => {
+    const set = setPendingTransaction('a', 'tx-1')(emptyState())
+    expect(set.pendingTransactions).toEqual({a: 'tx-1'})
+    expect(clearPendingTransaction('a')(set).pendingTransactions).toEqual({})
+  })
+
+  it('rolls back an optimistic edit while its transaction is still current', () => {
+    const previous = comment({_id: 'a', status: 'open'})
+    const pending = setPendingTransaction('a', 'tx-1')(stateWith([previous]))
+    const optimistic = applyCommentUpdate('a', {status: 'resolved'})(pending)
+
+    const rolledBack = rollbackCommentUpdate('a', 'tx-1', previous)(optimistic)
+
+    expect(rolledBack.entries[KEY]!.comments!['a'].status).toBe('open')
+    expect(rolledBack.pendingTransactions).toEqual({})
+  })
+
+  it('does not roll back once a newer transaction owns the comment', () => {
+    const previous = comment({_id: 'a', status: 'open'})
+    const pending = setPendingTransaction('a', 'tx-2')(stateWith([previous]))
+    const optimistic = applyCommentUpdate('a', {status: 'resolved'})(pending)
+
+    expect(rollbackCommentUpdate('a', 'tx-1', previous)(optimistic)).toBe(optimistic)
+  })
+})

--- a/packages/core/src/comments/reducers.test.ts
+++ b/packages/core/src/comments/reducers.test.ts
@@ -16,11 +16,11 @@ import {
   setCommentsError,
   setPendingTransaction,
 } from './reducers'
-import {type CommentDocument} from './types'
+import {type StoredComment} from './types'
 
 const KEY = getCommentsKey({documentId: 'doc-1'})
 
-function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_id'>) {
+function comment(overrides: Partial<StoredComment> & Pick<StoredComment, '_id'>) {
   return {
     _type: 'comment',
     _createdAt: '2026-01-01T00:00:00Z',
@@ -32,10 +32,10 @@ function comment(overrides: Partial<CommentDocument> & Pick<CommentDocument, '_i
     reactions: null,
     target: {documentType: 'author', document: {_ref: 'doc-1', _type: 'reference', _weak: true}},
     ...overrides,
-  } satisfies CommentDocument as CommentDocument
+  } satisfies StoredComment as StoredComment
 }
 
-function stateWith(comments: CommentDocument[]): CommentsStoreState {
+function stateWith(comments: StoredComment[]): CommentsStoreState {
   const base: CommentsStoreState = {
     entries: {[KEY]: {subscribers: ['sub-1']}},
     pendingCreates: {},

--- a/packages/core/src/comments/reducers.ts
+++ b/packages/core/src/comments/reducers.ts
@@ -1,0 +1,316 @@
+import {omitProperty} from '../utils/object'
+import {type CommentDocument, type CommentPostPayload} from './types'
+
+interface CommentsEntry {
+  /** `undefined` until the first snapshot arrives, which is what suspends readers. */
+  comments?: Record<string, CommentDocument>
+  error?: unknown
+  subscribers: string[]
+}
+
+export interface CommentsStoreState {
+  entries: {[key: string]: CommentsEntry | undefined}
+  /** Comment creates that have not been confirmed by the server yet. */
+  pendingCreates: {[commentId: string]: true | undefined}
+  /**
+   * The most recent transaction this client started per comment, held only
+   * while the write is in flight.
+   *
+   * The listener echoes our own writes back. Without this, an echo from an
+   * earlier transaction could arrive after a later one and undo it on screen.
+   * Cleared as soon as the write settles: applying our own echo after that is
+   * harmless, because it carries the same data we already show.
+   */
+  pendingTransactions: {[commentId: string]: string | undefined}
+  error?: unknown
+}
+
+export interface CommentsKeyParts {
+  documentId: string
+  documentVersionId?: string
+}
+
+export function getCommentsKey({documentId, documentVersionId}: CommentsKeyParts): string {
+  return JSON.stringify([documentId, documentVersionId ?? null])
+}
+
+export function parseCommentsKey(key: string): CommentsKeyParts {
+  const [documentId, documentVersionId] = JSON.parse(key) as [string, string | null]
+  return {documentId, ...(documentVersionId ? {documentVersionId} : {})}
+}
+
+export const addSubscriber =
+  (key: string, subscriptionId: string) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    const entry = prev.entries[key]
+    const subscribers = [...(entry?.subscribers ?? []), subscriptionId]
+    return {...prev, entries: {...prev.entries, [key]: {...entry, subscribers}}}
+  }
+
+export const removeSubscriber =
+  (key: string, subscriptionId: string) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    const entry = prev.entries[key]
+    if (!entry) return prev
+    const subscribers = entry.subscribers.filter((id) => id !== subscriptionId)
+    if (!subscribers.length) {
+      const pendingCreates = {...prev.pendingCreates}
+      const pendingTransactions = {...prev.pendingTransactions}
+
+      for (const commentId of Object.keys(entry.comments ?? {})) {
+        delete pendingCreates[commentId]
+        delete pendingTransactions[commentId]
+      }
+
+      return {
+        ...prev,
+        entries: omitProperty(prev.entries, key),
+        pendingCreates,
+        pendingTransactions,
+      }
+    }
+    return {...prev, entries: {...prev.entries, [key]: {...entry, subscribers}}}
+  }
+
+/** Replaces an entry's contents with a freshly fetched snapshot. */
+export const setComments =
+  (key: string, comments: CommentDocument[]) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    const entry = prev.entries[key]
+    if (!entry) return prev
+    const byId = Object.fromEntries(comments.map((comment) => [comment._id, comment]))
+    const pendingCreates = {...prev.pendingCreates}
+
+    for (const [commentId, localComment] of Object.entries(entry.comments ?? {})) {
+      if (Object.hasOwn(byId, commentId)) {
+        delete pendingCreates[commentId]
+      } else if (Object.hasOwn(pendingCreates, commentId) || localComment._state) {
+        // A snapshot can race an in-flight create. Failed creates are also local
+        // drafts and must remain available for retry.
+        byId[commentId] = localComment
+      }
+    }
+
+    return {
+      ...prev,
+      entries: {...prev.entries, [key]: {...entry, comments: byId, error: undefined}},
+      pendingCreates,
+    }
+  }
+
+export const setCommentsError =
+  (key: string, error: unknown) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    const entry = prev.entries[key]
+    if (!entry) return prev
+    return {...prev, entries: {...prev.entries, [key]: {...entry, error}}}
+  }
+
+/** A comment as it arrived from the server, replacing whatever we held. */
+export const receiveComment =
+  (key: string, comment: CommentDocument) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    const entry = prev.entries[key]
+    const pendingCreates = omitProperty(prev.pendingCreates, comment._id)
+    if (!entry) return {...prev, pendingCreates}
+    return {
+      ...prev,
+      pendingCreates,
+      entries: {
+        ...prev.entries,
+        [key]: {...entry, comments: {...entry.comments, [comment._id]: comment}},
+      },
+    }
+  }
+
+/**
+ * A comment we just wrote, shown before the server confirms it.
+ *
+ * `_createdAt` is assigned by the server, but the list sorts on it, so an
+ * optimistic comment needs a stand-in until the real value arrives.
+ */
+type OptimisticComment = CommentPostPayload & {_createdAt?: string; _rev?: string}
+
+/** A create that already failed once is being retried, not written fresh. */
+function isRetryingCreate(existing: CommentDocument | undefined): boolean {
+  const state = existing?._state?.type
+  return state === 'createError' || state === 'createRetrying'
+}
+
+function mergeOptimisticComment(
+  existing: CommentDocument | undefined,
+  comment: OptimisticComment,
+): CommentDocument {
+  return {
+    ...existing,
+    ...comment,
+    _createdAt: comment._createdAt ?? existing?._createdAt ?? new Date().toISOString(),
+    _rev: comment._rev ?? existing?._rev ?? '',
+    ...(isRetryingCreate(existing) ? {_state: {type: 'createRetrying'} as const} : {}),
+  }
+}
+
+export const addComment =
+  (key: string, comment: OptimisticComment) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    const entry = prev.entries[key]
+    if (!entry) return prev
+
+    const existing =
+      entry.comments && Object.hasOwn(entry.comments, comment._id)
+        ? entry.comments[comment._id]
+        : undefined
+
+    return {
+      ...prev,
+      pendingCreates: {...prev.pendingCreates, [comment._id]: true},
+      entries: {
+        ...prev.entries,
+        [key]: {
+          ...entry,
+          comments: {
+            ...entry.comments,
+            [comment._id]: mergeOptimisticComment(existing, comment),
+          },
+        },
+      },
+    }
+  }
+
+/**
+ * Merges a partial update into whichever entry holds the comment.
+ *
+ * Comment ids are unique, so this touches one entry in practice. Searching by
+ * id rather than taking a key means callers editing a comment do not have to
+ * say which document it belongs to.
+ */
+export const applyCommentUpdate =
+  (commentId: string, patch: Partial<CommentDocument>) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    const entries = {...prev.entries}
+    let changed = false
+
+    for (const [key, entry] of Object.entries(prev.entries)) {
+      const comment = entry?.comments?.[commentId]
+      if (!entry || !comment) continue
+      changed = true
+      entries[key] = {
+        ...entry,
+        comments: {...entry.comments, [commentId]: {...comment, ...patch}},
+      }
+    }
+
+    return changed ? {...prev, entries} : prev
+  }
+
+/** Removes a comment and, when it is a thread parent, its replies. */
+export const removeCommentById =
+  (commentId: string) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    const entries = {...prev.entries}
+    const removedIds = new Set<string>()
+    let changed = false
+
+    for (const [key, entry] of Object.entries(prev.entries)) {
+      if (!entry?.comments) continue
+
+      const remaining = Object.fromEntries(
+        Object.entries(entry.comments).filter(([id, comment]) => {
+          const keep = id !== commentId && comment.parentCommentId !== commentId
+          if (!keep) removedIds.add(id)
+          return keep
+        }),
+      )
+
+      if (Object.keys(remaining).length === Object.keys(entry.comments).length) continue
+
+      changed = true
+      entries[key] = {...entry, comments: remaining}
+    }
+
+    if (!changed) return prev
+
+    const pendingCreates = {...prev.pendingCreates}
+    const pendingTransactions = {...prev.pendingTransactions}
+    for (const id of removedIds) {
+      delete pendingCreates[id]
+      delete pendingTransactions[id]
+    }
+
+    return {...prev, entries, pendingCreates, pendingTransactions}
+  }
+
+export const setPendingTransaction =
+  (commentId: string, transactionId: string) =>
+  (prev: CommentsStoreState): CommentsStoreState => ({
+    ...prev,
+    pendingTransactions: {...prev.pendingTransactions, [commentId]: transactionId},
+  })
+
+export const clearPendingTransaction =
+  (commentId: string) =>
+  (prev: CommentsStoreState): CommentsStoreState => ({
+    ...prev,
+    pendingTransactions: omitProperty(prev.pendingTransactions, commentId),
+  })
+
+/** Marks a pending create as failed, unless another request already confirmed it. */
+export const setCommentCreateError =
+  (commentId: string, error: Error) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    if (!Object.hasOwn(prev.pendingCreates, commentId)) return prev
+    const next = applyCommentUpdate(commentId, {_state: {type: 'createError', error}})(prev)
+    return {...next, pendingCreates: omitProperty(next.pendingCreates, commentId)}
+  }
+
+/** Restores an optimistic edit if the failed transaction is still current. */
+export const rollbackCommentUpdate =
+  (commentId: string, transactionId: string, previous: CommentDocument) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    if (
+      !Object.hasOwn(prev.pendingTransactions, commentId) ||
+      prev.pendingTransactions[commentId] !== transactionId
+    ) {
+      return prev
+    }
+
+    const entries = Object.fromEntries(
+      Object.entries(prev.entries).map(([key, entry]) => {
+        if (!entry?.comments?.[commentId]) return [key, entry]
+        return [key, {...entry, comments: {...entry.comments, [commentId]: previous}}]
+      }),
+    )
+
+    return {
+      ...prev,
+      entries,
+      pendingTransactions: omitProperty(prev.pendingTransactions, commentId),
+    }
+  }
+
+/** Restores comments removed optimistically when the server delete fails. */
+export const restoreComments =
+  (removed: Array<{key: string; comments: CommentDocument[]}>) =>
+  (prev: CommentsStoreState): CommentsStoreState => {
+    const entries = {...prev.entries}
+    let changed = false
+
+    for (const {key, comments} of removed) {
+      const entry = entries[key]
+      if (!entry) continue
+      const missing = comments.filter(
+        (comment) => !Object.hasOwn(entry.comments ?? {}, comment._id),
+      )
+      if (!missing.length) continue
+      changed = true
+      entries[key] = {
+        ...entry,
+        comments: Object.fromEntries([
+          ...Object.entries(entry.comments ?? {}),
+          ...missing.map((comment) => [comment._id, comment] as const),
+        ]),
+      }
+    }
+
+    return changed ? {...prev, entries} : prev
+  }

--- a/packages/core/src/comments/reducers.ts
+++ b/packages/core/src/comments/reducers.ts
@@ -1,9 +1,9 @@
 import {omitProperty} from '../utils/object'
-import {type CommentDocument, type CommentPostPayload} from './types'
+import {type CommentPostPayload, type StoredComment} from './types'
 
 interface CommentsEntry {
   /** `undefined` until the first snapshot arrives, which is what suspends readers. */
-  comments?: Record<string, CommentDocument>
+  comments?: Record<string, StoredComment>
   error?: unknown
   subscribers: string[]
 }
@@ -74,7 +74,7 @@ export const removeSubscriber =
 
 /** Replaces an entry's contents with a freshly fetched snapshot. */
 export const setComments =
-  (key: string, comments: CommentDocument[]) =>
+  (key: string, comments: StoredComment[]) =>
   (prev: CommentsStoreState): CommentsStoreState => {
     const entry = prev.entries[key]
     if (!entry) return prev
@@ -108,7 +108,7 @@ export const setCommentsError =
 
 /** A comment as it arrived from the server, replacing whatever we held. */
 export const receiveComment =
-  (key: string, comment: CommentDocument) =>
+  (key: string, comment: StoredComment) =>
   (prev: CommentsStoreState): CommentsStoreState => {
     const entry = prev.entries[key]
     const pendingCreates = omitProperty(prev.pendingCreates, comment._id)
@@ -132,15 +132,15 @@ export const receiveComment =
 type OptimisticComment = CommentPostPayload & {_createdAt?: string; _rev?: string}
 
 /** A create that already failed once is being retried, not written fresh. */
-function isRetryingCreate(existing: CommentDocument | undefined): boolean {
+function isRetryingCreate(existing: StoredComment | undefined): boolean {
   const state = existing?._state?.type
   return state === 'createError' || state === 'createRetrying'
 }
 
 function mergeOptimisticComment(
-  existing: CommentDocument | undefined,
+  existing: StoredComment | undefined,
   comment: OptimisticComment,
-): CommentDocument {
+): StoredComment {
   return {
     ...existing,
     ...comment,
@@ -185,7 +185,7 @@ export const addComment =
  * say which document it belongs to.
  */
 export const applyCommentUpdate =
-  (commentId: string, patch: Partial<CommentDocument>) =>
+  (commentId: string, patch: Partial<StoredComment>) =>
   (prev: CommentsStoreState): CommentsStoreState => {
     const entries = {...prev.entries}
     let changed = false
@@ -265,7 +265,7 @@ export const setCommentCreateError =
 
 /** Restores an optimistic edit if the failed transaction is still current. */
 export const rollbackCommentUpdate =
-  (commentId: string, transactionId: string, previous: CommentDocument) =>
+  (commentId: string, transactionId: string, previous: StoredComment) =>
   (prev: CommentsStoreState): CommentsStoreState => {
     if (
       !Object.hasOwn(prev.pendingTransactions, commentId) ||
@@ -290,7 +290,7 @@ export const rollbackCommentUpdate =
 
 /** Restores comments removed optimistically when the server delete fails. */
 export const restoreComments =
-  (removed: Array<{key: string; comments: CommentDocument[]}>) =>
+  (removed: Array<{key: string; comments: StoredComment[]}>) =>
   (prev: CommentsStoreState): CommentsStoreState => {
     const entries = {...prev.entries}
     let changed = false

--- a/packages/core/src/comments/types.ts
+++ b/packages/core/src/comments/types.ts
@@ -45,27 +45,111 @@ export interface CommentTextSelection {
 }
 
 /**
- * Where in a document a thread hangs.
+ * An emoji reaction on a comment.
+ *
+ * Read only for now: a reaction added in the Studio shows up here, but there is
+ * no action for adding or removing one.
  * @beta
  */
-export interface CommentPath {
-  /**
-   * A stringified field path, for example `title` or
-   * `body[_key=="intro"].content`. Empty for a document-level thread.
-   */
+export interface CommentReaction {
+  shortName: string
+  userId: string
+  addedAt: string
+}
+
+/**
+ * Why a comment is not yet on the server.
+ *
+ * Local only, never written. Present on a comment whose create request failed,
+ * so an app can offer a retry.
+ * @beta
+ */
+export type CommentLocalState = {type: 'createError'; error: Error} | {type: 'createRetrying'}
+
+/**
+ * A single comment.
+ *
+ * Deliberately not the stored document. Comments are moving from per-dataset
+ * addon datasets to an organization-level store, and the two disagree on the
+ * document type, on how the commented document is referenced, and on where the
+ * author is recorded. Everything here reads the same on both sides, so an app
+ * written against this survives the move.
+ *
+ * Threads are flat: every comment in a thread shares a `threadId`, the thread's
+ * first comment has no `parentCommentId`, and replies carry that first comment's
+ * `id`. Use {@link CommentThread} to work with them grouped.
+ *
+ * @beta
+ */
+export interface Comment {
+  id: string
+  createdAt: string
+  /** Who wrote it. */
+  authorId: string
+  message: CommentMessage
+  threadId: string
+  /** Absent on the comment that starts a thread. */
+  parentCommentId?: string
+  status: CommentStatus
+  /** Set once the message has been rewritten. */
+  lastEditedAt?: string
+  /** The document the thread hangs on, always the published id. */
+  documentId: string
+  documentType: string
+  /** `''` for a thread about the document as a whole. */
+  fieldPath: string
+  /** Set when the comment is anchored to a run of text in a Portable Text field. */
+  selection?: CommentTextSelection
+  /** A copy of the content the comment was written about. */
+  contentSnapshot?: unknown
+  reactions: CommentReaction[]
+  /** Local only. Present while a create is failing or being retried. */
+  state?: CommentLocalState
+}
+
+/**
+ * A thread: one comment plus its replies.
+ *
+ * Unlike the Studio, the SDK returns every thread it finds. The Studio hides
+ * threads whose field is gone from the schema or hidden by a conditional, which
+ * it can do because it has the schema. Check `fieldPath` yourself if your app
+ * needs the same behaviour.
+ * @beta
+ */
+export interface CommentThread {
+  threadId: string
+  /** Empty for a thread about the document as a whole. */
+  fieldPath: string
+  parentComment: Comment
+  /** Oldest first. */
+  replies: Comment[]
+  /** The parent plus its replies. */
+  commentsCount: number
+  /** Taken from the parent comment; replies follow it. */
+  status: CommentStatus
+  /** `createdAt` of the most recent comment in the thread. */
+  lastActivityAt: string
+}
+
+/**
+ * Where in a document a thread hangs, as stored.
+ * @internal
+ */
+interface StoredCommentPath {
   field: string
   selection?: CommentTextSelection
 }
 
 /**
- * Ambient information about where a comment was written.
+ * Ambient information the Studio records about where a comment was written.
  *
- * Written by the Studio for its notification backend and read by nothing in the
- * Studio UI. The SDK fills in what it can and omits the rest; see the remarks on
- * {@link CreateCommentOptions.context}.
- * @beta
+ * Written for the notification backend and read by nothing in the Studio UI.
+ * Not surfaced on {@link Comment}: the organization-level store types this as a
+ * free-form object, so nothing about the shape is worth promising.
+ *
+ * @internal
  */
-export interface CommentContext {
+interface StoredCommentContext {
   tool: string
   payload?: Record<string, unknown>
   notification?: {
@@ -84,39 +168,25 @@ export interface CommentContext {
 }
 
 /**
- * An emoji reaction on a comment.
- *
- * The SDK reads these so a reaction added in the Studio is visible, but has no
- * action for adding or removing one.
- * @beta
+ * A reaction as stored, including the array key.
+ * @internal
  */
-export interface CommentReactionItem {
+interface StoredCommentReaction extends CommentReaction {
   _key: string
-  shortName: string
-  userId: string
-  addedAt: string
 }
 
 /**
- * Why a comment is not yet on the server.
- *
- * Local only, never written. Present on a comment whose create request failed,
- * so an app can offer a retry.
- * @beta
- */
-export type CommentLocalState = {type: 'createError'; error: Error} | {type: 'createRetrying'}
-
-/**
- * What a comment points at.
+ * What a stored comment points at.
  *
  * Comments live in a separate addon dataset, so `document` is a
  * `crossDatasetReference` back into the dataset holding the commented document.
  * It is deliberately weak: a strong reference would stop Content Lake deleting
  * the document it points at.
- * @beta
+ *
+ * @internal
  */
-export interface CommentTarget {
-  path?: CommentPath
+interface StoredCommentTarget {
+  path?: StoredCommentPath
   documentRevisionId?: string
   documentVersionId?: string
   documentType: string
@@ -136,14 +206,15 @@ export interface CommentTarget {
 }
 
 /**
- * A single comment, exactly as the Studio stores it.
+ * A comment exactly as the Studio stores it.
  *
- * Threads are flat: every comment in a thread shares a `threadId`, the thread's
- * first comment has no `parentCommentId`, and replies carry the first comment's
- * `_id`. Use {@link CommentThread} to work with them grouped.
- * @beta
+ * Internal on purpose. This is the addon dataset's shape, and it changes when
+ * comments move to the organization-level store. {@link Comment} is what
+ * consumers get.
+ *
+ * @internal
  */
-export interface CommentDocument {
+export interface StoredComment {
   _type: 'comment'
   _id: string
   _createdAt: string
@@ -158,41 +229,14 @@ export interface CommentDocument {
   parentCommentId?: string
   status: CommentStatus
   lastEditedAt?: string
-  reactions: CommentReactionItem[] | null
-  context?: CommentContext
-
-  /** A copy of the content the comment was written about. */
+  reactions: StoredCommentReaction[] | null
+  context?: StoredCommentContext
   contentSnapshot?: unknown
-
-  target: CommentTarget
+  target: StoredCommentTarget
 }
 
 /**
  * What gets written when a comment is created.
- * @beta
+ * @internal
  */
-export type CommentPostPayload = Omit<CommentDocument, '_rev' | '_createdAt' | '_state'>
-
-/**
- * A thread: one comment plus its replies.
- *
- * Unlike the Studio, the SDK returns every thread it finds. The Studio hides
- * threads whose field is gone from the schema or hidden by a conditional, which
- * it can do because it has the schema. Check `fieldPath` yourself if your app
- * needs the same behaviour.
- * @beta
- */
-export interface CommentThread {
-  threadId: string
-  /** Empty for a document-level thread. */
-  fieldPath: string
-  parentComment: CommentDocument
-  /** Oldest first. */
-  replies: CommentDocument[]
-  /** The parent plus its replies. */
-  commentsCount: number
-  /** Taken from the parent comment; replies follow it. */
-  status: CommentStatus
-  /** `_createdAt` of the most recent comment in the thread. */
-  lastActivityAt: string
-}
+export type CommentPostPayload = Omit<StoredComment, '_rev' | '_createdAt' | '_state'>

--- a/packages/core/src/comments/types.ts
+++ b/packages/core/src/comments/types.ts
@@ -96,7 +96,7 @@ export interface Comment {
   /** The document the thread hangs on, always the published id. */
   documentId: string
   documentType: string
-  /** `''` for a thread about the document as a whole. */
+  /** The field the thread hangs off, for example `title`. */
   fieldPath: string
   /** Set when the comment is anchored to a run of text in a Portable Text field. */
   selection?: CommentTextSelection
@@ -118,7 +118,7 @@ export interface Comment {
  */
 export interface CommentThread {
   threadId: string
-  /** Empty for a thread about the document as a whole. */
+  /** The field the thread hangs off, taken from its first comment. */
   fieldPath: string
   parentComment: Comment
   /** Oldest first. */

--- a/packages/core/src/comments/types.ts
+++ b/packages/core/src/comments/types.ts
@@ -1,0 +1,198 @@
+import {type PortableTextBlock} from '@sanity/types'
+
+/**
+ * Whether a thread is still being discussed or has been closed out.
+ * @beta
+ */
+export type CommentStatus = 'open' | 'resolved'
+
+/**
+ * The body of a comment, as Portable Text.
+ *
+ * Mentions appear here as inline objects of type `mention` carrying a `userId`.
+ * The SDK stores and returns them untouched, so a mention written in the Studio
+ * survives a round trip, but there is no API for composing one yet.
+ * @beta
+ */
+export type CommentMessage = PortableTextBlock[] | null
+
+/**
+ * One block touched by a text selection, and that block's text with the
+ * selection boundaries marked.
+ *
+ * `text` is the block's *entire* plain text with two private-use sentinel
+ * characters (U+F000 and U+F001) inserted where the selection starts and ends.
+ * Storing marked-up text rather than character offsets is what lets a highlight
+ * survive edits elsewhere in the same block.
+ * @beta
+ */
+export interface CommentTextSelectionItem {
+  _key: string
+  text: string
+}
+
+/**
+ * A comment anchored to a run of text inside a Portable Text field.
+ *
+ * The SDK passes this through untouched. Resolving it back to a position in a
+ * live editor needs the editor's current value, so that lives in
+ * `@portabletext/plugin-sdk-value` rather than here.
+ * @beta
+ */
+export interface CommentTextSelection {
+  type: 'text'
+  value: CommentTextSelectionItem[]
+}
+
+/**
+ * Where in a document a thread hangs.
+ * @beta
+ */
+export interface CommentPath {
+  /**
+   * A stringified field path, for example `title` or
+   * `body[_key=="intro"].content`. Empty for a document-level thread.
+   */
+  field: string
+  selection?: CommentTextSelection
+}
+
+/**
+ * Ambient information about where a comment was written.
+ *
+ * Written by the Studio for its notification backend and read by nothing in the
+ * Studio UI. The SDK fills in what it can and omits the rest; see the remarks on
+ * {@link CreateCommentOptions.context}.
+ * @beta
+ */
+export interface CommentContext {
+  tool: string
+  payload?: Record<string, unknown>
+  notification?: {
+    documentTitle: string
+    url?: string
+    workspaceTitle: string
+    workspaceName: string
+    currentThreadLength?: number
+    subscribers?: string[]
+  }
+  intent?: {
+    title: string
+    name: string
+    params: Record<string, unknown>
+  }
+}
+
+/**
+ * An emoji reaction on a comment.
+ *
+ * The SDK reads these so a reaction added in the Studio is visible, but has no
+ * action for adding or removing one.
+ * @beta
+ */
+export interface CommentReactionItem {
+  _key: string
+  shortName: string
+  userId: string
+  addedAt: string
+}
+
+/**
+ * Why a comment is not yet on the server.
+ *
+ * Local only, never written. Present on a comment whose create request failed,
+ * so an app can offer a retry.
+ * @beta
+ */
+export type CommentLocalState = {type: 'createError'; error: Error} | {type: 'createRetrying'}
+
+/**
+ * What a comment points at.
+ *
+ * Comments live in a separate addon dataset, so `document` is a
+ * `crossDatasetReference` back into the dataset holding the commented document.
+ * It is deliberately weak: a strong reference would stop Content Lake deleting
+ * the document it points at.
+ * @beta
+ */
+export interface CommentTarget {
+  path?: CommentPath
+  documentRevisionId?: string
+  documentVersionId?: string
+  documentType: string
+  document:
+    | {
+        _dataset: string
+        _projectId: string
+        _ref: string
+        _type: 'crossDatasetReference'
+        _weak: boolean
+      }
+    | {
+        _ref: string
+        _type: 'reference'
+        _weak: boolean
+      }
+}
+
+/**
+ * A single comment, exactly as the Studio stores it.
+ *
+ * Threads are flat: every comment in a thread shares a `threadId`, the thread's
+ * first comment has no `parentCommentId`, and replies carry the first comment's
+ * `_id`. Use {@link CommentThread} to work with them grouped.
+ * @beta
+ */
+export interface CommentDocument {
+  _type: 'comment'
+  _id: string
+  _createdAt: string
+  _rev: string
+
+  /** Local only. Never written to the server. */
+  _state?: CommentLocalState
+
+  authorId: string
+  message: CommentMessage
+  threadId: string
+  parentCommentId?: string
+  status: CommentStatus
+  lastEditedAt?: string
+  reactions: CommentReactionItem[] | null
+  context?: CommentContext
+
+  /** A copy of the content the comment was written about. */
+  contentSnapshot?: unknown
+
+  target: CommentTarget
+}
+
+/**
+ * What gets written when a comment is created.
+ * @beta
+ */
+export type CommentPostPayload = Omit<CommentDocument, '_rev' | '_createdAt' | '_state'>
+
+/**
+ * A thread: one comment plus its replies.
+ *
+ * Unlike the Studio, the SDK returns every thread it finds. The Studio hides
+ * threads whose field is gone from the schema or hidden by a conditional, which
+ * it can do because it has the schema. Check `fieldPath` yourself if your app
+ * needs the same behaviour.
+ * @beta
+ */
+export interface CommentThread {
+  threadId: string
+  /** Empty for a document-level thread. */
+  fieldPath: string
+  parentComment: CommentDocument
+  /** Oldest first. */
+  replies: CommentDocument[]
+  /** The parent plus its replies. */
+  commentsCount: number
+  /** Taken from the parent comment; replies follow it. */
+  status: CommentStatus
+  /** `_createdAt` of the most recent comment in the thread. */
+  lastActivityAt: string
+}

--- a/packages/core/src/comments/types.ts
+++ b/packages/core/src/comments/types.ts
@@ -84,8 +84,15 @@ export type CommentLocalState = {type: 'createError'; error: Error} | {type: 'cr
 export interface Comment {
   id: string
   createdAt: string
-  /** Who wrote it. */
-  authorId: string
+  /**
+   * Who wrote it.
+   *
+   * Absent when the server carries the author instead of the document. The
+   * Studio's comments dataset stores it on the document, so it is present on
+   * everything written today, but an agent-authored comment records
+   * attribution elsewhere. Render a fallback rather than assuming a user id.
+   */
+  authorId?: string
   message: CommentMessage
   threadId: string
   /** Absent on the comment that starts a thread. */

--- a/packages/core/src/comments/weakenReferences.test.ts
+++ b/packages/core/src/comments/weakenReferences.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from 'vitest'
+
+import {weakenReferencesInContentSnapshot} from './weakenReferences'
+
+describe('weakenReferencesInContentSnapshot', () => {
+  it('weakens a reference at the top level', () => {
+    expect(weakenReferencesInContentSnapshot({_ref: 'abc', _type: 'reference'})).toEqual({
+      _ref: 'abc',
+      _type: 'reference',
+      _weak: true,
+    })
+  })
+
+  it('weakens references nested in objects and arrays', () => {
+    expect(
+      weakenReferencesInContentSnapshot({
+        title: 'foo',
+        author: {_ref: 'bar', _type: 'reference'},
+        blocks: [{_key: 'a', tag: {_ref: 'baz', _type: 'reference'}}],
+      }),
+    ).toEqual({
+      title: 'foo',
+      author: {_ref: 'bar', _type: 'reference', _weak: true},
+      blocks: [{_key: 'a', tag: {_ref: 'baz', _type: 'reference', _weak: true}}],
+    })
+  })
+
+  it('leaves an already weak reference weak', () => {
+    expect(weakenReferencesInContentSnapshot({_ref: 'abc', _weak: true})).toEqual({
+      _ref: 'abc',
+      _weak: true,
+    })
+  })
+
+  it('passes primitives and null through', () => {
+    expect(weakenReferencesInContentSnapshot('foo')).toBe('foo')
+    expect(weakenReferencesInContentSnapshot(42)).toBe(42)
+    expect(weakenReferencesInContentSnapshot(null)).toBe(null)
+    expect(weakenReferencesInContentSnapshot(undefined)).toBe(undefined)
+  })
+
+  it('does not mutate its input', () => {
+    const snapshot = {author: {_ref: 'bar'}}
+    weakenReferencesInContentSnapshot(snapshot)
+    expect(snapshot).toEqual({author: {_ref: 'bar'}})
+  })
+})

--- a/packages/core/src/comments/weakenReferences.ts
+++ b/packages/core/src/comments/weakenReferences.ts
@@ -1,0 +1,29 @@
+function weaken(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(weaken)
+  }
+
+  if (node && typeof node === 'object') {
+    if ('_ref' in node) {
+      return {...node, _weak: true}
+    }
+
+    return Object.fromEntries(Object.entries(node).map(([key, value]) => [key, weaken(value)]))
+  }
+
+  return node
+}
+
+/**
+ * Marks every reference in a content snapshot weak.
+ *
+ * A comment's snapshot is written into the addon dataset, but its references
+ * point at documents in the main one. Left strong, Content Lake would refuse to
+ * delete any document a snapshot happens to mention, so an old comment could
+ * pin a document forever.
+ *
+ * @internal
+ */
+export function weakenReferencesInContentSnapshot(snapshot: unknown): unknown {
+  return weaken(snapshot)
+}


### PR DESCRIPTION
### Description

The SDK has no comments API, so an app built on it cannot read or write the comments people leave in Studio. This adds the framework-agnostic core layer: addon dataset discovery and provisioning, a realtime comments store, read selectors for flat lists and threads, and the five write actions (create, reply, update, set status, remove).

The written shape is an interop contract, which is the main reason this is worth careful review. Comments live in a per-dataset `comments` addon dataset, and Studio filters on `target.document._ref` and groups on `target.path.field`. If the SDK writes either differently, its comments silently stop appearing in Studio without anything failing.

Alternatives considered and rejected:

- Port Studio's `useCommentsStore` as-is. It is React-bound, and it loses mutations that land while its snapshot fetch is in flight because the older snapshot overwrites them.
- Keep comments in the app's own dataset. Simpler, but Studio would never see them.
- Fetch on demand instead of holding a listener. Drops realtime, which is most of the point of collaborative comments.

Core only. React hooks and the Portable Text inline-comment plugin follow as separate PRs in this stack.

### What to review

Scope is `packages/core` alone: everything new lives under `src/comments/`, plus additive exports in `src/_exports/index.ts`. No dependency changes.

In rough order of how expensive a mistake would be:

- **Interop.** `buildCommentPayload` in `commentActions.ts` and `toCommentFieldPath` in `commentFieldPath.ts`. Both have golden tests pinning the exact strings Studio writes, including the quoting Studio applies to field names GROQ reads as values (`true`, `false`, `null`). If you know Studio's comments code, this is the highest-value read.
- **Optimistic writes.** `commentActions.ts` with `reducers.ts`. A comment appears before the round trip and survives a snapshot landing mid-flight; a failed create stays on screen carrying its error so an app can retry with the same id; edits, status changes, and deletes roll back if the server rejects them. Status changes and deletes each go out as a single mutation so a thread and its replies cannot end up half-updated.
- **Listener behavior.** `observeComments.ts` buffers mutations that arrive while the snapshot fetch is running, rather than letting the older snapshot overwrite them. `commentsStore.ts` keeps following the addon client after a listener error, so a token refresh or reconnect recovers instead of leaving the document permanently unable to load.
- **Loading semantics.** `addonDatasetStore.ts` distinguishes "discovery still running" from "this project has no comments dataset". Collapsing the two would make a reader resolve an empty list on a project that does in fact have comments.

### Testing

Unit tests sit next to each source file. 112 tests across the comments module; the full core suite is green at 1,257.

Golden tests pin the written document shape and the field path serialization to what Studio produces, so drift fails loudly rather than quietly making comments invisible.

The races each have a regression test, written failing first and then fixed: a snapshot arriving against an in-flight create, an echo from a superseded transaction, listener recovery after an error, a read issued while discovery is still in flight, concurrent callers sharing one addon dataset setup call, and rollback on a failed edit, status change, or delete.

Not automated here: provisioning a real addon dataset against Content Lake, and confirming an SDK-written comment renders in Studio. Both need a live project, so they are worth a manual pass before this reaches users.

### Fun gif
![comments](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExMTI1MmRjM2YwcjVvMHVsYnVvcXBnbXZna3IwMWkyeGE1azBmOWZsaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1vZfYD1L2lwhLC7I9t/giphy.gif)
<!-- swap in before opening -->
