### PR TITLE
feat(core): add OAuth authorization-code + PKCE auth mode

### DIFF
--- a/packages/core/src/_exports/index.ts
+++ b/packages/core/src/_exports/index.ts
@@ -49,6 +49,14 @@ export {
 export {observeOrganizationVerificationState} from '../auth/getOrganizationVerificationState'
 export {handleAuthCallback} from '../auth/handleAuthCallback'
 export {logout} from '../auth/logout'
+export {
+  getOAuthTokensState,
+  handleOAuthCallback,
+  refreshOAuthTokens,
+  revokeOAuthTokens,
+  startOAuthAuthorization,
+} from '../auth/oauth/oauthActions'
+export {type OAuthTokens} from '../auth/oauth/types'
 export type {ClientStoreState as ClientState} from '../client/clientStore'
 export {type ClientOptions, getClient, getClientState} from '../client/clientStore'
 export {

--- a/packages/core/src/auth/authMode.test.ts
+++ b/packages/core/src/auth/authMode.test.ts
@@ -18,6 +18,30 @@ describe('resolveAuthMode', () => {
   it('returns "standalone" by default', () => {
     expect(resolveAuthMode({}, 'https://example.com')).toBe('standalone')
   })
+
+  it('returns "oauth" when auth.oauth config is provided', () => {
+    const config: SanityConfig = {
+      auth: {oauth: {clientId: 'c', redirectUri: 'https://app/cb', organizationId: 'o'}},
+    }
+    expect(resolveAuthMode(config, 'https://example.com')).toBe('oauth')
+  })
+
+  it('prefers "oauth" over dashboard context detection', () => {
+    const context = encodeURIComponent(JSON.stringify({orgId: '123'}))
+    const href = `https://example.com?_context=${context}`
+    const config: SanityConfig = {
+      auth: {oauth: {clientId: 'c', redirectUri: 'https://app/cb', organizationId: 'o'}},
+    }
+    expect(resolveAuthMode(config, href)).toBe('oauth')
+  })
+
+  it('prefers "studio" over oauth config', () => {
+    const config: SanityConfig = {
+      studio: {},
+      auth: {oauth: {clientId: 'c', redirectUri: 'https://app/cb', organizationId: 'o'}},
+    }
+    expect(resolveAuthMode(config, 'https://example.com')).toBe('studio')
+  })
 })
 
 describe('isStudioConfig', () => {

--- a/packages/core/src/auth/authMode.ts
+++ b/packages/core/src/auth/authMode.ts
@@ -6,6 +6,8 @@ import {DEFAULT_BASE} from './authConstants'
  *
  * - `studio`     — Running inside Sanity Studio. Token is discovered from
  *                  Studio's localStorage entry or via cookie auth.
+ * - `oauth`      — Configured with `auth.oauth`. Authenticates via Sanity's
+ *                  OAuth 2.0 authorization-code + PKCE flow.
  * - `dashboard`  — Running inside the Sanity Dashboard iframe. Token is
  *                  provided by the parent frame via Comlink.
  * - `standalone` — Running as an independent app. Token comes from
@@ -13,20 +15,23 @@ import {DEFAULT_BASE} from './authConstants'
  *
  * @internal
  */
-type AuthMode = 'studio' | 'dashboard' | 'standalone'
+type AuthMode = 'studio' | 'oauth' | 'dashboard' | 'standalone'
 
 /**
  * Determines the auth mode from instance config and environment.
  *
  * Priority:
  * 1. `studio` config provided → `'studio'`
- * 2. Dashboard context detected (`_context` URL param with content) → `'dashboard'`
- * 3. Otherwise → `'standalone'`
+ * 2. `auth.oauth` config provided → `'oauth'` (explicit config wins over
+ *    environment detection)
+ * 3. Dashboard context detected (`_context` URL param with content) → `'dashboard'`
+ * 4. Otherwise → `'standalone'`
  *
  * @internal
  */
 export function resolveAuthMode(config: SanityConfig, locationHref: string): AuthMode {
   if (isStudioConfig(config)) return 'studio'
+  if (config.auth?.oauth) return 'oauth'
   if (detectDashboardContext(locationHref)) return 'dashboard'
   return 'standalone'
 }

--- a/packages/core/src/auth/authStore.ts
+++ b/packages/core/src/auth/authStore.ts
@@ -11,6 +11,8 @@ import {resolveAuthMode} from './authMode'
 import {AuthStateType} from './authStateType'
 import {type AuthStrategyOptions} from './authStrategy'
 import {getDashboardInitialState, initializeDashboardAuth} from './dashboardAuth'
+import {getOauthInitialState, initializeOauthAuth} from './oauth/oauthAuth'
+import {type OAuthTokens} from './oauth/types'
 import {getStandaloneInitialState, initializeStandaloneAuth} from './standaloneAuth'
 import {getStudioInitialState, initializeStudioAuth} from './studioAuth'
 import {createLoggedInAuthState, getCleanedUrl, getDefaultLocation} from './utils'
@@ -91,8 +93,10 @@ export interface AuthStoreState {
     callbackUrl: string | undefined
     providedToken: string | undefined
     authMethod: AuthMethodOptions
+    oauth: AuthConfig['oauth']
   }
   dashboardContext?: DashboardContext
+  oauthTokens?: OAuthTokens
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +159,9 @@ export const authStore = defineStore<AuthStoreState>({
       case 'studio':
         result = getStudioInitialState(strategyOptions)
         break
+      case 'oauth':
+        result = getOauthInitialState(strategyOptions)
+        break
       case 'dashboard':
         result = getDashboardInitialState(strategyOptions)
         break
@@ -172,6 +179,7 @@ export const authStore = defineStore<AuthStoreState>({
     return {
       authState: result.authState,
       dashboardContext: result.dashboardContext,
+      oauthTokens: result.oauthTokens,
       options: {
         apiHost,
         loginUrl: loginUrl.toString(),
@@ -183,6 +191,7 @@ export const authStore = defineStore<AuthStoreState>({
         storageKey: result.storageKey,
         storageArea: result.storageArea,
         authMethod: result.authMethod,
+        oauth: authConfig.oauth,
       },
     }
   },
@@ -200,6 +209,9 @@ export const authStore = defineStore<AuthStoreState>({
     switch (mode) {
       case 'studio':
         initResult = initializeStudioAuth(context, tokenRefresherRunning)
+        break
+      case 'oauth':
+        initResult = initializeOauthAuth(context)
         break
       case 'dashboard':
         initResult = initializeDashboardAuth(context, tokenRefresherRunning)

--- a/packages/core/src/auth/authStrategy.ts
+++ b/packages/core/src/auth/authStrategy.ts
@@ -3,6 +3,7 @@ import {type ClientConfig, type SanityClient} from '@sanity/client'
 import {type AuthConfig} from '../config/authConfig'
 import {type TokenSource} from '../config/sanityConfig'
 import {type AuthMethodOptions, type AuthState, type DashboardContext} from './authStore'
+import {type OAuthTokens} from './oauth/types'
 
 /**
  * The result returned by each auth strategy's `getInitialState` function.
@@ -17,6 +18,7 @@ export interface AuthStrategyResult {
   storageArea: Storage | undefined
   authMethod: AuthMethodOptions
   dashboardContext: DashboardContext
+  oauthTokens?: OAuthTokens
 }
 
 /**

--- a/packages/core/src/auth/logout.test.ts
+++ b/packages/core/src/auth/logout.test.ts
@@ -5,6 +5,9 @@ import {createSanityInstance, type SanityInstance} from '../store/createSanityIn
 import {AuthStateType} from './authStateType'
 import {getAuthState} from './authStore'
 import {logout} from './logout'
+import {getOAuthTokensState, serializeTokens} from './oauth/oauthActions'
+import {OAUTH_TOKENS_KEY} from './oauth/oauthAuth'
+import {type OAuthTokens} from './oauth/types'
 import {subscribeToStateAndFetchCurrentUser} from './subscribeToStateAndFetchCurrentUser'
 import {subscribeToStorageEventsAndSetToken} from './subscribeToStorageEventsAndSetToken'
 import {getTokenFromStorage} from './utils'
@@ -164,6 +167,48 @@ describe('logout', () => {
 
     // Should still clean up storage
     expect(removeItem).toHaveBeenCalledWith('__sanity_auth_token')
+  })
+
+  it('clears the OAuth tokens from the store on logout', async () => {
+    const oauthTokens: OAuthTokens = {
+      accessToken: 'oauth-access',
+      tokenType: 'bearer',
+      expiresIn: 3600,
+      expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+      refreshToken: 'oauth-refresh',
+    }
+    const map = new Map<string, string>([[OAUTH_TOKENS_KEY, serializeTokens(oauthTokens)]])
+    const storageArea = {
+      getItem: (k: string) => map.get(k) ?? null,
+      setItem: (k: string, v: string) => void map.set(k, v),
+      removeItem: (k: string) => void map.delete(k),
+    } as Storage
+
+    const mockRequest = vi.fn().mockResolvedValue(undefined)
+    const clientFactory = vi.fn().mockReturnValue({request: mockRequest})
+
+    instance = createSanityInstance({
+      projectId: 'p',
+      dataset: 'd',
+      auth: {
+        clientFactory,
+        storageArea,
+        oauth: {
+          clientId: 'client-abc',
+          redirectUri: 'https://app.example.com/callback',
+          organizationId: 'org123',
+        },
+      },
+    })
+
+    // Boots logged in with the persisted OAuth tokens exposed on the store.
+    expect(getOAuthTokensState(instance).getCurrent()).toMatchObject({accessToken: 'oauth-access'})
+
+    await logout(instance)
+
+    expect(getOAuthTokensState(instance).getCurrent()).toBeNull()
+    expect(getAuthState(instance).getCurrent()).toMatchObject({type: AuthStateType.LOGGED_OUT})
+    expect(map.get(OAUTH_TOKENS_KEY)).toBeUndefined()
   })
 
   it('cleans up storage even if logout request fails', async () => {

--- a/packages/core/src/auth/logout.ts
+++ b/packages/core/src/auth/logout.ts
@@ -57,6 +57,7 @@ export const logout = bindActionGlobally(authStore, async ({state, instance}) =>
     logger.info('User logged out, clearing stored tokens')
     state.set('logoutSuccess', {
       authState: {type: AuthStateType.LOGGED_OUT, isDestroyingSession: false},
+      oauthTokens: undefined,
     })
     storageArea?.removeItem(storageKey)
     storageArea?.removeItem(`${storageKey}_last_refresh`)

--- a/packages/core/src/auth/oauth/oauthActions.test.ts
+++ b/packages/core/src/auth/oauth/oauthActions.test.ts
@@ -1,0 +1,420 @@
+import {type ClientConfig, type SanityClient} from '@sanity/client'
+import {NEVER} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createSanityInstance, type SanityInstance} from '../../store/createSanityInstance'
+import {AuthStateType} from '../authStateType'
+import {getAuthState} from '../authStore'
+import {subscribeToStateAndFetchCurrentUser} from '../subscribeToStateAndFetchCurrentUser'
+import {
+  getOAuthTokensState,
+  handleOAuthCallback,
+  OAUTH_STATE_KEY,
+  OAUTH_VERIFIER_KEY,
+  refreshOAuthTokens,
+  revokeOAuthTokens,
+  serializeTokens,
+  startOAuthAuthorization,
+} from './oauthActions'
+import {deserializeTokens, OAUTH_TOKENS_KEY} from './oauthAuth'
+import {type OAuthTokens} from './types'
+
+const readStored = (storage: Storage) => deserializeTokens(storage.getItem(OAUTH_TOKENS_KEY))
+
+vi.mock('../subscribeToStateAndFetchCurrentUser')
+vi.mock('../../utils/logger', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../utils/logger')>()
+  return {
+    ...original,
+    createLogger: vi.fn(() => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+    })),
+  }
+})
+
+const oauthConfig = {
+  clientId: 'client-abc',
+  redirectUri: 'https://app.example.com/callback',
+  organizationId: 'org123',
+}
+
+const seededTokens: OAuthTokens = {
+  accessToken: 'stored-access',
+  tokenType: 'bearer',
+  expiresIn: 3600,
+  expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+  refreshToken: 'stored-refresh',
+}
+
+const tokenResponse = {
+  access_token: 'new-access',
+  token_type: 'bearer',
+  expires_in: 3600,
+  refresh_token: 'new-refresh',
+}
+
+function createMemoryStorage(seed?: Record<string, string>): Storage {
+  const map = new Map<string, string>(Object.entries(seed ?? {}))
+  return {
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
+    removeItem: (k) => void map.delete(k),
+    clear: () => map.clear(),
+    key: (i) => [...map.keys()][i] ?? null,
+    get length() {
+      return map.size
+    },
+  } as Storage
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (v: T) => void
+  reject: (e: unknown) => void
+} {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return {promise, resolve, reject}
+}
+
+let instance: SanityInstance | undefined
+
+interface SetupOptions {
+  request?: ReturnType<typeof vi.fn>
+  storageSeed?: Record<string, string>
+  sessionSeed?: Record<string, string>
+  initialLocationHref?: string
+  withOAuthConfig?: boolean
+  apiHost?: string
+}
+
+function setup(options: SetupOptions = {}) {
+  const request = options.request ?? vi.fn().mockResolvedValue(tokenResponse)
+  const clientFactory = vi.fn((_config: ClientConfig) => ({request}) as unknown as SanityClient)
+  const storageArea = createMemoryStorage(options.storageSeed)
+  const session = createMemoryStorage(options.sessionSeed)
+  vi.stubGlobal('sessionStorage', session)
+
+  instance = createSanityInstance({
+    projectId: 'p',
+    dataset: 'd',
+    auth: {
+      clientFactory,
+      storageArea,
+      initialLocationHref: options.initialLocationHref ?? 'https://app.example.com/',
+      ...(options.apiHost && {apiHost: options.apiHost}),
+      ...(options.withOAuthConfig === false ? {} : {oauth: oauthConfig}),
+    },
+  })
+
+  return {request, clientFactory, storageArea, session}
+}
+
+function parseBody(body: unknown): URLSearchParams {
+  return new URLSearchParams(body as string)
+}
+
+beforeEach(() => {
+  vi.mocked(subscribeToStateAndFetchCurrentUser).mockReturnValue(NEVER.subscribe())
+})
+
+afterEach(() => {
+  instance?.dispose()
+  instance = undefined
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('startOAuthAuthorization', () => {
+  it('persists verifier/state and navigates to the authorize URL', async () => {
+    const assign = vi.fn()
+    vi.stubGlobal('window', {location: {assign}})
+    const {session} = setup({initialLocationHref: 'https://app.example.com/'})
+
+    await startOAuthAuthorization(instance!)
+
+    expect(session.getItem(OAUTH_VERIFIER_KEY)).toBeTruthy()
+    expect(session.getItem(OAUTH_STATE_KEY)).toBeTruthy()
+
+    expect(assign).toHaveBeenCalledTimes(1)
+    const url = new URL(assign.mock.calls[0][0])
+    expect(url.pathname).toBe('/v1/auth/oauth/authorize')
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('client_id')).toBe('client-abc')
+    expect(url.searchParams.get('redirect_uri')).toBe(oauthConfig.redirectUri)
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(url.searchParams.get('code_challenge')).toBeTruthy()
+    expect(url.searchParams.get('state')).toBe(session.getItem(OAUTH_STATE_KEY))
+    expect(url.searchParams.getAll('resource')).toEqual(['urn:io.sanity:organization:org123'])
+  })
+
+  it('throws when OAuth is not configured', async () => {
+    setup({withOAuthConfig: false})
+    await expect(startOAuthAuthorization(instance!)).rejects.toThrow(/OAuth is not configured/)
+  })
+})
+
+describe('handleOAuthCallback', () => {
+  const callbackHref = 'https://app.example.com/callback?code=auth-code&state=state-xyz'
+
+  it('exchanges the code, persists tokens, clears artifacts and logs in', async () => {
+    const {request, storageArea, session, clientFactory} = setup({
+      apiHost: 'https://api.sanity.work',
+      sessionSeed: {[OAUTH_STATE_KEY]: 'state-xyz', [OAUTH_VERIFIER_KEY]: 'verifier-1'},
+    })
+
+    const result = await handleOAuthCallback(instance!, callbackHref)
+
+    expect(result).toBe('https://app.example.com/callback')
+    expect(clientFactory).toHaveBeenCalledWith(
+      expect.objectContaining({apiHost: 'https://api.sanity.work'}),
+    )
+    expect(request).toHaveBeenCalledTimes(1)
+    const call = request.mock.calls[0][0]
+    expect(call).toMatchObject({
+      method: 'POST',
+      url: '/auth/oauth/token',
+      headers: {'content-type': 'application/x-www-form-urlencoded'},
+      tag: 'oauth.token',
+    })
+    const body = parseBody(call.body)
+    expect(body.get('grant_type')).toBe('authorization_code')
+    expect(body.get('code')).toBe('auth-code')
+    expect(body.get('code_verifier')).toBe('verifier-1')
+    expect(body.get('redirect_uri')).toBe(oauthConfig.redirectUri)
+    expect(body.get('client_id')).toBe('client-abc')
+    expect(body.get('resource')).toBe('urn:io.sanity:organization:org123')
+
+    expect(readStored(storageArea)).toMatchObject({accessToken: 'new-access'})
+    expect(session.getItem(OAUTH_VERIFIER_KEY)).toBeNull()
+    expect(session.getItem(OAUTH_STATE_KEY)).toBeNull()
+
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({
+      type: AuthStateType.LOGGED_IN,
+      token: 'new-access',
+    })
+  })
+
+  it('does not perform a second exchange on a duplicate concurrent invocation', async () => {
+    const pending = deferred<typeof tokenResponse>()
+    const request = vi.fn().mockReturnValue(pending.promise)
+    setup({
+      request,
+      sessionSeed: {[OAUTH_STATE_KEY]: 'state-xyz', [OAUTH_VERIFIER_KEY]: 'verifier-1'},
+    })
+
+    const first = handleOAuthCallback(instance!, callbackHref)
+    const second = await handleOAuthCallback(instance!, callbackHref)
+
+    expect(second).toBe(false)
+    expect(request).toHaveBeenCalledTimes(1)
+
+    pending.resolve(tokenResponse)
+    expect(await first).toBe('https://app.example.com/callback')
+  })
+
+  it('surfaces an ?error= callback as ERROR without exchanging', async () => {
+    const {request} = setup()
+
+    const result = await handleOAuthCallback(
+      instance!,
+      'https://app.example.com/callback?error=access_denied&error_description=denied',
+    )
+
+    expect(result).toBe('https://app.example.com/callback')
+    expect(request).not.toHaveBeenCalled()
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.ERROR})
+  })
+
+  it('surfaces an ?error= callback without a description', async () => {
+    setup()
+    await handleOAuthCallback(instance!, 'https://app.example.com/callback?error=access_denied')
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.ERROR})
+  })
+
+  it('rejects a state mismatch as ERROR without exchanging', async () => {
+    const {request} = setup({
+      sessionSeed: {[OAUTH_STATE_KEY]: 'different', [OAUTH_VERIFIER_KEY]: 'verifier-1'},
+    })
+
+    const result = await handleOAuthCallback(instance!, callbackHref)
+
+    expect(result).toBe('https://app.example.com/callback')
+    expect(request).not.toHaveBeenCalled()
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.ERROR})
+  })
+
+  it('errors when the code verifier is missing', async () => {
+    const {request} = setup({sessionSeed: {[OAUTH_STATE_KEY]: 'state-xyz'}})
+
+    const result = await handleOAuthCallback(instance!, callbackHref)
+
+    expect(result).toBe('https://app.example.com/callback')
+    expect(request).not.toHaveBeenCalled()
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.ERROR})
+  })
+
+  it('returns false when there is no code in the URL', async () => {
+    const {request} = setup()
+    const result = await handleOAuthCallback(instance!, 'https://app.example.com/callback')
+    expect(result).toBe(false)
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('sets ERROR when the token exchange fails', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('boom'))
+    const {session} = setup({
+      request,
+      sessionSeed: {[OAUTH_STATE_KEY]: 'state-xyz', [OAUTH_VERIFIER_KEY]: 'verifier-1'},
+    })
+
+    const result = await handleOAuthCallback(instance!, callbackHref)
+
+    expect(result).toBe('https://app.example.com/callback')
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.ERROR})
+    expect(session.getItem(OAUTH_VERIFIER_KEY)).toBeNull()
+  })
+})
+
+describe('refreshOAuthTokens', () => {
+  it('refreshes tokens and persists them', async () => {
+    const {request, storageArea} = setup({
+      storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(seededTokens)},
+    })
+
+    const result = await refreshOAuthTokens(instance!)
+
+    expect(request).toHaveBeenCalledTimes(1)
+    const body = parseBody(request.mock.calls[0][0].body)
+    expect(body.get('grant_type')).toBe('refresh_token')
+    expect(body.get('refresh_token')).toBe('stored-refresh')
+    expect(body.get('client_id')).toBe('client-abc')
+    expect(body.get('resource')).toBe('urn:io.sanity:organization:org123')
+
+    expect(result).toMatchObject({accessToken: 'new-access', refreshToken: 'new-refresh'})
+    expect(readStored(storageArea)).toMatchObject({accessToken: 'new-access'})
+  })
+
+  it('shares a single in-flight request across concurrent callers', async () => {
+    const pending = deferred<typeof tokenResponse>()
+    const request = vi.fn().mockReturnValue(pending.promise)
+    setup({
+      request,
+      storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(seededTokens)},
+    })
+
+    const a = refreshOAuthTokens(instance!)
+    const b = refreshOAuthTokens(instance!)
+
+    pending.resolve(tokenResponse)
+    const [ra, rb] = await Promise.all([a, b])
+
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(ra).toBe(rb)
+    expect(ra).toMatchObject({accessToken: 'new-access'})
+  })
+
+  it('keeps the previous refresh token when the endpoint omits one', async () => {
+    const request = vi.fn().mockResolvedValue({
+      access_token: 'new-access',
+      token_type: 'bearer',
+      expires_in: 3600,
+    })
+    const {storageArea} = setup({
+      request,
+      storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(seededTokens)},
+    })
+
+    await refreshOAuthTokens(instance!)
+
+    expect(readStored(storageArea)).toMatchObject({refreshToken: 'stored-refresh'})
+  })
+
+  it('logs out when there is no refresh token', async () => {
+    const noRefresh = {...seededTokens, refreshToken: undefined}
+    const {request, storageArea} = setup({
+      storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(noRefresh)},
+    })
+
+    const result = await refreshOAuthTokens(instance!)
+
+    expect(result).toBeNull()
+    expect(request).not.toHaveBeenCalled()
+    expect(readStored(storageArea)).toBeNull()
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.LOGGED_OUT})
+  })
+
+  it('clears tokens and logs out on an unrecoverable refresh failure', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('invalid_grant'))
+    const {storageArea} = setup({
+      request,
+      storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(seededTokens)},
+    })
+
+    await expect(refreshOAuthTokens(instance!)).rejects.toThrow('invalid_grant')
+    expect(readStored(storageArea)).toBeNull()
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.LOGGED_OUT})
+  })
+})
+
+describe('revokeOAuthTokens', () => {
+  it('revokes with token and client_id, then clears local state', async () => {
+    const {request, storageArea} = setup({
+      storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(seededTokens)},
+    })
+
+    await revokeOAuthTokens(instance!)
+
+    expect(request).toHaveBeenCalledTimes(1)
+    const call = request.mock.calls[0][0]
+    expect(call).toMatchObject({method: 'POST', url: '/auth/oauth/revoke', tag: 'oauth.revoke'})
+    const body = parseBody(call.body)
+    expect(body.get('token')).toBe('stored-refresh')
+    expect(body.get('client_id')).toBe('client-abc')
+
+    expect(readStored(storageArea)).toBeNull()
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.LOGGED_OUT})
+  })
+
+  it('clears local state even when the revoke request fails', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('revoke failed'))
+    const {storageArea} = setup({
+      request,
+      storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(seededTokens)},
+    })
+
+    await expect(revokeOAuthTokens(instance!)).resolves.toBeUndefined()
+    expect(readStored(storageArea)).toBeNull()
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.LOGGED_OUT})
+  })
+
+  it('clears state without calling the endpoint when there is no token', async () => {
+    const {request, storageArea} = setup()
+
+    await revokeOAuthTokens(instance!)
+
+    expect(request).not.toHaveBeenCalled()
+    expect(readStored(storageArea)).toBeNull()
+    expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.LOGGED_OUT})
+  })
+})
+
+describe('getOAuthTokensState', () => {
+  it('exposes the current OAuth tokens', () => {
+    setup({storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(seededTokens)}})
+    expect(getOAuthTokensState(instance!).getCurrent()).toEqual(seededTokens)
+  })
+
+  it('returns null when there are no OAuth tokens', () => {
+    setup()
+    expect(getOAuthTokensState(instance!).getCurrent()).toBeNull()
+  })
+})

--- a/packages/core/src/auth/oauth/oauthActions.test.ts
+++ b/packages/core/src/auth/oauth/oauthActions.test.ts
@@ -1,4 +1,4 @@
-import {type ClientConfig, type SanityClient} from '@sanity/client'
+import {type ClientConfig, ClientError, type SanityClient} from '@sanity/client'
 import {NEVER} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -352,16 +352,53 @@ describe('refreshOAuthTokens', () => {
     expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.LOGGED_OUT})
   })
 
-  it('clears tokens and logs out on an unrecoverable refresh failure', async () => {
-    const request = vi.fn().mockRejectedValue(new Error('invalid_grant'))
+  it('clears tokens and logs out on an unrecoverable (4xx) refresh failure', async () => {
+    const invalidGrant = new ClientError({
+      statusCode: 400,
+      headers: {},
+      body: {error: 'invalid_grant'},
+    })
+    const request = vi.fn().mockRejectedValue(invalidGrant)
     const {storageArea} = setup({
       request,
       storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(seededTokens)},
     })
 
-    await expect(refreshOAuthTokens(instance!)).rejects.toThrow('invalid_grant')
+    await expect(refreshOAuthTokens(instance!)).rejects.toBe(invalidGrant)
     expect(readStored(storageArea)).toBeNull()
     expect(getAuthState(instance!).getCurrent()).toMatchObject({type: AuthStateType.LOGGED_OUT})
+  })
+
+  it('keeps the session on a transient refresh failure', async () => {
+    const networkError = new Error('network down')
+    const request = vi.fn().mockRejectedValue(networkError)
+    const {storageArea} = setup({
+      request,
+      storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(seededTokens)},
+    })
+
+    await expect(refreshOAuthTokens(instance!)).rejects.toBe(networkError)
+    // Tokens are preserved and the user stays logged in for a retry.
+    expect(readStored(storageArea)).toMatchObject({accessToken: 'stored-access'})
+    expect(getOAuthTokensState(instance!).getCurrent()).toMatchObject({
+      accessToken: 'stored-access',
+    })
+  })
+
+  it('keeps the session on a 429 rate-limit refresh failure', async () => {
+    const rateLimited = new ClientError({
+      statusCode: 429,
+      headers: {},
+      body: {error: 'rate_limited'},
+    })
+    const request = vi.fn().mockRejectedValue(rateLimited)
+    const {storageArea} = setup({
+      request,
+      storageSeed: {[OAUTH_TOKENS_KEY]: serializeTokens(seededTokens)},
+    })
+
+    await expect(refreshOAuthTokens(instance!)).rejects.toBe(rateLimited)
+    expect(readStored(storageArea)).toMatchObject({accessToken: 'stored-access'})
   })
 })
 

--- a/packages/core/src/auth/oauth/oauthActions.ts
+++ b/packages/core/src/auth/oauth/oauthActions.ts
@@ -1,0 +1,371 @@
+import {type SanityClient} from '@sanity/client'
+
+import {bindActionGlobally} from '../../store/createActionBinder'
+import {createStateSourceAction} from '../../store/createStateSourceAction'
+import {type StoreContext} from '../../store/defineStore'
+import {DEFAULT_BASE, REQUEST_TAG_PREFIX} from '../authConstants'
+import {getAuthLogger} from '../authLogger'
+import {AuthStateType} from '../authStateType'
+import {authStore, type AuthStoreState} from '../authStore'
+import {createLoggedInAuthState, getDefaultLocation} from '../utils'
+import {generateCodeChallenge, generateCodeVerifier, generateState} from './pkce'
+import {type OAuthTokens} from './types'
+
+/** sessionStorage key for the PKCE `code_verifier`. */
+export const OAUTH_VERIFIER_KEY = '__sanity_oauth_verifier'
+
+/** sessionStorage key for the CSRF `state` value. */
+export const OAUTH_STATE_KEY = '__sanity_oauth_state'
+
+interface TokenEndpointResponse {
+  access_token: string
+  token_type: string
+  expires_in: number
+  refresh_token?: string
+}
+
+/** Builds the RFC 8707 resource indicator for an organisation. */
+function getResourceIndicator(organizationId: string): string {
+  return `urn:io.sanity:organization:${organizationId}`
+}
+
+/**
+ * Serialises tokens for storage, converting `expiresAt` to an ISO string.
+ *
+ * @internal
+ */
+export function serializeTokens(tokens: OAuthTokens): string {
+  return JSON.stringify({
+    accessToken: tokens.accessToken,
+    tokenType: tokens.tokenType,
+    expiresIn: tokens.expiresIn,
+    expiresAt: tokens.expiresAt.toISOString(),
+    ...(tokens.refreshToken !== undefined && {refreshToken: tokens.refreshToken}),
+  })
+}
+
+type AuthOptions = AuthStoreState['options']
+type ConfiguredOAuthOptions = AuthOptions & {oauth: NonNullable<AuthOptions['oauth']>}
+
+/**
+ * Reads the store options, throwing when the instance was not configured for
+ * OAuth.
+ */
+function getOAuthOptions(state: AuthStoreState): ConfiguredOAuthOptions {
+  const {options} = state
+  if (!options.oauth) {
+    throw new Error('OAuth is not configured on this instance (missing `auth.oauth`).')
+  }
+  return options as ConfiguredOAuthOptions
+}
+
+/** Creates a client for the (unauthenticated) public OAuth token/revoke calls. */
+function createOAuthClient(options: AuthOptions): SanityClient {
+  return options.clientFactory({
+    apiVersion: 'v1',
+    requestTagPrefix: REQUEST_TAG_PREFIX,
+    useProjectHostname: false,
+    useCdn: false,
+    ...(options.apiHost && {apiHost: options.apiHost}),
+  })
+}
+
+/** Converts a token endpoint response to the {@link OAuthTokens} shape. */
+function toOAuthTokens(response: TokenEndpointResponse): OAuthTokens {
+  return {
+    accessToken: response.access_token,
+    tokenType: 'bearer',
+    expiresIn: response.expires_in,
+    expiresAt: new Date(Date.now() + response.expires_in * 1000),
+    ...(response.refresh_token !== undefined && {refreshToken: response.refresh_token}),
+  }
+}
+
+/**
+ * Starts the OAuth authorization-code + PKCE flow: generates a `code_verifier`,
+ * `code_challenge` and `state`, persists the verifier and state to
+ * `sessionStorage`, then navigates the browser to the authorize endpoint.
+ *
+ * @public
+ */
+export const startOAuthAuthorization = bindActionGlobally(authStore, async ({state, instance}) => {
+  const logger = getAuthLogger(instance)
+  const options = getOAuthOptions(state.get())
+
+  const codeVerifier = generateCodeVerifier()
+  const oauthState = generateState()
+  const codeChallenge = await generateCodeChallenge(codeVerifier)
+
+  const session = typeof sessionStorage !== 'undefined' ? sessionStorage : undefined
+  session?.setItem(OAUTH_VERIFIER_KEY, codeVerifier)
+  session?.setItem(OAUTH_STATE_KEY, oauthState)
+
+  const authorizeUrl = new URL(
+    '/v1/auth/oauth/authorize',
+    options.apiHost ?? 'https://api.sanity.io',
+  )
+  authorizeUrl.searchParams.set('response_type', 'code')
+  authorizeUrl.searchParams.set('client_id', options.oauth.clientId)
+  authorizeUrl.searchParams.set('redirect_uri', options.oauth.redirectUri)
+  authorizeUrl.searchParams.set('state', oauthState)
+  authorizeUrl.searchParams.set('code_challenge', codeChallenge)
+  authorizeUrl.searchParams.set('code_challenge_method', 'S256')
+  authorizeUrl.searchParams.append('resource', getResourceIndicator(options.oauth.organizationId))
+
+  logger.info('Starting OAuth authorization')
+  if (typeof window !== 'undefined' && typeof window.location?.assign === 'function') {
+    window.location.assign(authorizeUrl.toString())
+  }
+})
+
+/**
+ * Handles the OAuth redirect callback: validates `state`, surfaces `error`
+ * responses, exchanges the authorization `code` for tokens, persists them, and
+ * transitions to `LOGGED_IN`.
+ *
+ * Returns the callback URL cleaned of OAuth params (for the caller to
+ * `history.replaceState`) when a callback was processed, or `false` when there
+ * was nothing to handle (no code, or an exchange already in progress).
+ *
+ * @public
+ */
+export const handleOAuthCallback = bindActionGlobally(
+  authStore,
+  async (
+    {state, instance},
+    locationHref: string = getDefaultLocation(),
+  ): Promise<string | false> => {
+    const logger = getAuthLogger(instance)
+    const options = getOAuthOptions(state.get())
+
+    const {authState} = state.get()
+    if (authState.type === AuthStateType.LOGGING_IN && authState.isExchangingToken) {
+      logger.debug('Skipping OAuth callback - token exchange already in progress')
+      return false
+    }
+
+    const callbackUrl = new URL(locationHref, DEFAULT_BASE)
+    const code = callbackUrl.searchParams.get('code')
+    const returnedState = callbackUrl.searchParams.get('state')
+    const error = callbackUrl.searchParams.get('error')
+    const errorDescription = callbackUrl.searchParams.get('error_description')
+
+    const session = typeof sessionStorage !== 'undefined' ? sessionStorage : undefined
+
+    const cleanedUrlObj = new URL(locationHref, DEFAULT_BASE)
+    for (const param of ['code', 'state', 'error', 'error_description']) {
+      cleanedUrlObj.searchParams.delete(param)
+    }
+    const cleanedUrl = cleanedUrlObj.toString()
+
+    if (error) {
+      logger.warn('OAuth callback returned an error', {error, errorDescription})
+      clearOAuthArtifacts(session)
+      state.set('oauthCallbackError', {
+        authState: {
+          type: AuthStateType.ERROR,
+          error: new Error(errorDescription ? `${error}: ${errorDescription}` : error),
+        },
+      })
+      return cleanedUrl
+    }
+
+    if (!code) {
+      logger.debug('No OAuth code found in callback URL')
+      return false
+    }
+
+    const storedState = session?.getItem(OAUTH_STATE_KEY) ?? null
+    if (!returnedState || !storedState || returnedState !== storedState) {
+      logger.error('OAuth state mismatch — rejecting callback')
+      clearOAuthArtifacts(session)
+      state.set('oauthStateMismatch', {
+        authState: {type: AuthStateType.ERROR, error: new Error('OAuth state mismatch')},
+      })
+      return cleanedUrl
+    }
+
+    const codeVerifier = session?.getItem(OAUTH_VERIFIER_KEY) ?? null
+    if (!codeVerifier) {
+      logger.error('OAuth code verifier missing — cannot exchange code')
+      clearOAuthArtifacts(session)
+      state.set('oauthVerifierMissing', {
+        authState: {type: AuthStateType.ERROR, error: new Error('OAuth code verifier missing')},
+      })
+      return cleanedUrl
+    }
+
+    logger.info('Exchanging OAuth code for tokens')
+    state.set('oauthExchange', {
+      authState: {type: AuthStateType.LOGGING_IN, isExchangingToken: true},
+    })
+
+    try {
+      const client = createOAuthClient(options)
+      const params = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: codeVerifier,
+        redirect_uri: options.oauth.redirectUri,
+        client_id: options.oauth.clientId,
+        resource: getResourceIndicator(options.oauth.organizationId),
+      })
+      const response = await client.request<TokenEndpointResponse>({
+        method: 'POST',
+        url: '/auth/oauth/token',
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+        body: params.toString(),
+        tag: 'oauth.token',
+      })
+
+      const tokens = toOAuthTokens(response)
+      options.storageArea?.setItem(options.storageKey, serializeTokens(tokens))
+      clearOAuthArtifacts(session)
+
+      logger.info('OAuth tokens obtained, user logged in')
+      state.set('oauthLoggedIn', {
+        authState: createLoggedInAuthState(tokens.accessToken, null),
+        oauthTokens: tokens,
+      })
+      return cleanedUrl
+    } catch (exchangeError) {
+      logger.error('Failed to exchange OAuth code for tokens', {error: exchangeError})
+      clearOAuthArtifacts(session)
+      state.set('oauthExchangeError', {
+        authState: {type: AuthStateType.ERROR, error: exchangeError},
+      })
+      return cleanedUrl
+    }
+  },
+)
+
+// Single-flight refresh shared across concurrent callers. Safe as a module
+// singleton because `authStore` is a global store (one shared state).
+// ponytail: module-level single-flight; upgrade to per-store keying only if
+// the auth store ever stops being global.
+let refreshInFlight: Promise<OAuthTokens | null> | null = null
+
+/**
+ * Refreshes the OAuth tokens using the `refresh_token` grant. Concurrent
+ * callers share a single in-flight request. An unrecoverable failure
+ * (e.g. `invalid_grant`) clears the tokens and transitions to `LOGGED_OUT`.
+ *
+ * @public
+ */
+export const refreshOAuthTokens = bindActionGlobally(authStore, (context) => {
+  if (refreshInFlight) return refreshInFlight
+  refreshInFlight = doRefreshOAuthTokens(context).finally(() => {
+    refreshInFlight = null
+  })
+  return refreshInFlight
+})
+
+async function doRefreshOAuthTokens({
+  state,
+  instance,
+}: StoreContext<AuthStoreState>): Promise<OAuthTokens | null> {
+  const logger = getAuthLogger(instance)
+  const options = getOAuthOptions(state.get())
+
+  const current = state.get().oauthTokens
+  if (!current?.refreshToken) {
+    logger.warn('No refresh token available — logging out')
+    options.storageArea?.removeItem(options.storageKey)
+    state.set('oauthRefreshNoToken', {
+      authState: {type: AuthStateType.LOGGED_OUT, isDestroyingSession: false},
+      oauthTokens: undefined,
+    })
+    return null
+  }
+
+  try {
+    const client = createOAuthClient(options)
+    const params = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: current.refreshToken,
+      client_id: options.oauth.clientId,
+      resource: getResourceIndicator(options.oauth.organizationId),
+    })
+    const response = await client.request<TokenEndpointResponse>({
+      method: 'POST',
+      url: '/auth/oauth/token',
+      headers: {'content-type': 'application/x-www-form-urlencoded'},
+      body: params.toString(),
+      tag: 'oauth.refresh',
+    })
+
+    const tokens = toOAuthTokens(response)
+    if (!tokens.refreshToken) tokens.refreshToken = current.refreshToken
+
+    options.storageArea?.setItem(options.storageKey, serializeTokens(tokens))
+    logger.info('OAuth tokens refreshed')
+    state.set('oauthRefreshed', {
+      authState: createLoggedInAuthState(tokens.accessToken, null),
+      oauthTokens: tokens,
+    })
+    return tokens
+  } catch (error) {
+    logger.error('OAuth token refresh failed — logging out', {error})
+    options.storageArea?.removeItem(options.storageKey)
+    state.set('oauthRefreshFailed', {
+      authState: {type: AuthStateType.LOGGED_OUT, isDestroyingSession: false},
+      oauthTokens: undefined,
+    })
+    throw error
+  }
+}
+
+/**
+ * Revokes the OAuth tokens then clears local storage and transitions to `LOGGED_OUT`.
+ * Local state is cleared even if the revoke request fails.
+ *
+ * @public
+ */
+export const revokeOAuthTokens = bindActionGlobally(authStore, async ({state, instance}) => {
+  const logger = getAuthLogger(instance)
+  const options = getOAuthOptions(state.get())
+
+  const current = state.get().oauthTokens
+  const token = current?.refreshToken ?? current?.accessToken
+
+  try {
+    if (token) {
+      const client = createOAuthClient(options)
+      const params = new URLSearchParams({token, client_id: options.oauth.clientId})
+      await client.request<void>({
+        method: 'POST',
+        url: '/auth/oauth/revoke',
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+        body: params.toString(),
+        tag: 'oauth.revoke',
+      })
+      logger.info('OAuth tokens revoked')
+    }
+  } catch (error) {
+    // Revocation is best-effort — local state is cleared regardless.
+    logger.warn('OAuth revoke request failed — clearing local state anyway', {error})
+  } finally {
+    options.storageArea?.removeItem(options.storageKey)
+    state.set('oauthRevoked', {
+      authState: {type: AuthStateType.LOGGED_OUT, isDestroyingSession: false},
+      oauthTokens: undefined,
+    })
+  }
+})
+
+/**
+ * A state source exposing the current OAuth tokens (including expiry), or
+ * `null` when not logged in via OAuth.
+ *
+ * @public
+ */
+export const getOAuthTokensState = bindActionGlobally(
+  authStore,
+  createStateSourceAction(({state}) => state.oauthTokens ?? null),
+)
+
+/** Removes the transient PKCE artifacts from session storage. */
+function clearOAuthArtifacts(session: Storage | undefined): void {
+  session?.removeItem(OAUTH_VERIFIER_KEY)
+  session?.removeItem(OAUTH_STATE_KEY)
+}

--- a/packages/core/src/auth/oauth/oauthActions.ts
+++ b/packages/core/src/auth/oauth/oauthActions.ts
@@ -1,4 +1,4 @@
-import {type SanityClient} from '@sanity/client'
+import {ClientError, type SanityClient} from '@sanity/client'
 
 import {bindActionGlobally} from '../../store/createActionBinder'
 import {createStateSourceAction} from '../../store/createStateSourceAction'
@@ -239,6 +239,16 @@ export const handleOAuthCallback = bindActionGlobally(
   },
 )
 
+/**
+ * A refresh failure is unrecoverable only when the token endpoint rejects the
+ * refresh token itself (a 4xx). Rate-limit (429) and request-timeout (408)
+ * responses, 5xx errors and network failures are transient, so the session is
+ * kept intact for the caller to retry rather than forcing a logout.
+ */
+function isUnrecoverableRefreshError(error: unknown): boolean {
+  return error instanceof ClientError && error.statusCode !== 408 && error.statusCode !== 429
+}
+
 // Single-flight refresh shared across concurrent callers. Safe as a module
 // singleton because `authStore` is a global store (one shared state).
 // ponytail: module-level single-flight; upgrade to per-store keying only if
@@ -247,8 +257,10 @@ let refreshInFlight: Promise<OAuthTokens | null> | null = null
 
 /**
  * Refreshes the OAuth tokens using the `refresh_token` grant. Concurrent
- * callers share a single in-flight request. An unrecoverable failure
- * (e.g. `invalid_grant`) clears the tokens and transitions to `LOGGED_OUT`.
+ * callers share a single in-flight request. An unrecoverable failure (a 4xx
+ * rejecting the refresh token) clears the tokens and transitions to
+ * `LOGGED_OUT`; transient failures (network, 5xx, rate limits) leave the
+ * session intact and rethrow so the caller can retry.
  *
  * @public
  */
@@ -305,6 +317,12 @@ async function doRefreshOAuthTokens({
     })
     return tokens
   } catch (error) {
+    if (!isUnrecoverableRefreshError(error)) {
+      // Transient (network / 5xx / rate limit) — keep the session so the
+      // caller can retry instead of forcing a logout.
+      logger.warn('OAuth token refresh failed — keeping session for retry', {error})
+      throw error
+    }
     logger.error('OAuth token refresh failed — logging out', {error})
     options.storageArea?.removeItem(options.storageKey)
     state.set('oauthRefreshFailed', {

--- a/packages/core/src/auth/oauth/oauthAuth.test.ts
+++ b/packages/core/src/auth/oauth/oauthAuth.test.ts
@@ -1,0 +1,206 @@
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type SanityInstance} from '../../store/createSanityInstance'
+import {type StoreContext} from '../../store/defineStore'
+import {AuthStateType} from '../authStateType'
+import {type AuthStoreState} from '../authStore'
+import {type AuthStrategyOptions} from '../authStrategy'
+import {subscribeToStateAndFetchCurrentUser} from '../subscribeToStateAndFetchCurrentUser'
+import {getStorageEvents} from '../utils'
+import {serializeTokens} from './oauthActions'
+import {
+  deserializeTokens,
+  getOauthInitialState,
+  initializeOauthAuth,
+  OAUTH_TOKENS_KEY,
+  subscribeToOAuthStorageEvents,
+} from './oauthAuth'
+import {type OAuthTokens} from './types'
+
+vi.mock('../subscribeToStateAndFetchCurrentUser')
+vi.mock('../utils', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../utils')>()
+  return {...original, getStorageEvents: vi.fn(() => new Subject())}
+})
+
+const tokens: OAuthTokens = {
+  accessToken: 'access-1',
+  tokenType: 'bearer',
+  expiresIn: 3600,
+  expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+  refreshToken: 'refresh-1',
+}
+
+function createMemoryStorage(seed?: Record<string, string>): Storage {
+  const map = new Map<string, string>(Object.entries(seed ?? {}))
+  return {
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
+    removeItem: (k) => void map.delete(k),
+    clear: () => map.clear(),
+    key: (i) => [...map.keys()][i] ?? null,
+    get length() {
+      return map.size
+    },
+  } as Storage
+}
+
+const baseOptions = (
+  overrides: Partial<AuthStrategyOptions> & {
+    oauthConfig?: {clientId: string; redirectUri: string; organizationId: string}
+    storageArea?: Storage
+  } = {},
+): AuthStrategyOptions => ({
+  authConfig: {
+    storageArea: overrides.storageArea,
+    oauth: overrides.oauthConfig ?? {
+      clientId: 'c',
+      redirectUri: 'https://app/callback',
+      organizationId: 'org',
+    },
+  },
+  projectId: 'p',
+  initialLocationHref: overrides.initialLocationHref ?? 'https://app/',
+  clientFactory: vi.fn(),
+})
+
+describe('serialize/deserialize tokens', () => {
+  it('round-trips tokens with expiresAt as an ISO string', () => {
+    const raw = serializeTokens(tokens)
+    expect(JSON.parse(raw).expiresAt).toBe('2030-01-01T00:00:00.000Z')
+    expect(deserializeTokens(raw)).toEqual(tokens)
+  })
+
+  it('omits refreshToken when absent', () => {
+    const {refreshToken: _omit, ...withoutRefresh} = tokens
+    expect(deserializeTokens(serializeTokens(withoutRefresh))).not.toHaveProperty('refreshToken')
+  })
+
+  it('returns null for missing or malformed values', () => {
+    expect(deserializeTokens(null)).toBeNull()
+    expect(deserializeTokens('not json')).toBeNull()
+    expect(deserializeTokens('{"foo":"bar"}')).toBeNull()
+    expect(deserializeTokens('123')).toBeNull()
+  })
+})
+
+describe('getOauthInitialState', () => {
+  it('returns LOGGED_IN with tokens when persisted tokens exist', () => {
+    const storageArea = createMemoryStorage({[OAUTH_TOKENS_KEY]: serializeTokens(tokens)})
+    const result = getOauthInitialState(baseOptions({storageArea}))
+    expect(result.authState).toMatchObject({type: AuthStateType.LOGGED_IN, token: 'access-1'})
+    expect(result.oauthTokens).toEqual(tokens)
+    expect(result.authMethod).toBe('localstorage')
+  })
+
+  it('returns LOGGING_IN when the callback URL matches the redirect URI', () => {
+    const storageArea = createMemoryStorage()
+    const result = getOauthInitialState(
+      baseOptions({storageArea, initialLocationHref: 'https://app/callback?code=c&state=s'}),
+    )
+    expect(result.authState).toEqual({type: AuthStateType.LOGGING_IN, isExchangingToken: false})
+  })
+
+  it('returns LOGGED_OUT when a callback URL does not match the redirect URI', () => {
+    const storageArea = createMemoryStorage()
+    const result = getOauthInitialState(
+      baseOptions({storageArea, initialLocationHref: 'https://other/callback?code=c&state=s'}),
+    )
+    expect(result.authState).toEqual({type: AuthStateType.LOGGED_OUT, isDestroyingSession: false})
+  })
+
+  it('returns LOGGED_OUT when there are no tokens and no callback', () => {
+    const storageArea = createMemoryStorage()
+    const result = getOauthInitialState(baseOptions({storageArea}))
+    expect(result.authState).toEqual({type: AuthStateType.LOGGED_OUT, isDestroyingSession: false})
+  })
+})
+
+describe('subscribeToOAuthStorageEvents', () => {
+  let events: Subject<StorageEvent>
+
+  beforeEach(() => {
+    events = new Subject<StorageEvent>()
+    vi.mocked(getStorageEvents).mockReturnValue(events)
+  })
+
+  function makeContext(storageArea: Storage): {
+    context: StoreContext<AuthStoreState>
+    set: ReturnType<typeof vi.fn>
+  } {
+    const set = vi.fn()
+    const context = {
+      state: {get: () => ({options: {storageArea}}), set},
+      instance: {config: {}} as SanityInstance,
+      key: null,
+    } as unknown as StoreContext<AuthStoreState>
+    return {context, set}
+  }
+
+  it('sets LOGGED_IN when tokens appear in another tab', () => {
+    const storageArea = createMemoryStorage({[OAUTH_TOKENS_KEY]: serializeTokens(tokens)})
+    const {context, set} = makeContext(storageArea)
+    subscribeToOAuthStorageEvents(context)
+
+    events.next({storageArea, key: OAUTH_TOKENS_KEY} as StorageEvent)
+
+    expect(set).toHaveBeenCalledWith(
+      'updateOAuthTokensFromStorageEvent',
+      expect.objectContaining({
+        authState: expect.objectContaining({type: AuthStateType.LOGGED_IN, token: 'access-1'}),
+        oauthTokens: tokens,
+      }),
+    )
+  })
+
+  it('sets LOGGED_OUT when tokens are cleared in another tab', () => {
+    const storageArea = createMemoryStorage()
+    const {context, set} = makeContext(storageArea)
+    subscribeToOAuthStorageEvents(context)
+
+    events.next({storageArea, key: OAUTH_TOKENS_KEY} as StorageEvent)
+
+    expect(set).toHaveBeenCalledWith('updateOAuthTokensFromStorageEvent', {
+      authState: {type: AuthStateType.LOGGED_OUT, isDestroyingSession: false},
+      oauthTokens: undefined,
+    })
+  })
+
+  it('ignores events for other keys or storage areas', () => {
+    const storageArea = createMemoryStorage()
+    const {context, set} = makeContext(storageArea)
+    subscribeToOAuthStorageEvents(context)
+
+    events.next({storageArea, key: 'other'} as StorageEvent)
+    events.next({storageArea: createMemoryStorage(), key: OAUTH_TOKENS_KEY} as StorageEvent)
+
+    expect(set).not.toHaveBeenCalled()
+  })
+})
+
+describe('initializeOauthAuth', () => {
+  beforeEach(() => {
+    vi.mocked(getStorageEvents).mockReturnValue(new Subject())
+    vi.mocked(subscribeToStateAndFetchCurrentUser).mockReturnValue(new Subject().subscribe())
+  })
+
+  function makeContext(storageArea: Storage | undefined): StoreContext<AuthStoreState> {
+    return {
+      state: {get: () => ({options: {storageArea}}), set: vi.fn()},
+      instance: {config: {}} as SanityInstance,
+      key: null,
+    } as unknown as StoreContext<AuthStoreState>
+  }
+
+  it('does not start the stamped-token refresher', () => {
+    const result = initializeOauthAuth(makeContext(createMemoryStorage()))
+    expect(result.tokenRefresherStarted).toBe(false)
+    result.dispose()
+  })
+
+  it('subscribes without a storage area without throwing', () => {
+    const result = initializeOauthAuth(makeContext(undefined))
+    expect(() => result.dispose()).not.toThrow()
+  })
+})

--- a/packages/core/src/auth/oauth/oauthAuth.ts
+++ b/packages/core/src/auth/oauth/oauthAuth.ts
@@ -1,0 +1,168 @@
+import {defer, distinctUntilChanged, filter, map, type Subscription} from 'rxjs'
+
+import {type StoreContext} from '../../store/defineStore'
+import {DEFAULT_BASE} from '../authConstants'
+import {AuthStateType} from '../authStateType'
+import {type AuthStoreState} from '../authStore'
+import {type AuthStrategyOptions, type AuthStrategyResult} from '../authStrategy'
+import {subscribeToStateAndFetchCurrentUser} from '../subscribeToStateAndFetchCurrentUser'
+import {createLoggedInAuthState, getDefaultStorage, getStorageEvents} from '../utils'
+import {type OAuthTokens} from './types'
+
+/** localStorage (or configured `storageArea`) key for persisted OAuth tokens. */
+export const OAUTH_TOKENS_KEY = '__sanity_oauth_tokens'
+
+/** The persisted JSON shape of {@link OAuthTokens}, `expiresAt` as an ISO string. */
+interface SerializedOAuthTokens extends Omit<OAuthTokens, 'expiresAt'> {
+  expiresAt: string
+}
+
+/**
+ * Parses persisted token JSON back into {@link OAuthTokens}. Returns `null`
+ * when the value is missing or malformed.
+ *
+ * @internal
+ */
+export function deserializeTokens(raw: string | null): OAuthTokens | null {
+  if (!raw) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('accessToken' in parsed) ||
+      typeof (parsed as SerializedOAuthTokens).accessToken !== 'string' ||
+      !('expiresAt' in parsed) ||
+      typeof (parsed as SerializedOAuthTokens).expiresAt !== 'string'
+    ) {
+      return null
+    }
+    const value = parsed as SerializedOAuthTokens
+    return {
+      accessToken: value.accessToken,
+      tokenType: 'bearer',
+      expiresIn: value.expiresIn,
+      expiresAt: new Date(value.expiresAt),
+      ...(value.refreshToken !== undefined && {refreshToken: value.refreshToken}),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolves the initial auth state for OAuth mode.
+ *
+ * State discovery order:
+ * 1. Persisted tokens in `__sanity_oauth_tokens` → `LOGGED_IN`
+ * 2. Callback URL (contains `code`/`state`/`error` and matches `redirectUri`)
+ *    → `LOGGING_IN`
+ * 3. Otherwise → `LOGGED_OUT`
+ *
+ * @internal
+ */
+export function getOauthInitialState(options: AuthStrategyOptions): AuthStrategyResult {
+  const {authConfig, initialLocationHref} = options
+  const storageKey = OAUTH_TOKENS_KEY
+  const storageArea = authConfig.storageArea ?? getDefaultStorage()
+  const redirectUri = authConfig.oauth?.redirectUri
+
+  // Persisted tokens win
+  const tokens = deserializeTokens(storageArea?.getItem(OAUTH_TOKENS_KEY) ?? null)
+  if (tokens) {
+    return {
+      authState: createLoggedInAuthState(tokens.accessToken, null),
+      storageKey,
+      storageArea,
+      authMethod: 'localstorage',
+      dashboardContext: {},
+      oauthTokens: tokens,
+    }
+  }
+
+  // Callback URL with code/state/error whose origin + pathname match our
+  // redirect URI (query and hash are ignored).
+  const {searchParams} = new URL(initialLocationHref, DEFAULT_BASE)
+  const isCallback =
+    searchParams.has('code') || searchParams.has('state') || searchParams.has('error')
+  if (redirectUri && isCallback) {
+    const loc = new URL(initialLocationHref, DEFAULT_BASE)
+    const redirect = new URL(redirectUri, DEFAULT_BASE)
+    if (loc.origin === redirect.origin && loc.pathname === redirect.pathname) {
+      return {
+        authState: {type: AuthStateType.LOGGING_IN, isExchangingToken: false},
+        storageKey,
+        storageArea,
+        authMethod: undefined,
+        dashboardContext: {},
+      }
+    }
+  }
+
+  // No tokens, not a callback
+  return {
+    authState: {type: AuthStateType.LOGGED_OUT, isDestroyingSession: false},
+    storageKey,
+    storageArea,
+    authMethod: undefined,
+    dashboardContext: {},
+  }
+}
+
+/**
+ * Subscribes to cross-tab `storage` events for the OAuth tokens key, syncing
+ * this tab's auth state when tokens change in another tab.
+ *
+ * @internal
+ */
+export function subscribeToOAuthStorageEvents({state}: StoreContext<AuthStoreState>): Subscription {
+  const {storageArea} = state.get().options
+
+  const tokens$ = defer(getStorageEvents).pipe(
+    filter((e) => e.storageArea === storageArea && e.key === OAUTH_TOKENS_KEY),
+    map(() => deserializeTokens(storageArea?.getItem(OAUTH_TOKENS_KEY) ?? null)),
+    distinctUntilChanged((a, b) => a?.accessToken === b?.accessToken),
+  )
+
+  return tokens$.subscribe((tokens) => {
+    state.set('updateOAuthTokensFromStorageEvent', {
+      authState: tokens
+        ? createLoggedInAuthState(tokens.accessToken, null)
+        : {type: AuthStateType.LOGGED_OUT, isDestroyingSession: false},
+      oauthTokens: tokens ?? undefined,
+    })
+  })
+}
+
+/**
+ * Initialize OAuth auth subscriptions:
+ * - Subscribe to state changes and fetch current user
+ * - Subscribe to cross-tab storage events for the OAuth tokens key
+ *
+ * OAuth tokens are refreshed via the `refresh_token` grant (see
+ * `refreshOAuthTokens`), so the stamped-token refresher is not started here.
+ *
+ * @internal
+ */
+export function initializeOauthAuth(context: StoreContext<AuthStoreState>): {
+  dispose: () => void
+  tokenRefresherStarted: boolean
+} {
+  const subscriptions: Subscription[] = []
+
+  subscriptions.push(subscribeToStateAndFetchCurrentUser(context, {useProjectHostname: false}))
+
+  const storageArea = context.state.get().options?.storageArea
+  if (storageArea) {
+    subscriptions.push(subscribeToOAuthStorageEvents(context))
+  }
+
+  return {
+    dispose: () => {
+      for (const subscription of subscriptions) {
+        subscription.unsubscribe()
+      }
+    },
+    tokenRefresherStarted: false,
+  }
+}

--- a/packages/core/src/auth/oauth/pkce.test.ts
+++ b/packages/core/src/auth/oauth/pkce.test.ts
@@ -1,0 +1,44 @@
+import {createHash} from 'node:crypto'
+
+import {describe, expect, it} from 'vitest'
+
+import {base64UrlEncode, generateCodeChallenge, generateCodeVerifier, generateState} from './pkce'
+
+describe('base64UrlEncode', () => {
+  it('encodes bytes as base64url without padding', () => {
+    // 0xff 0xef 0xbf → "/++/" in base64, "_--_" in base64url (minus padding)
+    const encoded = base64UrlEncode(new Uint8Array([0xff, 0xef, 0xbf]))
+    expect(encoded).not.toContain('+')
+    expect(encoded).not.toContain('/')
+    expect(encoded).not.toContain('=')
+    expect(encoded).toBe('_--_')
+  })
+})
+
+describe('generateCodeVerifier / generateState', () => {
+  it('generates unique, URL-safe strings', () => {
+    const a = generateCodeVerifier()
+    const b = generateCodeVerifier()
+    const s = generateState()
+    expect(a).not.toBe(b)
+    expect(a).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(s).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(a.length).toBeGreaterThanOrEqual(43)
+  })
+})
+
+describe('generateCodeChallenge', () => {
+  it('produces base64url(sha256(verifier))', async () => {
+    const verifier = 'test-verifier'
+    const challenge = await generateCodeChallenge(verifier)
+
+    const expected = createHash('sha256')
+      .update(verifier)
+      .digest('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+
+    expect(challenge).toBe(expected)
+  })
+})

--- a/packages/core/src/auth/oauth/pkce.ts
+++ b/packages/core/src/auth/oauth/pkce.ts
@@ -1,0 +1,60 @@
+/**
+ * PKCE (Proof Key for Code Exchange, RFC 7636) helpers for the OAuth
+ * authorization-code flow.
+ *
+ * @internal
+ */
+
+/** Number of random bytes used for the `code_verifier` and `state`. */
+const RANDOM_BYTE_LENGTH = 32
+
+/**
+ * Encodes a byte array as a base64url string (RFC 4648 §5) with no padding,
+ * as required for PKCE `code_verifier`/`code_challenge` values.
+ *
+ * @internal
+ */
+export function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function randomString(): string {
+  const bytes = new Uint8Array(RANDOM_BYTE_LENGTH)
+  crypto.getRandomValues(bytes)
+  return base64UrlEncode(bytes)
+}
+
+/**
+ * Generates a PKCE `code_verifier`
+ *
+ * @internal
+ */
+export function generateCodeVerifier(): string {
+  return randomString()
+}
+
+/**
+ * Generates the `state` parameter used to defend against CSRF on the OAuth
+ * callback.
+ *
+ * @internal
+ */
+export function generateState(): string {
+  return randomString()
+}
+
+/**
+ * Derives the PKCE `code_challenge` from a `code_verifier` using
+ * `base64url(sha256(verifier))` (the `S256` method).
+ *
+ * @internal
+ */
+export async function generateCodeChallenge(codeVerifier: string): Promise<string> {
+  const data = new TextEncoder().encode(codeVerifier)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return base64UrlEncode(new Uint8Array(digest))
+}

--- a/packages/core/src/auth/oauth/types.ts
+++ b/packages/core/src/auth/oauth/types.ts
@@ -1,0 +1,12 @@
+/**
+ * OAuth tokens issued by Sanity's OAuth token endpoint.
+ *
+ * @public
+ */
+export interface OAuthTokens {
+  accessToken: string
+  tokenType: 'bearer'
+  expiresIn: number
+  expiresAt: Date
+  refreshToken?: string
+}

--- a/packages/core/src/config/authConfig.ts
+++ b/packages/core/src/config/authConfig.ts
@@ -76,4 +76,22 @@ export interface AuthConfig {
    * ignoring any storage or callback handling.
    */
   token?: string
+
+  oauth?: {
+    /**
+     * Opaque OAuth `client_id`.
+     */
+    clientId: string
+
+    /**
+     * The redirect URI registered for this client. The OAuth provider
+     * redirects back here with the authorization `code` and `state`.
+     */
+    redirectUri: string
+
+    /**
+     * Organisation id used for RFC 8707 resource scoping.
+     */
+    organizationId: string
+  }
 }


### PR DESCRIPTION
### Description

Adds `oauth` as a fourth auth mode in `packages/core`, alongside studio, dashboard, and standalone. Configured via `auth.oauth` (`clientId`, `redirectUri`, `organizationId`), it uses the OAuth 2.0 authorization-code + PKCE flow and scopes tokens to an organisation via RFC 8707 resource indicators.

Core handles PKCE generation, the authorize redirect, code exchange, token refresh, revocation, and cross-tab token persistence, exposed as bound actions (`startOAuthAuthorization`, `handleOAuthCallback`, `refreshOAuthTokens`, `revokeOAuthTokens`) and a `getOAuthTokensState` accessor. `handleOAuthCallback` is single-flight so a repeated or StrictMode-double-invoked call does not attempt a second exchange of a single-use code.


### Fun Gif

<img width="600" height="338" alt="gif-by-lakeshore-records" src="https://github.com/user-attachments/assets/d579bb0a-0e19-409e-b9d7-91af94ff48ae" />

