### PR TITLE
ci: rename create-github-app-token app-id input to client-id

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: generate-token
         with:
-          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          client-id: ${{ secrets.ECOSPARK_APP_ID }}
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       # This action will create a release PR when regular conventional commits are pushed to main, it'll also detect if a release PR is merged and npm publish should happen
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: generate-token
         with:
-          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          client-id: ${{ secrets.ECOSPARK_APP_ID }}
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:


### PR DESCRIPTION
### Description

`actions/create-github-app-token` deprecated the `app-id` input in favor of `client-id`. Every release run logs that twice (main + post). This only renames the input. The value stays `secrets.ECOSPARK_APP_ID` because GitHub still accepts the numeric App ID as the JWT issuer.

Did not switch to a Client ID org variable (unnecessary for this warning). Did not replace the Node 20 CircleCI / Linear actions; that warning is theirs until they ship `node24`.

Fixes [SDK-2446](https://linear.app/sanity/issue/SDK-2446/silence-release-please-github-actions-deprecation-warnings). 

### What to review

`.github/workflows/release-please.yml` and `release-rc.yml`: the `create-github-app-token` step only. Confirm we did not change the secret or anything in `post-release-steps`.

### Testing

No automated test for this. After merge, the next `chore: release main` run (or a `workflow_dispatch` of Release Please) should have no `app-id` annotation. The Node 20 annotation on `post-release-steps` will still be there.


### Fun gif



![Name](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWI5MHJxNnF0bzJncTIwMThncW16aHZvYzZ2MHlwcmY4bGtkbWY3YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/VvUSgdmSlRjpVzsRxz/giphy.gif)

