### PR TITLE
fix(react): transpile JSX in the published bundle

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,11 +40,11 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": "./dist/index.js",
       "./package.json": "./package.json"
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "pkg build --strict --clean --check",

--- a/packages/react/tsconfig.dist.json
+++ b/packages/react/tsconfig.dist.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.settings",
+  "compilerOptions": {
+    // The base config uses "preserve" for source code, but we want to ship compiled JSX;
+    // rolldown reads this to compile JSX with the automatic runtime during builds
+    "jsx": "react-jsx"
+  },
   "include": ["./package.json", "./src"],
   "exclude": [
     "./src/**/__fixtures__",


### PR DESCRIPTION
FIXES SDK-2350

### Description
The pkg-utils v12 migration (#1096) removed the Babel stage that used to transpile JSX during builds (since it was meant to be covered by `pkg-util`). In v12 the bundler takes its JSX mode from the build tsconfig, and the shared base config uses "jsx": "preserve" — so @sanity/sdk-react@2.20.0 shipped raw JSX (and no JSX runtime import) in dist/index.js.

Any consumer that parses the bundle as plain JS was breaking. This included  `sanity dev` during dependency prebundling, and `sanity schema extract` / `schema deploy` / TypeGen during Vite import analysis.

This is also in line with Studio -- ref https://github.com/sanity-io/sanity/blob/e089afde2646ed4c649e81bebf5e4af4ba0b6188/packages/%40repo/tsconfig/build.json#L10.

### What to review
The changed config -- is it the right place?

### Testing
To confirm the broken behavior, run:
```
npm create sanity@latest -- --template clean --project ppsg7ml5 \
    --dataset test --typescript --output-path /tmp/jsx-test-studio

cd /tmp/jsx-test-studio
npm run dev
```
You should see the error.

To confirm the fix, run:
```
pnpm --filter @sanity/sdk-react build cd packages/react && pnpm pack --out /tmp/sanity-sdk-react-fixed.tgz
```

Update the tmp package.json of the studio you just made:
```
"overrides": {
  "@sanity/sdk-react": "file:/tmp/sanity-sdk-react-fixed.tgz"
}

rm -rf node_modules package-lock.json && npm install
npm ls @sanity/sdk-react   # confirm it resolved to the tarball, not the registry
```

and try:
```
npm run dev
```

again. No error!