### PR TITLE
docs(react): correct editDocument patch shape in useApplyDocumentActions example

### DIFF
--- a/packages/react/src/hooks/document/useApplyDocumentActions.ts
+++ b/packages/react/src/hooks/document/useApplyDocumentActions.ts
@@ -199,7 +199,7 @@ interface UseApplyDocumentActions {
  *       perspective: {releaseName: 'summer-drop'},
  *     })
  *
- *     apply(editDocument(docHandle, {title: 'Updated for release'}))
+ *     apply(editDocument(docHandle, {set: {title: 'Updated for release'}}))
  *   }
  *
  *   return <button onClick={handleEdit}>Edit in Release</button>


### PR DESCRIPTION
### Description

The `Edit an existing document in a release` example on `useApplyDocumentActions` passed a document-shaped object to `editDocument`:

```ts
apply(editDocument(docHandle, {title: 'Updated for release'}))
```

`editDocument` takes `PatchOperations`, so the call fails type-checking and would not set `title` at runtime. Anyone copying the example hit a compile error with no hint at the fix. The nearby `createDocument` examples are correct, and that function does accept an initial-values object, which is the likely source of the mix-up.

This matters beyond editor tooltips: `upload-docs.yml` builds typedoc on release and uploads it to the reference API, so the broken call was in the published docs for `@sanity/sdk-react`.

Closes SDK-2474.

### What to review

One line of TSDoc in `packages/react`, no runtime code. Worth confirming the patch shape against the `editDocument` overloads in `packages/core/src/document/actions.ts`. The rest of that example is unchanged and still accurate; `perspective: {releaseName: 'summer-drop'}` matches what `getEffectiveDocumentId` reads in `packages/core/src/document/util.ts`.

This was the only occurrence in the repo. Every other `editDocument` call site already uses `{set: {...}}` or `{unset: [...]}`.

### Testing

No automated test covers this, because TSDoc examples are not compiled by the build or the type check. That gap is why the error survived.

Verified by hand instead: I copied the example body into a temporary `.tsx` file under `packages/react/src` and ran `tsc --noEmit` both ways. The old form fails with `TS2769: No overload matches this call`, reporting that `title` exists on neither `PatchMutation` nor `PatchOperations`. The corrected form compiles. The temp file was deleted, so the diff is the single doc line. `pnpm ts:check`, `pnpm lint`, and `pnpm fallow audit` all pass.

### Fun gif
![ackchhually](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExdDV4cjNxaXY2OXk4MGRyYmtxcXg3anQ1ZWtuMTllanV3M29vb296MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/4wCo7XotrtMVM31lUH/giphy.gif)