### PR TITLE
fix: allow insecure random IDs, shorten where possible

### DIFF
--- a/apps/kitchensink-react/src/Comments/CommentsRoute.tsx
+++ b/apps/kitchensink-react/src/Comments/CommentsRoute.tsx
@@ -1,3 +1,4 @@
+import {randomUuid} from '@sanity/sdk/_internal'
 import {
   type Comment,
   type CommentMessage,
@@ -70,10 +71,10 @@ function toMessage(text: string): CommentMessage {
   return [
     {
       _type: 'block',
-      _key: crypto.randomUUID(),
+      _key: randomUuid(),
       style: 'normal',
       markDefs: [],
-      children: [{_type: 'span', _key: crypto.randomUUID(), text, marks: []}],
+      children: [{_type: 'span', _key: randomUuid(), text, marks: []}],
     },
   ]
 }

--- a/apps/kitchensink-react/src/routes/AgentActionsRoute.tsx
+++ b/apps/kitchensink-react/src/routes/AgentActionsRoute.tsx
@@ -1,3 +1,4 @@
+import {randomUuid} from '@sanity/sdk/_internal'
 import {type AgentGenerateOptions, type AgentPromptOptions} from '@sanity/sdk/agent'
 import {useAgentGenerate, useAgentPrompt} from '@sanity/sdk-react'
 import {Box, Button, Card, Code, Label, Stack, Text} from '@sanity/ui'
@@ -19,7 +20,7 @@ export function AgentActionsRoute(): JSX.Element {
       schemaId: '_.schemas.default',
       targetDocument: {
         operation: 'create',
-        _id: crypto.randomUUID(),
+        _id: randomUuid(),
         _type: 'movie',
       },
       instruction:

--- a/apps/kitchensink-react/src/routes/releases/ReleaseActionsDialog.tsx
+++ b/apps/kitchensink-react/src/routes/releases/ReleaseActionsDialog.tsx
@@ -1,3 +1,4 @@
+import {randomId} from '@sanity/sdk/_internal'
 import {
   archiveRelease,
   createRelease,
@@ -37,8 +38,8 @@ interface ReleaseActionsDialogProps {
 }
 
 function generateReleaseId(): string {
-  // Match the studio's short ID style: `r<7 hex chars>`.
-  return `r${crypto.randomUUID().replace(/-/g, '').slice(0, 7)}`
+  // Match the studio's release ID style: `r` + 8 alphanumeric chars.
+  return `r${randomId(8)}`
 }
 
 function toDatetimeLocal(iso?: string): string {

--- a/packages/@repo/config-eslint/index.mjs
+++ b/packages/@repo/config-eslint/index.mjs
@@ -96,6 +96,15 @@ export default [
           ],
         },
       ],
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'crypto',
+          property: 'randomUUID',
+          message:
+            'crypto.randomUUID() throws on insecure origins (plain http, e.g. testing from a phone on a local network). Use randomUuid() for a v4 UUID, or randomId() for a short base62 ID - both from utils/ids (core) or @sanity/sdk/_internal.',
+        },
+      ],
       'no-shadow': 'error',
       'no-unused-vars': 'off',
       'no-warning-comments': [

--- a/packages/core/src/_exports/_internal.ts
+++ b/packages/core/src/_exports/_internal.ts
@@ -24,4 +24,5 @@ export {
 export {getTelemetryManager, initTelemetry, trackHookMounted} from '../telemetry/initTelemetry'
 export {getUsersKey, parseUsersKey} from '../users/reducers' // only used for memoizing in React, not needed for actual functionality
 export {createGroqSearchFilter} from '../utils/createGroqSearchFilter'
+export {randomId, randomUuid} from '../utils/ids'
 export {isDeepEqual, pickProperties} from '../utils/object'

--- a/packages/core/src/comments/commentActions.ts
+++ b/packages/core/src/comments/commentActions.ts
@@ -16,6 +16,7 @@ import {bindActionByResource, type BoundResourceKey} from '../store/createAction
 import {type SanityInstance} from '../store/createSanityInstance'
 import {type StoreState} from '../store/createStoreState'
 import {type StoreContext} from '../store/defineStore'
+import {randomUuid} from '../utils/ids'
 import {
   assertDatasetResource,
   getAddonDatasetState,
@@ -326,7 +327,7 @@ export const createComment: (
       options,
       buildCommentPayload({
         authorId: requireCurrentUserId(instance),
-        commentId: options.commentId ?? crypto.randomUUID(),
+        commentId: options.commentId ?? randomUuid(),
         contentSnapshot: options.contentSnapshot,
         context: options.context,
         documentRevisionId: options.documentRevisionId,
@@ -336,7 +337,7 @@ export const createComment: (
         fieldPath,
         selection: options.selection,
         status: options.status ?? 'open',
-        threadId: options.threadId ?? crypto.randomUUID(),
+        threadId: options.threadId ?? randomUuid(),
         ...(isReleasePerspective(perspective) ? {documentVersionId: perspective.releaseName} : {}),
       }),
     )
@@ -386,7 +387,7 @@ export const replyToComment: (
       options,
       buildCommentPayload({
         authorId: requireCurrentUserId(instance),
-        commentId: options.commentId ?? crypto.randomUUID(),
+        commentId: options.commentId ?? randomUuid(),
         handle: options,
         message: options.message,
         // Replies to a reply belong to the thread's first comment, matching how
@@ -420,7 +421,7 @@ export const updateComment: (
     {commentId, message}: UpdateCommentOptions,
   ) => {
     const lastEditedAt = new Date().toISOString()
-    const transactionId = crypto.randomUUID()
+    const transactionId = randomUuid()
     const previous = findCommentById(state, commentId)
 
     if (previous) {
@@ -468,7 +469,7 @@ export const setCommentStatus: (
     {state, instance, key}: StoreContext<CommentsStoreState, BoundResourceKey>,
     {commentId, status}: SetCommentStatusOptions,
   ) => {
-    const transactionId = crypto.randomUUID()
+    const transactionId = randomUuid()
     const previousComments: StoredComment[] = []
 
     for (const entry of Object.values(state.get().entries)) {

--- a/packages/core/src/comments/commentsStore.ts
+++ b/packages/core/src/comments/commentsStore.ts
@@ -29,7 +29,7 @@ import {
 } from '../store/createStateSourceAction'
 import {type StoreState} from '../store/createStoreState'
 import {defineStore, type StoreContext} from '../store/defineStore'
-import {insecureRandomId} from '../utils/ids'
+import {randomId} from '../utils/ids'
 import {setCleanupTimeout} from '../utils/setCleanupTimeout'
 import {observeAddonDatasetClient} from './addonDatasetStore'
 import {buildCommentThreads} from './buildCommentThreads'
@@ -360,7 +360,7 @@ export const getCommentsState: (
     selector: selectComments,
     onSubscribe: ({state, instance}, options: CommentsOptions) => {
       const key = getCommentsKey(toCommentsKeyParts(instance, options))
-      const subscriptionId = insecureRandomId()
+      const subscriptionId = randomId(16)
       state.set('addSubscriber', addSubscriber(key, subscriptionId))
 
       return () => {
@@ -390,7 +390,7 @@ export const getCommentThreadsState: (
     selector: selectCommentThreads,
     onSubscribe: ({state, instance}, options: CommentsOptions) => {
       const key = getCommentsKey(toCommentsKeyParts(instance, options))
-      const subscriptionId = insecureRandomId()
+      const subscriptionId = randomId(16)
       state.set('addSubscriber', addSubscriber(key, subscriptionId))
 
       return () => {
@@ -452,7 +452,7 @@ function resolveList<T>(
   // fetch and this promise would never settle. Holding it only for the duration
   // of the resolve also means a component that suspends and then errors before
   // mounting does not leave a subscriber-less entry behind holding its error.
-  const subscriptionId = insecureRandomId()
+  const subscriptionId = randomId(16)
   state.set('addSubscriber', addSubscriber(key, subscriptionId))
 
   const release = () => state.set('removeSubscriber', removeSubscriber(key, subscriptionId))

--- a/packages/core/src/document/applyDocumentActions.ts
+++ b/packages/core/src/document/applyDocumentActions.ts
@@ -5,6 +5,7 @@ import {type DocumentResource} from '../config/sanityConfig'
 import {bindActionByResource} from '../store/createActionBinder'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {type StoreContext} from '../store/defineStore'
+import {randomUuid} from '../utils/ids'
 import {type Action} from './actions'
 import {documentStore, type DocumentStoreState} from './documentStore'
 import {type DocumentTransactionSubmissionResult} from './events'
@@ -74,12 +75,7 @@ const boundApplyDocumentActions = bindActionByResource(documentStore, _applyDocu
 /** @internal */
 async function _applyDocumentActions(
   {state}: StoreContext<DocumentStoreState>,
-  {
-    actions,
-    resource,
-    transactionId = crypto.randomUUID(),
-    disableBatching,
-  }: ApplyDocumentActionsOptions,
+  {actions, resource, transactionId = randomUuid(), disableBatching}: ApplyDocumentActionsOptions,
 ): Promise<ActionsResult> {
   const {events} = state.get()
 

--- a/packages/core/src/document/documentStore.concurrency.test.ts
+++ b/packages/core/src/document/documentStore.concurrency.test.ts
@@ -44,6 +44,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {getClientState} from '../client/clientStore'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
+import {randomUuid} from '../utils/ids'
 import {editDocument, publishDocument} from './actions'
 import {applyDocumentActions} from './applyDocumentActions'
 import {getDocumentState, getDocumentSyncStatus} from './documentStore'
@@ -273,7 +274,7 @@ function createMockClient(server: MockContentLake): SanityClient {
 
   const action = vi.fn(async (input: HttpAction | HttpAction[], options?: BaseActionOptions) => {
     const actions = Array.isArray(input) ? input : [input]
-    return server.submitActions(actions, options?.transactionId ?? crypto.randomUUID())
+    return server.submitActions(actions, options?.transactionId ?? randomUuid())
   })
 
   const request = vi.fn(async () => {

--- a/packages/core/src/document/documentStore.test.ts
+++ b/packages/core/src/document/documentStore.test.ts
@@ -36,6 +36,7 @@ import {getClientState} from '../client/clientStore'
 import {createDocumentHandle} from '../config/handles'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
+import {randomUuid} from '../utils/ids'
 import {
   createDocument,
   deleteDocument,
@@ -369,7 +370,7 @@ it('labels an echo that arrives after the last subscriber left as its own', asyn
   // and out of band, which is the ordering the real API produces
   const clientActionMockImplementation = vi.mocked(client.action).getMockImplementation()!
   vi.mocked(client.action).mockImplementation(
-    async (_input, {transactionId = crypto.randomUUID()} = {}) => ({transactionId}),
+    async (_input, {transactionId = randomUuid()} = {}) => ({transactionId}),
   )
 
   const patchEvents: DocumentRemotePatchesEvent[] = []
@@ -671,7 +672,7 @@ it('fetches documents if there are no active subscriptions for the actions appli
 })
 
 it('batches edit transaction into one outgoing transaction', async () => {
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const doc = createDocumentHandle({documentId: randomUuid(), documentType: 'article'})
 
   const unsubscribe = getDocumentState(instance, doc).subscribe()
 
@@ -747,7 +748,7 @@ it('submits liveEdit document edits through observable.mutate', async () => {
 })
 
 it('provides the consistency status via `getDocumentSyncStatus`', async () => {
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const doc = createDocumentHandle({documentId: randomUuid(), documentType: 'article'})
 
   const syncStatus = getDocumentSyncStatus(instance, doc)
   expect(syncStatus.getCurrent()).toBeUndefined()
@@ -802,7 +803,7 @@ it('reverts failed outgoing transaction locally', async () => {
     })
   })
 
-  const documentId = DocumentId(crypto.randomUUID())
+  const documentId = DocumentId(randomUuid())
   const doc = createDocumentHandle({documentId, documentType: 'article'})
 
   const {getCurrent, subscribe} = getDocumentState(instance, doc)
@@ -870,7 +871,7 @@ it('removes a queued transaction if it fails to apply', async () => {
     })
   })
 
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const doc = createDocumentHandle({documentId: randomUuid(), documentType: 'article'})
   const state = getDocumentState(instance, doc)
   const unsubscribe = state.subscribe()
 
@@ -975,8 +976,8 @@ it('fetches dataset ACL and updates grants in the document store state', async (
   ]
   vi.mocked(client.request).mockResolvedValue(datasetAcl)
 
-  const book = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'book'})
-  const author = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'author'})
+  const book = createDocumentHandle({documentId: randomUuid(), documentType: 'book'})
+  const author = createDocumentHandle({documentId: randomUuid(), documentType: 'author'})
 
   expect(await resolvePermissions(instance, {actions: [createDocument(book)]})).toEqual({
     allowed: true,
@@ -988,7 +989,7 @@ it('fetches dataset ACL and updates grants in the document store state', async (
 })
 
 it('does not send credentials with the dataset ACL request', async () => {
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const doc = createDocumentHandle({documentId: randomUuid(), documentType: 'article'})
   await resolvePermissions(instance, {actions: [createDocument(doc)]})
 
   const aclCall = vi
@@ -1011,7 +1012,7 @@ it('retries transient dataset ACL fetch failures instead of failing fatally', as
     }),
   )
 
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const doc = createDocumentHandle({documentId: randomUuid(), documentType: 'article'})
   const result = await resolvePermissions(instance, {actions: [createDocument(doc)]})
 
   expect(result).toEqual({allowed: true})
@@ -1037,7 +1038,7 @@ it('does not retry dataset ACL fetch failures caused by 4xx client errors', asyn
     }),
   )
 
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const doc = createDocumentHandle({documentId: randomUuid(), documentType: 'article'})
   const documentState = getDocumentState(instance, doc)
   const unsubscribe = documentState.subscribe()
 
@@ -1070,7 +1071,7 @@ it('retries dataset ACL fetch failures caused by 429 rate-limit errors', async (
     }),
   )
 
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const doc = createDocumentHandle({documentId: randomUuid(), documentType: 'article'})
   const result = await resolvePermissions(instance, {actions: [createDocument(doc)]})
 
   expect(result).toEqual({allowed: true})
@@ -1087,7 +1088,7 @@ it('fetches ACL for MediaLibraryResource', async () => {
   const datasetAcl = [{filter: 'true', permissions: ['read', 'update', 'create', 'history']}]
   vi.mocked(client.request).mockResolvedValue(datasetAcl)
 
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const doc = createDocumentHandle({documentId: randomUuid(), documentType: 'article'})
   const mediaLibraryResource = {mediaLibraryId: 'test-media-library'}
 
   const result = await resolvePermissions(mediaLibraryInstance, {
@@ -1105,7 +1106,7 @@ it('fetches ACL for CanvasResource', async () => {
   const datasetAcl = [{filter: 'true', permissions: ['read', 'update', 'create', 'history']}]
   vi.mocked(client.request).mockResolvedValue(datasetAcl)
 
-  const doc = createDocumentHandle({documentId: crypto.randomUUID(), documentType: 'article'})
+  const doc = createDocumentHandle({documentId: randomUuid(), documentType: 'article'})
   const canvasResource = {canvasId: 'test-canvas'}
 
   const result = await resolvePermissions(canvasInstance, {
@@ -1118,7 +1119,7 @@ it('fetches ACL for CanvasResource', async () => {
 })
 
 it('returns a promise that resolves when a document has been loaded in the store (useful for suspense)', async () => {
-  const documentId = DocumentId(crypto.randomUUID())
+  const documentId = DocumentId(randomUuid())
   const doc = createDocumentHandle({documentId, documentType: 'article'})
 
   expect(await resolveDocument(instance, doc)).toBe(null)
@@ -1143,7 +1144,7 @@ it('emits an event for each action after an outgoing transaction has been accept
   const handler = vi.fn()
   const unsubscribe = subscribeDocumentEvents(instance, {resource, eventHandler: handler})
 
-  const documentId = DocumentId(crypto.randomUUID())
+  const documentId = DocumentId(randomUuid())
   const doc = createDocumentHandle({documentId, documentType: 'article'})
   expect(handler).toHaveBeenCalledTimes(0)
 
@@ -1574,7 +1575,7 @@ beforeEach(() => {
       mutations: Mutation[],
       options: BaseMutationOptions = {},
     ): Promise<MultipleMutationResult> => {
-      const transactionId = options.transactionId ?? crypto.randomUUID()
+      const transactionId = options.transactionId ?? randomUuid()
       const timestamp = new Date().toISOString()
       const prior = {...documents}
       let next = {...documents}
@@ -1647,7 +1648,7 @@ beforeEach(() => {
   const action = vi.fn(
     async (
       input: HttpAction | HttpAction[],
-      {transactionId = crypto.randomUUID(), dryRun}: BaseActionOptions,
+      {transactionId = randomUuid(), dryRun}: BaseActionOptions,
     ): Promise<SingleActionResult | MultipleActionResult> => {
       const actions = Array.isArray(input) ? input : [input]
       let next: DocumentSet = {...documents}

--- a/packages/core/src/document/permissions.ts
+++ b/packages/core/src/document/permissions.ts
@@ -5,6 +5,7 @@ import {createSelector} from 'reselect'
 
 import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
 import {type SelectorContext} from '../store/createStateSourceAction'
+import {randomId} from '../utils/ids'
 import {MultiKeyWeakMap} from '../utils/MultiKeyWeakMap'
 import {type DocumentAction} from './actions'
 import {ActionError, PermissionActionError, processActions} from './processActions/processActions'
@@ -190,7 +191,7 @@ const _calculatePermissions = createSelector(
     try {
       processActions({
         actions,
-        transactionId: crypto.randomUUID(),
+        transactionId: randomId(16),
         working: documents,
         base: documents,
         timestamp,

--- a/packages/core/src/document/processActions.test.ts
+++ b/packages/core/src/document/processActions.test.ts
@@ -2,6 +2,7 @@ import {type CreateMutation, type Reference, type SanityDocument} from '@sanity/
 import {parse} from 'groq-js'
 import {describe, expect, it} from 'vitest'
 
+import {randomUuid} from '../utils/ids'
 import {type Action, type DocumentAction} from './actions'
 import {ActionError, processActions} from './processActions/processActions'
 import {type DocumentSet, processMutations} from './processMutations'
@@ -973,7 +974,7 @@ describe('processActions', () => {
     })
 
     it('should strengthen `_strengthenOnPublish` references', () => {
-      const _ref = crypto.randomUUID()
+      const _ref = randomUuid()
       const referenceToStrength: Reference = {
         _ref,
         _type: 'reference',

--- a/packages/core/src/document/processMutations.ts
+++ b/packages/core/src/document/processMutations.ts
@@ -5,6 +5,7 @@ import {
   type SanityDocument,
 } from '@sanity/types'
 
+import {randomUuid} from '../utils/ids'
 import {
   dec,
   diffMatchPatch,
@@ -63,8 +64,8 @@ const patchOperations = {
  * [- source](https://www.sanity.io/docs/http-mutations#c732f27330a4)
  */
 export function getId(id?: string): string {
-  if (!id || typeof id !== 'string') return crypto.randomUUID()
-  if (id.endsWith('.')) return `${id}${crypto.randomUUID()}`
+  if (!id || typeof id !== 'string') return randomUuid()
+  if (id.endsWith('.')) return `${id}${randomUuid()}`
   return id
 }
 

--- a/packages/core/src/document/reducers.ts
+++ b/packages/core/src/document/reducers.ts
@@ -4,7 +4,7 @@ import {type Mutation, type PatchOperations, type SanityDocumentLike} from '@san
 import {type DocumentHandle} from '../config/sanityConfig'
 import {isReleasePerspective} from '../releases/utils/isReleasePerspective'
 import {type StoreContext} from '../store/defineStore'
-import {insecureRandomId} from '../utils/ids'
+import {randomId} from '../utils/ids'
 import {isDeepEqual, omitProperty} from '../utils/object'
 import {setCleanupTimeout} from '../utils/setCleanupTimeout'
 import {type Action} from './actions'
@@ -790,7 +790,7 @@ export function manageSubscriberIds(
 ): () => void {
   const documentIds = getDocumentIdsFromHandleLikes(handles)
 
-  const subscriptionId = insecureRandomId()
+  const subscriptionId = randomId(16)
   state.set('addSubscribers', (prev) =>
     documentIds.reduce(
       (acc, id) => addSubscriptionIdToDocument(acc, id, subscriptionId),

--- a/packages/core/src/presence/presenceStore.test.ts
+++ b/packages/core/src/presence/presenceStore.test.ts
@@ -24,6 +24,12 @@ vi.mock('../client/clientStore')
 vi.mock('../users/usersStore')
 vi.mock('./bifurTransport')
 
+function lastTransportSessionId(): string {
+  const call = vi.mocked(createBifurTransport).mock.calls.at(-1)
+  if (!call) throw new Error('createBifurTransport was not called')
+  return call[0].sessionId
+}
+
 describe('presenceStore', () => {
   let instance: SanityInstance
   let mockClient: SanityClient
@@ -48,13 +54,6 @@ describe('presenceStore', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-
-    // Mock crypto.randomUUID
-    Object.defineProperty(global, 'crypto', {
-      value: {
-        randomUUID: vi.fn(() => 'test-session-id'),
-      },
-    })
 
     mockClient = {
       withConfig: vi.fn().mockReturnThis(),
@@ -103,7 +102,7 @@ describe('presenceStore', () => {
       expect(createBifurTransport).toHaveBeenCalledWith({
         client: mockClient,
         token$: expect.any(Object),
-        sessionId: 'test-session-id',
+        sessionId: expect.stringMatching(/^[a-zA-Z0-9]{16}$/),
       })
     })
 
@@ -164,7 +163,7 @@ describe('presenceStore', () => {
       mockIncomingEvents.next({
         type: 'state',
         userId: 'user-1',
-        sessionId: 'test-session-id', // Same as our session
+        sessionId: lastTransportSessionId(), // Same as our session
         timestamp: '2023-01-01T12:00:00Z',
         locations: [],
       })
@@ -1050,7 +1049,7 @@ describe('presenceStore', () => {
         mockIncomingEvents.next({
           type: 'rollCall',
           userId: 'user-1',
-          sessionId: 'test-session-id',
+          sessionId: lastTransportSessionId(),
         })
         await flush()
 
@@ -1139,25 +1138,19 @@ describe('presenceStore', () => {
   })
 
   describe('session id', () => {
-    afterEach(() => {
-      vi.unstubAllGlobals()
-    })
-
     it('gives each store its own id, so nothing can collide across tabs', () => {
       // Ids are deliberately not persisted: a tab that inherits another's
       // session storage would otherwise reuse the id and the two live clients
       // would filter each other out as their own session.
-      let counter = 0
-      vi.stubGlobal('crypto', {randomUUID: vi.fn(() => `session-${++counter}`)})
-
       getPresence(instance, {resource: {projectId: 'p1', dataset: 'd1'}}).subscribe(() => {})
-      const first = vi.mocked(createBifurTransport).mock.calls.at(-1)?.[0].sessionId
+      const first = lastTransportSessionId()
 
       getPresence(instance, {resource: {projectId: 'p2', dataset: 'd2'}}).subscribe(() => {})
-      const second = vi.mocked(createBifurTransport).mock.calls.at(-1)?.[0].sessionId
+      const second = lastTransportSessionId()
 
-      expect(first).toBe('session-1')
-      expect(second).toBe('session-2')
+      expect(first).toMatch(/^[a-zA-Z0-9]{16}$/)
+      expect(second).toMatch(/^[a-zA-Z0-9]{16}$/)
+      expect(first).not.toBe(second)
     })
   })
 })

--- a/packages/core/src/presence/presenceStore.ts
+++ b/packages/core/src/presence/presenceStore.ts
@@ -38,6 +38,7 @@ import {
 import {defineStore, type StoreContext} from '../store/defineStore'
 import {type SanityUser} from '../users/types'
 import {getUserState} from '../users/usersStore'
+import {randomId} from '../utils/ids'
 import {createLogger} from '../utils/logger'
 import {createBifurTransport} from './bifurTransport'
 import {startsWithPath} from './paths'
@@ -198,7 +199,7 @@ export const presenceStore = defineStore<PresenceStoreState, BoundResourceKey>({
     // storage (`window.open`, or a same-origin iframe), making two live clients
     // filter each other out as self. Stale sessions are handled by the
     // disconnect on unload, with the expiry sweep above as the backstop.
-    const sessionId = crypto.randomUUID()
+    const sessionId = randomId(16)
 
     // Dataset resources must use the project hostname so the socket URL is project-specific.
     // Canvas resources use the global API endpoint via the resource config.

--- a/packages/core/src/projection/getProjectionState.test.ts
+++ b/packages/core/src/projection/getProjectionState.test.ts
@@ -4,7 +4,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {createSanityInstance, type SanityInstance} from '../store/createSanityInstance'
 import {type StoreState} from '../store/createStoreState'
 import {hashString} from '../utils/hashString'
-import {insecureRandomId} from '../utils/ids'
+import {randomId} from '../utils/ids'
 import {getProjectionState} from './getProjectionState'
 import {subscribeToStateAndFetchBatches} from './subscribeToStateAndFetchBatches'
 import {type ProjectionStoreState} from './types'
@@ -19,7 +19,7 @@ vi.mock('../utils/ids', async (importOriginal) => {
   // Mock implementation uses the external counter
   return {
     ...util,
-    insecureRandomId: vi.fn(() => {
+    randomId: vi.fn(() => {
       const id = `testSubId_${++mockIdCounter}`
       return id
     }),
@@ -39,8 +39,7 @@ describe('getProjectionState', () => {
   let state: StoreState<ProjectionStoreState & {extra?: unknown}>
 
   beforeEach(() => {
-    mockIdCounter = 0
-    vi.mocked(insecureRandomId).mockClear()
+    vi.mocked(randomId).mockClear()
 
     // Capture state
     vi.mocked(subscribeToStateAndFetchBatches).mockImplementation((context) => {
@@ -49,6 +48,9 @@ describe('getProjectionState', () => {
     })
 
     instance = createSanityInstance({projectId: 'exampleProject', dataset: 'exampleDataset'})
+    // Reset after instance creation: the instanceId also comes from randomId,
+    // but the test ids should only count subscription-related calls
+    mockIdCounter = 0
     vi.useFakeTimers() // Enable fake timers for each test
   })
 

--- a/packages/core/src/projection/getProjectionState.ts
+++ b/packages/core/src/projection/getProjectionState.ts
@@ -10,7 +10,7 @@ import {
   type StateSource,
 } from '../store/createStateSourceAction'
 import {hashString} from '../utils/hashString'
-import {insecureRandomId} from '../utils/ids'
+import {randomId} from '../utils/ids'
 import {omitProperty} from '../utils/object'
 import {setCleanupTimeout} from '../utils/setCleanupTimeout'
 import {projectionStore} from './projectionStore'
@@ -85,7 +85,7 @@ export const _getProjectionState = bindActionByResourceAndPerspective(
     },
     onSubscribe: ({state}, options: ProjectionOptions<string, string, string, string>) => {
       const {projection, ...docHandle} = options
-      const subscriptionId = insecureRandomId()
+      const subscriptionId = randomId(16)
       const documentId = getPublishedId(DocumentId(docHandle.documentId))
       const validProjection = validateProjection(projection)
       const projectionHash = hashString(validProjection)

--- a/packages/core/src/query/queryStore.ts
+++ b/packages/core/src/query/queryStore.ts
@@ -36,7 +36,7 @@ import {
 } from '../store/createStateSourceAction'
 import {type StoreState} from '../store/createStoreState'
 import {defineStore, type StoreContext} from '../store/defineStore'
-import {insecureRandomId} from '../utils/ids'
+import {randomId} from '../utils/ids'
 import {setCleanupTimeout} from '../utils/setCleanupTimeout'
 import {
   QUERY_STATE_CLEAR_DELAY,
@@ -309,7 +309,7 @@ const _getQueryState = bindActionByResource(
       return queryState?.result
     },
     onSubscribe: ({state, instance}, options: QueryOptions) => {
-      const subscriptionId = insecureRandomId()
+      const subscriptionId = randomId(16)
       const key = getQueryKey(instance, options)
 
       state.set('addSubscriber', addSubscriber(key, subscriptionId))
@@ -370,7 +370,7 @@ const _resolveQuery = bindActionByResource(
     // while a component is suspended leaves a subscriber-less key behind — the
     // component never commits, so no other subscriber exists — and its stored
     // error would be rethrown on every future mount without ever refetching.
-    const subscriptionId = insecureRandomId()
+    const subscriptionId = randomId(16)
     state.set('addSubscriber', addSubscriber(key, subscriptionId))
 
     const aborted$ = signal

--- a/packages/core/src/store/createSanityInstance.test.ts
+++ b/packages/core/src/store/createSanityInstance.test.ts
@@ -6,7 +6,7 @@ import {createSanityInstance} from './createSanityInstance'
 describe('createSanityInstance', () => {
   it('should create an instance with a unique instanceId and given config', () => {
     const instance = createSanityInstance({projectId: 'proj1', dataset: 'ds1'})
-    expect(typeof instance.instanceId).toBe('string')
+    expect(instance.instanceId).toMatch(/^[a-zA-Z0-9]{16}$/)
     expect(instance.config).toEqual({projectId: 'proj1', dataset: 'ds1'})
     expect(instance.isDisposed()).toBe(false)
   })

--- a/packages/core/src/store/createSanityInstance.ts
+++ b/packages/core/src/store/createSanityInstance.ts
@@ -1,5 +1,5 @@
 import {type SanityConfig} from '../config/sanityConfig'
-import {insecureRandomId} from '../utils/ids'
+import {randomId} from '../utils/ids'
 import {createLogger, type InstanceContext} from '../utils/logger'
 
 /**
@@ -10,7 +10,7 @@ import {createLogger, type InstanceContext} from '../utils/logger'
 export interface SanityInstance {
   /**
    * Unique identifier for this instance
-   * @remarks Generated using crypto.randomUUID()
+   * @remarks Generated as a random 16-character alphanumeric ID
    */
   readonly instanceId: string
 
@@ -47,7 +47,7 @@ export interface SanityInstance {
  * @public
  */
 export function createSanityInstance(config: SanityConfig = {}): SanityInstance {
-  const instanceId = crypto.randomUUID()
+  const instanceId = randomId(16)
   const disposeListeners = new Map<string, () => void>()
   const disposed = {current: false}
 
@@ -99,7 +99,7 @@ export function createSanityInstance(config: SanityConfig = {}): SanityInstance 
       logger.info('Instance disposed')
     },
     onDispose: (cb) => {
-      const listenerId = insecureRandomId()
+      const listenerId = randomId(16)
       disposeListeners.set(listenerId, cb)
       return () => {
         disposeListeners.delete(listenerId)

--- a/packages/core/src/store/createStoreInstance.test.ts
+++ b/packages/core/src/store/createStoreInstance.test.ts
@@ -8,11 +8,6 @@ describe('createStoreInstance', () => {
   let instance: ReturnType<typeof createSanityInstance>
 
   beforeEach(() => {
-    // Mock crypto for predictable instance IDs
-    vi.stubGlobal('crypto', {
-      randomUUID: () => 'test-uuid-1234',
-    })
-
     instance = createSanityInstance({projectId: 'test', dataset: 'test'})
   })
 

--- a/packages/core/src/users/usersStore.ts
+++ b/packages/core/src/users/usersStore.ts
@@ -30,7 +30,7 @@ import {bindActionGlobally} from '../store/createActionBinder'
 import {createStateSourceAction, type SelectorContext} from '../store/createStateSourceAction'
 import {type StoreState} from '../store/createStoreState'
 import {defineStore, type StoreContext} from '../store/defineStore'
-import {insecureRandomId} from '../utils/ids'
+import {randomId} from '../utils/ids'
 import {setCleanupTimeout} from '../utils/setCleanupTimeout'
 import {
   addSubscription,
@@ -310,7 +310,7 @@ export const getUsersState = bindActionGlobally(
       },
     ),
     onSubscribe: ({instance, state}, options?: GetUsersOptions) => {
-      const subscriptionId = insecureRandomId()
+      const subscriptionId = randomId(16)
       const key = getUsersKey(instance, options)
       state.set('addSubscription', addSubscription(subscriptionId, key))
       return () => {

--- a/packages/core/src/utils/ids.test.ts
+++ b/packages/core/src/utils/ids.test.ts
@@ -1,26 +1,51 @@
-import {describe, expect, it} from 'vitest'
+import {afterEach, describe, expect, it, vi} from 'vitest'
 
-import {insecureRandomId} from './ids'
+import {randomId, randomUuid} from './ids'
 
-describe('insecureRandomId', () => {
-  it('should generate 16-character string', () => {
-    expect(insecureRandomId()).toHaveLength(16)
+describe('randomId', () => {
+  it('should generate an 8-character base62 id by default', () => {
+    expect(randomId()).toMatch(/^[a-zA-Z0-9]{8}$/)
   })
 
-  it('should generate hex string', () => {
-    expect(insecureRandomId()).toMatch(/^[0-9a-f]{16}$/)
+  it('should generate an id of the given length', () => {
+    expect(randomId(16)).toMatch(/^[a-zA-Z0-9]{16}$/)
   })
 
   it('should generate different ids on each call', () => {
-    const id1 = insecureRandomId()
-    const id2 = insecureRandomId()
-    expect(id1).not.toBe(id2)
+    expect(randomId()).not.toBe(randomId())
+  })
+})
+
+describe('randomUuid', () => {
+  const uuidV4Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
-  it('should generate properly formatted strings multiple times', () => {
-    for (let i = 0; i < 100; i++) {
-      const id = insecureRandomId()
-      expect(id).toMatch(/^[0-9a-f]{16}$/)
-    }
+  it('should generate a v4 UUID', () => {
+    expect(randomUuid()).toMatch(uuidV4Pattern)
+  })
+
+  it('should use crypto.randomUUID when available', () => {
+    vi.stubGlobal('crypto', {randomUUID: () => 'native-uuid'})
+    expect(randomUuid()).toBe('native-uuid')
+  })
+
+  it('should generate a v4 UUID when crypto.randomUUID is unavailable (insecure contexts)', () => {
+    const originalCrypto = globalThis.crypto
+    vi.stubGlobal('crypto', {
+      getRandomValues: (array: Uint8Array<ArrayBuffer>) => originalCrypto.getRandomValues(array),
+    })
+    expect(randomUuid()).toMatch(uuidV4Pattern)
+  })
+
+  it('should generate unique ids when crypto.randomUUID is unavailable', () => {
+    const originalCrypto = globalThis.crypto
+    vi.stubGlobal('crypto', {
+      getRandomValues: (array: Uint8Array<ArrayBuffer>) => originalCrypto.getRandomValues(array),
+    })
+    const ids = new Set(Array.from({length: 100}, () => randomUuid()))
+    expect(ids.size).toBe(100)
   })
 })

--- a/packages/core/src/utils/ids.ts
+++ b/packages/core/src/utils/ids.ts
@@ -1,3 +1,48 @@
-export function insecureRandomId(): string {
-  return Array.from({length: 16}, () => Math.floor(Math.random() * 16).toString(16)).join('')
+const ID_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+
+/**
+ * Generates a random ID of the given length from the alphabet `[a-zA-Z0-9]`, the same shape
+ * `@sanity/client` and Sanity Studio use for short IDs such as release IDs.
+ *
+ * Ported from `@sanity/client`'s `generateReleaseId`, which uses rejection sampling to keep
+ * the output unbiased. Uses `crypto.getRandomValues`, which unlike `crypto.randomUUID` is
+ * also available on insecure origins (plain http).
+ *
+ * @internal
+ */
+export function randomId(length: number = 8): string {
+  let id = ''
+  while (id.length < length) {
+    const bytes = crypto.getRandomValues(new Uint8Array(length - id.length))
+    for (const byte of bytes) {
+      const index = byte & 63
+      if (index < ID_ALPHABET.length) id += ID_ALPHABET.charAt(index)
+    }
+  }
+  return id
+}
+
+/**
+ * Generates a random v4 UUID.
+ *
+ * Prefers the native `crypto.randomUUID`, which is only available in secure contexts
+ * (https, localhost). Falls back to deriving the UUID from `crypto.getRandomValues`,
+ * which has no such restriction, so ID generation also works when an app is served over
+ * plain http, e.g. when testing from a phone on a local network.
+ *
+ * @internal
+ */
+export function randomUuid(): string {
+  // eslint-disable-next-line no-restricted-properties -- this is the sanctioned wrapper around crypto.randomUUID
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID()
+
+  const bytes = crypto.getRandomValues(new Uint8Array(16))
+  const hex = Array.from(bytes, (byte, index) => {
+    // Set the version (4) and variant (RFC 4122) bits
+    if (index === 6) byte = (byte & 0x0f) | 0x40
+    if (index === 8) byte = (byte & 0x3f) | 0x80
+    return byte.toString(16).padStart(2, '0')
+  }).join('')
+
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
 }

--- a/packages/react/src/hooks/document/useCreateDocument.ts
+++ b/packages/react/src/hooks/document/useCreateDocument.ts
@@ -1,4 +1,5 @@
 import {createDocument} from '@sanity/sdk'
+import {randomUuid} from '@sanity/sdk/_internal'
 import {type SanityDocument} from 'groq'
 
 import {type DocumentHandle, type DocumentTypeHandle} from '../../config/handles'
@@ -109,7 +110,7 @@ export function useCreateDocument(
   const apply = useApplyDocumentActions()
 
   return async (initialValue, overrides) => {
-    const documentId = overrides?.documentId ?? options.documentId ?? crypto.randomUUID()
+    const documentId = overrides?.documentId ?? options.documentId ?? randomUuid()
     const handle: DocumentHandle = {...options, documentId}
     await apply(createDocument(handle, initialValue))
     return handle


### PR DESCRIPTION
### Description

There are cases where you'd want/need to test an SDK app or a studio in a non-secure context (eg `http://192.168.x.x:3333` to test mobile rendering or similar). Currently that crashes the browser because it attempts to use `crypto.randomUUID()` in a non-secure context, which is not available.

This PR does a few changes:
- Add a new `randomUuid` function which uses `crypto.randomUUID()` when available, falling back to `crypto.getRandomValues()` if not - which _is_ available even on insecure contexts.
- Adds a new `randomId` function which is used for generating random IDs with a uppercase+lowercase+numbers alphabet, for IDs that do not need to be as globally unique as UUIDs, and swaps to this where it makes sense - instance ids and the like do not need to be 128 bits.
- Adds a lint rule to make us utilize these functions over the browser built-ins, as it'll be very easy to regress on this when adding new functionality, as non-secure and non-localhost origins isn't something you test very often.

### What to review

Do the changes in ID generation appear safe and logical?

### Testing

Relying on existing tests, but also improved a few tests that were written in a less optimal way than they potentially could :)

### Fun gif

![Shuffle it](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTl2eDVtbXl6YXVqMjAyMHp2YWhucnZuM3JidzB3bjk2N3FzYzk5diZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/CMbKxKYpfjm6g5K7gt/giphy.gif)
