### PR TITLE
fix(kitchensink): force schema extraction overwrite

### DIFF
--- a/apps/kitchensink-react/package.json
+++ b/apps/kitchensink-react/package.json
@@ -12,7 +12,7 @@
     "install": "npm run schema:extract && npm run types:generate",
     "lint": "eslint .",
     "preview": "sanity preview",
-    "schema:extract": "sanity schema extract --workspace ppsg7ml5-test --path schema.ppsg7ml5.test.json && sanity schema extract --workspace vo1ysemo-production --path schema.vo1ysemo.production.json",
+    "schema:extract": "sanity schema extract --workspace ppsg7ml5-test --path schema.ppsg7ml5.test.json --force && sanity schema extract --workspace vo1ysemo-production --path schema.vo1ysemo.production.json --force",
     "test:e2e": "playwright test",
     "tsc": "tsc --noEmit",
     "types:generate": "node scripts/typegen.mjs"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds `--force` to both kitchensink schema extraction commands. Sanity CLI 7.11.0 and later rejects existing output files in unattended mode unless overwrite is explicitly enabled, causing repeated `pnpm install` runs and CI installs to fail.

### What to review

Confirm both workspace schema extraction commands opt into overwriting their generated JSON files.

### Testing

- `CI=1 pnpm install --frozen-lockfile` twice: passed with existing generated schemas
- `pnpm test`: 173 files passed, 1,643 tests passed, 3 skipped
- `pnpm ts:check`: 4 tasks passed
- `pnpm lint`: passed with 7 pre-existing warnings and no errors
- `pnpm fallow audit --base origin/main`: no issues in the changed file

[Repeated unattended schema install validation](https://cursor.com/agents/bc-5dd0a1e8-208f-5e9f-9450-d7d640abfaad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepeated_schema_install_validation.png)

### Fun gif

![A determined cat typing](https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sanity-io.slack.com/archives/C07RS3HV1K9/p1788469922551439?thread_ts=1788469922.551439&cid=C07RS3HV1K9)

<div><a href="https://cursor.com/agents/bc-5dd0a1e8-208f-5e9f-9450-d7d640abfaad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dd0a1e8-208f-5e9f-9450-d7d640abfaad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

