### PR TITLE
fix(react): transpile JSX in distributed build output

### DIFF
--- a/packages/react/tsconfig.settings.json
+++ b/packages/react/tsconfig.settings.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist",
+    "jsx": "react-jsx",
     // For import.meta.env/import.meta.hot definitions and similar
     "types": ["vite/client", "node"],
     "paths": {


### PR DESCRIPTION
### Description

#### What changes are introduced?
Added `"jsx": "react-jsx"` to `packages/react/tsconfig.settings.json` so `@sanity/pkg-utils` transpiles all JSX (including output from `babel-plugin-react-compiler`) into standard `/* @__PURE__ */ jsx(...)` runtime calls in the emitted `dist/index.js` bundle.

#### Why are these changes introduced?
When creating a brand new Sanity Studio scaffold and running `sanity dev` with Vite 8 / Rolldown, the dev server immediately crashes on startup during dependency pre-bundling with the following error:
[![Screenshot-2026-08-21-at-3-35-04-PM.png](https://i.postimg.cc/rpQnWvC5/Screenshot-2026-08-21-at-3-35-04-PM.png)](https://postimg.cc/McfmJ3LG)

#### Root cause: 

`packages/react/tsconfig.settings.json` was inheriting `"jsx": "preserve"` from the base `@repo/tsconfig/base.json`. When pkg build ran with `babel-plugin-react-compiler`, the compiler emitted memoized JSX (e.g. `<DashboardTokenRefresh>`), but because `jsx` was preserved, raw JSX tags were published directly inside `dist/index.js`. Downstream bundlers parsing `.js` files in `node_modules` as standard ECMAScript fail on these raw JSX tags.

Explicitly setting `"jsx": "react-jsx"` in `tsconfig.settings.json` overrides the base config and ensures all JSX is compiled to valid JavaScript before packaging.


#### What issue(s) does this solve?
* Fixes sanity-io/sanity [#14236](https://github.com/sanity-io/sanity/issues/14236#issue-5213372217)

### What to review

* **File changed:** `packages/react/tsconfig.settings.json`
* **Verification:** Check that `compilerOptions.jsx` is explicitly set to `"react-jsx"`, ensuring that JSX is transpiled to `/* @__PURE__ */ jsx(...)` during the `pkg build` step.

### Testing

* Ran `pnpm build:packages` to verify that both `@sanity/sdk` and `@sanity/sdk-react` build successfully without errors.
* Inspected `packages/react/dist/index.js` to confirm all raw JSX elements are now transpiled to `_jsx` calls.
* Ran the full test suite (`pnpm --filter @sanity/sdk-react test`) — all 72 test suites (390 tests) passed cleanly.

### Fun gif
![Fri-nally!](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWU1OHp1OHdsYTZvOTY0OWh4bGJxOHIwYXByNG81MmFvZWpqOThhNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/NQGJRZnxNIqSsiNMgK/giphy.gif)
