### PR TITLE
test: try the @sanity/client get-it 9 preview build (do not merge)

### DIFF
--- a/.claude/rules/request-tag-conventions.md
+++ b/.claude/rules/request-tag-conventions.md
@@ -22,15 +22,13 @@ All outgoing Sanity API requests from the SDK must use the `sanity.sdk.*` tag na
 ```typescript
 // BAD: ad hoc prefix, no request tag
 const client = clientFactory({requestTagPrefix: 'my-feature'})
-await client.request({uri: '/users/me', method: 'GET'})
+await client.request({url: '/users/me', method: 'GET'})
 
 // GOOD (auth code): use the shared constant prefix, set an explicit tag
 const client = clientFactory({requestTagPrefix: REQUEST_TAG_PREFIX})
-await client.request({uri: '/users/me', method: 'GET', tag: 'users.get-current'})
+await client.request({url: '/users/me', method: 'GET', tag: 'users.get-current'})
 
 // GOOD (non-auth code): omit requestTagPrefix to inherit the default
-const client = clientFactory({
-  /* ...other config... */
-})
-await client.request({uri: '/users/me', method: 'GET', tag: 'users.get-current'})
+const client = clientFactory({/* ...other config... */})
+await client.request({url: '/users/me', method: 'GET', tag: 'users.get-current'})
 ```

--- a/packages/core/src/auth/handleAuthCallback.test.ts
+++ b/packages/core/src/auth/handleAuthCallback.test.ts
@@ -94,7 +94,7 @@ describe('handleCallback', () => {
       method: 'GET',
       query: {sid: authCode},
       tag: 'fetch-token',
-      uri: '/auth/fetch',
+      url: '/auth/fetch',
     })
     expect(setItem).toHaveBeenCalledWith('__sanity_auth_token', '{"token":"new-token"}')
   })
@@ -236,7 +236,7 @@ describe('handleCallback', () => {
       method: 'GET',
       query: {sid: authCode},
       tag: 'fetch-token',
-      uri: '/auth/fetch',
+      url: '/auth/fetch',
     })
   })
 

--- a/packages/core/src/auth/handleAuthCallback.ts
+++ b/packages/core/src/auth/handleAuthCallback.ts
@@ -94,7 +94,7 @@ export const handleAuthCallback = bindActionGlobally(
       logger.debug('Fetching token from auth endpoint')
       const {token} = await client.request<{token: string; label: string}>({
         method: 'GET',
-        uri: '/auth/fetch',
+        url: '/auth/fetch',
         query: {sid: authCode},
         tag: 'fetch-token',
       })

--- a/packages/core/src/auth/logout.test.ts
+++ b/packages/core/src/auth/logout.test.ts
@@ -75,7 +75,7 @@ describe('logout', () => {
       useProjectHostname: false,
       useCdn: false,
     })
-    expect(mockRequest).toHaveBeenCalledWith({method: 'POST', uri: '/auth/logout', tag: 'logout'})
+    expect(mockRequest).toHaveBeenCalledWith({method: 'POST', url: '/auth/logout', tag: 'logout'})
     expect(removeItem).toHaveBeenCalledWith('__sanity_auth_token')
   })
 

--- a/packages/core/src/auth/logout.ts
+++ b/packages/core/src/auth/logout.ts
@@ -44,7 +44,7 @@ export const logout = bindActionGlobally(authStore, async ({state, instance}) =>
       })
 
       logger.debug('Calling logout endpoint')
-      await client.request<void>({uri: '/auth/logout', method: 'POST', tag: 'logout'})
+      await client.request<void>({url: '/auth/logout', method: 'POST', tag: 'logout'})
     } else {
       logger.debug('No token to logout - already logged out')
     }

--- a/packages/core/src/auth/refreshStampedToken.ts
+++ b/packages/core/src/auth/refreshStampedToken.ts
@@ -36,7 +36,7 @@ function createTokenRefreshStream(
 
     const subscription = client.observable
       .request<{token: string}>({
-        uri: 'auth/refresh-token',
+        url: 'auth/refresh-token',
         method: 'POST',
         tag: 'refresh-token',
         body: {

--- a/packages/core/src/auth/studioModeAuth.test.ts
+++ b/packages/core/src/auth/studioModeAuth.test.ts
@@ -35,7 +35,7 @@ describe('checkForCookieAuth', () => {
 
     expect(result).toBe(true)
     expect(mockClient.request).toHaveBeenCalledWith({
-      uri: '/users/me',
+      url: '/users/me',
       withCredentials: true,
       tag: 'users.get-current',
     })

--- a/packages/core/src/auth/studioModeAuth.ts
+++ b/packages/core/src/auth/studioModeAuth.ts
@@ -30,7 +30,7 @@ export async function checkForCookieAuth(
       timeout: COOKIE_AUTH_TIMEOUT_MS,
     })
     const user = await client.request({
-      uri: '/users/me',
+      url: '/users/me',
       withCredentials: true,
       tag: 'users.get-current',
     })

--- a/packages/core/src/auth/subscribeToStateAndFetchCurrentUser.test.ts
+++ b/packages/core/src/auth/subscribeToStateAndFetchCurrentUser.test.ts
@@ -57,7 +57,7 @@ describe('subscribeToStateAndFetchCurrentUser', () => {
     })
     expect(mockRequest).toHaveBeenCalledWith({
       method: 'GET',
-      uri: '/users/me',
+      url: '/users/me',
       tag: 'users.get-current',
     })
 
@@ -97,7 +97,7 @@ describe('subscribeToStateAndFetchCurrentUser', () => {
     })
     expect(mockRequest).toHaveBeenCalledWith({
       method: 'GET',
-      uri: '/users/me',
+      url: '/users/me',
       tag: 'users.get-current',
     })
 

--- a/packages/core/src/auth/subscribeToStateAndFetchCurrentUser.ts
+++ b/packages/core/src/auth/subscribeToStateAndFetchCurrentUser.ts
@@ -73,7 +73,7 @@ export const subscribeToStateAndFetchCurrentUser = (
       switchMap((client) =>
         client.observable
           .request<CurrentUser>({
-            uri: '/users/me',
+            url: '/users/me',
             method: 'GET',
             tag: 'users.get-current',
           })

--- a/packages/core/src/document/documentStore.test.ts
+++ b/packages/core/src/document/documentStore.test.ts
@@ -924,7 +924,7 @@ it('does not send credentials with the dataset ACL request', async () => {
 
   const aclCall = vi
     .mocked(client.request)
-    .mock.calls.find(([options]) => options.uri?.endsWith('/acl'))
+    .mock.calls.find(([options]) => options.url?.endsWith('/acl'))
   expect(aclCall).toBeDefined()
   expect(aclCall![0]).not.toHaveProperty('withCredentials')
 })

--- a/packages/core/src/document/documentStore.ts
+++ b/packages/core/src/document/documentStore.ts
@@ -550,13 +550,13 @@ const subscribeToClientAndFetchDatasetAcl = ({
 }: StoreContext<DocumentStoreState, BoundResourceKey>) => {
   const clientOptions: ClientOptions = {apiVersion: API_VERSION, resource}
 
-  let uri: string
+  let url: string
   if (resource && isDatasetResource(resource)) {
-    uri = `/projects/${resource.projectId}/datasets/${resource.dataset}/acl`
+    url = `/projects/${resource.projectId}/datasets/${resource.dataset}/acl`
   } else if (resource && isMediaLibraryResource(resource)) {
-    uri = `/media-libraries/${resource.mediaLibraryId}/acl`
+    url = `/media-libraries/${resource.mediaLibraryId}/acl`
   } else if (resource && isCanvasResource(resource)) {
-    uri = `/canvases/${resource.canvasId}/acl`
+    url = `/canvases/${resource.canvasId}/acl`
   } else {
     throw new Error(`Received invalid resource: ${JSON.stringify(resource)}`)
   }
@@ -566,7 +566,7 @@ const subscribeToClientAndFetchDatasetAcl = ({
       switchMap((client) =>
         client.observable
           .request<DatasetAcl>({
-            uri,
+            url,
             tag: 'acl.get',
           })
           .pipe(

--- a/packages/core/src/organization/organization.test.ts
+++ b/packages/core/src/organization/organization.test.ts
@@ -35,7 +35,7 @@ describe('organization', () => {
     const result = await resolveOrganization(instance, {organizationId: 'org_1'})
     expect(result).toEqual(organization)
     expect(request).toHaveBeenCalledWith({
-      uri: '/organizations/org_1',
+      url: '/organizations/org_1',
       query: {includeMembers: 'false', includeFeatures: 'false'},
       tag: 'organization.get',
     })
@@ -58,7 +58,7 @@ describe('organization', () => {
     })
 
     expect(request).toHaveBeenCalledWith({
-      uri: '/organizations/org_1',
+      url: '/organizations/org_1',
       query: {
         includeMembers: 'true',
         includeFeatures: 'true',

--- a/packages/core/src/organization/organization.ts
+++ b/packages/core/src/organization/organization.ts
@@ -129,7 +129,7 @@ const organization = createFetcherStore({
         )
 
         return client.observable.request({
-          uri: `/organizations/${organizationId}`,
+          url: `/organizations/${organizationId}`,
           query,
           tag: 'organization.get',
         })

--- a/packages/core/src/organizations/organizations.test.ts
+++ b/packages/core/src/organizations/organizations.test.ts
@@ -35,7 +35,7 @@ describe('organizations', () => {
     const result = await resolveOrganizations(instance)
     expect(result).toEqual(organizations)
     expect(request).toHaveBeenCalledWith({
-      uri: '/organizations',
+      url: '/organizations',
       query: {
         includeImplicitMemberships: 'false',
         includeMembers: 'false',
@@ -62,7 +62,7 @@ describe('organizations', () => {
     })
 
     expect(request).toHaveBeenCalledWith({
-      uri: '/organizations',
+      url: '/organizations',
       query: {
         includeImplicitMemberships: 'true',
         includeMembers: 'true',

--- a/packages/core/src/organizations/organizations.ts
+++ b/packages/core/src/organizations/organizations.ts
@@ -95,7 +95,7 @@ const organizations = createFetcherStore({
         )
 
         return client.observable.request({
-          uri: `/organizations`,
+          url: `/organizations`,
           query,
           tag: 'organizations.get',
         })

--- a/packages/core/src/presence/presenceStore.test.ts
+++ b/packages/core/src/presence/presenceStore.test.ts
@@ -314,7 +314,7 @@ describe('presenceStore', () => {
       getPresence(instance, {resource: canvasResource})
 
       expect(mockClient.observable.request).toHaveBeenCalledWith({
-        uri: '/canvases/canvas123',
+        url: '/canvases/canvas123',
         tag: 'canvases.get',
       })
     })

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -411,7 +411,7 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
       subscription.add(
         globalClient.observable
           .request<{organizationId: string}>({
-            uri: `/canvases/${resource.canvasId}`,
+            url: `/canvases/${resource.canvasId}`,
             tag: 'canvases.get',
           })
           .subscribe({

--- a/packages/core/src/project/project.test.ts
+++ b/packages/core/src/project/project.test.ts
@@ -35,7 +35,7 @@ describe('project', () => {
     const result = await resolveProject(instance, {projectId: 'a'})
     expect(result).toEqual(project)
     expect(request).toHaveBeenCalledWith({
-      uri: '/projects/a',
+      url: '/projects/a',
       query: {includeMembers: 'true', includeFeatures: 'true'},
       tag: 'project.get',
     })
@@ -58,7 +58,7 @@ describe('project', () => {
     })
 
     expect(request).toHaveBeenCalledWith({
-      uri: '/projects/a',
+      url: '/projects/a',
       query: {
         includeMembers: 'false',
         includeFeatures: 'false',
@@ -79,7 +79,7 @@ describe('project', () => {
 
     await resolveProject(instance)
     expect(request).toHaveBeenCalledWith({
-      uri: '/projects/p',
+      url: '/projects/p',
       query: {includeMembers: 'true', includeFeatures: 'true'},
       tag: 'project.get',
     })

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -130,7 +130,7 @@ const project = createFetcherStore({
         )
 
         return client.observable.request({
-          uri: `/projects/${projectId}`,
+          url: `/projects/${projectId}`,
           query,
           tag: 'project.get',
         })

--- a/packages/core/src/projects/projects.test.ts
+++ b/packages/core/src/projects/projects.test.ts
@@ -35,7 +35,7 @@ describe('projects', () => {
     const result = await resolveProjects(instance)
     expect(result).toEqual(projects)
     expect(request).toHaveBeenCalledWith({
-      uri: '/projects',
+      url: '/projects',
       query: {includeMembers: 'false', includeFeatures: 'true', onlyExplicitMembership: 'false'},
       tag: 'projects.get',
     })
@@ -58,7 +58,7 @@ describe('projects', () => {
     })
 
     expect(request).toHaveBeenCalledWith({
-      uri: '/projects',
+      url: '/projects',
       query: {
         organizationId: 'org123',
         includeMembers: 'true',

--- a/packages/core/src/projects/projects.ts
+++ b/packages/core/src/projects/projects.ts
@@ -59,7 +59,7 @@ const projects = createFetcherStore({
         )
 
         return client.observable.request({
-          uri: '/projects',
+          url: '/projects',
           query,
           tag: 'projects.get',
         })

--- a/packages/core/src/telemetry/telemetryManager.test.ts
+++ b/packages/core/src/telemetry/telemetryManager.test.ts
@@ -280,7 +280,7 @@ describe('createTelemetryManager', () => {
       const result = await manager.checkConsent()
       expect(result).toBe(true)
       expect(mockClient.request).toHaveBeenCalledWith(
-        expect.objectContaining({uri: '/intake/telemetry-status'}),
+        expect.objectContaining({url: '/intake/telemetry-status'}),
       )
     })
 

--- a/packages/core/src/telemetry/telemetryManager.ts
+++ b/packages/core/src/telemetry/telemetryManager.ts
@@ -86,7 +86,7 @@ export function createTelemetryManager(options: TelemetryManagerOptions): Teleme
     try {
       const client = getClient()
       const result = await client.request<{status: ConsentStatus}>({
-        uri: '/intake/telemetry-status',
+        url: '/intake/telemetry-status',
         tag: CONSENT_TAG,
       })
       cachedConsent = result
@@ -120,7 +120,7 @@ export function createTelemetryManager(options: TelemetryManagerOptions): Teleme
     const client = getClient()
     log.debug('sending event batch', {batchSize: batch.length, environment})
     return client.request({
-      uri: '/intake/batch',
+      url: '/intake/batch',
       method: 'POST',
       body: {projectId, batch: enrichBatch(batch)},
       tag: BATCH_TAG,

--- a/packages/core/src/users/usersStore.test.ts
+++ b/packages/core/src/users/usersStore.test.ts
@@ -450,7 +450,7 @@ describe('usersStore', () => {
       )
       expect(specificRequest).toHaveBeenCalledWith({
         method: 'GET',
-        uri: `/users/${projectUserId}`,
+        url: `/users/${projectUserId}`,
         tag: 'users.get',
       })
 

--- a/packages/core/src/users/usersStore.ts
+++ b/packages/core/src/users/usersStore.ts
@@ -130,7 +130,7 @@ const listenForLoadMoreAndFetch = ({state, instance}: StoreContext<UsersStoreSta
                 return client.observable
                   .request<PatchedSanityUserFromClient>({
                     method: 'GET',
-                    uri: `/users/${userId}`,
+                    url: `/users/${userId}`,
                     tag: 'users.get',
                   })
                   .pipe(
@@ -184,7 +184,7 @@ const listenForLoadMoreAndFetch = ({state, instance}: StoreContext<UsersStoreSta
               return client.observable
                 .request<SanityUser | SanityUserResponse>({
                   method: 'GET',
-                  uri: `access/${resourceType}/${resourceId}/users/${userId}`,
+                  url: `access/${resourceType}/${resourceId}/users/${userId}`,
                   tag: 'users.get',
                 })
                 .pipe(
@@ -253,7 +253,7 @@ const listenForLoadMoreAndFetch = ({state, instance}: StoreContext<UsersStoreSta
               switchMap(([[resource, client], cursor]) =>
                 client.observable.request<SanityUserResponse>({
                   method: 'GET',
-                  uri: `access/${resource.type}/${resource.id}/users`,
+                  url: `access/${resource.type}/${resource.id}/users`,
                   tag: 'users.list',
                   query: cursor
                     ? {nextCursor: cursor, limit: batchSize.toString()}

--- a/packages/react/src/utils/resolveOrgResources.test.ts
+++ b/packages/react/src/utils/resolveOrgResources.test.ts
@@ -52,10 +52,10 @@ describe('resolveOrgResources', () => {
     await resolveOrgResources(mockInstance, ORG_ID)
 
     expect(mockRequest).toHaveBeenCalledWith(
-      expect.objectContaining({uri: '/media-libraries', query: {organizationId: ORG_ID}}),
+      expect.objectContaining({url: '/media-libraries', query: {organizationId: ORG_ID}}),
     )
     expect(mockRequest).toHaveBeenCalledWith(
-      expect.objectContaining({uri: '/canvases', query: {organizationId: ORG_ID}}),
+      expect.objectContaining({url: '/canvases', query: {organizationId: ORG_ID}}),
     )
   })
 

--- a/packages/react/src/utils/resolveOrgResources.ts
+++ b/packages/react/src/utils/resolveOrgResources.ts
@@ -48,12 +48,12 @@ export async function resolveOrgResources(
 
   const [mediaLibrariesResult, canvasesResult] = await Promise.allSettled([
     client.request<OrgResourcesApiResponse>({
-      uri: `/media-libraries`,
+      url: `/media-libraries`,
       query: {organizationId},
       tag: 'org-resources.media-libraries',
     }),
     client.request<OrgResourcesApiResponse>({
-      uri: `/canvases`,
+      url: `/canvases`,
       query: {organizationId},
       tag: 'org-resources.canvases',
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ catalogs:
       specifier: ^1.0.5
       version: 1.0.5
     '@sanity/client':
-      specifier: ^7.26.2
+      specifier: https://pkg.pr.new/@sanity/client@1217
       version: 7.26.2
     '@sanity/comlink':
       specifier: ^4.0.3
@@ -402,7 +402,7 @@ importers:
     dependencies:
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: https://pkg.pr.new/@sanity/client@1217(vitest@4.1.10)
       '@sanity/uuid':
         specifier: ^3.0.3
         version: 3.0.3
@@ -489,7 +489,7 @@ importers:
         version: 1.0.0
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: https://pkg.pr.new/@sanity/client@1217(vitest@4.1.10)
       '@sanity/comlink':
         specifier: 'catalog:'
         version: 4.0.3
@@ -586,7 +586,7 @@ importers:
     dependencies:
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: https://pkg.pr.new/@sanity/client@1217(vitest@4.1.10)
       '@sanity/message-protocol':
         specifier: 'catalog:'
         version: 0.24.0
@@ -3338,6 +3338,11 @@ packages:
     resolution: {integrity: sha512-iEkGiHbrxCnT/A30A6pH+vX4otP3lLp935Vwuv0/YrnETxrKCn6PnsZU+TfTm6ZEZ9kZGs8wKP5yBLmZw5S6OQ==}
     engines: {node: '>=20'}
 
+  '@sanity/client@https://pkg.pr.new/@sanity/client@1217':
+    resolution: {tarball: https://pkg.pr.new/@sanity/client@1217}
+    version: 7.26.2
+    engines: {node: '>=22.12.0'}
+
   '@sanity/codegen@3.88.1-typegen-experimental.0':
     resolution: {integrity: sha512-9GuT4aTNA1r8F8k6Rv2H2chmatzrmdK40fo4mosDr426nSsAkTD2gl632KVjmuI6veBnfT+ecv5Q/QvmvXl4SA==}
     engines: {node: '>=18'}
@@ -5354,6 +5359,10 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource-parser@4.0.0:
+    resolution: {integrity: sha512-aIpvYxbqTx4KYWw73KpCt1Rh22tEAJ144F1qR76CT3Ex+LNMEPKf5HFrK5Yz9fMP1EVT0GrfA35VZvWQhMPuSQ==}
+    engines: {node: '>=22.12'}
+
   eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
     engines: {node: '>=12.0.0'}
@@ -5361,6 +5370,10 @@ packages:
   eventsource@4.1.0:
     resolution: {integrity: sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==}
     engines: {node: '>=20.0.0'}
+
+  eventsource@5.0.0:
+    resolution: {integrity: sha512-iNd5IgeR56Om1Aje0ACZTd5oRQ+u5i6RfRkKdIuhlykeH3o+f0vIiiT0i9t1SXABfTnsfxVPadAB2T4cLS32Sw==}
+    engines: {node: '>=22.12.0'}
 
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
@@ -5578,13 +5591,18 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
-  get-it@8.8.0:
-    resolution: {integrity: sha512-vRyooMBzoIdEbARGT3JcvWqMD67YzC5SKlMqofyfck1ebLh2zzlpD4hVQ3xiuuiADk4jNs0rTezVlxCMqOlZfA==}
-    engines: {node: '>=14.0.0'}
-
   get-it@8.8.3:
     resolution: {integrity: sha512-IfkbWqOGO2kd2Ccgiz/NIzk3bcwjtVqBm3RNa3j/veHg2q7c1DgS3EXrCrvIWH0jbNTbhkdblnxBP7Dm8CiH+A==}
     engines: {node: '>=14.0.0'}
+
+  get-it@9.4.1:
+    resolution: {integrity: sha512-WEYs8b65nMYdYvbi0AwlyfRWrnkto1xLG1YqxFGKrU4yb7Vd06ryIS5XAFrBgRnYwsoszsZEsUGimQMQE7ztVA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
 
   get-latest-version@6.0.1:
     resolution: {integrity: sha512-6Zub9FhioDbCJzGTZtetVvAkLeA5UnvQEbKfFZUc62hcZm3gO3Txr21oRGOcT6SdiKhjI0vWd/Jxct+wuLJgHA==}
@@ -6657,11 +6675,6 @@ packages:
   nano-pubsub@3.0.0:
     resolution: {integrity: sha512-zoTNyBafxG0+F5PP3T3j1PKMr7gedriSdYRhLFLRFCz0OnQfQ6BkVk9peXVF30hz633Bw0Zh5McleOrXPjWYCQ==}
     engines: {node: '>=18'}
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.17:
     resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
@@ -11024,10 +11037,10 @@ snapshots:
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
       '@oclif/core': 4.11.11
-      '@sanity/client': 7.24.0
+      '@sanity/client': 7.26.2
       boxen: 8.0.1
       debug: 4.4.3(supports-color@8.1.1)
-      get-it: 8.8.0
+      get-it: 8.8.3
       get-tsconfig: 4.14.0
       import-meta-resolve: 4.2.0
       jiti: 2.7.0
@@ -11065,13 +11078,13 @@ snapshots:
       '@oclif/plugin-not-found': 3.2.87(@types/node@24.13.3)
       '@sanity/cli-build': 2.0.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.0.1)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(node-fetch@2.7.0)(rolldown@1.1.5)(terser@5.36.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       '@sanity/cli-core': 2.1.3(@noble/hashes@2.0.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.36.0)(yaml@2.9.0)
-      '@sanity/client': 7.24.0
+      '@sanity/client': 7.26.2
       '@sanity/codegen': 7.0.3(@oclif/core@4.11.11)(@sanity/cli-core@2.1.3(@noble/hashes@2.0.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.36.0)(yaml@2.9.0))(oxfmt@0.58.0)(react@19.2.7)
       '@sanity/descriptors': 1.3.0
       '@sanity/export': 6.2.0
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
-      '@sanity/import': 6.0.3(@sanity/client@7.24.0)(@types/react@19.2.17)
+      '@sanity/import': 6.0.3(@sanity/client@7.26.2)(@types/react@19.2.17)
       '@sanity/migrate': 7.0.3(@oclif/core@4.11.11)(@sanity/cli-core@2.1.3(@noble/hashes@2.0.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.36.0)(yaml@2.9.0))(@types/react@19.2.17)(xstate@5.32.5)
       '@sanity/runtime-cli': 17.1.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.36.0)(tsx@4.23.1)(yaml@2.9.0)
       '@sanity/schema': 6.3.0(@types/react@19.2.17)
@@ -11161,8 +11174,8 @@ snapshots:
   '@sanity/client@7.24.0':
     dependencies:
       '@sanity/eventsource': 5.0.4
-      get-it: 8.8.0
-      nanoid: 3.3.16
+      get-it: 8.8.3
+      nanoid: 3.3.17
       rxjs: 7.8.2
 
   '@sanity/client@7.26.2':
@@ -11171,6 +11184,17 @@ snapshots:
       get-it: 8.8.3
       nanoid: 3.3.17
       rxjs: 7.8.2
+
+  '@sanity/client@https://pkg.pr.new/@sanity/client@1217(vitest@4.1.10)':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      eventsource: 5.0.0
+      get-it: 9.4.1(vitest@4.1.10)
+      nanoid: 3.3.17
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - supports-color
+      - vitest
 
   '@sanity/codegen@3.88.1-typegen-experimental.0':
     dependencies:
@@ -11265,7 +11289,7 @@ snapshots:
   '@sanity/export@6.2.0':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      get-it: 8.8.0
+      get-it: 8.8.3
       json-stream-stringify: 3.1.6
       p-queue: 9.1.0
       tar: 7.5.15
@@ -11295,14 +11319,14 @@ snapshots:
     dependencies:
       '@sanity/signed-urls': 2.0.2
 
-  '@sanity/import@6.0.3(@sanity/client@7.24.0)(@types/react@19.2.17)':
+  '@sanity/import@6.0.3(@sanity/client@7.26.2)(@types/react@19.2.17)':
     dependencies:
       '@sanity/asset-utils': 2.3.0
-      '@sanity/client': 7.24.0
+      '@sanity/client': 7.26.2
       '@sanity/generate-help-url': 4.0.0
       '@sanity/mutator': 6.3.0(@types/react@19.2.17)
       debug: 4.4.3(supports-color@8.1.1)
-      get-it: 8.8.0
+      get-it: 8.8.3
       gunzip-maybe: 1.4.2
       p-map: 7.0.3
       tar-fs: 3.1.2
@@ -11347,7 +11371,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.11.11
       '@sanity/cli-core': 2.1.3(@noble/hashes@2.0.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.36.0)(yaml@2.9.0)
-      '@sanity/client': 7.24.0
+      '@sanity/client': 7.26.2
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/types': 6.5.0(@types/react@19.2.17)
       '@sanity/util': 6.3.0(@types/react@19.2.17)
@@ -11475,7 +11499,7 @@ snapshots:
       '@sanity-labs/design-tokens': 0.0.2-alpha.4
       '@sanity/blueprints': 0.20.1
       '@sanity/blueprints-parser': 0.4.0
-      '@sanity/client': 7.24.0
+      '@sanity/client': 7.26.2
       adm-zip: 0.5.17
       array-treeify: 0.1.5
       cardinal: 2.1.1
@@ -11525,7 +11549,7 @@ snapshots:
   '@sanity/sdk@2.15.0(@types/react@19.2.17)(immer@10.1.1)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.5)':
     dependencies:
       '@sanity/bifur-client': 1.0.0
-      '@sanity/client': 7.24.0
+      '@sanity/client': 7.26.2
       '@sanity/comlink': 4.0.1
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/diff-patch': 6.0.0
@@ -11571,13 +11595,13 @@ snapshots:
 
   '@sanity/types@6.3.0(@types/react@19.2.17)':
     dependencies:
-      '@sanity/client': 7.24.0
+      '@sanity/client': 7.26.2
       '@sanity/media-library-types': 1.6.0
       '@types/react': 19.2.17
 
   '@sanity/types@6.5.0(@types/react@19.2.17)':
     dependencies:
-      '@sanity/client': 7.24.0
+      '@sanity/client': 7.26.2
       '@sanity/media-library-types': 1.6.0
       '@types/react': 19.2.17
 
@@ -11627,7 +11651,7 @@ snapshots:
     dependencies:
       '@date-fns/tz': 1.5.0
       '@date-fns/utc': 2.1.1
-      '@sanity/client': 7.24.0
+      '@sanity/client': 7.26.2
       '@sanity/types': 6.3.0(@types/react@19.2.17)
       date-fns: 4.4.0
       rxjs: 7.8.2
@@ -13554,11 +13578,17 @@ snapshots:
 
   eventsource-parser@3.1.0: {}
 
+  eventsource-parser@4.0.0: {}
+
   eventsource@2.0.2: {}
 
   eventsource@4.1.0:
     dependencies:
       eventsource-parser: 3.1.0
+
+  eventsource@5.0.0:
+    dependencies:
+      eventsource-parser: 4.0.0
 
   execa@9.6.1:
     dependencies:
@@ -13813,13 +13843,6 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  get-it@8.8.0:
-    dependencies:
-      decompress-response: 7.0.0
-      is-retry-allowed: 2.2.0
-      through2: 4.0.2
-      tunnel-agent: 0.6.0
-
   get-it@8.8.3:
     dependencies:
       decompress-response: 7.0.0
@@ -13827,9 +13850,15 @@ snapshots:
       through2: 4.0.2
       tunnel-agent: 0.6.0
 
+  get-it@9.4.1(vitest@4.1.10):
+    dependencies:
+      undici: 7.28.0
+    optionalDependencies:
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.23.1)(yaml@2.9.0))
+
   get-latest-version@6.0.1:
     dependencies:
-      get-it: 8.8.0
+      get-it: 8.8.3
       registry-auth-token: 5.1.1
       registry-url: 7.2.0
       semver: 7.8.5
@@ -14872,8 +14901,6 @@ snapshots:
 
   nano-pubsub@3.0.0: {}
 
-  nanoid@3.3.16: {}
-
   nanoid@3.3.17: {}
 
   nanoid@5.1.16: {}
@@ -15282,7 +15309,7 @@ snapshots:
 
   postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,11 +25,17 @@ minimumReleaseAgeExclude:
   - '@oxfmt/*'
   # Renovate security update: react-router@7.18.2
   - react-router@7.18.2
+  # TESTING ONLY: the get-it 9 client preview depends on eventsource@5, published
+  # 2026-08-10. Remove along with the '@sanity/client' catalog pin below.
+  - eventsource
+  - eventsource-parser
 
 catalog:
   '@playwright/test': '^1.61.1'
   '@sanity/browserslist-config': '^1.0.5'
-  '@sanity/client': '^7.26.2'
+  # TESTING ONLY: get-it 9 / fetch preview build from sanity-io/client#1217.
+  # Revert to '^7.26.2' before this branch goes anywhere near main.
+  '@sanity/client': 'https://pkg.pr.new/@sanity/client@1217'
   '@sanity/comlink': '^4.0.3'
   '@sanity/message-protocol': '^0.24.0'
   '@sanity/pkg-utils': '^10.9.2'


### PR DESCRIPTION
### Description

Tries the `@sanity/client` preview build from sanity-io/client#1217 (get-it 9, `fetch` for every runtime, ESM only) against the SDK, so the client team gets feedback before the release goes out.

**Not for merge.** The second commit pins the catalog to a `pkg.pr.new` tarball and must be reverted before this branch goes anywhere.

Two commits:

1. `refactor:` renames the raw request option from `uri` to `url` across the SDK. This one stands on its own and is safe to merge today, see below.
2. `test:` pins `@sanity/client` to the preview build and excludes `eventsource` / `eventsource-parser` from `minimumReleaseAge`, since the preview depends on releases younger than our window.

### What to review

The rename is the only source change. The preview keeps `uri` working as an alias, but it logs a deprecation warning on every request that uses it, and the SDK passed `uri` for all of its raw requests (`/users/me`, the auth endpoints, projects, organizations, canvases, media libraries, the dataset ACL fetch, telemetry intake, and the users store). Left as is, an app would print that warning several times on load. Both option names are accepted by the current release, so the rename does not depend on the upgrade.

Everything else on the branch is the pin and the lockfile.

### Testing

Green against the preview build: 1522 tests across 157 files, `pnpm ts:check`, `pnpm build` for both packages and both apps, `pnpm lint`, and `pnpm fallow audit`.

Beyond the suite, the SDK's own code paths were driven against the API on Node 24 to exercise the new transport for real. Current user lookup, project listing, a GROQ query, live events, `client.listen`, and the error shape on a bad query all behaved the same as on the current release. Both server-sent event paths received their `welcome` event, live events in 80ms and `listen` in 591ms. A failed query still rejects with `ClientError` and `statusCode` 400.

The kitchensink app boots and the auth redirect works, with no new console errors on a headless load. The authenticated part of the app has not been clicked through yet, so that is the remaining gap.

Bundle size is a wash. Gzipped app JS for `standalone-react` came to 135,851 bytes on the preview against 136,032 on the current release, so 181 bytes smaller.

### Notes for the client team

- The `uri` deprecation warning is the only thing that reached the SDK. Worth checking it does not fire for the client's own internal calls.
- `minimumReleaseAge` blocks the install until `eventsource` and `eventsource-parser` are excluded. Anyone with that pnpm setting will hit it on release day.
- Dropping CommonJS costs the SDK nothing. Both packages are already `type: module` with no `require` condition.
- Neither package declares an `engines` field, so nothing warns a consumer on Node 20 that the floor moved to 22.12. That is on us to add with the real upgrade, not a blocker here.
- Removing the `requester` client option does not affect `main`, which never used it. It does rule out the approach prototyped in #809, which cloned the requester to append query params. get-it 9 still supports middleware, but only when the requester is created, and the client no longer accepts one. A public way to pass middleware, or a supported `fetch` wrapper, would cover that case.
