### PR TITLE
fix(deps): declare typescript in @repo/config-eslint

### DIFF
--- a/packages/@repo/config-eslint/package.json
+++ b/packages/@repo/config-eslint/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-tsdoc": "^0.5.2",
     "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^17.12.0",
+    "typescript": "catalog:",
     "typescript-eslint": "^8.69.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,9 @@ importers:
       globals:
         specifier: ^17.12.0
         version: 17.12.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
       typescript-eslint:
         specifier: ^8.69.0
         version: 8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.3)


### PR DESCRIPTION
## The bug

`pnpm lint` failed across all 9 packages on any branch that regenerated the lockfile:

```
typescript-eslint does not support TS 7.0.
```

`main` was green, so this looked branch-specific. It wasn't.

## Root cause

Two things had to line up.

`fallow` (a root devDependency, our own audit tool) has an optional dependency `fallow-type-aware@3.22.0`, which hard-depends on `typescript: 7.0.2`. That is the only thing in the whole graph pulling TS 7:

```
fallow-type-aware@3.22.0
└─┬ fallow@3.22.0
  └── sdk-root@0.0.0 (devDependencies)
```

Separately, `@repo/config-eslint` owns the entire eslint toolchain (`typescript-eslint`, the plugins, the resolvers) but never declared `typescript` itself. Every one of those packages declares `typescript` as a **peer**, so with nothing satisfying it locally, pnpm went looking in the workspace root's graph. Both 6.0.3 (direct, from the catalog) and 7.0.2 (via fallow) are reachable from there, and on re-resolution pnpm picked 7.0.2. It knew this violated the range and said so:

```
✕ unmet peer typescript@">=4.8.4 <6.1.0": found 7.0.2
```

`main` stayed green only because its lockfile already recorded 6.0.3, so `pnpm install` there was a no-op that never re-ran peer resolution. Any branch touching dependencies moved 55 peer suffixes to `typescript@7.0.2`.

## The fix

`@repo/config-eslint` now declares the TypeScript it actually lints with:

```json
"typescript": "catalog:",
```

The peer resolves locally from the catalog pin (6.0.3) and stops being searched for in the root graph.

This is not a pin with an expiry date, it's the missing declaration. A package running type-aware eslint rules should depend on the compiler those rules need. Nothing to remove later.

Total diff: 4 lines. The lockfile gains only the new importer entry; all 55 previously-flipped peer suffixes stay on 6.0.3.

## Verification

Reproduced first in a throwaway worktree by adding an unrelated dependency to `packages/@repo/e2e`, which produced the exact 55-line lockfile diff. Applied the fix and confirmed it survives repeated re-resolution.

After wiping `node_modules` and reinstalling:

- `pnpm lint` — 9 successful, 9 total
- `pnpm ts:check` — 4 successful, 4 total
- `pnpm test` — 173 files, 1643 passed, 3 skipped
- `pnpm fallow audit` — no issues
- `ls node_modules/.pnpm | grep -E '^typescript-eslint@.*typescript@7'` — empty

Only `typescript@7.0.2` itself remains in the store, which is correct: `fallow-type-aware` genuinely needs it, and nothing in the eslint toolchain touches it anymore.

## Notes for the reviewer

An earlier attempt used `overrides` entries in `pnpm-workspace.yaml` to pin the peer. That made the lockfile look right but a clean install still put the TS 7 variants on disk, because the peer was being resolved from the wrong place rather than overridden to the wrong version.

One thing stays latent: while `fallow-type-aware` is in the graph, any future package with a `typescript` peer that doesn't declare `typescript` could flip the same way. Declaring the peer where it's used is the defense.

Unblocks #1179 (`SDK-2271/typegen-compatibility-shim`), which has to regenerate the lockfile because it changes `groq`'s resolution. Nothing in that PR causes this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
