### PR TITLE
fix!: split other utils into subdomain and internal exports

### DIFF
--- a/apps/kitchensink-react/src/routes/AgentActionsRoute.tsx
+++ b/apps/kitchensink-react/src/routes/AgentActionsRoute.tsx
@@ -1,9 +1,5 @@
-import {
-  type AgentGenerateOptions,
-  type AgentPromptOptions,
-  useAgentGenerate,
-  useAgentPrompt,
-} from '@sanity/sdk-react'
+import {type AgentGenerateOptions, type AgentPromptOptions} from '@sanity/sdk/agent'
+import {useAgentGenerate, useAgentPrompt} from '@sanity/sdk-react'
 import {Box, Button, Card, Code, Label, Stack, Text} from '@sanity/ui'
 import {type JSX, useMemo, useState} from 'react'
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -9,6 +9,18 @@ The App SDK Core is a pure TypeScript implementation of the App SDK’s business
 
 We highly recommend that users default to using the hooks provided by the React SDK for building custom apps on the Sanity platform, unless you’re looking to create your own Sanity App SDK using this core layer.
 
+## Entry points
+
+The package exposes multiple entry points:
+
+| Entry point           | Contents                                                                |
+| --------------------- | ----------------------------------------------------------------------- |
+| `@sanity/sdk`         | Core SDK — auth, documents, queries, presence, projects, users, etc.    |
+| `@sanity/sdk/agent`   | AI agent utilities — `agentGenerate`, `agentPatch`, `agentPrompt`, etc. |
+| `@sanity/sdk/comlink` | Comlink channel/controller/node utilities and message types             |
+
+`@sanity/sdk-react` re-exports the main `@sanity/sdk` entry point only. Import the agent and comlink utilities from their sub-entries directly.
+
 **Looking for our React SDK?** You’ll find it on:
 
 - [GitHub](https://github.com/sanity-io/sdk/tree/main/packages/react)

--- a/packages/core/package.bundle.ts
+++ b/packages/core/package.bundle.ts
@@ -6,7 +6,10 @@ export default defineConfig(() => {
     build: {
       lib: {
         entry: {
-          index: './src/_exports/index.ts',
+          'index': './src/_exports/index.ts',
+          '_exports/_internal': './src/_exports/_internal.ts',
+          '_exports/agent': './src/_exports/agent.ts',
+          '_exports/comlink': './src/_exports/comlink.ts',
         },
       },
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,16 @@
       "source": "./src/_exports/_internal.ts",
       "import": "./dist/_exports/_internal.js",
       "default": "./dist/_exports/_internal.js"
+    },
+    "./agent": {
+      "source": "./src/_exports/agent.ts",
+      "import": "./dist/_exports/agent.js",
+      "default": "./dist/_exports/agent.js"
+    },
+    "./comlink": {
+      "source": "./src/_exports/comlink.ts",
+      "import": "./dist/_exports/comlink.js",
+      "default": "./dist/_exports/comlink.js"
     }
   },
   "publishConfig": {

--- a/packages/core/src/_exports/agent.ts
+++ b/packages/core/src/_exports/agent.ts
@@ -1,0 +1,19 @@
+export type {
+  AgentGenerateOptions,
+  AgentGenerateResult,
+  AgentPatchOptions,
+  AgentPatchResult,
+  AgentPromptOptions,
+  AgentPromptResult,
+  AgentTransformOptions,
+  AgentTransformResult,
+  AgentTranslateOptions,
+  AgentTranslateResult,
+} from '../agent/agentActions'
+export {
+  agentGenerate,
+  agentPatch,
+  agentPrompt,
+  agentTransform,
+  agentTranslate,
+} from '../agent/agentActions'

--- a/packages/core/src/_exports/comlink.ts
+++ b/packages/core/src/_exports/comlink.ts
@@ -1,0 +1,16 @@
+export {
+  type ComlinkControllerState,
+  destroyController,
+  getOrCreateChannel,
+  getOrCreateController,
+  releaseChannel,
+} from '../comlink/controller/comlinkControllerStore'
+export type {ComlinkNodeState} from '../comlink/node/comlinkNodeStore'
+export {getOrCreateNode, releaseNode} from '../comlink/node/comlinkNodeStore'
+export {getNodeState, type NodeState} from '../comlink/node/getNodeState'
+export {
+  type FrameMessage,
+  type NewTokenResponseMessage,
+  type RequestNewTokenMessage,
+  type WindowMessage,
+} from '../comlink/types'

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -7,25 +7,6 @@ export type SanityProject = _SanityProject
 
 export {checkPermissions} from '../access/checkPermissions'
 export {type AccessResourceType} from '../access/checkPermissions'
-export type {
-  AgentGenerateOptions,
-  AgentGenerateResult,
-  AgentPatchOptions,
-  AgentPatchResult,
-  AgentPromptOptions,
-  AgentPromptResult,
-  AgentTransformOptions,
-  AgentTransformResult,
-  AgentTranslateOptions,
-  AgentTranslateResult,
-} from '../agent/agentActions'
-export {
-  agentGenerate,
-  agentPatch,
-  agentPrompt,
-  agentTransform,
-  agentTranslate,
-} from '../agent/agentActions'
 export {
   application,
   applications,
@@ -64,7 +45,6 @@ export {
   type UserApplicationsOptions,
   type UserApplicationWriteFields,
 } from '../applications/userApplications'
-export {isStudioConfig} from '../auth/authMode'
 export {AuthStateType} from '../auth/authStateType'
 export {
   type AuthState,
@@ -84,31 +64,8 @@ export {
 export {observeOrganizationVerificationState} from '../auth/getOrganizationVerificationState'
 export {handleAuthCallback} from '../auth/handleAuthCallback'
 export {logout} from '../auth/logout'
-export {
-  type ApiErrorBody,
-  getClientErrorApiBody,
-  getClientErrorApiDescription,
-  getClientErrorApiType,
-  isProjectUserNotFoundClientError,
-} from '../auth/utils'
 export type {ClientStoreState as ClientState} from '../client/clientStore'
 export {type ClientOptions, getClient, getClientState} from '../client/clientStore'
-export {
-  type ComlinkControllerState,
-  destroyController,
-  getOrCreateChannel,
-  getOrCreateController,
-  releaseChannel,
-} from '../comlink/controller/comlinkControllerStore'
-export type {ComlinkNodeState} from '../comlink/node/comlinkNodeStore'
-export {getOrCreateNode, releaseNode} from '../comlink/node/comlinkNodeStore'
-export {getNodeState, type NodeState} from '../comlink/node/getNodeState'
-export {
-  type FrameMessage,
-  type NewTokenResponseMessage,
-  type RequestNewTokenMessage,
-  type WindowMessage,
-} from '../comlink/types'
 export {type AuthConfig, type AuthProvider} from '../config/authConfig'
 export {
   createDatasetHandle,
@@ -255,8 +212,6 @@ export type {
   UserPresence,
 } from '../presence/types'
 export {getPreviewState, type GetPreviewStateOptions} from '../preview/getPreviewState'
-export {PREVIEW_PROJECTION} from '../preview/previewConstants'
-export {transformProjectionToPreview} from '../preview/previewProjectionUtils'
 export {resolvePreview, type ResolvePreviewOptions} from '../preview/resolvePreview'
 export type {
   PreviewMedia,
@@ -280,19 +235,12 @@ export {resolveProjection} from '../projection/resolveProjection'
 export {type ProjectionValuePending, type ValidProjection} from '../projection/types'
 export {projects} from '../projects/projects'
 export {type ProjectsOptions} from '../projects/projects'
-export {
-  getQueryKey,
-  getQueryState,
-  parseQueryKey,
-  type QueryOptions,
-  resolveQuery,
-} from '../query/queryStore'
+export {getQueryState, type QueryOptions, resolveQuery} from '../query/queryStore'
 export {getPerspectiveState} from '../releases/getPerspectiveState'
 export type {ReleaseState} from '../releases/releasesStore'
 export {getActiveReleasesState, getAllReleasesState} from '../releases/releasesStore'
 export {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 export {type Selector, type StateSource} from '../store/createStateSourceAction'
-export {getUsersKey, parseUsersKey} from '../users/reducers'
 export {
   type GetUserOptions,
   type GetUsersOptions,
@@ -313,7 +261,6 @@ export {
   resolveUsers,
 } from '../users/usersStore'
 export {type FetcherStore, type FetcherStoreState} from '../utils/createFetcherStore'
-export {createGroqSearchFilter} from '../utils/createGroqSearchFilter'
 export {getCorsErrorProjectId} from '../utils/getCorsErrorProjectId'
 export {isImportError} from '../utils/isImportError'
 export {CORE_SDK_VERSION} from '../version'

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -80,9 +80,10 @@ export interface ResolveQueryOptions<
 
 const EMPTY_ARRAY: never[] = []
 
-/** @beta */
-export const getQueryKey = (options: QueryOptions): string => JSON.stringify(options)
-/** @beta */
+/** @internal */
+export const getQueryKey = (instance: SanityInstance, options: QueryOptions): string =>
+  JSON.stringify(normalizeOptionsWithPerspective(instance, options))
+/** @internal */
 export const parseQueryKey = (key: string): QueryOptions => JSON.parse(key)
 
 /**
@@ -302,14 +303,14 @@ const _getQueryState = bindActionByResource(
   createStateSourceAction({
     selector: ({state, instance}: SelectorContext<QueryStoreState>, options: QueryOptions) => {
       if (state.error) throw state.error
-      const key = getQueryKey(normalizeOptionsWithPerspective(instance, options))
+      const key = getQueryKey(instance, options)
       const queryState = state.queries[key]
       if (queryState?.error) throw queryState.error
       return queryState?.result
     },
     onSubscribe: ({state, instance}, options: QueryOptions) => {
       const subscriptionId = insecureRandomId()
-      const key = getQueryKey(normalizeOptionsWithPerspective(instance, options))
+      const key = getQueryKey(instance, options)
 
       state.set('addSubscriber', addSubscriber(key, subscriptionId))
 
@@ -362,7 +363,7 @@ const _resolveQuery = bindActionByResource(
   ({state, instance}, {signal, ...options}: ResolveQueryOptions) => {
     const normalized = normalizeOptionsWithPerspective(instance, options)
     const {getCurrent} = getQueryState(instance, normalized)
-    const key = getQueryKey(normalized)
+    const key = getQueryKey(instance, normalized)
 
     // Hold a temporary subscription for the lifetime of this resolution so the
     // key participates in normal cleanup. Without one, a fetch that errors

--- a/packages/react/guides/0-Migration-Guide.md
+++ b/packages/react/guides/0-Migration-Guide.md
@@ -76,6 +76,36 @@ The `useDispatchIntent` hook and the `defineIntent` function have been removed, 
 
 The other half of this system was never built: defined intents were never registered anywhere, and a dispatched intent had no handler to resolve to. `dispatchIntent()` sent a window message that nothing listened for, so removing these APIs does not change how your app behaves at runtime.
 
+5. `@sanity/sdk` agent and comlink utilities moved to sub-entries
+
+Agent and comlink utilities are now available only from dedicated sub-entry points:
+
+| Previously in `@sanity/sdk`                                                                             | Now in                |
+| ------------------------------------------------------------------------------------------------------- | --------------------- |
+| `agentGenerate`, `agentPatch`, `agentPrompt`, `agentTransform`, `agentTranslate` and their option types | `@sanity/sdk/agent`   |
+| `getOrCreateController`, `getOrCreateChannel`, `getOrCreateNode`, `getNodeState`, `FrameMessage`, etc.  | `@sanity/sdk/comlink` |
+
+**Before:**
+
+```typescript
+import {agentGenerate, type AgentGenerateOptions, type FrameMessage} from '@sanity/sdk'
+```
+
+**After:**
+
+```typescript
+import {agentGenerate, type AgentGenerateOptions} from '@sanity/sdk/agent'
+import {type FrameMessage} from '@sanity/sdk/comlink'
+```
+
+`@sanity/sdk-react` re-exports the main `@sanity/sdk` entry point, but not these two sub-entries. Make the above code changes to get access to these.
+
+6. Internal utilities removed from the public API
+
+A handful of helpers that only existed to support the React layer are no longer part of the public API: `isStudioConfig`, `getClientErrorApiBody`, `getClientErrorApiDescription`, `getClientErrorApiType`, `isProjectUserNotFoundClientError`, `ApiErrorBody`, `PREVIEW_PROJECTION`, `transformProjectionToPreview`, `getQueryKey`, `parseQueryKey`, `getUsersKey`, `parseUsersKey`, and `createGroqSearchFilter`.
+
+These were never intended as app-facing APIs and have no stability guarantee. If you depend on one, open an issue describing your use case so we can consider a supported replacement.
+
 ### New in v3
 
 Non-breaking additions:

--- a/packages/react/src/components/SanityApp.tsx
+++ b/packages/react/src/components/SanityApp.tsx
@@ -1,4 +1,5 @@
-import {type DocumentResource, isStudioConfig, type SanityConfig} from '@sanity/sdk'
+import {type DocumentResource, type SanityConfig} from '@sanity/sdk'
+import {isStudioConfig} from '@sanity/sdk/_internal'
 import {type ReactElement, useContext, useEffect, useMemo} from 'react'
 
 import {SDKStudioContext, type StudioWorkspaceHandle} from '../context/SDKStudioContext'

--- a/packages/react/src/components/auth/AuthBoundary.tsx
+++ b/packages/react/src/components/auth/AuthBoundary.tsx
@@ -1,5 +1,6 @@
 import {CorsOriginError} from '@sanity/client'
-import {AuthStateType, getCorsErrorProjectId, isImportError, isStudioConfig} from '@sanity/sdk'
+import {AuthStateType, getCorsErrorProjectId, isImportError} from '@sanity/sdk'
+import {isStudioConfig} from '@sanity/sdk/_internal'
 import {useEffect, useMemo} from 'react'
 import {ErrorBoundary, type FallbackProps} from 'react-error-boundary'
 

--- a/packages/react/src/components/auth/LoginError.tsx
+++ b/packages/react/src/components/auth/LoginError.tsx
@@ -1,11 +1,10 @@
 import {ClientError} from '@sanity/client'
+import {AuthStateType, getIsInDashboardState} from '@sanity/sdk'
 import {
-  AuthStateType,
   getClientErrorApiBody,
   getClientErrorApiDescription,
-  getIsInDashboardState,
   isProjectUserNotFoundClientError,
-} from '@sanity/sdk'
+} from '@sanity/sdk/_internal'
 import {Suspense, useCallback, useEffect, useMemo, useRef} from 'react'
 import {type FallbackProps} from 'react-error-boundary'
 

--- a/packages/react/src/context/ComlinkTokenRefresh.tsx
+++ b/packages/react/src/context/ComlinkTokenRefresh.tsx
@@ -1,15 +1,13 @@
 import {type ClientError} from '@sanity/client'
 import {SDK_CHANNEL_NAME, SDK_NODE_NAME} from '@sanity/message-protocol'
+import {AuthStateType, getIsInDashboardState, setAuthToken} from '@sanity/sdk'
+import {isStudioConfig} from '@sanity/sdk/_internal'
 import {
-  AuthStateType,
   type FrameMessage,
-  getIsInDashboardState,
-  isStudioConfig,
   type NewTokenResponseMessage,
   type RequestNewTokenMessage,
-  setAuthToken,
   type WindowMessage,
-} from '@sanity/sdk'
+} from '@sanity/sdk/comlink'
 import React, {type PropsWithChildren, useCallback, useEffect, useMemo, useRef} from 'react'
 
 import {useAuthState} from '../hooks/auth/useAuthState'

--- a/packages/react/src/hooks/agent/agentActions.test.tsx
+++ b/packages/react/src/hooks/agent/agentActions.test.tsx
@@ -12,7 +12,7 @@ import {
   useAgentTranslate,
 } from './agentActions'
 
-vi.mock('@sanity/sdk', async (orig) => {
+vi.mock('@sanity/sdk/agent', async (orig) => {
   const actual = await orig()
   return {
     ...(actual as Record<string, any>),

--- a/packages/react/src/hooks/agent/agentActions.ts
+++ b/packages/react/src/hooks/agent/agentActions.ts
@@ -11,7 +11,7 @@ import {
   type AgentTransformOptions,
   agentTranslate,
   type AgentTranslateOptions,
-} from '@sanity/sdk'
+} from '@sanity/sdk/agent'
 import {useCallback} from 'react'
 import {firstValueFrom} from 'rxjs'
 

--- a/packages/react/src/hooks/agent/useAgentResourceContext.ts
+++ b/packages/react/src/hooks/agent/useAgentResourceContext.ts
@@ -1,5 +1,5 @@
 import {type Events, SDK_CHANNEL_NAME, SDK_NODE_NAME} from '@sanity/message-protocol'
-import {type FrameMessage} from '@sanity/sdk'
+import {type FrameMessage} from '@sanity/sdk/comlink'
 import {useCallback, useEffect, useRef} from 'react'
 
 import {useWindowConnection} from '../comlink/useWindowConnection'

--- a/packages/react/src/hooks/comlink/useFrameConnection.test.tsx
+++ b/packages/react/src/hooks/comlink/useFrameConnection.test.tsx
@@ -4,7 +4,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {act, renderHook} from '../../../test/test-utils'
 import {useFrameConnection} from './useFrameConnection'
 
-vi.mock(import('@sanity/sdk'), async (importOriginal) => {
+vi.mock(import('@sanity/sdk/comlink'), async (importOriginal) => {
   const actual = await importOriginal()
   return {
     ...actual,
@@ -14,7 +14,8 @@ vi.mock(import('@sanity/sdk'), async (importOriginal) => {
   }
 })
 
-const {getOrCreateChannel, getOrCreateController, releaseChannel} = await import('@sanity/sdk')
+const {getOrCreateChannel, getOrCreateController, releaseChannel} =
+  await import('@sanity/sdk/comlink')
 
 interface TestControllerMessage {
   type: 'TEST_MESSAGE'

--- a/packages/react/src/hooks/comlink/useFrameConnection.ts
+++ b/packages/react/src/hooks/comlink/useFrameConnection.ts
@@ -5,7 +5,7 @@ import {
   getOrCreateController,
   releaseChannel,
   type WindowMessage,
-} from '@sanity/sdk'
+} from '@sanity/sdk/comlink'
 import {useCallback, useEffect, useRef} from 'react'
 
 import {useSanityInstance} from '../context/useSanityInstance'

--- a/packages/react/src/hooks/comlink/useWindowConnection.test.tsx
+++ b/packages/react/src/hooks/comlink/useWindowConnection.test.tsx
@@ -1,5 +1,6 @@
 import {type Message, type Node} from '@sanity/comlink'
-import {getNodeState, type NodeState, type StateSource} from '@sanity/sdk'
+import {type StateSource} from '@sanity/sdk'
+import {getNodeState, type NodeState} from '@sanity/sdk/comlink'
 import {screen} from '@testing-library/react'
 import {Suspense} from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
@@ -7,8 +8,8 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {render, renderHook} from '../../../test/test-utils'
 import {useWindowConnection} from './useWindowConnection'
 
-vi.mock('@sanity/sdk', async () => {
-  const actual = await vi.importActual('@sanity/sdk')
+vi.mock('@sanity/sdk/comlink', async () => {
+  const actual = await vi.importActual('@sanity/sdk/comlink')
   return {
     ...actual,
     getNodeState: vi.fn(),

--- a/packages/react/src/hooks/comlink/useWindowConnection.ts
+++ b/packages/react/src/hooks/comlink/useWindowConnection.ts
@@ -1,12 +1,11 @@
 import {type MessageData, type NodeInput} from '@sanity/comlink'
+import {type SanityInstance, type StateSource} from '@sanity/sdk'
 import {
   type FrameMessage,
   getNodeState,
   type NodeState,
-  type SanityInstance,
-  type StateSource,
   type WindowMessage,
-} from '@sanity/sdk'
+} from '@sanity/sdk/comlink'
 import {useCallback, useEffect, useRef} from 'react'
 import {filter, firstValueFrom} from 'rxjs'
 

--- a/packages/react/src/hooks/dashboard/useManageFavorite.ts
+++ b/packages/react/src/hooks/dashboard/useManageFavorite.ts
@@ -9,10 +9,10 @@ import {
 import {
   type DocumentHandle,
   type FavoriteStatusResponse,
-  type FrameMessage,
   getFavoritesState,
   resolveFavoritesState,
 } from '@sanity/sdk'
+import {type FrameMessage} from '@sanity/sdk/comlink'
 import {useCallback, useMemo, useSyncExternalStore} from 'react'
 
 import {useWindowConnection} from '../comlink/useWindowConnection'

--- a/packages/react/src/hooks/dashboard/useRecordDocumentHistoryEvent.ts
+++ b/packages/react/src/hooks/dashboard/useRecordDocumentHistoryEvent.ts
@@ -6,7 +6,8 @@ import {
   SDK_NODE_NAME,
   type StudioResource,
 } from '@sanity/message-protocol'
-import {type DocumentHandle, type FrameMessage} from '@sanity/sdk'
+import {type DocumentHandle} from '@sanity/sdk'
+import {type FrameMessage} from '@sanity/sdk/comlink'
 import {useCallback} from 'react'
 
 import {useWindowConnection} from '../comlink/useWindowConnection'

--- a/packages/react/src/hooks/documents/useDocuments.ts
+++ b/packages/react/src/hooks/documents/useDocuments.ts
@@ -1,10 +1,5 @@
-import {
-  createGroqSearchFilter,
-  type DocumentHandle,
-  isDatasetResource,
-  type QueryOptions,
-} from '@sanity/sdk'
-import {pickProperties} from '@sanity/sdk/_internal'
+import {type DocumentHandle, isDatasetResource, type QueryOptions} from '@sanity/sdk'
+import {createGroqSearchFilter, pickProperties} from '@sanity/sdk/_internal'
 import {type SortOrderingItem} from '@sanity/types'
 import {useCallback, useMemo, useState} from 'react'
 

--- a/packages/react/src/hooks/paginatedDocuments/usePaginatedDocuments.ts
+++ b/packages/react/src/hooks/paginatedDocuments/usePaginatedDocuments.ts
@@ -1,10 +1,5 @@
-import {
-  createGroqSearchFilter,
-  type DocumentHandle,
-  isDatasetResource,
-  type QueryOptions,
-} from '@sanity/sdk'
-import {pickProperties} from '@sanity/sdk/_internal'
+import {type DocumentHandle, isDatasetResource, type QueryOptions} from '@sanity/sdk'
+import {createGroqSearchFilter, pickProperties} from '@sanity/sdk/_internal'
 import {type SortOrderingItem} from '@sanity/types'
 import {useCallback, useMemo, useState} from 'react'
 

--- a/packages/react/src/hooks/preview/useDocumentPreview.tsx
+++ b/packages/react/src/hooks/preview/useDocumentPreview.tsx
@@ -1,9 +1,5 @@
-import {
-  PREVIEW_PROJECTION,
-  type PreviewQueryResult,
-  type PreviewValue,
-  transformProjectionToPreview,
-} from '@sanity/sdk'
+import {type PreviewQueryResult, type PreviewValue} from '@sanity/sdk'
+import {PREVIEW_PROJECTION, transformProjectionToPreview} from '@sanity/sdk/_internal'
 import {useMemo} from 'react'
 
 import {type DocumentHandle} from '../../config/handles'

--- a/packages/react/src/hooks/query/useQuery.ts
+++ b/packages/react/src/hooks/query/useQuery.ts
@@ -1,10 +1,5 @@
-import {
-  getQueryKey,
-  getQueryState,
-  parseQueryKey,
-  type QueryOptions,
-  resolveQuery,
-} from '@sanity/sdk'
+import {getQueryState, type QueryOptions, resolveQuery} from '@sanity/sdk'
+import {getQueryKey, parseQueryKey} from '@sanity/sdk/_internal'
 import {type SanityQueryResult} from 'groq'
 import {useEffect, useMemo, useRef, useState, useSyncExternalStore, useTransition} from 'react'
 
@@ -162,7 +157,7 @@ export function useQuery(options: WithResourceNameSupport<QueryOptions>): {
   const [isPending, startTransition] = useTransition()
 
   // Get the unique key for this query and its options (using normalized options)
-  const queryKey = getQueryKey(normalized)
+  const queryKey = getQueryKey(instance, normalized)
   // Use a deferred state to avoid immediate re-renders when the query changes
   const [deferredQueryKey, setDeferredQueryKey] = useState(queryKey)
 

--- a/packages/react/src/hooks/users/useUser.ts
+++ b/packages/react/src/hooks/users/useUser.ts
@@ -1,11 +1,5 @@
-import {
-  type GetUserOptions,
-  getUsersKey,
-  getUsersState,
-  parseUsersKey,
-  resolveUsers,
-  type SanityUser,
-} from '@sanity/sdk'
+import {type GetUserOptions, getUsersState, resolveUsers, type SanityUser} from '@sanity/sdk'
+import {getUsersKey, parseUsersKey} from '@sanity/sdk/_internal'
 import {useEffect, useMemo, useState, useSyncExternalStore, useTransition} from 'react'
 
 import {useSanityInstance} from '../context/useSanityInstance'

--- a/packages/react/src/hooks/users/useUsers.ts
+++ b/packages/react/src/hooks/users/useUsers.ts
@@ -1,12 +1,11 @@
 import {
-  getUsersKey,
   type GetUsersOptions,
   getUsersState,
   loadMoreUsers,
-  parseUsersKey,
   resolveUsers,
   type SanityUser,
 } from '@sanity/sdk'
+import {getUsersKey, parseUsersKey} from '@sanity/sdk/_internal'
 import {useCallback, useEffect, useMemo, useState, useSyncExternalStore, useTransition} from 'react'
 
 import {useSanityInstance} from '../context/useSanityInstance'


### PR DESCRIPTION
### Description
While we're making a breaking change, it would be nice to clean up some DX. This PR moves some exports to subdomains for a bit better organization.

Note that this won't budge our package size, unfortunately; we bundle our code. I tried seeing what things would look like unbundled, but our main hooks are so interdependent (client and auth stores rely on each other, everything depends on the query store and store generics) that I only saw a 30% improvement through some manual testing.

PreviewStoreState et al should also be removed, but that's a bigger refactor.

I didn't move the applications / userapplications / installations, but those might be a good candidate and something to run by the current Workbench work.

### What to review
Is this a sane reorganization?

### Testing
Shouldn't be required.