### PR TITLE
ci(renovate): run Renovate from GitHub Actions

### DIFF
--- a/.github/RENOVATE_STRATEGY.md
+++ b/.github/RENOVATE_STRATEGY.md
@@ -14,6 +14,7 @@ For Renovate's own docs, see [Dependency Dashboard](https://docs.renovatebot.com
 ## Where to look
 
 - Config: [`.github/renovate.json`](renovate.json)
+- Runner: [`.github/workflows/renovate.yml`](workflows/renovate.yml)
 - Running state: [Dependency Dashboard issue](../../issues/9)
 - Auto-approve workflow: [`.github/workflows/renovate-auto-approve.yml`](workflows/renovate-auto-approve.yml)
 

--- a/.github/RENOVATE_STRATEGY.md
+++ b/.github/RENOVATE_STRATEGY.md
@@ -105,6 +105,8 @@ Renovate reads the pnpm version from the root `package.json` `packageManager` fi
 
 Branch protection requires at least 1 approval before merging. The auto-approve workflow (`.github/workflows/renovate-auto-approve.yml`) waits for CI (build, test, lint, typecheck) and then approves so Renovate's automerge can proceed.
 
+Renovate PRs are identified by a `renovate/` branch in this repository, rather than by the bot account that opened them. This works with the self-hosted Ecospark identity without trusting similarly named branches from forks.
+
 **Known gap**: the workflow uses `GITHUB_TOKEN`, whose approvals don't count toward CODEOWNERS or team-approval rules. Under the current branch protection, each Renovate PR still needs a qualifying reviewer.
 
 ## Expected weekly flow

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,9 +9,19 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'skip-review') &&
-      github.actor != 'squiggler[bot]' &&
-      github.actor != 'squiggler-app[bot]' &&
-      (github.actor != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'major-update'))
+      (
+        (
+          !(github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.event.pull_request.head.ref, 'renovate/')) &&
+          github.actor != 'squiggler[bot]' &&
+          github.actor != 'squiggler-app[bot]' &&
+          github.actor != 'renovate[bot]'
+        ) ||
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.event.pull_request.head.ref, 'renovate/') &&
+          contains(github.event.pull_request.labels.*.name, 'major-update')
+        )
+      )
 
     runs-on: ubuntu-latest
     permissions:
@@ -36,7 +46,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code Review
-        if: github.actor != 'renovate[bot]'
+        if: >-
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.event.pull_request.head.ref, 'renovate/'))
         id: claude-review
         uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
         with:
@@ -53,7 +65,9 @@ jobs:
           allowed_bots: 'cursor,renovate'
 
       - name: Run Claude Review for Renovate Major Update
-        if: github.actor == 'renovate[bot]'
+        if: >-
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.event.pull_request.head.ref, 'renovate/')
         id: claude-review-renovate
         uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
         with:

--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -12,7 +12,8 @@ jobs:
   auto-approve:
     runs-on: ubuntu-latest
     if: |
-      github.actor == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'renovate/') &&
       !contains(github.event.pull_request.labels.*.name, 'needs-review')
 
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,7 +24,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'renovate/')) ||
-      (github.event_name == 'issues' && github.event.sender.type != 'Bot')
+      (github.event_name == 'issues' && github.event.sender.type != 'Bot' && github.event.issue.number == 9)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
@@ -64,4 +64,4 @@ jobs:
         env:
           GITHUB_COM_TOKEN: ${{ github.token }}
           NODE_OPTIONS: '--max-old-space-size=4096'
-          LOG_LEVEL: debug
+          LOG_LEVEL: ${{ github.event_name == 'workflow_dispatch' && 'debug' || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,67 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 */2 * * *' # Every 2 hours
+  pull_request:
+    types: [closed]
+    branches: [main]
+  issues:
+    types: [edited]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    # Filter out noise: only run for schedule, manual dispatch, merged Renovate PRs,
+    # and human-edited issues (not bot updates to the Dependency Dashboard).
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'renovate/')) ||
+      (github.event_name == 'issues' && github.event.sender.type != 'Bot')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Generate Renovate runner config
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          CONFIG_FILE="$GITHUB_WORKSPACE/.renovate-runner-config.json5"
+
+          cat > "$CONFIG_FILE" <<'EOF'
+          {
+            $schema: "https://docs.renovatebot.com/renovate-schema.json",
+            onboarding: false,
+            requireConfig: "optional",
+          EOF
+
+          echo "  repositories: [\"$REPOSITORY\"]," >> "$CONFIG_FILE"
+          echo '}' >> "$CONFIG_FILE"
+
+          echo "Generated config:"
+          cat "$CONFIG_FILE"
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@39b914146caeff8cd512e61c8992f1d5913af85c # v46.2.5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          configurationFile: .renovate-runner-config.json5
+        env:
+          GITHUB_COM_TOKEN: ${{ github.token }}
+          NODE_OPTIONS: '--max-old-space-size=4096'
+          LOG_LEVEL: debug


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Runs Renovate from GitHub Actions instead of relying on the hosted Renovate app, following the setup in `sanity-io/sanity`.

The workflow runs every two hours, after merged Renovate PRs, after human edits to the Dependency Dashboard, and through manual dispatch. It uses the existing Ecospark GitHub App credentials and raises Renovate's Node.js heap limit to 4 GB.

Renovate PR detection now uses trusted same-repository `renovate/*` branches instead of the hosted app's `renovate[bot]` identity. This preserves auto-approval and major-update Claude reviews when PRs are authored by `squiggler-app[bot]`.

Disable the hosted Renovate app immediately before merging this PR to prevent overlapping instances from updating the same branches and dashboard.

### What to review

- `.github/workflows/renovate.yml` and its event filters
- GitHub App token generation with `ECOSPARK_APP_ID` and `ECOSPARK_APP_PRIVATE_KEY`
- Renovate detection in the auto-approve and Claude-review workflows
- The generated single-repository runner configuration

### Testing

- Workflow YAML and expressions validated with `actionlint`
- Renovate repository configuration validated with `renovate-config-validator`
- Changed files audited with Fallow

### Fun gif

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sanity-io.slack.com/archives/C07RS3HV1K9/p1788463937899689?thread_ts=1788463937.899689&cid=C07RS3HV1K9)

<div><a href="https://cursor.com/agents/bc-d88b2743-4327-597e-a9a0-183dac92abba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d88b2743-4327-597e-a9a0-183dac92abba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

