### PR TITLE
feat(react)!: require React 19.2 baseline

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,11 +40,11 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": "./dist/index.js",
       "./package.json": "./package.json"
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "pkg build --strict --clean --check",
@@ -101,8 +101,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "browserslist": "extends @sanity/browserslist-config",
   "packageManager": "pnpm@10.33.4",


### PR DESCRIPTION
### Description

Raises the React baseline for `@sanity/sdk-react` to 19.2. The published peer dependency range moves from `^18.0.0 || ^19.0.0` to `^19.2.0`, so React 18 is no longer supported. The dev toolchain already built and tested against 19.2 via the workspace catalog; this aligns what we ship with what we test.

**BREAKING CHANGE:** `@sanity/sdk-react` now requires React 19.2 or newer. Apps still on React 18 must upgrade before taking this release.