### PR TITLE
fix(core): align application types with brett

### DIFF
--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -20,6 +20,7 @@ export {
   type ApplicationDeployment,
   type ApplicationInclude,
   type ApplicationInterface,
+  type ApplicationInterfacePlacementMetadata,
   type ApplicationsOptions,
   type ApplicationsResponse,
   type ApplicationStudioConfig,

--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -195,7 +195,6 @@ export {
   type InstallationActiveConfig,
   type InstallationBase,
   type InstallationInclude,
-  type InstallationInterface,
   type InstallationsOptions,
   type InstallationsResponse,
 } from '../installations/installations'

--- a/packages/core/src/applications/applications.test-d.ts
+++ b/packages/core/src/applications/applications.test-d.ts
@@ -39,11 +39,14 @@ test('ApplicationInterface — matches the interface response', () => {
   expectTypeOf<ApplicationInterface['type']>().toEqualTypeOf<
     'app' | 'worker' | 'asset_source' | 'panel' | 'tile'
   >()
-  expectTypeOf<ApplicationInterface['metadata']>().toEqualTypeOf<{
+  expectTypeOf<Extract<ApplicationInterface, {type: 'app'}>['metadata']>().toEqualTypeOf<{
     dock?: {group?: string; order?: number}
-    order?: number
-    size?: 'small' | 'large' | 'banner'
   } | null>()
+  expectTypeOf<Extract<ApplicationInterface, {type: 'worker'}>['metadata']>().toEqualTypeOf<null>()
+  expectTypeOf<Extract<ApplicationInterface, {type: 'tile'}>['metadata']>().toEqualTypeOf<{
+    order?: number
+    size: 'small' | 'large' | 'banner'
+  }>()
 })
 
 test('Application — config.studio adds config with an optional stored value', () => {

--- a/packages/core/src/applications/applications.test-d.ts
+++ b/packages/core/src/applications/applications.test-d.ts
@@ -10,6 +10,7 @@ import {
   type ApplicationDeployment,
   type ApplicationInclude,
   type ApplicationInterface,
+  type ApplicationInterfacePlacementMetadata,
   applications,
   type ApplicationsResponse,
   type ApplicationStudioConfig,
@@ -39,9 +40,15 @@ test('ApplicationInterface — matches the interface response', () => {
   expectTypeOf<ApplicationInterface['type']>().toEqualTypeOf<
     'app' | 'worker' | 'asset_source' | 'panel' | 'tile'
   >()
-  expectTypeOf<Extract<ApplicationInterface, {type: 'app'}>['metadata']>().toEqualTypeOf<{
+  expectTypeOf<ApplicationInterfacePlacementMetadata>().toEqualTypeOf<{
     dock?: {group?: string; order?: number}
-  } | null>()
+  }>()
+  expectTypeOf<
+    Extract<ApplicationInterface, {type: 'app'}>['metadata']
+  >().toEqualTypeOf<ApplicationInterfacePlacementMetadata | null>()
+  expectTypeOf<
+    Extract<ApplicationInterface, {type: 'panel'}>['metadata']
+  >().toEqualTypeOf<ApplicationInterfacePlacementMetadata | null>()
   expectTypeOf<Extract<ApplicationInterface, {type: 'worker'}>['metadata']>().toEqualTypeOf<null>()
   expectTypeOf<Extract<ApplicationInterface, {type: 'tile'}>['metadata']>().toEqualTypeOf<{
     order?: number

--- a/packages/core/src/applications/applications.test-d.ts
+++ b/packages/core/src/applications/applications.test-d.ts
@@ -35,10 +35,21 @@ test('ApplicationBase — carries name and reference as strings', () => {
   expectTypeOf<ApplicationBase['reference']>().toEqualTypeOf<string>()
 })
 
-test('Application — config.studio adds a required config.studio', () => {
-  expectTypeOf<
-    Application<'config.studio'>['config']['studio']
-  >().toEqualTypeOf<ApplicationStudioConfig>()
+test('ApplicationInterface — matches the interface response', () => {
+  expectTypeOf<ApplicationInterface['type']>().toEqualTypeOf<
+    'app' | 'worker' | 'asset_source' | 'panel' | 'tile'
+  >()
+  expectTypeOf<ApplicationInterface['metadata']>().toEqualTypeOf<{
+    dock?: {group?: string; order?: number}
+    order?: number
+    size?: 'small' | 'large' | 'banner'
+  } | null>()
+})
+
+test('Application — config.studio adds config with an optional stored value', () => {
+  expectTypeOf<Application<'config.studio'>['config']['studio']>().toEqualTypeOf<
+    ApplicationStudioConfig | undefined
+  >()
   // mfManifest not requested → not present under config
   expectTypeOf<
     Extract<keyof Application<'config.studio'>['config'], 'mfManifest'>
@@ -51,7 +62,7 @@ test('Application — config.studio adds a required config.studio', () => {
 
 test('Application — both config tokens merge under a single config', () => {
   type Config = Application<'config.studio' | 'config.mfManifest'>['config']
-  expectTypeOf<Config['studio']>().toEqualTypeOf<ApplicationStudioConfig>()
+  expectTypeOf<Config['studio']>().toEqualTypeOf<ApplicationStudioConfig | undefined>()
   expectTypeOf<Config['mfManifest']>().toEqualTypeOf<unknown>()
 })
 
@@ -73,6 +84,9 @@ test('Application — a wide include array makes config and activeDeployment opt
   type Wide = Application<ApplicationInclude>
   expectTypeOf<KeyModifier<Wide, 'activeDeployment'>>().toEqualTypeOf<'optional'>()
   expectTypeOf<KeyModifier<Wide, 'config'>>().toEqualTypeOf<'optional'>()
+  type Config = NonNullable<Wide['config']>
+  expectTypeOf<Config['studio']>().toEqualTypeOf<ApplicationStudioConfig | undefined>()
+  expectTypeOf<Config['mfManifest']>().toEqualTypeOf<unknown>()
 })
 
 test('applications.resolveState — resolves the wide list envelope', () => {

--- a/packages/core/src/applications/applications.ts
+++ b/packages/core/src/applications/applications.ts
@@ -35,6 +35,16 @@ type ApplicationInterfaceBase = {
 }
 
 /**
+ * Placement metadata for application and panel interfaces.
+ *
+ * @see https://www.sanity.io/docs/http-reference/applications-api
+ * @public
+ */
+export type ApplicationInterfacePlacementMetadata = {
+  dock?: {group?: string; order?: number}
+}
+
+/**
  * An interface exposed by a deployment, embedded when `interfaces` is included.
  *
  * @see https://www.sanity.io/docs/http-reference/applications-api
@@ -42,8 +52,8 @@ type ApplicationInterfaceBase = {
  */
 export type ApplicationInterface = ApplicationInterfaceBase &
   (
-    | {type: 'app'; metadata: {dock?: {group?: string; order?: number}} | null}
-    | {type: 'panel'; metadata: {dock?: {group?: string; order?: number}} | null}
+    | {type: 'app'; metadata: ApplicationInterfacePlacementMetadata | null}
+    | {type: 'panel'; metadata: ApplicationInterfacePlacementMetadata | null}
     | {type: 'asset_source'; metadata: null}
     | {type: 'worker'; metadata: null}
     | {type: 'tile'; metadata: {order?: number; size: 'small' | 'large' | 'banner'}}

--- a/packages/core/src/applications/applications.ts
+++ b/packages/core/src/applications/applications.ts
@@ -25,26 +25,29 @@ export type ApplicationInclude =
   | 'config.mfManifest'
   | 'activeDeployment'
 
+type ApplicationInterfaceBase = {
+  id: string
+  name: string
+  title: string
+  version: string
+  /** Module federation module ID; resolved from the host mf-manifest at runtime */
+  moduleId: string
+}
+
 /**
  * An interface exposed by a deployment, embedded when `interfaces` is included.
  *
  * @see https://www.sanity.io/docs/http-reference/applications-api
  * @public
  */
-export interface ApplicationInterface {
-  id: string
-  type: 'app' | 'worker' | 'asset_source' | 'panel' | 'tile'
-  name: string
-  title: string
-  version: string
-  /** Module federation module ID; resolved from the host mf-manifest at runtime */
-  moduleId: string
-  metadata: {
-    dock?: {group?: string; order?: number}
-    order?: number
-    size?: 'small' | 'large' | 'banner'
-  } | null
-}
+export type ApplicationInterface = ApplicationInterfaceBase &
+  (
+    | {type: 'app'; metadata: {dock?: {group?: string; order?: number}} | null}
+    | {type: 'panel'; metadata: {dock?: {group?: string; order?: number}} | null}
+    | {type: 'asset_source'; metadata: null}
+    | {type: 'worker'; metadata: null}
+    | {type: 'tile'; metadata: {order?: number; size: 'small' | 'large' | 'banner'}}
+  )
 
 /**
  * A studio workspace of a deployment, embedded when `workspaces` is included.

--- a/packages/core/src/applications/applications.ts
+++ b/packages/core/src/applications/applications.ts
@@ -33,13 +33,17 @@ export type ApplicationInclude =
  */
 export interface ApplicationInterface {
   id: string
-  type: 'app' | 'worker' | 'asset_source' | 'panel'
+  type: 'app' | 'worker' | 'asset_source' | 'panel' | 'tile'
   name: string
   title: string
   version: string
   /** Module federation module ID; resolved from the host mf-manifest at runtime */
   moduleId: string
-  metadata: {group?: string; priority?: number} | null
+  metadata: {
+    dock?: {group?: string; order?: number}
+    order?: number
+    size?: 'small' | 'large' | 'banner'
+  } | null
 }
 
 /**
@@ -136,16 +140,24 @@ export interface ApplicationBase {
 
 // Requesting any of these tokens forces the deployment summary into the response.
 type DeploymentToken = 'activeDeployment' | 'interfaces' | 'workspaces' | 'access'
+type ConfigToken = 'config.studio' | 'config.mfManifest'
 
-// `config` is present when either config child was requested; each child is
-// gated on its own token.
-type ApplicationConfigShape<Include extends ApplicationInclude> = Included<
+type ApplicationConfig<Include extends ApplicationInclude> = Included<
   ApplicationInclude,
   'config.studio',
   Include,
-  {config: {studio: ApplicationStudioConfig}}
+  {studio?: ApplicationStudioConfig}
 > &
-  Included<ApplicationInclude, 'config.mfManifest', Include, {config: {mfManifest: unknown}}>
+  Included<ApplicationInclude, 'config.mfManifest', Include, {mfManifest?: unknown}>
+
+// Brett returns `config: {}` when a requested config value is not stored.
+type ApplicationConfigShape<Include extends ApplicationInclude> = [ApplicationInclude] extends [
+  Include,
+]
+  ? {config?: ApplicationConfig<Include>}
+  : IncludesAny<Include, ConfigToken> extends true
+    ? {config: ApplicationConfig<Include>}
+    : unknown
 
 // `activeDeployment` is present when any deployment-related token was requested;
 // a wide include array makes it optional.

--- a/packages/core/src/installations/installations.test-d.ts
+++ b/packages/core/src/installations/installations.test-d.ts
@@ -1,5 +1,6 @@
 import {expectTypeOf, test} from 'vitest'
 
+import {type ApplicationInterface} from '../applications/applications'
 import {type SanityInstance} from '../store/createSanityInstance'
 import {type StateSource} from '../store/createStateSourceAction'
 import {type FetcherSnapshot} from '../store/fetcherStore'
@@ -32,6 +33,10 @@ test('Installation — no includes: only the base shape', () => {
 test('InstallationBase — the application sub-object carries name and reference', () => {
   expectTypeOf<InstallationBase['application']['name']>().toEqualTypeOf<string>()
   expectTypeOf<InstallationBase['application']['reference']>().toEqualTypeOf<string>()
+})
+
+test('InstallationInterface — reuses the application interface response', () => {
+  expectTypeOf<InstallationInterface>().toEqualTypeOf<ApplicationInterface>()
 })
 
 test('Installation — each token adds its top-level field, required, others absent', () => {

--- a/packages/core/src/installations/installations.test-d.ts
+++ b/packages/core/src/installations/installations.test-d.ts
@@ -11,7 +11,6 @@ import {
   type InstallationActiveConfig,
   type InstallationBase,
   type InstallationInclude,
-  type InstallationInterface,
   installations,
   type InstallationsResponse,
 } from './installations'
@@ -35,17 +34,13 @@ test('InstallationBase — the application sub-object carries name and reference
   expectTypeOf<InstallationBase['application']['reference']>().toEqualTypeOf<string>()
 })
 
-test('InstallationInterface — reuses the application interface response', () => {
-  expectTypeOf<InstallationInterface>().toEqualTypeOf<ApplicationInterface>()
-})
-
 test('Installation — each token adds its top-level field, required, others absent', () => {
   expectTypeOf<Installation<'access'>['access']>().toEqualTypeOf<InstallationAccess[]>()
   expectTypeOf<
     Extract<keyof Installation<'access'>, 'activeConfig' | 'interfaces'>
   >().toEqualTypeOf<never>()
 
-  expectTypeOf<Installation<'interfaces'>['interfaces']>().toEqualTypeOf<InstallationInterface[]>()
+  expectTypeOf<Installation<'interfaces'>['interfaces']>().toEqualTypeOf<ApplicationInterface[]>()
   expectTypeOf<
     Installation<'activeConfig'>['activeConfig']
   >().toEqualTypeOf<InstallationActiveConfig | null>()
@@ -54,7 +49,7 @@ test('Installation — each token adds its top-level field, required, others abs
 test('Installation — multiple tokens add each field', () => {
   type Both = Installation<'access' | 'interfaces'>
   expectTypeOf<Both['access']>().toEqualTypeOf<InstallationAccess[]>()
-  expectTypeOf<Both['interfaces']>().toEqualTypeOf<InstallationInterface[]>()
+  expectTypeOf<Both['interfaces']>().toEqualTypeOf<ApplicationInterface[]>()
   expectTypeOf<Extract<keyof Both, 'activeConfig'>>().toEqualTypeOf<never>()
 })
 

--- a/packages/core/src/installations/installations.ts
+++ b/packages/core/src/installations/installations.ts
@@ -31,15 +31,6 @@ export interface InstallationAccess {
 }
 
 /**
- * An interface exposed by an installation, embedded when `interfaces` is
- * included.
- *
- * @see https://www.sanity.io/docs/http-reference/applications-api
- * @public
- */
-export type InstallationInterface = ApplicationInterface
-
-/**
  * The active config of an installation, embedded when `activeConfig` is
  * included. `null` when nothing is deployed.
  *
@@ -96,7 +87,7 @@ export type Installation<Include extends InstallationInclude = never> = Installa
     {activeConfig: InstallationActiveConfig | null}
   > &
   Included<InstallationInclude, 'access', Include, {access: InstallationAccess[]}> &
-  Included<InstallationInclude, 'interfaces', Include, {interfaces: InstallationInterface[]}>
+  Included<InstallationInclude, 'interfaces', Include, {interfaces: ApplicationInterface[]}>
 
 /**
  * Options for listing an organization's installations.

--- a/packages/core/src/installations/installations.ts
+++ b/packages/core/src/installations/installations.ts
@@ -1,5 +1,6 @@
 import {switchMap} from 'rxjs'
 
+import {type ApplicationInterface} from '../applications/applications'
 import {getClientState} from '../client/clientStore'
 import {defineFetcher} from '../store/fetcherStore'
 import {buildQuery} from '../utils/buildQuery'
@@ -36,16 +37,7 @@ export interface InstallationAccess {
  * @see https://www.sanity.io/docs/http-reference/applications-api
  * @public
  */
-export interface InstallationInterface {
-  id: string
-  type: 'app' | 'worker' | 'asset_source' | 'panel'
-  name: string
-  title: string
-  version: string
-  /** Module federation module ID; resolved from the host mf-manifest at runtime */
-  moduleId: string
-  metadata: {group?: string; priority?: number} | null
-}
+export type InstallationInterface = ApplicationInterface
 
 /**
  * The active config of an installation, embedded when `activeConfig` is

--- a/packages/react/src/hooks/applications/useApplication.test-d.ts
+++ b/packages/react/src/hooks/applications/useApplication.test-d.ts
@@ -1,6 +1,7 @@
 import {
   type Application,
   type ApplicationDeployment,
+  type ApplicationStudioConfig,
 } from '@sanity/sdk'
 import {expectTypeOf, test} from 'vitest'
 
@@ -18,6 +19,7 @@ test('useApplication — no include: the base application', () => {
 test('useApplication — config.studio include adds config.studio', () => {
   const result = useApplication('app_1', {include: ['config.studio']})
   expectTypeOf(result.data).toEqualTypeOf<Application<'config.studio'>>()
+  expectTypeOf(result.data.config.studio).toEqualTypeOf<ApplicationStudioConfig | undefined>()
 })
 
 test('useApplication — a deployment-child include forces the deployment in', () => {

--- a/packages/react/src/hooks/applications/useApplication.test-d.ts
+++ b/packages/react/src/hooks/applications/useApplication.test-d.ts
@@ -1,7 +1,6 @@
 import {
   type Application,
   type ApplicationDeployment,
-  type ApplicationStudioConfig,
 } from '@sanity/sdk'
 import {expectTypeOf, test} from 'vitest'
 
@@ -19,7 +18,6 @@ test('useApplication — no include: the base application', () => {
 test('useApplication — config.studio include adds config.studio', () => {
   const result = useApplication('app_1', {include: ['config.studio']})
   expectTypeOf(result.data).toEqualTypeOf<Application<'config.studio'>>()
-  expectTypeOf(result.data.config.studio).toEqualTypeOf<ApplicationStudioConfig>()
 })
 
 test('useApplication — a deployment-child include forces the deployment in', () => {


### PR DESCRIPTION
### Description

The SDK types don't match Brett's response: Brett's application and installation endpoints share the interface response, and requested config values may be absent.

This aligns both endpoints around one interface contract with updated types for interface metadata.

> [!NOTE]
> Are we ok to remove `InstallationInterface`? Conceptually we only have `ApplicationInterface` and installation interfaces aren't any different. I can add it back, but I think removing it is the right call and a bugfix even though the type interface changes 