### PR TITLE
fix: fix subscription leak in fetcher store

### DIFF
--- a/packages/core/src/store/fetcherStore.test.ts
+++ b/packages/core/src/store/fetcherStore.test.ts
@@ -1,4 +1,4 @@
-import {NEVER, of, startWith, Subject, throwError} from 'rxjs'
+import {concatWith, NEVER, of, startWith, Subject, throwError} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createSanityInstance, type SanityInstance} from './createSanityInstance'
@@ -63,6 +63,28 @@ describe('fetcherStore', () => {
     fetcher.invalidate(instance, 1)
     await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2))
     unsub3()
+  })
+
+  it('revalidates a stale entry on re-subscribe when the fetch source does not complete', async () => {
+    let n = 0
+    const fetchSpy = vi.fn(() => of(++n).pipe(concatWith(NEVER)))
+    const fetcher = defineFetcher<[], number>({
+      name: 'swr-non-completing',
+      staleTime: 0,
+      getKey: () => 'k',
+      fetch: () => fetchSpy,
+    })
+
+    const first = fetcher.getState(instance)
+    const unsub1 = first.subscribe()
+    await vi.waitFor(() => expect(first.getCurrent().data).toBe(1))
+    unsub1()
+
+    const second = fetcher.getState(instance)
+    const unsub2 = second.subscribe()
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2))
+    expect(second.getCurrent().data).toBe(2)
+    unsub2()
   })
 
   it('invalidate refetches an actively-subscribed entry', async () => {

--- a/packages/core/src/store/fetcherStore.ts
+++ b/packages/core/src/store/fetcherStore.ts
@@ -1,4 +1,4 @@
-import {filter, firstValueFrom, map, type Observable, Subscription} from 'rxjs'
+import {filter, firstValueFrom, map, type Observable, Subscription, take} from 'rxjs'
 
 import {setCleanupInterval, setCleanupTimeout} from '../utils/setCleanupTimeout'
 import {bindActionGlobally} from './createActionBinder'
@@ -490,6 +490,7 @@ const startFetch = (
   sub.add(
     def
       .fetch(instance)(...params)
+      .pipe(take(1))
       .subscribe({
         next: (data) => {
           const current = state.get().entries[key]


### PR DESCRIPTION
### Description
Claude [caught a bug](https://github.com/sanity-io/sdk/pull/1119#issuecomment-5428402627) in the fetcher store while we were about to merge v3. The subscription added when a fetch began was never able to be cleaned up. Although the `client.observable.request` completes, `getClientState.observable` does not (because of the StateSourceAction logic).

This means any new request would see that old subscription, see it in progress, and return its promise. You can recreate this on the `v3` branch by doing the following:
1. Open your network tab.
2. Go to the `projects` page in Kitchensink (running dev locally)
3. You should see fresh `projects` API calls being made.
4. Navigate somewhere else and wait for 30 seconds (the fetcher store `staleTime`)
5. Go back to the `projects` page
6. No new API calls 😢 

This also left the subscription hanging around, which is also not so good. Adding a `take(1)` here lets the `complete` and teardown in the fetcher store happen.

### What to review
Is `take(1)` the right move? Any side effects? Do we need to do a share or anything?

### Testing
A regression test was added. You can follow the same steps above on THIS branch to see the fix in action.