### PR TITLE
feat(react): add comment hooks

### DIFF
--- a/apps/kitchensink-react/e2e/comments.spec.ts
+++ b/apps/kitchensink-react/e2e/comments.spec.ts
@@ -186,15 +186,20 @@ test.describe('Comments', () => {
     await expect(app.getByTestId('thread')).toBeVisible()
     await expect(app.getByTestId('thread-field')).toHaveText('name')
 
-    // The stored document is the interop contract. The Studio finds a comment by
-    // `target.document._ref` and groups it by `target.path.field`, and reaches
-    // across datasets to do it, so all three have to be right or the comment is
-    // invisible there while looking fine here.
+    // A full round trip: written, read back off the server, and still pointed at
+    // the right document and field. The published id matters, since a comment
+    // anchored to a draft id would be invisible from the published document.
+    //
+    // The written shape is not checked here. Comments are returned normalised,
+    // so the cross dataset reference the Studio actually reads is no longer
+    // visible through the public API. That is pinned instead by the payload test
+    // in `commentActions.test.ts`, which asserts the whole `target` object
+    // against what the client is handed.
     await app.getByTestId('comment-inspect').first().click()
     const stored = app.getByTestId('comment-json')
-    await expect(stored).toContainText('"_type": "crossDatasetReference"')
-    await expect(stored).toContainText(`"_ref": "${documentId}"`)
-    await expect(stored).toContainText('"field": "name"')
+    await expect(stored).toContainText(`"documentId": "${documentId}"`)
+    await expect(stored).toContainText('"fieldPath": "name"')
+    await expect(stored).toContainText('"documentType": "author"')
 
     // Narrowing to the other field excludes it, which is the same filter an app
     // would use to put a count beside each input.

--- a/apps/kitchensink-react/e2e/comments.spec.ts
+++ b/apps/kitchensink-react/e2e/comments.spec.ts
@@ -32,7 +32,17 @@ async function settle(page: Page, action: () => Promise<void>): Promise<void> {
   ])
 }
 
-async function startThread(context: PageContext, message: string): Promise<void> {
+/**
+ * Every comment hangs off a field, so the target is always named. The picker is
+ * separate from the filter above it: one control doing both once meant a new
+ * thread silently attached to nothing.
+ */
+async function startThread(
+  context: PageContext,
+  message: string,
+  field: string = 'name',
+): Promise<void> {
+  await context.getByTestId('comments-new-thread-field').selectOption(field)
   await context.getByTestId('comments-new-thread-input').fill(message)
   await context.getByTestId('comments-new-thread-submit').click()
 }
@@ -180,8 +190,7 @@ test.describe('Comments', () => {
     await page.goto(`./comments?documentId=${documentId}`)
     const app = await getPageContext(page)
 
-    await app.getByTestId('comments-field').selectOption('name')
-    await settle(page, () => startThread(app, 'Rename this'))
+    await settle(page, () => startThread(app, 'Rename this', 'name'))
 
     await expect(app.getByTestId('thread')).toBeVisible()
     await expect(app.getByTestId('thread-field')).toHaveText('name')

--- a/apps/kitchensink-react/e2e/comments.spec.ts
+++ b/apps/kitchensink-react/e2e/comments.spec.ts
@@ -1,0 +1,182 @@
+import {expect, type PageContext, test} from '@repo/e2e'
+
+/**
+ * Comments do not live in the dataset under test. They live in a `comments`
+ * add-on dataset paired to it, which does not exist until the first comment is
+ * written. Every run gets a fresh dataset, so the first write in each of these
+ * specs provisions one, and the cleanup script deletes it alongside its parent.
+ *
+ * That provisioning is a discovery call plus a setup call before the create,
+ * which is why the first assertion that requires a server round trip is given
+ * room rather than the default timeout.
+ */
+const FIRST_WRITE_TIMEOUT = 30_000
+
+async function startThread(context: PageContext, message: string): Promise<void> {
+  await context.getByTestId('comments-new-thread-input').fill(message)
+  await context.getByTestId('comments-new-thread-submit').click()
+}
+
+async function reply(context: PageContext, message: string): Promise<void> {
+  await context.getByTestId('thread-reply-input').fill(message)
+  await context.getByTestId('thread-reply-submit').click()
+}
+
+test.describe('Comments', () => {
+  test('a thread survives a reload, then takes replies and edits', async ({
+    page,
+    createDocuments,
+    getPageContext,
+  }) => {
+    const {documentIds} = await createDocuments([{_type: 'author', name: 'Comment Subject'}], {
+      asDraft: false,
+    })
+    const documentId = documentIds[0]
+    const url = `./comments?documentId=${documentId}`
+
+    await page.goto(url)
+    const app = await getPageContext(page)
+    await expect(app.getByTestId('comments-document-id')).toHaveText(documentId)
+    await expect(app.getByTestId('threads-empty')).toBeVisible()
+
+    await startThread(app, 'First thought')
+
+    // Shown before the server confirms it, so this says nothing about the write
+    // yet.
+    await expect(app.getByTestId('thread')).toBeVisible()
+    await expect(app.getByTestId('comment-message').first()).toHaveText('First thought')
+
+    // A create that failed keeps the comment on screen carrying its error, so
+    // the absence of that badge is what separates "written" from "displayed".
+    await expect(app.getByText('createError')).toBeHidden()
+
+    // The real proof: gone from memory, read back from the add-on dataset. This
+    // is also what proves provisioning worked.
+    await page.reload()
+    const reloaded = await getPageContext(page)
+    await expect(reloaded.getByTestId('thread')).toBeVisible({timeout: FIRST_WRITE_TIMEOUT})
+    await expect(reloaded.getByTestId('comment-message').first()).toHaveText('First thought')
+
+    await reply(reloaded, 'Second thought')
+    await expect(reloaded.getByTestId('thread')).toHaveAttribute('data-count', '2')
+
+    // Editing the parent leaves the reply alone.
+    await reloaded.getByTestId('comment-edit-start').first().click()
+    await reloaded.getByTestId('comment-edit-input').fill('First thought, revised')
+    await reloaded.getByTestId('comment-edit-submit').click()
+
+    await expect(reloaded.getByTestId('comment-message').first()).toHaveText(
+      'First thought, revised',
+    )
+    await expect(reloaded.getByTestId('comment-message').nth(1)).toHaveText('Second thought')
+    await expect(reloaded.getByText('edited').first()).toBeVisible()
+  })
+
+  test('resolving carries the replies, and deleting the parent takes them too', async ({
+    page,
+    createDocuments,
+    getPageContext,
+  }) => {
+    const {documentIds} = await createDocuments([{_type: 'author', name: 'Resolve Subject'}], {
+      asDraft: false,
+    })
+    await page.goto(`./comments?documentId=${documentIds[0]}`)
+    const app = await getPageContext(page)
+
+    await startThread(app, 'Needs a decision')
+    await expect(app.getByTestId('thread')).toBeVisible({timeout: FIRST_WRITE_TIMEOUT})
+    await reply(app, 'Agreed')
+    await expect(app.getByTestId('thread')).toHaveAttribute('data-count', '2')
+
+    await app.getByTestId('thread-toggle-status').click()
+
+    // The whole thread moves, replies included. Filtering is by thread status,
+    // which comes from the parent, so a reply left open would not show here.
+    await app.getByTestId('comments-status').selectOption('open')
+    await expect(app.getByTestId('threads-empty')).toBeVisible()
+
+    await app.getByTestId('comments-status').selectOption('resolved')
+    await expect(app.getByTestId('thread')).toHaveAttribute('data-count', '2')
+
+    await app.getByTestId('comments-status').selectOption('all')
+    await app.getByTestId('comment-delete').first().click()
+
+    // Deleting the first comment in a thread deletes its replies, so the whole
+    // thread goes rather than leaving orphans behind.
+    await expect(app.getByTestId('threads-empty')).toBeVisible()
+
+    await page.reload()
+    const reloaded = await getPageContext(page)
+    await expect(reloaded.getByTestId('threads-empty')).toBeVisible()
+  })
+
+  test('a comment written in one tab reaches another', async ({
+    page,
+    createDocuments,
+    getPageContext,
+  }) => {
+    const {documentIds} = await createDocuments([{_type: 'author', name: 'Realtime Subject'}], {
+      asDraft: false,
+    })
+    const url = `./comments?documentId=${documentIds[0]}`
+
+    await page.goto(url)
+    const first = await getPageContext(page)
+    await expect(first.getByTestId('threads-empty')).toBeVisible()
+
+    const secondPage = await page.context().newPage()
+
+    try {
+      await secondPage.goto(url)
+      const second = await getPageContext(secondPage)
+      await expect(second.getByTestId('threads-empty')).toBeVisible()
+
+      await startThread(first, 'Anyone there?')
+
+      // Nothing polls here. The second tab is holding a listener on the add-on
+      // dataset and receives the mutation.
+      await expect(second.getByTestId('thread')).toBeVisible({timeout: FIRST_WRITE_TIMEOUT})
+      await expect(second.getByTestId('comment-message').first()).toHaveText('Anyone there?')
+
+      // And back the other way, into a thread the second tab did not create.
+      await reply(second, 'Here')
+      await expect(first.getByTestId('thread')).toHaveAttribute('data-count', '2')
+    } finally {
+      await secondPage.close()
+    }
+  })
+
+  test('a field comment records the path the Studio reads', async ({
+    page,
+    createDocuments,
+    getPageContext,
+  }) => {
+    const {documentIds} = await createDocuments([{_type: 'author', name: 'Field Subject'}], {
+      asDraft: false,
+    })
+    const documentId = documentIds[0]
+    await page.goto(`./comments?documentId=${documentId}`)
+    const app = await getPageContext(page)
+
+    await app.getByTestId('comments-field').selectOption('name')
+    await startThread(app, 'Rename this')
+
+    await expect(app.getByTestId('thread')).toBeVisible({timeout: FIRST_WRITE_TIMEOUT})
+    await expect(app.getByTestId('thread-field')).toHaveText('name')
+
+    // The stored document is the interop contract. The Studio finds a comment by
+    // `target.document._ref` and groups it by `target.path.field`, and reaches
+    // across datasets to do it, so all three have to be right or the comment is
+    // invisible there while looking fine here.
+    await app.getByTestId('comment-inspect').first().click()
+    const stored = app.getByTestId('comment-json')
+    await expect(stored).toContainText('"_type": "crossDatasetReference"')
+    await expect(stored).toContainText(`"_ref": "${documentId}"`)
+    await expect(stored).toContainText('"field": "name"')
+
+    // Narrowing to the other field excludes it, which is the same filter an app
+    // would use to put a count beside each input.
+    await app.getByTestId('comments-field').selectOption('role')
+    await expect(app.getByTestId('threads-empty')).toBeVisible()
+  })
+})

--- a/apps/kitchensink-react/e2e/comments.spec.ts
+++ b/apps/kitchensink-react/e2e/comments.spec.ts
@@ -1,16 +1,36 @@
+import {type Page} from '@playwright/test'
 import {expect, type PageContext, test} from '@repo/e2e'
 
 /**
  * Comments do not live in the dataset under test. They live in a `comments`
  * add-on dataset paired to it, which does not exist until the first comment is
- * written. Every run gets a fresh dataset, so the first write in each of these
- * specs provisions one, and the cleanup script deletes it alongside its parent.
+ * written. Every run gets a fresh dataset, so the first write in this file
+ * provisions one, and the cleanup script deletes it alongside its parent.
  *
- * That provisioning is a discovery call plus a setup call before the create,
- * which is why the first assertion that requires a server round trip is given
- * room rather than the default timeout.
+ * That provisioning is a discovery call and a setup call before the create even
+ * starts, on top of a page load and a reload. The default 30s per test is not
+ * enough for that on the slower browsers.
  */
-const FIRST_WRITE_TIMEOUT = 30_000
+test.describe.configure({timeout: 90_000})
+
+/**
+ * Waits for a write to reach Content Lake rather than just the screen.
+ *
+ * Every comment action updates local state before the request goes out, so the
+ * UI is already correct while the mutation is still in flight. Reloading at that
+ * point aborts the request: the screen showed the change, the server never got
+ * it, and the assertion after the reload fails. Anything that reloads, or that
+ * depends on the server having agreed, has to settle first.
+ */
+async function settle(page: Page, action: () => Promise<void>): Promise<void> {
+  await Promise.all([
+    page.waitForResponse(
+      (response) => response.url().includes('/data/mutate/') && response.status() < 400,
+      {timeout: 60_000},
+    ),
+    action(),
+  ])
+}
 
 async function startThread(context: PageContext, message: string): Promise<void> {
   await context.getByTestId('comments-new-thread-input').fill(message)
@@ -32,17 +52,16 @@ test.describe('Comments', () => {
       asDraft: false,
     })
     const documentId = documentIds[0]
-    const url = `./comments?documentId=${documentId}`
 
-    await page.goto(url)
+    await page.goto(`./comments?documentId=${documentId}`)
     const app = await getPageContext(page)
     await expect(app.getByTestId('comments-document-id')).toHaveText(documentId)
     await expect(app.getByTestId('threads-empty')).toBeVisible()
 
-    await startThread(app, 'First thought')
+    // The first write in this file, so this is the one that provisions the
+    // add-on dataset.
+    await settle(page, () => startThread(app, 'First thought'))
 
-    // Shown before the server confirms it, so this says nothing about the write
-    // yet.
     await expect(app.getByTestId('thread')).toBeVisible()
     await expect(app.getByTestId('comment-message').first()).toHaveText('First thought')
 
@@ -50,20 +69,21 @@ test.describe('Comments', () => {
     // the absence of that badge is what separates "written" from "displayed".
     await expect(app.getByText('createError')).toBeHidden()
 
-    // The real proof: gone from memory, read back from the add-on dataset. This
-    // is also what proves provisioning worked.
+    // The real proof: gone from memory, read back from the add-on dataset.
     await page.reload()
     const reloaded = await getPageContext(page)
-    await expect(reloaded.getByTestId('thread')).toBeVisible({timeout: FIRST_WRITE_TIMEOUT})
+    await expect(reloaded.getByTestId('thread')).toBeVisible()
     await expect(reloaded.getByTestId('comment-message').first()).toHaveText('First thought')
 
-    await reply(reloaded, 'Second thought')
+    await settle(page, () => reply(reloaded, 'Second thought'))
     await expect(reloaded.getByTestId('thread')).toHaveAttribute('data-count', '2')
 
     // Editing the parent leaves the reply alone.
-    await reloaded.getByTestId('comment-edit-start').first().click()
-    await reloaded.getByTestId('comment-edit-input').fill('First thought, revised')
-    await reloaded.getByTestId('comment-edit-submit').click()
+    await settle(page, async () => {
+      await reloaded.getByTestId('comment-edit-start').first().click()
+      await reloaded.getByTestId('comment-edit-input').fill('First thought, revised')
+      await reloaded.getByTestId('comment-edit-submit').click()
+    })
 
     await expect(reloaded.getByTestId('comment-message').first()).toHaveText(
       'First thought, revised',
@@ -83,12 +103,14 @@ test.describe('Comments', () => {
     await page.goto(`./comments?documentId=${documentIds[0]}`)
     const app = await getPageContext(page)
 
-    await startThread(app, 'Needs a decision')
-    await expect(app.getByTestId('thread')).toBeVisible({timeout: FIRST_WRITE_TIMEOUT})
-    await reply(app, 'Agreed')
+    await settle(page, () => startThread(app, 'Needs a decision'))
+    await expect(app.getByTestId('thread')).toBeVisible()
+    await settle(page, () => reply(app, 'Agreed'))
     await expect(app.getByTestId('thread')).toHaveAttribute('data-count', '2')
 
-    await app.getByTestId('thread-toggle-status').click()
+    // Settled before filtering: an unsettled status could still roll back, and
+    // the filter below would then be reading a value the server never accepted.
+    await settle(page, () => app.getByTestId('thread-toggle-status').click())
 
     // The whole thread moves, replies included. Filtering is by thread status,
     // which comes from the parent, so a reply left open would not show here.
@@ -99,7 +121,7 @@ test.describe('Comments', () => {
     await expect(app.getByTestId('thread')).toHaveAttribute('data-count', '2')
 
     await app.getByTestId('comments-status').selectOption('all')
-    await app.getByTestId('comment-delete').first().click()
+    await settle(page, () => app.getByTestId('comment-delete').first().click())
 
     // Deleting the first comment in a thread deletes its replies, so the whole
     // thread goes rather than leaving orphans behind.
@@ -131,15 +153,15 @@ test.describe('Comments', () => {
       const second = await getPageContext(secondPage)
       await expect(second.getByTestId('threads-empty')).toBeVisible()
 
-      await startThread(first, 'Anyone there?')
+      await settle(page, () => startThread(first, 'Anyone there?'))
 
       // Nothing polls here. The second tab is holding a listener on the add-on
       // dataset and receives the mutation.
-      await expect(second.getByTestId('thread')).toBeVisible({timeout: FIRST_WRITE_TIMEOUT})
+      await expect(second.getByTestId('thread')).toBeVisible()
       await expect(second.getByTestId('comment-message').first()).toHaveText('Anyone there?')
 
       // And back the other way, into a thread the second tab did not create.
-      await reply(second, 'Here')
+      await settle(secondPage, () => reply(second, 'Here'))
       await expect(first.getByTestId('thread')).toHaveAttribute('data-count', '2')
     } finally {
       await secondPage.close()
@@ -159,9 +181,9 @@ test.describe('Comments', () => {
     const app = await getPageContext(page)
 
     await app.getByTestId('comments-field').selectOption('name')
-    await startThread(app, 'Rename this')
+    await settle(page, () => startThread(app, 'Rename this'))
 
-    await expect(app.getByTestId('thread')).toBeVisible({timeout: FIRST_WRITE_TIMEOUT})
+    await expect(app.getByTestId('thread')).toBeVisible()
     await expect(app.getByTestId('thread-field')).toHaveText('name')
 
     // The stored document is the interop contract. The Studio finds a comment by

--- a/apps/kitchensink-react/src/AppRoutes.tsx
+++ b/apps/kitchensink-react/src/AppRoutes.tsx
@@ -4,6 +4,7 @@ import {Route, Routes} from 'react-router'
 
 import Framed from './Comlink/Framed'
 import ParentApp from './Comlink/ParentApp'
+import {CommentsRoute} from './Comments/CommentsRoute'
 import {DocumentDashboardInteractionsRoute} from './DocumentCollection/DocumentDashboardInteractionsRoute'
 import {DocumentEditorRoute} from './DocumentCollection/DocumentEditorRoute'
 import {DocumentGridRoute} from './DocumentCollection/DocumentGridRoute'
@@ -77,6 +78,10 @@ const documentCollectionRoutes = [
   {
     path: 'presence',
     element: <PresenceRoute />,
+  },
+  {
+    path: 'comments',
+    element: <CommentsRoute />,
   },
   {
     path: 'media-library',

--- a/apps/kitchensink-react/src/Comments/CommentsRoute.tsx
+++ b/apps/kitchensink-react/src/Comments/CommentsRoute.tsx
@@ -1,0 +1,546 @@
+import {
+  type CommentDocument,
+  type CommentMessage,
+  type CommentStatus,
+  type CommentThread,
+  useCommentActions,
+  useCommentThreads,
+  useDocumentProjection,
+  useDocuments,
+  useResource,
+} from '@sanity/sdk-react'
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Code,
+  Flex,
+  Inline,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+} from '@sanity/ui'
+import {type JSX, useState} from 'react'
+import {useSearchParams} from 'react-router'
+
+import {PageLayout} from '../components/PageLayout'
+
+const DOCUMENT_TYPE = 'author'
+
+/**
+ * The Studio serving the kitchensink's default resource, `ppsg7ml5` / `test`.
+ * Override with `?studio=<baseUrl>` when pointing at another one.
+ */
+const DEFAULT_STUDIO_BASE_URL = 'https://test-studio.sanity.build/test'
+
+/**
+ * Fields to hang threads off.
+ *
+ * Both exist on the `author` schema. That matters for the interop check: a
+ * comment can be written against any path, but a Studio with no input at that
+ * path has nowhere to show it, so a made-up field would look like a failure.
+ */
+const FIELDS = [
+  {value: '', label: 'Whole document'},
+  {value: 'name', label: 'Name'},
+  {value: 'role', label: 'Role'},
+] as const
+
+type Perspective = 'drafts' | 'published'
+type StatusFilter = CommentStatus | 'all'
+
+/** How a thread reads in each state, picked once instead of per prop. */
+const RESOLVED_DISPLAY = {
+  tone: 'transparent',
+  badge: 'default',
+  action: 'Reopen',
+  nextStatus: 'open',
+} as const
+
+const OPEN_DISPLAY = {
+  tone: 'default',
+  badge: 'primary',
+  action: 'Resolve',
+  nextStatus: 'resolved',
+} as const
+
+/** Wraps plain text as the Portable Text the Studio stores. */
+function toMessage(text: string): CommentMessage {
+  return [
+    {
+      _type: 'block',
+      _key: crypto.randomUUID(),
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: crypto.randomUUID(), text, marks: []}],
+    },
+  ]
+}
+
+/** Flattens a message for display. Mentions render as nothing, which is fine here. */
+function toPlainText(message: CommentMessage): string {
+  if (!message) return ''
+  return message
+    .map((block) => {
+      const children = (block as {children?: {text?: string}[]}).children ?? []
+      return children.map((child) => child.text ?? '').join('')
+    })
+    .join('\n')
+}
+
+function Composer({
+  label,
+  initialValue = '',
+  testId,
+  onSubmit,
+  onCancel,
+}: {
+  label: string
+  initialValue?: string
+  testId: string
+  onSubmit: (text: string) => void
+  onCancel?: () => void
+}): JSX.Element {
+  const [text, setText] = useState(initialValue)
+
+  return (
+    <Flex gap={2} align="center">
+      <Box flex={1}>
+        <TextInput
+          data-testid={`${testId}-input`}
+          value={text}
+          placeholder={label}
+          onChange={(event) => setText(event.currentTarget.value)}
+        />
+      </Box>
+      <Button
+        data-testid={`${testId}-submit`}
+        mode="default"
+        text={label}
+        disabled={text.trim().length === 0}
+        onClick={() => {
+          onSubmit(text.trim())
+          setText('')
+        }}
+      />
+      {onCancel ? (
+        <Button data-testid={`${testId}-cancel`} mode="bleed" text="Cancel" onClick={onCancel} />
+      ) : null}
+    </Flex>
+  )
+}
+
+function CommentRow({
+  comment,
+  onSelect,
+}: {
+  comment: CommentDocument
+  onSelect: (comment: CommentDocument) => void
+}): JSX.Element {
+  const {updateComment, removeComment} = useCommentActions()
+  const [editing, setEditing] = useState(false)
+
+  return (
+    <Card padding={3} radius={2} border data-testid="comment" data-comment-id={comment._id}>
+      <Stack space={3}>
+        <Flex align="center" gap={2}>
+          <Code size={0} data-testid="comment-author">
+            {comment.authorId}
+          </Code>
+          {comment.lastEditedAt ? <Badge tone="caution">edited</Badge> : null}
+          {comment._state ? <Badge tone="critical">{comment._state.type}</Badge> : null}
+        </Flex>
+
+        {editing ? (
+          <Composer
+            label="Save"
+            testId="comment-edit"
+            initialValue={toPlainText(comment.message)}
+            onCancel={() => setEditing(false)}
+            onSubmit={(text) => {
+              updateComment({commentId: comment._id, message: toMessage(text)})
+              setEditing(false)
+            }}
+          />
+        ) : (
+          <Text size={1} data-testid="comment-message">
+            {toPlainText(comment.message)}
+          </Text>
+        )}
+
+        <Inline space={2}>
+          <Button
+            data-testid="comment-edit-start"
+            mode="bleed"
+            text="Edit"
+            onClick={() => setEditing(true)}
+          />
+          <Button
+            data-testid="comment-delete"
+            mode="bleed"
+            tone="critical"
+            text="Delete"
+            onClick={() => removeComment({commentId: comment._id})}
+          />
+          <Button
+            data-testid="comment-inspect"
+            mode="bleed"
+            text="Inspect"
+            onClick={() => onSelect(comment)}
+          />
+        </Inline>
+      </Stack>
+    </Card>
+  )
+}
+
+function ThreadCard({
+  thread,
+  documentId,
+  perspective,
+  onSelect,
+}: {
+  thread: CommentThread
+  documentId: string
+  perspective: Perspective
+  onSelect: (comment: CommentDocument) => void
+}): JSX.Element {
+  const {replyToComment, setCommentStatus} = useCommentActions()
+  const display = thread.status === 'resolved' ? RESOLVED_DISPLAY : OPEN_DISPLAY
+
+  return (
+    <Card
+      padding={3}
+      radius={2}
+      border
+      tone={display.tone}
+      data-testid="thread"
+      data-thread-id={thread.threadId}
+      data-count={thread.commentsCount}
+    >
+      <Stack space={3}>
+        <Flex align="center" gap={2}>
+          <Badge tone={display.badge}>{thread.status}</Badge>
+          <Text size={1} muted data-testid="thread-field">
+            {thread.fieldPath || 'whole document'}
+          </Text>
+          <Box flex={1} />
+          <Button
+            data-testid="thread-toggle-status"
+            mode="ghost"
+            text={display.action}
+            onClick={() =>
+              setCommentStatus({
+                commentId: thread.parentComment._id,
+                status: display.nextStatus,
+              })
+            }
+          />
+        </Flex>
+
+        <CommentRow comment={thread.parentComment} onSelect={onSelect} />
+
+        {thread.replies.map((reply) => (
+          <Box key={reply._id} paddingLeft={4}>
+            <CommentRow comment={reply} onSelect={onSelect} />
+          </Box>
+        ))}
+
+        <Composer
+          label="Reply"
+          testId="thread-reply"
+          onSubmit={(text) =>
+            replyToComment({
+              documentId,
+              documentType: DOCUMENT_TYPE,
+              perspective,
+              parentCommentId: thread.parentComment._id,
+              message: toMessage(text),
+            })
+          }
+        />
+      </Stack>
+    </Card>
+  )
+}
+
+function ThreadList({
+  documentId,
+  perspective,
+  fieldPath,
+  status,
+  onSelect,
+}: {
+  documentId: string
+  perspective: Perspective
+  fieldPath: string | undefined
+  status: StatusFilter
+  onSelect: (comment: CommentDocument) => void
+}): JSX.Element {
+  const {threads, isPending} = useCommentThreads({
+    documentId,
+    documentType: DOCUMENT_TYPE,
+    perspective,
+    ...(fieldPath === undefined ? {} : {fieldPath}),
+    ...(status === 'all' ? {} : {status}),
+  })
+
+  if (threads.length === 0) {
+    return (
+      <Card padding={3} radius={2} tone="transparent">
+        <Text size={1} muted data-testid="threads-empty">
+          No comments yet. Writing the first one in this project creates the comments dataset.
+        </Text>
+      </Card>
+    )
+  }
+
+  return (
+    <Stack space={3} data-testid="threads" data-count={threads.length} data-pending={isPending}>
+      {threads.map((thread) => (
+        <ThreadCard
+          key={thread.threadId}
+          thread={thread}
+          documentId={documentId}
+          perspective={perspective}
+          onSelect={onSelect}
+        />
+      ))}
+    </Stack>
+  )
+}
+
+/** The project and dataset in play, so a mismatch with the Studio link is visible. */
+function ScopeText(): JSX.Element | null {
+  const resource = useResource()
+  if (!resource || !('projectId' in resource)) return null
+
+  return (
+    <Text size={1} muted>
+      {`Project ${resource.projectId} · dataset ${resource.dataset}`}
+    </Text>
+  )
+}
+
+function Toolbar({
+  perspective,
+  onPerspectiveChange,
+  fieldPath,
+  onFieldPathChange,
+  status,
+  onStatusChange,
+}: {
+  perspective: Perspective
+  onPerspectiveChange: (next: Perspective) => void
+  fieldPath: string | undefined
+  onFieldPathChange: (next: string | undefined) => void
+  status: StatusFilter
+  onStatusChange: (next: StatusFilter) => void
+}): JSX.Element {
+  return (
+    <Flex gap={3} wrap="wrap">
+      <Select
+        data-testid="comments-perspective"
+        value={perspective}
+        onChange={(event) =>
+          onPerspectiveChange(event.currentTarget.value === 'published' ? 'published' : 'drafts')
+        }
+      >
+        <option value="drafts">drafts</option>
+        <option value="published">published</option>
+      </Select>
+
+      <Select
+        data-testid="comments-field"
+        value={fieldPath ?? 'any'}
+        onChange={(event) => {
+          const next = event.currentTarget.value
+          onFieldPathChange(next === 'any' ? undefined : next)
+        }}
+      >
+        <option value="any">Every field</option>
+        {FIELDS.map((field) => (
+          <option key={field.value} value={field.value}>
+            {field.label}
+          </option>
+        ))}
+      </Select>
+
+      <Select
+        data-testid="comments-status"
+        value={status}
+        onChange={(event) => onStatusChange(event.currentTarget.value as StatusFilter)}
+      >
+        <option value="all">Open and resolved</option>
+        <option value="open">Open</option>
+        <option value="resolved">Resolved</option>
+      </Select>
+    </Flex>
+  )
+}
+
+function DocumentCard({
+  documentId,
+  studioUrl,
+}: {
+  documentId: string
+  studioUrl: string
+}): JSX.Element {
+  const {data} = useDocumentProjection<{name: string | null}>({
+    documentId,
+    documentType: DOCUMENT_TYPE,
+    projection: `{name}`,
+  })
+
+  return (
+    <Card padding={3} radius={2} tone="transparent">
+      <Flex align="flex-start" gap={3}>
+        <Stack space={3} flex={1}>
+          <Text size={1} weight="medium">
+            {data?.name ?? 'Untitled'}
+          </Text>
+          <Code size={0} data-testid="comments-document-id">
+            {documentId}
+          </Code>
+          <ScopeText />
+        </Stack>
+        <Button
+          as="a"
+          href={studioUrl}
+          target="_blank"
+          rel="noreferrer"
+          mode="ghost"
+          text="Open in Studio"
+          data-testid="comments-studio-link"
+        />
+      </Flex>
+    </Card>
+  )
+}
+
+/**
+ * The selected comment, verbatim.
+ *
+ * The most useful thing on this page for checking interop: put it beside a
+ * Studio-written comment and the `target` objects should match field for field.
+ */
+function Inspector({comment}: {comment: CommentDocument | undefined}): JSX.Element | null {
+  if (!comment) return null
+
+  return (
+    <Stack space={2}>
+      <Text size={1} weight="semibold">
+        Stored document
+      </Text>
+      <Card padding={3} radius={2} border overflow="auto">
+        <Code size={0} language="json" data-testid="comment-json">
+          {JSON.stringify(comment, null, 2)}
+        </Code>
+      </Card>
+    </Stack>
+  )
+}
+
+function CommentsDemo({documentId}: {documentId: string}): JSX.Element {
+  const [searchParams] = useSearchParams()
+  const [perspective, setPerspective] = useState<Perspective>('drafts')
+  const [fieldPath, setFieldPath] = useState<string | undefined>(undefined)
+  const [status, setStatus] = useState<StatusFilter>('all')
+  const [selected, setSelected] = useState<CommentDocument | undefined>(undefined)
+  const {createComment} = useCommentActions()
+
+  const studioBase = searchParams.get('studio') ?? DEFAULT_STUDIO_BASE_URL
+  const studioUrl = `${studioBase}/intent/edit/id=${encodeURIComponent(documentId)};type=${DOCUMENT_TYPE}`
+
+  // A new thread hangs off whichever field is selected; "Every field" means the
+  // document as a whole.
+  const newThreadFieldPath = fieldPath ?? ''
+
+  return (
+    <PageLayout
+      title="Comments"
+      subtitle="These are the same comments the Studio shows. Write one here and it appears there, and the other way round."
+    >
+      <DocumentCard documentId={documentId} studioUrl={studioUrl} />
+
+      <Toolbar
+        perspective={perspective}
+        onPerspectiveChange={setPerspective}
+        fieldPath={fieldPath}
+        onFieldPathChange={setFieldPath}
+        status={status}
+        onStatusChange={setStatus}
+      />
+
+      <Stack space={3}>
+        <Text size={1} weight="semibold">
+          {newThreadFieldPath === ''
+            ? 'New thread on the document'
+            : `New thread on ${newThreadFieldPath}`}
+        </Text>
+        <Composer
+          label="Comment"
+          testId="comments-new-thread"
+          onSubmit={(text) =>
+            createComment({
+              documentId,
+              documentType: DOCUMENT_TYPE,
+              perspective,
+              fieldPath: newThreadFieldPath,
+              message: toMessage(text),
+            })
+          }
+        />
+      </Stack>
+
+      <ThreadList
+        documentId={documentId}
+        perspective={perspective}
+        fieldPath={fieldPath}
+        status={status}
+        onSelect={setSelected}
+      />
+
+      <Inspector comment={selected} />
+    </PageLayout>
+  )
+}
+
+function NoDocuments({documentIdParam}: {documentIdParam: string | null}): JSX.Element {
+  const detail = documentIdParam
+    ? `No ${DOCUMENT_TYPE} document with id ${documentIdParam}.`
+    : `No ${DOCUMENT_TYPE} documents in this dataset.`
+
+  return (
+    <PageLayout title="Comments" subtitle="Nothing to comment on">
+      <Card padding={3} radius={2} tone="caution">
+        <Text size={1} data-testid="comments-no-documents">
+          {detail}
+        </Text>
+      </Card>
+    </PageLayout>
+  )
+}
+
+export function CommentsRoute(): JSX.Element {
+  const [searchParams] = useSearchParams()
+  const documentIdParam = searchParams.get('documentId')
+
+  // Defaults to a real document so the route is useful straight away, with no id
+  // to look up first.
+  const {data} = useDocuments({
+    documentType: DOCUMENT_TYPE,
+    batchSize: 1,
+    orderings: [{field: '_createdAt', direction: 'desc'}],
+    ...(documentIdParam
+      ? {filter: '_id == $documentId', params: {documentId: documentIdParam}}
+      : {}),
+  })
+
+  const documentId = data[0]?.documentId
+  if (!documentId) return <NoDocuments documentIdParam={documentIdParam} />
+
+  return <CommentsDemo documentId={documentId} />
+}

--- a/apps/kitchensink-react/src/Comments/CommentsRoute.tsx
+++ b/apps/kitchensink-react/src/Comments/CommentsRoute.tsx
@@ -43,7 +43,6 @@ const DEFAULT_STUDIO_BASE_URL = 'https://test-studio.sanity.build/test'
  * path has nowhere to show it, so a made-up field would look like a failure.
  */
 const FIELDS = [
-  {value: '', label: 'Whole document'},
   {value: 'name', label: 'Name'},
   {value: 'role', label: 'Role'},
 ] as const
@@ -224,7 +223,7 @@ function ThreadCard({
         <Flex align="center" gap={2}>
           <Badge tone={display.badge}>{thread.status}</Badge>
           <Text size={1} muted data-testid="thread-field">
-            {thread.fieldPath || 'whole document'}
+            {thread.fieldPath}
           </Text>
           <Box flex={1} />
           <Button
@@ -449,14 +448,14 @@ function CommentsDemo({documentId}: {documentId: string}): JSX.Element {
   const [fieldPath, setFieldPath] = useState<string | undefined>(undefined)
   const [status, setStatus] = useState<StatusFilter>('all')
   const [selected, setSelected] = useState<Comment | undefined>(undefined)
+  // Separate from the filter above. One control doing both meant "Every field",
+  // a sensible default for reading, silently became "attach to nothing" when
+  // writing.
+  const [newThreadFieldPath, setNewThreadFieldPath] = useState<string>(FIELDS[0].value)
   const {createComment} = useCommentActions()
 
   const studioBase = searchParams.get('studio') ?? DEFAULT_STUDIO_BASE_URL
   const studioUrl = `${studioBase}/intent/edit/id=${encodeURIComponent(documentId)};type=${DOCUMENT_TYPE}`
-
-  // A new thread hangs off whichever field is selected; "Every field" means the
-  // document as a whole.
-  const newThreadFieldPath = fieldPath ?? ''
 
   return (
     <PageLayout
@@ -476,10 +475,24 @@ function CommentsDemo({documentId}: {documentId: string}): JSX.Element {
 
       <Stack space={3}>
         <Text size={1} weight="semibold">
-          {newThreadFieldPath === ''
-            ? 'New thread on the document'
-            : `New thread on ${newThreadFieldPath}`}
+          New thread
         </Text>
+        <Flex gap={2} align="center">
+          <Text size={1} muted>
+            On field
+          </Text>
+          <Select
+            data-testid="comments-new-thread-field"
+            value={newThreadFieldPath}
+            onChange={(event) => setNewThreadFieldPath(event.currentTarget.value)}
+          >
+            {FIELDS.map((field) => (
+              <option key={field.value} value={field.value}>
+                {field.label}
+              </option>
+            ))}
+          </Select>
+        </Flex>
         <Composer
           label="Comment"
           testId="comments-new-thread"

--- a/apps/kitchensink-react/src/Comments/CommentsRoute.tsx
+++ b/apps/kitchensink-react/src/Comments/CommentsRoute.tsx
@@ -131,6 +131,14 @@ function Composer({
   )
 }
 
+/**
+ * The author is optional: the organization store records it server-side rather
+ * than on the document, so it can genuinely be absent.
+ */
+function authorLabel(comment: Comment): string {
+  return comment.authorId ?? 'unknown author'
+}
+
 function CommentRow({
   comment,
   onSelect,
@@ -146,7 +154,7 @@ function CommentRow({
       <Stack space={3}>
         <Flex align="center" gap={2}>
           <Code size={0} data-testid="comment-author">
-            {comment.authorId}
+            {authorLabel(comment)}
           </Code>
           {comment.lastEditedAt ? <Badge tone="caution">edited</Badge> : null}
           {comment.state ? <Badge tone="critical">{comment.state.type}</Badge> : null}

--- a/apps/kitchensink-react/src/Comments/CommentsRoute.tsx
+++ b/apps/kitchensink-react/src/Comments/CommentsRoute.tsx
@@ -1,5 +1,5 @@
 import {
-  type CommentDocument,
+  type Comment,
   type CommentMessage,
   type CommentStatus,
   type CommentThread,
@@ -136,21 +136,21 @@ function CommentRow({
   comment,
   onSelect,
 }: {
-  comment: CommentDocument
-  onSelect: (comment: CommentDocument) => void
+  comment: Comment
+  onSelect: (comment: Comment) => void
 }): JSX.Element {
   const {updateComment, removeComment} = useCommentActions()
   const [editing, setEditing] = useState(false)
 
   return (
-    <Card padding={3} radius={2} border data-testid="comment" data-comment-id={comment._id}>
+    <Card padding={3} radius={2} border data-testid="comment" data-comment-id={comment.id}>
       <Stack space={3}>
         <Flex align="center" gap={2}>
           <Code size={0} data-testid="comment-author">
             {comment.authorId}
           </Code>
           {comment.lastEditedAt ? <Badge tone="caution">edited</Badge> : null}
-          {comment._state ? <Badge tone="critical">{comment._state.type}</Badge> : null}
+          {comment.state ? <Badge tone="critical">{comment.state.type}</Badge> : null}
         </Flex>
 
         {editing ? (
@@ -160,7 +160,7 @@ function CommentRow({
             initialValue={toPlainText(comment.message)}
             onCancel={() => setEditing(false)}
             onSubmit={(text) => {
-              updateComment({commentId: comment._id, message: toMessage(text)})
+              updateComment({commentId: comment.id, message: toMessage(text)})
               setEditing(false)
             }}
           />
@@ -182,7 +182,7 @@ function CommentRow({
             mode="bleed"
             tone="critical"
             text="Delete"
-            onClick={() => removeComment({commentId: comment._id})}
+            onClick={() => removeComment({commentId: comment.id})}
           />
           <Button
             data-testid="comment-inspect"
@@ -205,7 +205,7 @@ function ThreadCard({
   thread: CommentThread
   documentId: string
   perspective: Perspective
-  onSelect: (comment: CommentDocument) => void
+  onSelect: (comment: Comment) => void
 }): JSX.Element {
   const {replyToComment, setCommentStatus} = useCommentActions()
   const display = thread.status === 'resolved' ? RESOLVED_DISPLAY : OPEN_DISPLAY
@@ -233,7 +233,7 @@ function ThreadCard({
             text={display.action}
             onClick={() =>
               setCommentStatus({
-                commentId: thread.parentComment._id,
+                commentId: thread.parentComment.id,
                 status: display.nextStatus,
               })
             }
@@ -243,7 +243,7 @@ function ThreadCard({
         <CommentRow comment={thread.parentComment} onSelect={onSelect} />
 
         {thread.replies.map((reply) => (
-          <Box key={reply._id} paddingLeft={4}>
+          <Box key={reply.id} paddingLeft={4}>
             <CommentRow comment={reply} onSelect={onSelect} />
           </Box>
         ))}
@@ -256,7 +256,7 @@ function ThreadCard({
               documentId,
               documentType: DOCUMENT_TYPE,
               perspective,
-              parentCommentId: thread.parentComment._id,
+              parentCommentId: thread.parentComment.id,
               message: toMessage(text),
             })
           }
@@ -277,7 +277,7 @@ function ThreadList({
   perspective: Perspective
   fieldPath: string | undefined
   status: StatusFilter
-  onSelect: (comment: CommentDocument) => void
+  onSelect: (comment: Comment) => void
 }): JSX.Element {
   const {threads, isPending} = useCommentThreads({
     documentId,
@@ -426,7 +426,7 @@ function DocumentCard({
  * The most useful thing on this page for checking interop: put it beside a
  * Studio-written comment and the `target` objects should match field for field.
  */
-function Inspector({comment}: {comment: CommentDocument | undefined}): JSX.Element | null {
+function Inspector({comment}: {comment: Comment | undefined}): JSX.Element | null {
   if (!comment) return null
 
   return (
@@ -448,7 +448,7 @@ function CommentsDemo({documentId}: {documentId: string}): JSX.Element {
   const [perspective, setPerspective] = useState<Perspective>('drafts')
   const [fieldPath, setFieldPath] = useState<string | undefined>(undefined)
   const [status, setStatus] = useState<StatusFilter>('all')
-  const [selected, setSelected] = useState<CommentDocument | undefined>(undefined)
+  const [selected, setSelected] = useState<Comment | undefined>(undefined)
   const {createComment} = useCommentActions()
 
   const studioBase = searchParams.get('studio') ?? DEFAULT_STUDIO_BASE_URL

--- a/packages/@repo/e2e/src/helpers/pageContext.ts
+++ b/packages/@repo/e2e/src/helpers/pageContext.ts
@@ -1,6 +1,7 @@
 import {type FrameLocator, type Page} from '@playwright/test'
 
 /**
+ * @internal
  * Unified interface for detecting elements in pages whether in iframe or not.
  * Methods delegate to either Page or FrameLocator depending on context,
  * and all arguments (including options like {exact: true}) are forwarded.

--- a/packages/@repo/e2e/src/index.ts
+++ b/packages/@repo/e2e/src/index.ts
@@ -105,4 +105,5 @@ export const createPlaywrightConfig = (
 
 // Export test fixtures
 export {test} from './fixtures'
+export {type PageContext} from './helpers/pageContext'
 export {expect} from '@playwright/test'

--- a/packages/@repo/e2e/src/scripts/cleanup-datasets.ts
+++ b/packages/@repo/e2e/src/scripts/cleanup-datasets.ts
@@ -1,12 +1,62 @@
 #!/usr/bin/env node
 
 /* eslint-disable no-console */
+import {type SanityClient} from '@sanity/client'
+
 import {getClient} from '../helpers/clients'
 import {getE2EEnv} from '../helpers/getE2EEnv'
 import {sanitizeDatasetName} from '../helpers/sanitizeDatasetName'
 import {startTimer} from '../helpers/timer'
 
 const env = getE2EEnv()
+
+/**
+ * The comments add-on paired to a dataset, when a run wrote a comment.
+ *
+ * Writing the first comment on a dataset creates one of these, so any spec that
+ * exercises comments leaves one behind. The name cannot be derived: the suffix
+ * is best-effort and shortens for longer dataset names, so it has to come from
+ * the same query the SDK discovers it with.
+ */
+async function findCommentsAddon(
+  client: SanityClient,
+  dataset: string,
+): Promise<string | undefined> {
+  try {
+    const datasets = await client.request<{name: string}[] | undefined>({
+      uri: `/projects/${env.SANITY_APP_E2E_PROJECT_ID}/datasets?datasetProfile=comments&addonFor=${dataset}`,
+    })
+    return datasets?.[0]?.name
+  } catch (error) {
+    console.error(`Failed to look up the comments add-on for ${dataset}:`, error)
+    return undefined
+  }
+}
+
+async function deleteDataset(client: SanityClient, label: string, name: string): Promise<void> {
+  try {
+    await client.datasets.delete(name)
+    console.log(`Successfully deleted ${label} ${name}`)
+  } catch (error) {
+    console.error(`Failed to delete ${label} ${name}:`, error)
+  }
+}
+
+/**
+ * Deletes a run's dataset and the comments add-on paired to it.
+ *
+ * The add-on goes first. It is only findable through `addonFor=<parent>`, so
+ * deleting the parent first risks leaving one behind with no way left to
+ * identify it. Add-on datasets are free and off-quota, which is exactly why an
+ * orphan would sit there unnoticed.
+ */
+async function deleteWithAddon(client: SanityClient, label: string, dataset: string) {
+  const addon = await findCommentsAddon(client, dataset)
+  if (addon) {
+    await deleteDataset(client, `${label} comments add-on`, addon)
+  }
+  await deleteDataset(client, label, dataset)
+}
 
 // must be run as a separate script to avoid race conditions with the tests
 async function cleanupDatasets() {
@@ -22,21 +72,8 @@ async function cleanupDatasets() {
   const timer = startTimer('Cleaning up test datasets')
 
   try {
-    // Delete primary dataset
-    try {
-      await client.datasets.delete(primaryDataset)
-      console.log(`Successfully deleted primary dataset ${primaryDataset}`)
-    } catch (error) {
-      console.error(`Failed to delete primary dataset ${primaryDataset}:`, error)
-    }
-
-    // Delete secondary dataset
-    try {
-      await client.datasets.delete(secondaryDataset)
-      console.log(`Successfully deleted secondary dataset ${secondaryDataset}`)
-    } catch (error) {
-      console.error(`Failed to delete secondary dataset ${secondaryDataset}:`, error)
-    }
+    await deleteWithAddon(client, 'primary dataset', primaryDataset)
+    await deleteWithAddon(client, 'secondary dataset', secondaryDataset)
 
     timer.end()
   } catch (error) {

--- a/packages/core/src/_exports/_internal.ts
+++ b/packages/core/src/_exports/_internal.ts
@@ -6,6 +6,7 @@ export {
   getClientErrorApiType,
   isProjectUserNotFoundClientError,
 } from '../auth/utils'
+export {getCommentsOptionsKey, parseCommentsOptionsKey} from '../comments/commentsStore' // only used for memoizing in React, not needed for actual functionality
 export {PREVIEW_PROJECTION} from '../preview/previewConstants'
 export {transformProjectionToPreview} from '../preview/previewProjectionUtils'
 export {getQueryKey, parseQueryKey} from '../query/queryStore' // only used for memoizing in React, not needed for actual functionality

--- a/packages/core/src/comments/commentsStore.test.ts
+++ b/packages/core/src/comments/commentsStore.test.ts
@@ -8,8 +8,10 @@ import {createSanityInstance, type SanityInstance} from '../store/createSanityIn
 import {observeAddonDatasetClient} from './addonDatasetStore'
 import {
   commentsStore,
+  getCommentsOptionsKey,
   getCommentsState,
   getCommentThreadsState,
+  parseCommentsOptionsKey,
   resolveComments,
 } from './commentsStore'
 import {setPendingTransaction} from './reducers'
@@ -91,6 +93,37 @@ beforeEach(() => {
 
 afterEach(() => {
   instance.dispose()
+})
+
+describe('getCommentsOptionsKey', () => {
+  it('round-trips the options it is given', () => {
+    const options = {
+      ...HANDLE,
+      perspective: {releaseName: 'summer'},
+      fieldPath: 'title',
+      status: 'resolved' as const,
+    }
+
+    expect(parseCommentsOptionsKey(getCommentsOptionsKey(options))).toEqual(options)
+  })
+
+  it('gives a path array and its string form the same key', () => {
+    expect(
+      getCommentsOptionsKey({...HANDLE, fieldPath: ['body', {_key: 'intro'}, 'content']}),
+    ).toBe(getCommentsOptionsKey({...HANDLE, fieldPath: 'body[_key=="intro"].content'}))
+  })
+
+  it('separates lists that differ only by filter', () => {
+    const keys = new Set([
+      getCommentsOptionsKey(HANDLE),
+      getCommentsOptionsKey({...HANDLE, fieldPath: ''}),
+      getCommentsOptionsKey({...HANDLE, fieldPath: 'title'}),
+      getCommentsOptionsKey({...HANDLE, status: 'open'}),
+      getCommentsOptionsKey({...HANDLE, documentId: 'doc-2'}),
+    ])
+
+    expect(keys.size).toBe(5)
+  })
 })
 
 describe('getCommentsState', () => {

--- a/packages/core/src/comments/commentsStore.ts
+++ b/packages/core/src/comments/commentsStore.ts
@@ -71,6 +71,51 @@ export interface ResolveCommentsOptions extends CommentsOptions {
 }
 
 /**
+ * Fields on {@link CommentsOptions} that are deliberately left out of the key
+ * below, because neither changes which comments an option set addresses.
+ *
+ * `source` is the deprecated alias for `resource` and is folded into it before
+ * a key is ever built, so keying on both would give one list two keys.
+ * `liveEdit` describes the document rather than its comments, which hang off
+ * the published id whether or not drafts exist.
+ */
+type CommentsKeyIrrelevantField = 'source' | 'liveEdit'
+
+/**
+ * A stable string standing for one set of read options.
+ *
+ * Only React needs this: it holds one state source steady across renders and
+ * defers swapping to a new one while the previous list is still on screen.
+ * `fieldPath` is normalised on the way in, so a path array and the equivalent
+ * string address the same list.
+ *
+ * @internal
+ */
+export function getCommentsOptionsKey(options: CommentsOptions): string {
+  return JSON.stringify({
+    documentId: options.documentId,
+    documentType: options.documentType,
+    projectId: options.projectId,
+    dataset: options.dataset,
+    resource: options.resource,
+    perspective: options.perspective,
+    fieldPath: options.fieldPath === undefined ? undefined : toCommentFieldPath(options.fieldPath),
+    status: options.status,
+    // The `Record` half makes a new field on `CommentsOptions` a compile
+    // error here unless it is listed above or named as irrelevant. Left to
+    // `satisfies CommentsOptions` alone, a forgotten field would just be
+    // absent from the key, and a reader would keep the list it had while the
+    // caller thought it had asked for a different one.
+  } satisfies CommentsOptions &
+    Record<Exclude<keyof CommentsOptions, CommentsKeyIrrelevantField>, unknown>)
+}
+
+/** @internal */
+export function parseCommentsOptionsKey(key: string): CommentsOptions {
+  return JSON.parse(key) as CommentsOptions
+}
+
+/**
  * Which comment list an option set addresses.
  *
  * Comments hang off the published id, so a draft and its published document

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -45,6 +45,9 @@ export {
   type WindowConnection,
   type WindowMessageHandler,
 } from '../hooks/comlink/useWindowConnection'
+export {type CommentActions, useCommentActions} from '../hooks/comments/useCommentActions'
+export {useComments, type UseCommentsResult} from '../hooks/comments/useComments'
+export {useCommentThreads, type UseCommentThreadsResult} from '../hooks/comments/useCommentThreads'
 export {useResource} from '../hooks/context/useResource'
 export {useSanityInstance} from '../hooks/context/useSanityInstance'
 export {useDashboardNavigate} from '../hooks/dashboard/useDashboardNavigate'

--- a/packages/react/src/hooks/comments/useCommentActions.test.tsx
+++ b/packages/react/src/hooks/comments/useCommentActions.test.tsx
@@ -26,6 +26,9 @@ vi.mock('@sanity/sdk', async (importOriginal) => {
 
 const HANDLE = {documentId: 'doc-1', documentType: 'author'}
 
+/** Creates name a field, since a comment with no path is refused. */
+const CREATE = {...HANDLE, fieldPath: 'name'}
+
 // Hoisted: an inline object here would be a new value on every render, and the
 // callbacks are memoised against it.
 const RESOURCES = {other: {projectId: 'p2', dataset: 'd2'}}
@@ -70,7 +73,7 @@ describe('useCommentActions', () => {
   it('forwards each action to the store', () => {
     const {result} = setup()
 
-    result.current.createComment({...HANDLE, message: null})
+    result.current.createComment({...CREATE, message: null})
     result.current.replyToComment({...HANDLE, parentCommentId: 'p1', message: null})
     result.current.updateComment({commentId: 'c1', message: null})
     result.current.setCommentStatus({commentId: 'c1', status: 'resolved'})
@@ -86,7 +89,7 @@ describe('useCommentActions', () => {
   it('fills in the resource from context', () => {
     const {result} = setup()
 
-    result.current.createComment({...HANDLE, message: null})
+    result.current.createComment({...CREATE, message: null})
 
     expect(createComment).toHaveBeenCalledWith(
       expect.anything(),
@@ -121,7 +124,7 @@ describe('useCommentActions', () => {
     // reports an error.
     const {result} = setup(PerspectiveWrapper)
 
-    result.current.createComment({...HANDLE, message: null})
+    result.current.createComment({...CREATE, message: null})
     result.current.replyToComment({...HANDLE, parentCommentId: 'p1', message: null})
 
     expect(createComment).toHaveBeenCalledWith(
@@ -137,7 +140,7 @@ describe('useCommentActions', () => {
   it('lets a call override the perspective from context', () => {
     const {result} = setup(PerspectiveWrapper)
 
-    result.current.createComment({...HANDLE, message: null, perspective: 'published'})
+    result.current.createComment({...CREATE, message: null, perspective: 'published'})
 
     expect(createComment).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/react/src/hooks/comments/useCommentActions.test.tsx
+++ b/packages/react/src/hooks/comments/useCommentActions.test.tsx
@@ -1,0 +1,147 @@
+import {
+  createComment,
+  removeComment,
+  replyToComment,
+  setCommentStatus,
+  updateComment,
+} from '@sanity/sdk'
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {ResourceProvider} from '../../context/ResourceProvider'
+import {ResourcesContext} from '../../context/ResourcesContext'
+import {useCommentActions} from './useCommentActions'
+
+vi.mock('@sanity/sdk', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sanity/sdk')>()
+  return {
+    ...original,
+    createComment: vi.fn(),
+    replyToComment: vi.fn(),
+    updateComment: vi.fn(),
+    setCommentStatus: vi.fn(),
+    removeComment: vi.fn(),
+  }
+})
+
+const HANDLE = {documentId: 'doc-1', documentType: 'author'}
+
+// Hoisted: an inline object here would be a new value on every render, and the
+// callbacks are memoised against it.
+const RESOURCES = {other: {projectId: 'p2', dataset: 'd2'}}
+
+/** Hoisted for the same reason as `RESOURCES`. */
+const RELEASE_PERSPECTIVE = {releaseName: 'summer'}
+
+function Wrapper({children}: {children: React.ReactNode}) {
+  return (
+    <ResourceProvider projectId="p" dataset="d" fallback={null}>
+      <ResourcesContext.Provider value={RESOURCES}>{children}</ResourcesContext.Provider>
+    </ResourceProvider>
+  )
+}
+
+function PerspectiveWrapper({children}: {children: React.ReactNode}) {
+  return (
+    <ResourceProvider projectId="p" dataset="d" perspective={RELEASE_PERSPECTIVE} fallback={null}>
+      <ResourcesContext.Provider value={RESOURCES}>{children}</ResourcesContext.Provider>
+    </ResourceProvider>
+  )
+}
+
+function setup(wrapper: typeof Wrapper = Wrapper) {
+  return renderHook(() => useCommentActions(), {wrapper})
+}
+
+describe('useCommentActions', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('keeps the callbacks stable across renders', () => {
+    const {result, rerender} = setup()
+    const first = result.current
+
+    rerender()
+
+    expect(result.current).toBe(first)
+  })
+
+  it('forwards each action to the store', () => {
+    const {result} = setup()
+
+    result.current.createComment({...HANDLE, message: null})
+    result.current.replyToComment({...HANDLE, parentCommentId: 'p1', message: null})
+    result.current.updateComment({commentId: 'c1', message: null})
+    result.current.setCommentStatus({commentId: 'c1', status: 'resolved'})
+    result.current.removeComment({commentId: 'c1'})
+
+    expect(createComment).toHaveBeenCalledOnce()
+    expect(replyToComment).toHaveBeenCalledOnce()
+    expect(updateComment).toHaveBeenCalledOnce()
+    expect(setCommentStatus).toHaveBeenCalledOnce()
+    expect(removeComment).toHaveBeenCalledOnce()
+  })
+
+  it('fills in the resource from context', () => {
+    const {result} = setup()
+
+    result.current.createComment({...HANDLE, message: null})
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({resource: {projectId: 'p', dataset: 'd'}}),
+    )
+  })
+
+  it('lets a call choose a different named resource', () => {
+    // Resolution happens per call, so one set of callbacks serves several
+    // resources.
+    const {result} = setup()
+
+    result.current.removeComment({commentId: 'c1', resourceName: 'other'})
+
+    expect(removeComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({resource: {projectId: 'p2', dataset: 'd2'}}),
+    )
+  })
+
+  it('rejects a call naming a resource that is not in context', () => {
+    const {result} = setup()
+
+    expect(() => result.current.removeComment({commentId: 'c1', resourceName: 'missing'})).toThrow(
+      /no resource named "missing"/,
+    )
+  })
+
+  it('fills in the perspective from context', () => {
+    // Core turns a release perspective into `target.documentVersionId`, so
+    // losing it here files the comment against the wrong release and nothing
+    // reports an error.
+    const {result} = setup(PerspectiveWrapper)
+
+    result.current.createComment({...HANDLE, message: null})
+    result.current.replyToComment({...HANDLE, parentCommentId: 'p1', message: null})
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({perspective: RELEASE_PERSPECTIVE}),
+    )
+    expect(replyToComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({perspective: RELEASE_PERSPECTIVE}),
+    )
+  })
+
+  it('lets a call override the perspective from context', () => {
+    const {result} = setup(PerspectiveWrapper)
+
+    result.current.createComment({...HANDLE, message: null, perspective: 'published'})
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({perspective: 'published'}),
+    )
+  })
+})

--- a/packages/react/src/hooks/comments/useCommentActions.ts
+++ b/packages/react/src/hooks/comments/useCommentActions.ts
@@ -1,0 +1,113 @@
+import {
+  type CommentDocument,
+  createComment,
+  type CreateCommentOptions,
+  type DocumentResource,
+  type PerspectiveHandle,
+  removeComment,
+  type RemoveCommentOptions,
+  replyToComment,
+  type ReplyToCommentOptions,
+  setCommentStatus,
+  type SetCommentStatusOptions,
+  updateComment,
+  type UpdateCommentOptions,
+} from '@sanity/sdk'
+import {useContext, useMemo} from 'react'
+
+import {PerspectiveContext} from '../../context/PerspectiveContext'
+import {ResourcesContext} from '../../context/ResourcesContext'
+import {useSanityInstance} from '../context/useSanityInstance'
+import {
+  normalizeResourceOptions,
+  useEffectiveContextResource,
+  type WithResourceNameSupport,
+} from '../helpers/useNormalizedResourceOptions'
+import {trackHookUsage} from '../helpers/useTrackHookUsage'
+
+/**
+ * @public
+ * @category Types
+ */
+export interface CommentActions {
+  /** Starts a thread on a document, or on one of its fields. */
+  createComment: (
+    options: WithResourceNameSupport<CreateCommentOptions>,
+  ) => Promise<CommentDocument>
+  /** Adds a reply to an existing thread. */
+  replyToComment: (
+    options: WithResourceNameSupport<ReplyToCommentOptions>,
+  ) => Promise<CommentDocument>
+  /** Rewrites a comment's message. */
+  updateComment: (options: WithResourceNameSupport<UpdateCommentOptions>) => Promise<void>
+  /** Resolves or reopens a thread. Pass the thread's first comment. */
+  setCommentStatus: (options: WithResourceNameSupport<SetCommentStatusOptions>) => Promise<void>
+  /** Deletes a comment, and its replies when it starts a thread. */
+  removeComment: (options: WithResourceNameSupport<RemoveCommentOptions>) => Promise<void>
+}
+
+type Resolvable = {
+  resource?: DocumentResource
+  resourceName?: string
+  projectId?: string
+  dataset?: string
+  perspective?: PerspectiveHandle['perspective']
+}
+
+/**
+ * Returns the five comment write actions, bound to the current instance.
+ *
+ * Each writes optimistically: the change shows immediately and is rolled back
+ * if the server rejects it, so an app can render straight from
+ * {@link useComments} without tracking pending state itself.
+ *
+ * Creating is the exception, and `replyToComment` counts as creating. A comment
+ * that fails to post stays on screen carrying `_state.createError` rather than
+ * disappearing, so passing the same `commentId` again retries it instead of
+ * losing what someone typed.
+ *
+ * The resource is resolved when an action is called rather than when the hook
+ * runs, so one set of callbacks works across several resources. Pass `resource`
+ * or `resourceName` per call to choose; otherwise the surrounding
+ * `ResourceProvider` decides.
+ *
+ * @category Comments
+ * @function
+ * @returns The five write actions
+ *
+ * @example Resolve a thread
+ * ```tsx
+ * function ResolveButton({commentId}: {commentId: string}) {
+ *   const {setCommentStatus} = useCommentActions()
+ *
+ *   return (
+ *     <button onClick={() => setCommentStatus({commentId, status: 'resolved'})}>
+ *       Resolve
+ *     </button>
+ *   )
+ * }
+ * ```
+ *
+ * @public
+ */
+export function useCommentActions(): CommentActions {
+  const instance = useSanityInstance()
+  trackHookUsage(instance, 'useCommentActions')
+
+  const resources = useContext(ResourcesContext)
+  const contextResource = useEffectiveContextResource()
+  const contextPerspective = useContext(PerspectiveContext)
+
+  return useMemo(() => {
+    const resolve = <T extends Resolvable>(options: T) =>
+      normalizeResourceOptions(options, resources, contextResource, contextPerspective)
+
+    return {
+      createComment: (options) => createComment(instance, resolve(options)),
+      replyToComment: (options) => replyToComment(instance, resolve(options)),
+      updateComment: (options) => updateComment(instance, resolve(options)),
+      setCommentStatus: (options) => setCommentStatus(instance, resolve(options)),
+      removeComment: (options) => removeComment(instance, resolve(options)),
+    }
+  }, [contextPerspective, contextResource, instance, resources])
+}

--- a/packages/react/src/hooks/comments/useCommentActions.ts
+++ b/packages/react/src/hooks/comments/useCommentActions.ts
@@ -1,5 +1,5 @@
 import {
-  type CommentDocument,
+  type Comment,
   createComment,
   type CreateCommentOptions,
   type DocumentResource,
@@ -31,13 +31,9 @@ import {trackHookUsage} from '../helpers/useTrackHookUsage'
  */
 export interface CommentActions {
   /** Starts a thread on a document, or on one of its fields. */
-  createComment: (
-    options: WithResourceNameSupport<CreateCommentOptions>,
-  ) => Promise<CommentDocument>
+  createComment: (options: WithResourceNameSupport<CreateCommentOptions>) => Promise<Comment>
   /** Adds a reply to an existing thread. */
-  replyToComment: (
-    options: WithResourceNameSupport<ReplyToCommentOptions>,
-  ) => Promise<CommentDocument>
+  replyToComment: (options: WithResourceNameSupport<ReplyToCommentOptions>) => Promise<Comment>
   /** Rewrites a comment's message. */
   updateComment: (options: WithResourceNameSupport<UpdateCommentOptions>) => Promise<void>
   /** Resolves or reopens a thread. Pass the thread's first comment. */

--- a/packages/react/src/hooks/comments/useCommentList.ts
+++ b/packages/react/src/hooks/comments/useCommentList.ts
@@ -1,0 +1,79 @@
+import {type CommentsOptions, type SanityInstance, type StateSource} from '@sanity/sdk'
+import {getCommentsOptionsKey, parseCommentsOptionsKey} from '@sanity/sdk/_internal'
+import {useEffect, useMemo, useRef, useState, useSyncExternalStore, useTransition} from 'react'
+
+import {useSanityInstance} from '../context/useSanityInstance'
+import {
+  useNormalizedResourceOptions,
+  type WithResourceNameSupport,
+} from '../helpers/useNormalizedResourceOptions'
+import {trackHookUsage} from '../helpers/useTrackHookUsage'
+
+/** The pair of core functions backing one read hook. */
+export interface CommentListSource<T> {
+  getState: (instance: SanityInstance, options: CommentsOptions) => StateSource<T | undefined>
+  resolve: (
+    instance: SanityInstance,
+    options: CommentsOptions & {signal?: AbortSignal},
+  ) => Promise<T>
+}
+
+/**
+ * Shared body of {@link useComments} and {@link useCommentThreads}.
+ *
+ * Suspends until the first snapshot arrives. Changing documents or filters
+ * happens in a transition, so the list already on screen stays put and
+ * `isPending` reports the swap instead of the component suspending again. The
+ * previous read is aborted, which drops its listener when nothing else is
+ * reading it.
+ *
+ * @internal
+ */
+export function useCommentList<T>(
+  hookName: string,
+  options: WithResourceNameSupport<CommentsOptions>,
+  {getState, resolve}: CommentListSource<T>,
+): {value: T; isPending: boolean} {
+  const instance = useSanityInstance()
+  trackHookUsage(instance, hookName)
+
+  const normalized = useNormalizedResourceOptions(options)
+  const [isPending, startTransition] = useTransition()
+
+  const key = getCommentsOptionsKey(normalized)
+  // Held one render behind `key`, so the swap can happen inside a transition.
+  const [deferredKey, setDeferredKey] = useState(key)
+  const abortRef = useRef<AbortController>(new AbortController())
+
+  useEffect(() => {
+    if (key === deferredKey) return
+
+    startTransition(() => {
+      if (!abortRef.current.signal.aborted) {
+        abortRef.current.abort()
+        abortRef.current = new AbortController()
+      }
+      setDeferredKey(key)
+    })
+  }, [deferredKey, key])
+
+  const deferred = useMemo(() => parseCommentsOptionsKey(deferredKey), [deferredKey])
+  const {getCurrent, subscribe} = useMemo(
+    () => getState(instance, deferred),
+    [deferred, getState, instance],
+  )
+
+  if (getCurrent() === undefined) {
+    // Reading the ref mid-render is safe here: React runs no effects for a
+    // render that suspends, so the signal captured now cannot be swapped
+    // underneath this pass.
+    const currentSignal = abortRef.current.signal
+
+    // eslint-disable-next-line react-hooks/refs -- intentional during a suspended render; see above
+    throw resolve(instance, {...deferred, signal: currentSignal})
+  }
+
+  // Not memoised: both callers destructure this immediately and memoise their
+  // own result object, so a stable identity here would never be observed.
+  return {value: useSyncExternalStore(subscribe, getCurrent) as T, isPending}
+}

--- a/packages/react/src/hooks/comments/useCommentThreads.test.tsx
+++ b/packages/react/src/hooks/comments/useCommentThreads.test.tsx
@@ -1,0 +1,107 @@
+import {
+  type CommentThread,
+  getCommentThreadsState,
+  resolveCommentThreads,
+  type StateSource,
+} from '@sanity/sdk'
+import {act, render, screen} from '@testing-library/react'
+import {Suspense} from 'react'
+import {type Observable} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {ResourceProvider} from '../../context/ResourceProvider'
+import {useCommentThreads} from './useCommentThreads'
+
+vi.mock('@sanity/sdk', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sanity/sdk')>()
+  return {...original, getCommentThreadsState: vi.fn(), resolveCommentThreads: vi.fn()}
+})
+
+const HANDLE = {documentId: 'doc-1', documentType: 'author'}
+
+function thread(threadId: string) {
+  return {threadId, commentsCount: 2, fieldPath: ''} as CommentThread
+}
+
+function mockSource(getCurrent: () => CommentThread[] | undefined) {
+  vi.mocked(getCommentThreadsState).mockReturnValue({
+    getCurrent,
+    subscribe: vi.fn(() => () => {}),
+    get observable(): Observable<CommentThread[] | undefined> {
+      throw new Error('Not implemented')
+    },
+  } as StateSource<CommentThread[] | undefined>)
+}
+
+function Wrapper({children}: {children: React.ReactNode}) {
+  return (
+    <ResourceProvider projectId="p" dataset="d" fallback={<p>Loading…</p>}>
+      <Suspense fallback={<p data-testid="suspended">Suspended</p>}>{children}</Suspense>
+    </ResourceProvider>
+  )
+}
+
+describe('useCommentThreads', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('renders the threads once they are loaded', () => {
+    const loaded = [thread('t1'), thread('t2')]
+    mockSource(() => loaded)
+
+    function TestComponent() {
+      const {threads, isPending} = useCommentThreads(HANDLE)
+      return <div data-testid="out">{`${threads.length} ${isPending ? 'pending' : 'idle'}`}</div>
+    }
+
+    render(<TestComponent />, {wrapper: Wrapper})
+
+    expect(screen.getByTestId('out').textContent).toBe('2 idle')
+  })
+
+  it('suspends until the threads are available', async () => {
+    const loaded = [thread('t1')]
+    const ref: {current: CommentThread[] | undefined} = {current: undefined}
+    mockSource(() => ref.current)
+
+    let settle: () => void = () => {}
+    vi.mocked(resolveCommentThreads).mockReturnValue(
+      new Promise<CommentThread[]>((resolve) => {
+        settle = () => resolve(loaded)
+      }),
+    )
+
+    function TestComponent() {
+      const {threads} = useCommentThreads(HANDLE)
+      return <div data-testid="out">{threads.length}</div>
+    }
+
+    render(<TestComponent />, {wrapper: Wrapper})
+    expect(screen.getByTestId('suspended')).toBeInTheDocument()
+
+    await act(async () => {
+      ref.current = loaded
+      settle()
+    })
+
+    expect(screen.getByTestId('out').textContent).toBe('1')
+  })
+
+  it('narrows to one field when asked', () => {
+    const loaded: CommentThread[] = []
+    mockSource(() => loaded)
+
+    function TestComponent() {
+      useCommentThreads({...HANDLE, fieldPath: 'title'})
+      return null
+    }
+
+    render(<TestComponent />, {wrapper: Wrapper})
+
+    expect(getCommentThreadsState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({fieldPath: 'title'}),
+    )
+  })
+})

--- a/packages/react/src/hooks/comments/useCommentThreads.ts
+++ b/packages/react/src/hooks/comments/useCommentThreads.ts
@@ -1,0 +1,73 @@
+import {
+  type CommentsOptions,
+  type CommentThread,
+  getCommentThreadsState,
+  resolveCommentThreads,
+} from '@sanity/sdk'
+import {useMemo} from 'react'
+
+import {type WithResourceNameSupport} from '../helpers/useNormalizedResourceOptions'
+import {type CommentListSource, useCommentList} from './useCommentList'
+
+/**
+ * @public
+ * @category Types
+ */
+export interface UseCommentThreadsResult {
+  /** Newest thread first, each with its replies oldest first. */
+  threads: CommentThread[]
+  /** True while switching to a different document or filter. */
+  isPending: boolean
+}
+
+const SOURCE: CommentListSource<CommentThread[]> = {
+  getState: getCommentThreadsState,
+  resolve: resolveCommentThreads,
+}
+
+/**
+ * Reads a document's comments grouped into threads.
+ *
+ * A thread is one comment plus its replies. Its `status` and `fieldPath` come
+ * from the first comment, so filtering by either selects whole threads rather
+ * than stray replies.
+ *
+ * Unlike the Studio, every thread is returned. The Studio hides threads whose
+ * field has left the schema or is hidden by a conditional, which it can do
+ * because it has the schema to check against. Inspect `fieldPath` yourself if
+ * your app needs to do the same.
+ *
+ * @category Comments
+ * @function
+ * @param options - The document to read, optionally narrowed by `fieldPath` or `status`
+ * @returns The matching threads, and whether a switch is in flight
+ *
+ * @example Render the open threads on a document
+ * ```tsx
+ * function Threads({documentId}: {documentId: string}) {
+ *   const {threads} = useCommentThreads({
+ *     documentId,
+ *     documentType: 'article',
+ *     status: 'open',
+ *   })
+ *
+ *   return (
+ *     <ul>
+ *       {threads.map((thread) => (
+ *         <li key={thread.threadId}>
+ *           {thread.fieldPath || 'Document'} — {thread.commentsCount} comments
+ *         </li>
+ *       ))}
+ *     </ul>
+ *   )
+ * }
+ * ```
+ *
+ * @public
+ */
+export function useCommentThreads(
+  options: WithResourceNameSupport<CommentsOptions>,
+): UseCommentThreadsResult {
+  const {value, isPending} = useCommentList('useCommentThreads', options, SOURCE)
+  return useMemo(() => ({threads: value, isPending}), [isPending, value])
+}

--- a/packages/react/src/hooks/comments/useComments.test.tsx
+++ b/packages/react/src/hooks/comments/useComments.test.tsx
@@ -1,0 +1,231 @@
+import {
+  type CommentDocument,
+  type CommentsOptions,
+  getCommentsState,
+  resolveComments,
+  type StateSource,
+} from '@sanity/sdk'
+import {act, render, screen} from '@testing-library/react'
+import {Suspense} from 'react'
+import {type Observable, Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {ResourceProvider} from '../../context/ResourceProvider'
+import {ResourcesContext} from '../../context/ResourcesContext'
+import {useComments} from './useComments'
+
+vi.mock('@sanity/sdk', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sanity/sdk')>()
+  return {...original, getCommentsState: vi.fn(), resolveComments: vi.fn()}
+})
+
+const HANDLE = {documentId: 'doc-1', documentType: 'author'}
+
+function comment(id: string) {
+  return {_id: id, message: null} as CommentDocument
+}
+
+/**
+ * Stands in for the store, one source per option set so a test can hold one
+ * document loaded and another not.
+ *
+ * `getCurrent` must hand back the same array every call for a given option set.
+ * Returning a fresh one sends `useSyncExternalStore` into a render loop, which
+ * is why the store memoises its selectors.
+ */
+function mockSource(
+  getCurrent: (options: CommentsOptions) => CommentDocument[] | undefined,
+  changed$?: Subject<void>,
+) {
+  vi.mocked(getCommentsState).mockImplementation(
+    (_instance, options) =>
+      ({
+        getCurrent: () => getCurrent(options),
+        subscribe: vi.fn((cb?: () => void) => {
+          const subscription = changed$?.subscribe(() => cb?.())
+          return () => subscription?.unsubscribe()
+        }),
+        get observable(): Observable<CommentDocument[] | undefined> {
+          throw new Error('Not implemented')
+        },
+      }) as StateSource<CommentDocument[] | undefined>,
+  )
+}
+
+/** Hoisted so the context value stays identical across renders. */
+const RELEASE_PERSPECTIVE = {releaseName: 'summer'}
+
+function Wrapper({children}: {children: React.ReactNode}) {
+  return (
+    <ResourceProvider projectId="p" dataset="d" fallback={<p>Loading…</p>}>
+      <ResourcesContext.Provider value={{other: {projectId: 'p2', dataset: 'd2'}}}>
+        <Suspense fallback={<p data-testid="suspended">Suspended</p>}>{children}</Suspense>
+      </ResourcesContext.Provider>
+    </ResourceProvider>
+  )
+}
+
+function PerspectiveWrapper({children}: {children: React.ReactNode}) {
+  return (
+    <ResourceProvider
+      projectId="p"
+      dataset="d"
+      perspective={RELEASE_PERSPECTIVE}
+      fallback={<p>Loading…</p>}
+    >
+      <Suspense fallback={<p data-testid="suspended">Suspended</p>}>{children}</Suspense>
+    </ResourceProvider>
+  )
+}
+
+describe('useComments', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('renders the comments once they are loaded', () => {
+    const loaded = [comment('a'), comment('b')]
+    mockSource(() => loaded)
+
+    function TestComponent() {
+      const {comments, isPending} = useComments(HANDLE)
+      return <div data-testid="out">{`${comments.length} ${isPending ? 'pending' : 'idle'}`}</div>
+    }
+
+    render(<TestComponent />, {wrapper: Wrapper})
+
+    expect(screen.getByTestId('out').textContent).toBe('2 idle')
+  })
+
+  it('suspends until the first snapshot arrives', async () => {
+    const loaded = [comment('a')]
+    const ref: {current: CommentDocument[] | undefined} = {current: undefined}
+    const changed$ = new Subject<void>()
+    mockSource(() => ref.current, changed$)
+
+    let settle: () => void = () => {}
+    vi.mocked(resolveComments).mockReturnValue(
+      new Promise<CommentDocument[]>((resolve) => {
+        settle = () => resolve(loaded)
+      }),
+    )
+
+    function TestComponent() {
+      const {comments} = useComments(HANDLE)
+      return <div data-testid="out">{comments.length}</div>
+    }
+
+    render(<TestComponent />, {wrapper: Wrapper})
+    expect(screen.getByTestId('suspended')).toBeInTheDocument()
+
+    await act(async () => {
+      ref.current = loaded
+      settle()
+    })
+
+    expect(screen.getByTestId('out').textContent).toBe('1')
+  })
+
+  it('passes the field path and status through to the store', () => {
+    const loaded: CommentDocument[] = []
+    mockSource(() => loaded)
+
+    function TestComponent() {
+      useComments({...HANDLE, fieldPath: ['body', {_key: 'intro'}], status: 'resolved'})
+      return null
+    }
+
+    render(<TestComponent />, {wrapper: Wrapper})
+
+    expect(getCommentsState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        documentId: 'doc-1',
+        fieldPath: 'body[_key=="intro"]',
+        status: 'resolved',
+        resource: {projectId: 'p', dataset: 'd'},
+      }),
+    )
+  })
+
+  it('resolves a named resource from context', () => {
+    const loaded: CommentDocument[] = []
+    mockSource(() => loaded)
+
+    function TestComponent() {
+      useComments({...HANDLE, resourceName: 'other'})
+      return null
+    }
+
+    render(<TestComponent />, {wrapper: Wrapper})
+
+    expect(getCommentsState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({resource: {projectId: 'p2', dataset: 'd2'}}),
+    )
+  })
+
+  it('fills in the perspective from context', () => {
+    // Core turns a release perspective into `target.documentVersionId` and into
+    // the key the list is stored under, so dropping it here would read and
+    // write the wrong release with nothing to show that anything went wrong.
+    const loaded: CommentDocument[] = []
+    mockSource(() => loaded)
+
+    function TestComponent() {
+      useComments(HANDLE)
+      return null
+    }
+
+    render(<TestComponent />, {wrapper: PerspectiveWrapper})
+
+    expect(getCommentsState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({perspective: RELEASE_PERSPECTIVE}),
+    )
+  })
+
+  it('keeps the previous list on screen while a different document loads', async () => {
+    const first = [comment('a')]
+    const second = [comment('b'), comment('c')]
+    // Only `doc-1` is loaded, so switching to `doc-2` has to suspend.
+    const byDocument: Record<string, CommentDocument[] | undefined> = {'doc-1': first}
+    mockSource((options) => byDocument[options.documentId])
+
+    let settle: () => void = () => {}
+    vi.mocked(resolveComments).mockReturnValue(
+      new Promise<CommentDocument[]>((resolve) => {
+        settle = () => resolve(second)
+      }),
+    )
+
+    function TestComponent({documentId}: {documentId: string}) {
+      const {comments, isPending} = useComments({...HANDLE, documentId})
+      return <div data-testid="out">{`${comments.length} ${isPending ? 'pending' : 'idle'}`}</div>
+    }
+
+    const {rerender} = render(<TestComponent documentId="doc-1" />, {wrapper: Wrapper})
+    expect(screen.getByTestId('out').textContent).toBe('1 idle')
+
+    await act(async () => {
+      rerender(<TestComponent documentId="doc-2" />)
+    })
+
+    // The swap happens inside a transition, so the render that suspends is
+    // thrown away rather than falling back: `doc-1` stays on screen and
+    // `isPending` is what reports the switch.
+    expect(screen.queryByTestId('suspended')).not.toBeInTheDocument()
+    expect(screen.getByTestId('out').textContent).toBe('1 pending')
+    expect(getCommentsState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({documentId: 'doc-2'}),
+    )
+
+    await act(async () => {
+      byDocument['doc-2'] = second
+      settle()
+    })
+
+    expect(screen.getByTestId('out').textContent).toBe('2 idle')
+  })
+})

--- a/packages/react/src/hooks/comments/useComments.test.tsx
+++ b/packages/react/src/hooks/comments/useComments.test.tsx
@@ -1,5 +1,5 @@
 import {
-  type CommentDocument,
+  type Comment,
   type CommentsOptions,
   getCommentsState,
   resolveComments,
@@ -21,8 +21,19 @@ vi.mock('@sanity/sdk', async (importOriginal) => {
 
 const HANDLE = {documentId: 'doc-1', documentType: 'author'}
 
-function comment(id: string) {
-  return {_id: id, message: null} as CommentDocument
+function comment(id: string): Comment {
+  return {
+    id,
+    createdAt: '2026-01-01T00:00:00Z',
+    authorId: 'user-1',
+    message: null,
+    threadId: 'thread-1',
+    status: 'open',
+    documentId: 'doc-1',
+    documentType: 'author',
+    fieldPath: '',
+    reactions: [],
+  }
 }
 
 /**
@@ -34,7 +45,7 @@ function comment(id: string) {
  * is why the store memoises its selectors.
  */
 function mockSource(
-  getCurrent: (options: CommentsOptions) => CommentDocument[] | undefined,
+  getCurrent: (options: CommentsOptions) => Comment[] | undefined,
   changed$?: Subject<void>,
 ) {
   vi.mocked(getCommentsState).mockImplementation(
@@ -45,10 +56,10 @@ function mockSource(
           const subscription = changed$?.subscribe(() => cb?.())
           return () => subscription?.unsubscribe()
         }),
-        get observable(): Observable<CommentDocument[] | undefined> {
+        get observable(): Observable<Comment[] | undefined> {
           throw new Error('Not implemented')
         },
-      }) as StateSource<CommentDocument[] | undefined>,
+      }) as StateSource<Comment[] | undefined>,
   )
 }
 
@@ -99,13 +110,13 @@ describe('useComments', () => {
 
   it('suspends until the first snapshot arrives', async () => {
     const loaded = [comment('a')]
-    const ref: {current: CommentDocument[] | undefined} = {current: undefined}
+    const ref: {current: Comment[] | undefined} = {current: undefined}
     const changed$ = new Subject<void>()
     mockSource(() => ref.current, changed$)
 
     let settle: () => void = () => {}
     vi.mocked(resolveComments).mockReturnValue(
-      new Promise<CommentDocument[]>((resolve) => {
+      new Promise<Comment[]>((resolve) => {
         settle = () => resolve(loaded)
       }),
     )
@@ -127,7 +138,7 @@ describe('useComments', () => {
   })
 
   it('passes the field path and status through to the store', () => {
-    const loaded: CommentDocument[] = []
+    const loaded: Comment[] = []
     mockSource(() => loaded)
 
     function TestComponent() {
@@ -149,7 +160,7 @@ describe('useComments', () => {
   })
 
   it('resolves a named resource from context', () => {
-    const loaded: CommentDocument[] = []
+    const loaded: Comment[] = []
     mockSource(() => loaded)
 
     function TestComponent() {
@@ -169,7 +180,7 @@ describe('useComments', () => {
     // Core turns a release perspective into `target.documentVersionId` and into
     // the key the list is stored under, so dropping it here would read and
     // write the wrong release with nothing to show that anything went wrong.
-    const loaded: CommentDocument[] = []
+    const loaded: Comment[] = []
     mockSource(() => loaded)
 
     function TestComponent() {
@@ -189,12 +200,12 @@ describe('useComments', () => {
     const first = [comment('a')]
     const second = [comment('b'), comment('c')]
     // Only `doc-1` is loaded, so switching to `doc-2` has to suspend.
-    const byDocument: Record<string, CommentDocument[] | undefined> = {'doc-1': first}
+    const byDocument: Record<string, Comment[] | undefined> = {'doc-1': first}
     mockSource((options) => byDocument[options.documentId])
 
     let settle: () => void = () => {}
     vi.mocked(resolveComments).mockReturnValue(
-      new Promise<CommentDocument[]>((resolve) => {
+      new Promise<Comment[]>((resolve) => {
         settle = () => resolve(second)
       }),
     )

--- a/packages/react/src/hooks/comments/useComments.ts
+++ b/packages/react/src/hooks/comments/useComments.ts
@@ -1,9 +1,4 @@
-import {
-  type CommentDocument,
-  type CommentsOptions,
-  getCommentsState,
-  resolveComments,
-} from '@sanity/sdk'
+import {type Comment, type CommentsOptions, getCommentsState, resolveComments} from '@sanity/sdk'
 import {useMemo} from 'react'
 
 import {type WithResourceNameSupport} from '../helpers/useNormalizedResourceOptions'
@@ -15,12 +10,12 @@ import {type CommentListSource, useCommentList} from './useCommentList'
  */
 export interface UseCommentsResult {
   /** Every matching comment, newest first, replies included. */
-  comments: CommentDocument[]
+  comments: Comment[]
   /** True while switching to a different document or filter. */
   isPending: boolean
 }
 
-const SOURCE: CommentListSource<CommentDocument[]> = {
+const SOURCE: CommentListSource<Comment[]> = {
   getState: getCommentsState,
   resolve: resolveComments,
 }

--- a/packages/react/src/hooks/comments/useComments.ts
+++ b/packages/react/src/hooks/comments/useComments.ts
@@ -1,0 +1,64 @@
+import {
+  type CommentDocument,
+  type CommentsOptions,
+  getCommentsState,
+  resolveComments,
+} from '@sanity/sdk'
+import {useMemo} from 'react'
+
+import {type WithResourceNameSupport} from '../helpers/useNormalizedResourceOptions'
+import {type CommentListSource, useCommentList} from './useCommentList'
+
+/**
+ * @public
+ * @category Types
+ */
+export interface UseCommentsResult {
+  /** Every matching comment, newest first, replies included. */
+  comments: CommentDocument[]
+  /** True while switching to a different document or filter. */
+  isPending: boolean
+}
+
+const SOURCE: CommentListSource<CommentDocument[]> = {
+  getState: getCommentsState,
+  resolve: resolveComments,
+}
+
+/**
+ * Reads a document's comments and keeps them up to date.
+ *
+ * Comments are shared with the Studio: they live in the project's comments
+ * dataset, so a thread started here shows up there and the other way round. The
+ * list is flat, replies included; reach for {@link useCommentThreads} to read it
+ * grouped.
+ *
+ * Suspends until the comments have loaded. Switching document or filter is a
+ * transition, so the previous list stays on screen and `isPending` goes true
+ * rather than the component suspending again.
+ *
+ * @category Comments
+ * @function
+ * @param options - The document to read, optionally narrowed by `fieldPath` or `status`
+ * @returns The matching comments, and whether a switch is in flight
+ *
+ * @example Count the open threads on a field
+ * ```tsx
+ * function TitleCommentCount({documentId}: {documentId: string}) {
+ *   const {comments} = useComments({
+ *     documentId,
+ *     documentType: 'article',
+ *     fieldPath: 'title',
+ *     status: 'open',
+ *   })
+ *
+ *   return <span>{comments.length}</span>
+ * }
+ * ```
+ *
+ * @public
+ */
+export function useComments(options: WithResourceNameSupport<CommentsOptions>): UseCommentsResult {
+  const {value, isPending} = useCommentList('useComments', options, SOURCE)
+  return useMemo(() => ({comments: value, isPending}), [isPending, value])
+}


### PR DESCRIPTION
### Description
This adds the three hooks for comments. Both read hooks follow `useQuery` rather than the simpler `createStateSourceHook`. Comments are subscription-backed, and `createStateSourceHook` builds a fresh state source every render, which would re-register a subscriber each time. The deferred-key memo avoids that and gives `isPending` for free.

`useCommentActions` resolves the resource when an action is called rather than when the hook runs, matching `useApplyDocumentActions`, so one set of callbacks serves an app spanning several resources.

Stacked on #1085. Base is `comments-core`, not `main`. The Portable Text inline-comment plugin follows in the editor repo once this publishes.


### What to review

Two packages plus the kitchensink app. Nothing outside `src/hooks/comments/`, `src/comments/commentsStore.ts`, the two export manifests, and the new route. No dependency changes.

In rough order of how expensive a mistake would be:

- **`useCommentList.ts`.** The only non-obvious file. It holds a deferred key so a document or filter switch runs in a transition instead of suspending a second time, aborts the previous read so its listener drops when nothing else is reading, and suppresses `react-hooks/refs` on the throw. The suppression is deliberate and matches `useQuery`: React runs no effects for a render that suspends, so the captured signal cannot be swapped underneath it.
- **`getCommentsOptionsKey` in `commentsStore.ts`.** A field missing from this key means a reader silently keeps the list it had while the caller believes it asked for a different one. The `satisfies` intersection makes adding a field to `CommentsOptions` a compile error here unless it is keyed or explicitly named irrelevant.
- **`useCommentActions.ts`.** Resource resolution happens per call. Worth checking the tiers behave as you expect when a call names a resource that context does not have.
- **`CommentsRoute.tsx`.** Read last. Longest file, least surprising.

### Testing

16 hook tests alongside the hooks, 3 more on the core key helpers. The comments module is at 115 core tests and 16 React; the full suite is green at 1,649.

Covered: suspending until the first snapshot, keeping the previous list on screen while a different document loads rather than falling back, perspective inherited from context (dropping it would read and write the wrong release with nothing to show for it), named-resource resolution, callback identity across renders, and per-call resource override.

### Fun gif
![comment](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGQ0aGVucTNwcXc1ODV4Z2MzNm45b2lnMXRiZWM0ampteTc4eHlqOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/o3chaFJ6NfzM5Tp1Tq/giphy.gif)
<!--
Add a cute animal or fun gif that captures the essence of this PR and makes PR review process more enjoyable (https://giphy.com)

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)

-->
