### PR TITLE
fix(core): don't stop saving after an edit with emoji or accented text

### DIFF
--- a/packages/core/src/document/patchOperations.test.ts
+++ b/packages/core/src/document/patchOperations.test.ts
@@ -565,6 +565,33 @@ describe('diffMatchPatch', () => {
     expect(output).toEqual(input)
   })
 
+  it('applies the patch when its offsets miss a multi-byte boundary', () => {
+    // `\u00f8` is two bytes, so this patch's offsets land inside it and the byte
+    // walk overshoots. The default is to throw, which escapes the rebase loop in
+    // `reducers.ts` and kills the whole outgoing-actions pipeline: the instance
+    // then silently stops writing every document. The patch itself is fine and
+    // still applies.
+    const input = {foo: 'abcdefg\u00f8'}
+    const patch = '@@ -9,1 +9,2 @@\n \u00f8\n+!\n'
+
+    expect(() => diffMatchPatch(input, {foo: patch})).not.toThrow()
+    expect(diffMatchPatch(input, {foo: patch})).toEqual({foo: 'abcdefg\u00f8!'})
+  })
+
+  it('still patches the other properties in the same mutation', () => {
+    const input = {multibyte: 'abcdefg\u00f8', ascii: 'the quick brown fox'}
+
+    const output = diffMatchPatch(input, {
+      multibyte: '@@ -9,1 +9,2 @@\n \u00f8\n+!\n',
+      ascii: '@@ -13,7 +13,7 @@\n own \n-fox\n+cat\n',
+    })
+
+    expect(output).toEqual({
+      multibyte: 'abcdefg\u00f8!',
+      ascii: 'the quick brown cat',
+    })
+  })
+
   it('applies a diff-match-patch that makes no changes', () => {
     const input = {foo: 'unchanged'}
     const patch = '@@ -1,9 +1,9 @@\n unchanged\n'

--- a/packages/core/src/document/patchOperations.ts
+++ b/packages/core/src/document/patchOperations.ts
@@ -617,7 +617,16 @@ export function diffMatchPatch(
         )
       }
 
-      const [nextValue] = applyPatches(parsePatch(dmp), value)
+      // Offsets arrive as UTF-8 byte positions and can overshoot when they
+      // land inside a multi-byte character, which happens once the string a
+      // patch was computed against has diverged. The default is to throw, and
+      // that throw escapes the rebase loop in `reducers.ts`, kills the
+      // outgoing-actions pipeline, and leaves the instance silently dropping
+      // every write. Clamping to the nearest index applies the patch instead,
+      // which is what the Studio and the Portable Text editor already do.
+      const [nextValue] = applyPatches(parsePatch(dmp), value, {
+        allowExceedingIndices: true,
+      })
       return {path, value: nextValue}
     })
     .reduce((acc, {path, value}) => setDeep(acc, path, value), input)

--- a/packages/core/src/document/reducers.test.ts
+++ b/packages/core/src/document/reducers.test.ts
@@ -1178,6 +1178,85 @@ describe('applyRemoteDocument', () => {
     })
   })
 
+  describe('rebase over multi-byte text', () => {
+    it('does not kill the pipeline when a plain edit rebases onto multi-byte text', () => {
+      // The reported production failure: a byte-offset throw from
+      // `@sanity/diff-match-patch` is a plain `Error`, and `createMutationApplier`
+      // only converts to `ActionError` when `preserveOperations` is set. So for an
+      // ordinary `editDocument` it escapes this rebase loop, reaches the rxjs
+      // subscription, and the outgoing-actions pipeline for the whole instance
+      // dies. Every later write is then dropped silently, for every document.
+      const docId = getDraftId(DocumentId('doc1'))
+      const originalDoc: SanityDocument = {
+        ...exampleDoc,
+        _id: docId,
+        _rev: 'rev1',
+        title: 'abcdefg\u00f8',
+      }
+      const locallyEditedDoc: SanityDocument = {
+        ...originalDoc,
+        title: 'abcdefg\u00f8!',
+        _rev: 'txnLocal',
+      }
+
+      const appliedTransaction: AppliedTransaction = {
+        transactionId: 'txnLocal',
+        actions: [
+          {
+            type: 'document.edit',
+            documentId: 'doc1',
+            documentType: 'author',
+            patches: [{diffMatchPatch: {title: '@@ -9,1 +9,2 @@\n \u00f8\n+!\n'}}],
+          },
+        ],
+        previous: {[docId]: originalDoc},
+        base: {[docId]: originalDoc},
+        working: {[docId]: locallyEditedDoc},
+        previousRevs: {[docId]: 'rev1'},
+        timestamp: '2025-02-06T00:16:00.000Z',
+        outgoingActions: [],
+        outgoingMutations: [],
+      }
+
+      const initialState: SyncTransactionState = {
+        queued: [],
+        applied: [appliedTransaction],
+        outgoing: undefined,
+        grants,
+        documentStates: {
+          [docId]: {
+            id: docId,
+            subscriptions: ['sub1'],
+            local: locallyEditedDoc,
+            remote: originalDoc,
+            unverifiedRevisions: {},
+          },
+        },
+      }
+
+      // someone else changed the same field, so the local patch is rebased onto
+      // a base its byte offsets were not computed against
+      const remoteDoc: SanityDocument = {
+        ...originalDoc,
+        title: '\u00f8\u00f8\u00f8\u00f8\u00f8\u00f8',
+        _rev: 'txnForeign',
+      }
+      const remote: RemoteDocument = {
+        type: 'mutation',
+        documentId: docId,
+        document: remoteDoc,
+        revision: 'txnForeign',
+        previousRev: 'rev1',
+        timestamp: '2025-02-06T00:17:00.000Z',
+        mutations: [{patch: {id: docId, set: {title: '\u00f8\u00f8\u00f8\u00f8\u00f8\u00f8'}}}],
+      }
+
+      const events = new Subject<DocumentEvent>()
+
+      expect(() => applyRemoteDocument(initialState, remote, events)).not.toThrow()
+    })
+  })
+
   describe('rebase with preserved operations', () => {
     it('skips a preserved-operations transaction that fails to re-apply and emits rebase-error', () => {
       const docId = getDraftId(DocumentId('doc1'))


### PR DESCRIPTION
### Description

Fixes SDK-1443

An app using the SDK can stop saving, without saying so, and stay that way until the page is reloaded.

Two things have to line up. Someone edits a text field holding a character that takes more than one byte, so an emoji, a curly quote, an em dash, or a letter like `ø` or `é`. Meanwhile the stored text has moved on since that edit was queued, usually because someone else changed the same field.

After that, no write reaches Content Lake. Not for that field, not for that document, not for any document on that `SanityInstance`. Meanwhile `applyDocumentActions` still resolves, document state still updates, and the UI looks completely normal. The user keeps typing and everything appears saved.

Here is why one bad patch takes down everything:

Diff-match-patch offsets are counted in bytes. Once the text has changed underneath, an offset can point into the middle of a multi-byte character, and `applyPatches` throws `Failed to determine byte offset` rather than coping with it.

That throw is a plain `Error`. `createMutationApplier` only converts errors into `ActionError`, and only when `preserveOperations` is set, so an ordinary `editDocument` produces a plain one. Both rebase loops in `reducers.ts` skip an `ActionError` and rethrow anything else. So it escapes, reaches the error handler on the rxjs subscription, and ends the outgoing-actions stream. Nothing starts it again.

The fix is one option. `allowExceedingIndices: true` clamps the offset to the nearest index instead of throwing, and the patch still applies.

Every other first-party caller already passes it:

- `@portabletext/patches`, `string.ts:15`
- `@portabletext/editor`, `applyPatch.ts:84` and `:108`
- `@sanity/mutator`, `DiffMatchPatch.ts:9`
- `sanity`, `core/form/patch/string.ts:20` and the inline-comments range util

The ticket suggests changing the default in `@sanity/diff-match-patch` instead. That would work, but it isn't needed here. Matching what the Studio has done for years fixes it today, with no upstream release to wait for.

### What to review

`packages/core/src/document/patchOperations.ts` is the whole change. Everything else is tests.

Two things I would like a second opinion on.

Clamping is a trade. When the text really has diverged, the patch now applies at an offset the sender did not mean, so an unlucky concurrent edit could garble some text instead of failing loudly. The Studio already accepts that trade, and garbled text beats losing every later write, but it is a trade and not a free win.

The wider problem is still there. Any error that isn't an `ActionError` will end the outgoing-actions stream the same way. This change removes the one trigger we know about, not the whole class. Making `createMutationApplier` wrap unconditionally rather than only under `preserveOperations` looks like the right follow-up, though it changes which errors are fatal and did not belong in a targeted fix.

Worth knowing while reviewing: this is not Portable Text specific, and Portable Text is the case that already worked. `plugin-sdk-value` sets `preserveOperations`, so its writes were skipped and reported. Plain field edits are the ones that escape. Every string edit is affected, because `diffValue` emits a `diffMatchPatch` operation for any string change at all, down to a single character.

### Testing

Three tests, each confirmed to fail against `main` with the real error:

- a patch whose offsets miss a multi-byte boundary now applies instead of throwing
- one bad property no longer stops the other properties in the same mutation being patched
- an ordinary edit rebasing onto multi-byte text no longer throws out of `applyRemoteDocument`, which is the path that ends the stream

The third one is the one that matters. The first two cover the error, that one covers the damage.

Full suite passes: 1666 tests, 3 skipped. `ts:check` and `lint` are clean.

### Fun gif

![accénto](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExbzB1MnJkOTkwZHJuMmx6bXJ5ZmlwZThnZnl1ZGpoOHdrYXV3ajYybCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vhtcpbuuix9XW/giphy.gif)
