### PR TITLE
chore(deps): use latest @sanity/types in workspace catalog

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^2.2.1
       version: 2.2.1
     '@sanity/types':
-      specifier: ^6.9.1
-      version: 6.9.2
+      specifier: ^6.11.0
+      version: 6.11.0
     '@testing-library/jest-dom':
       specifier: ^6.9.1
       version: 6.9.1
@@ -533,7 +533,7 @@ importers:
         version: 1.1.0(react@19.2.7)
       '@sanity/types':
         specifier: 'catalog:'
-        version: 6.9.2(@types/react@19.2.17)(vitest@4.1.10)
+        version: 6.11.0(@types/react@19.2.17)(vitest@4.1.10)
       groq:
         specifier: 'catalog:'
         version: 3.88.1-typegen-experimental.0
@@ -609,7 +609,7 @@ importers:
         version: link:../core
       '@sanity/types':
         specifier: 'catalog:'
-        version: 6.9.2(@types/react@19.2.17)(vitest@4.1.10)
+        version: 6.11.0(@types/react@19.2.17)(vitest@4.1.10)
       '@sanity/workbench':
         specifier: 0.1.0-alpha.24
         version: 0.1.0-alpha.24(@sanity/sdk@packages+core)(node-fetch@2.7.0)(react@19.2.7)(xstate@5.32.5)
@@ -3345,13 +3345,14 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@sanity/types@6.3.0':
-    resolution: {integrity: sha512-IMll1cRPr8DGHEwiOoYiGIvRCA4i0ug25V5tzrCBeWhvJPX9vr4vA7jTHf6dEzvSZW9q6Fo/0X/9aBS42IOrxQ==}
+  '@sanity/types@6.11.0':
+    resolution: {integrity: sha512-40al7sIC4K/owr9yDj6kL5VtjBOx8Pdgo5A5bVbeN8+rsF/SkhdmtkMdyO+ZxdrXxe+TfcktrpNaIfq32J1nNA==}
+    engines: {node: '>=22.12'}
     peerDependencies:
       '@types/react': '*'
 
-  '@sanity/types@6.9.2':
-    resolution: {integrity: sha512-AKITu+phxMU4iSOr1Kv6F3cTaKzOe8QEjXrMOSo+9sec4fz8AkxnDjZlGGuYTD6uyYPwICnjr98CYfxc4Z0OfA==}
+  '@sanity/types@6.3.0':
+    resolution: {integrity: sha512-IMll1cRPr8DGHEwiOoYiGIvRCA4i0ug25V5tzrCBeWhvJPX9vr4vA7jTHf6dEzvSZW9q6Fo/0X/9aBS42IOrxQ==}
     peerDependencies:
       '@types/react': '*'
 
@@ -10450,7 +10451,7 @@ snapshots:
     dependencies:
       '@portabletext/schema': 2.2.3
       '@sanity/schema': 6.3.0(@types/react@19.2.17)(vitest@4.1.10)
-      '@sanity/types': 6.9.2(@types/react@19.2.17)(vitest@4.1.10)
+      '@sanity/types': 6.3.0(@types/react@19.2.17)(vitest@4.1.10)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
@@ -10660,7 +10661,7 @@ snapshots:
       '@sanity/generate-help-url': 4.0.0
       '@sanity/schema': 6.3.0(@types/react@19.2.17)(vitest@4.1.10)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
-      '@sanity/types': 6.9.2(@types/react@19.2.17)(vitest@4.1.10)
+      '@sanity/types': 6.3.0(@types/react@19.2.17)(vitest@4.1.10)
       '@sanity/workbench-cli': 1.1.3(@noble/hashes@2.0.1)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.36.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.2)(jiti@2.7.0)(node-fetch@2.7.0)(terser@5.36.0)(tsx@4.23.12)(typescript@6.0.3)(vitest@4.1.10)(yaml@2.9.0)
       '@vitejs/plugin-react': 6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.36.0)(tsx@4.23.12)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.36.0)(tsx@4.23.12)(yaml@2.9.0))
       chokidar: 5.0.0
@@ -10764,7 +10765,7 @@ snapshots:
       '@sanity/schema': 6.3.0(@types/react@19.2.17)(vitest@4.1.10)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
       '@sanity/template-validator': 3.1.0
-      '@sanity/types': 6.9.2(@types/react@19.2.17)(vitest@4.1.10)
+      '@sanity/types': 6.3.0(@types/react@19.2.17)(vitest@4.1.10)
       '@sanity/workbench-cli': 1.1.3(@noble/hashes@2.0.1)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.2)(rolldown@1.2.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.36.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.2)(jiti@2.7.0)(node-fetch@2.7.0)(terser@5.36.0)(tsx@4.23.12)(typescript@6.0.3)(vitest@4.1.10)(yaml@2.9.0)
       '@sanity/worker-channels': 2.0.0
       '@vercel/frameworks': 3.29.0
@@ -11033,7 +11034,7 @@ snapshots:
       '@sanity/cli-core': 2.1.3(@noble/hashes@2.0.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.2)(terser@5.36.0)(vitest@4.1.10)(yaml@2.9.0)
       '@sanity/client': 8.4.0(vitest@4.1.10)
       '@sanity/mutate': 0.18.1(vitest@4.1.10)(xstate@5.32.5)
-      '@sanity/types': 6.9.2(@types/react@19.2.17)(vitest@4.1.10)
+      '@sanity/types': 6.3.0(@types/react@19.2.17)(vitest@4.1.10)
       '@sanity/util': 6.3.0(@types/react@19.2.17)(vitest@4.1.10)
       arrify: 2.0.1
       console-table-printer: 2.15.0
@@ -11216,7 +11217,7 @@ snapshots:
       '@sanity/message-protocol': 0.23.0
       '@sanity/mutate': 0.18.1(vitest@4.1.10)(xstate@5.32.5)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
-      '@sanity/types': 6.9.2(@types/react@19.2.17)(vitest@4.1.10)
+      '@sanity/types': 6.3.0(@types/react@19.2.17)(vitest@4.1.10)
       groq: 3.88.1-typegen-experimental.0
       groq-js: 1.30.3
       reselect: 5.2.0
@@ -11279,7 +11280,7 @@ snapshots:
       - supports-color
       - vite
 
-  '@sanity/types@6.3.0(@types/react@19.2.17)(vitest@4.1.10)':
+  '@sanity/types@6.11.0(@types/react@19.2.17)(vitest@4.1.10)':
     dependencies:
       '@sanity/client': 8.4.0(vitest@4.1.10)
       '@sanity/media-library-types': 1.6.0
@@ -11287,7 +11288,7 @@ snapshots:
     transitivePeerDependencies:
       - vitest
 
-  '@sanity/types@6.9.2(@types/react@19.2.17)(vitest@4.1.10)':
+  '@sanity/types@6.3.0(@types/react@19.2.17)(vitest@4.1.10)':
     dependencies:
       '@sanity/client': 8.4.0(vitest@4.1.10)
       '@sanity/media-library-types': 1.6.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ catalog:
   '@sanity/message-protocol': '^0.24.0'
   '@sanity/pkg-utils': '^12.1.0'
   '@sanity/tsconfig': '^2.2.1'
-  '@sanity/types': '^6.9.1'
+  '@sanity/types': '^6.11.0'
   '@testing-library/jest-dom': '^6.9.1'
   '@testing-library/react': '^16.3.2'
   '@types/lodash-es': '^4.17.12'


### PR DESCRIPTION
### Description

Bump `@sanity/types` to the latest version.
