### PR TITLE
fix(renovate): target self-hosted dependency dashboard

### DIFF
--- a/.github/RENOVATE_STRATEGY.md
+++ b/.github/RENOVATE_STRATEGY.md
@@ -15,7 +15,7 @@ For Renovate's own docs, see [Dependency Dashboard](https://docs.renovatebot.com
 
 - Config: [`.github/renovate.json`](renovate.json)
 - Runner: [`.github/workflows/renovate.yml`](workflows/renovate.yml)
-- Running state: [Dependency Dashboard issue](../../issues/9)
+- Running state: [Dependency Dashboard issue](../../issues/1166)
 - Auto-approve workflow: [`.github/workflows/renovate-auto-approve.yml`](workflows/renovate-auto-approve.yml)
 
 ## Reading the dashboard
@@ -119,7 +119,7 @@ Renovate PRs are identified by a `renovate/` branch in this repository, rather t
 
 ### Weekly checklist
 
-- Skim the [Dependency Dashboard](../../issues/9) for anything stuck (errored, or repeatedly failing automerge).
+- Skim the [Dependency Dashboard](../../issues/1166) for anything stuck (errored, or repeatedly failing automerge).
 - Merge the release-please PR if ready.
 - Note any major updates that need planning.
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,7 +24,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'renovate/')) ||
-      (github.event_name == 'issues' && github.event.sender.type != 'Bot' && github.event.issue.number == 9)
+      (github.event_name == 'issues' && github.event.sender.type != 'Bot' && github.event.issue.number == 1166)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3


### PR DESCRIPTION
## Summary

- Route human edits of Dependency Dashboard #1166 to self-hosted Renovate
- Update strategy links from the old dashboard, #9, to #1166

The Squiggler bot created #1166 after the repository switched to self-hosted Renovate. The workflow still matched #9, so edits to the active dashboard produced skipped jobs.

## Testing

- `git diff --check`
- `pnpm fallow audit`