### PR TITLE
feat(react)!: scope useNavigate to the dashboard entrypoint

### DIFF
--- a/apps/kitchensink-react/src/App.tsx
+++ b/apps/kitchensink-react/src/App.tsx
@@ -1,10 +1,11 @@
 import './global.css'
 
-import {configureLogging, SanityApp, useDashboardNavigate} from '@sanity/sdk-react'
+import {configureLogging, SanityApp} from '@sanity/sdk-react'
+import {useNavigate} from '@sanity/sdk-react/dashboard'
 import {Spinner, ThemeProvider} from '@sanity/ui'
 import {buildTheme} from '@sanity/ui/theme'
 import {type JSX, Suspense} from 'react'
-import {BrowserRouter, useNavigate} from 'react-router'
+import {BrowserRouter, useNavigate as useRouterNavigate} from 'react-router'
 
 import {AppRoutes} from './AppRoutes'
 import {devResources, e2eResources, isE2E} from './sanityConfigs'
@@ -20,8 +21,8 @@ configureLogging({
 const theme = buildTheme({})
 
 function NavigationHandler() {
-  const navigate = useNavigate()
-  useDashboardNavigate(({path, type}) => {
+  const navigate = useRouterNavigate()
+  useNavigate(({path, type}) => {
     navigate(path, {replace: type === 'replace'})
   })
   return null

--- a/packages/react/guides/0-Migration-Guide.md
+++ b/packages/react/guides/0-Migration-Guide.md
@@ -241,6 +241,7 @@ Dashboard hooks are now available only from the dedicated `@sanity/sdk-react/das
 | Previously in `@sanity/sdk-react` | Now in `@sanity/sdk-react/dashboard` |
 | --------------------------------- | ------------------------------------ |
 | `useDashboardOrganizationId`      | `useOrganizationId`                  |
+| `useDashboardNavigate`            | `useNavigate`                        |
 
 ### New in v3
 

--- a/packages/react/src/_exports/dashboard.ts
+++ b/packages/react/src/_exports/dashboard.ts
@@ -1,1 +1,2 @@
 export {useOrganizationId} from '../hooks/dashboard/useOrganizationId'
+export {useNavigate} from '../hooks/dashboard/useNavigate'

--- a/packages/react/src/_exports/sdk-react.ts
+++ b/packages/react/src/_exports/sdk-react.ts
@@ -54,7 +54,6 @@ export {useComments, type UseCommentsResult} from '../hooks/comments/useComments
 export {useCommentThreads, type UseCommentThreadsResult} from '../hooks/comments/useCommentThreads'
 export {useResource} from '../hooks/context/useResource'
 export {useSanityInstance} from '../hooks/context/useSanityInstance'
-export {useDashboardNavigate} from '../hooks/dashboard/useDashboardNavigate'
 export {useManageFavorite} from '../hooks/dashboard/useManageFavorite'
 export {
   type NavigateToStudioResult,

--- a/packages/react/src/hooks/dashboard/useNavigate.test.ts
+++ b/packages/react/src/hooks/dashboard/useNavigate.test.ts
@@ -2,7 +2,7 @@ import {type PathChangeMessage} from '@sanity/message-protocol'
 import {renderHook} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {useDashboardNavigate} from './useDashboardNavigate'
+import {useNavigate} from './useNavigate'
 
 const mockOnMessage = vi.fn()
 let mockMessageHandler: ((data: PathChangeMessage['data']) => void) | undefined
@@ -22,7 +22,7 @@ vi.mock('../comlink/useWindowConnection', () => {
   }
 })
 
-describe('useDashboardNavigate', () => {
+describe('useNavigate', () => {
   const mockNavigateFn = vi.fn()
 
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('useDashboardNavigate', () => {
   })
 
   it('calls navigate function with correct data when message is received', () => {
-    renderHook(() => useDashboardNavigate(mockNavigateFn))
+    renderHook(() => useNavigate(mockNavigateFn))
 
     const mockNavigationData = {
       path: '/test-path',

--- a/packages/react/src/hooks/dashboard/useNavigate.ts
+++ b/packages/react/src/hooks/dashboard/useNavigate.ts
@@ -21,13 +21,13 @@ import {useWindowConnection} from '../comlink/useWindowConnection'
  *
  * @example
  * ```tsx
- * import {useDashboardNavigate} from '@sanity/sdk-react'
- * import {BrowserRouter, useNavigate} from 'react-router'
+ * import {useNavigate} from '@sanity/sdk-react/dashboard'
+ * import {BrowserRouter, useNavigate as useRouterNavigate} from 'react-router'
  * import {Suspense} from 'react'
  *
  * function DashboardNavigationHandler() {
- *   const navigate = useNavigate()
- *   useDashboardNavigate(({path, type}) => {
+ *   const navigate = useRouterNavigate()
+ *   useNavigate(({path, type}) => {
  *     navigate(path, {replace: type === 'replace'})
  *   })
  *   return null
@@ -45,7 +45,7 @@ import {useWindowConnection} from '../comlink/useWindowConnection'
  * }
  * ```
  */
-export function useDashboardNavigate(
+export function useNavigate(
   navigateFn: (options: PathChangeMessage['data']) => void,
 ): void {
   useWindowConnection<PathChangeMessage, never>({


### PR DESCRIPTION
### Description

Rename `useDashboardNavigate` to `useNavigate` and move it into the dashboard-specific entrypoint `@sanity/sdk-react/dashboard` that will contain all dashboard-related code in the future.
