### PR TITLE
feat: surface application name and reference on application and installation types

### DIFF
--- a/packages/core/src/applications/applications.test-d.ts
+++ b/packages/core/src/applications/applications.test-d.ts
@@ -30,6 +30,11 @@ test('Application — no includes: only the base shape, no config or activeDeplo
   expectTypeOf<Extract<keyof Application, ChildKeys>>().toEqualTypeOf<never>()
 })
 
+test('ApplicationBase — carries name and reference as strings', () => {
+  expectTypeOf<ApplicationBase['name']>().toEqualTypeOf<string>()
+  expectTypeOf<ApplicationBase['reference']>().toEqualTypeOf<string>()
+})
+
 test('Application — config.studio adds a required config.studio', () => {
   expectTypeOf<
     Application<'config.studio'>['config']['studio']

--- a/packages/core/src/applications/applications.ts
+++ b/packages/core/src/applications/applications.ts
@@ -120,6 +120,10 @@ export interface ApplicationBase {
   id: string
   type: 'studio' | 'coreApp'
   title: string
+  /** Stable, immutable identity, distinct from the mutable `slug` address. */
+  name: string
+  /** Qualified, globally-unique handle: `sanity/<name>` for singletons, `<organizationId>/<name>` otherwise. */
+  reference: string
   icon: string | null
   isSingleton: boolean
   visibility: 'default' | 'unlisted' | 'disabled'

--- a/packages/core/src/installations/installations.test-d.ts
+++ b/packages/core/src/installations/installations.test-d.ts
@@ -29,6 +29,11 @@ test('Installation — no includes: only the base shape', () => {
   expectTypeOf<Extract<keyof Installation, IncludeKeys>>().toEqualTypeOf<never>()
 })
 
+test('InstallationBase — the application sub-object carries name and reference', () => {
+  expectTypeOf<InstallationBase['application']['name']>().toEqualTypeOf<string>()
+  expectTypeOf<InstallationBase['application']['reference']>().toEqualTypeOf<string>()
+})
+
 test('Installation — each token adds its top-level field, required, others absent', () => {
   expectTypeOf<Installation<'access'>['access']>().toEqualTypeOf<InstallationAccess[]>()
   expectTypeOf<

--- a/packages/core/src/installations/installations.ts
+++ b/packages/core/src/installations/installations.ts
@@ -79,6 +79,10 @@ export interface InstallationBase {
   updatedAt: string
   application: {
     title: string
+    /** Stable, immutable identity of the installed singleton, distinct from `slug`. */
+    name: string
+    /** Qualified, globally-unique handle of the installed singleton (e.g. `sanity/<name>`). */
+    reference: string
     slug: string | null
   }
 }


### PR DESCRIPTION
The App SDK's application types don't expose the stable `name` or qualified `reference` that the Applications API now returns, so consumers can't read either without casting. This adds `name` and `reference` to `ApplicationBase` and to the `application` sub-object on `InstallationBase`.

The change is additive and type-only — the fetchers already forward the raw payload verbatim, so there's no runtime change. It's safe to merge ahead of the API rollout: the fields are typed here and populated server-side.