### PR TITLE
chore(ci): set explicit GITHUB_TOKEN permissions on workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   depcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published] # triggers only when a new release is published
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -54,6 +57,9 @@ jobs:
     if: ${{ !cancelled() }}
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   type-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Fixes the `actions/missing-workflow-permissions` CodeQL alerts in [code scanning](https://github.com/sanity-io/sdk/security/code-scanning) by giving each workflow an explicit `permissions` block so the `GITHUB_TOKEN` gets least privilege instead of the repo default.

- `build`, `depcheck`, `lint`, `type-check`, `test`: top-level `contents: read`.
- `test` → `report-coverage` job: adds `pull-requests: write` so the coverage action can still comment on PRs.
- `release-notes`: `permissions: {}`, it only calls a Slack webhook.

Not changed: `upload-docs` already got a permissions block in #1157, so its alert is stale. The remaining `js/incomplete-sanitization` alert is a source change and will be a separate PR.

### What to review

- Each job still has the permissions it actually uses. The shared setup action only runs `setup-node`, `pnpm/action-setup`, and `actions/cache`, which all work with `contents: read`.
- The coverage report job is the only one that writes to a PR.

### Testing

CI on this PR exercises every changed workflow except `release-notes`, which only runs on a published release. No token is used there, so an empty permissions block cannot break it.

### Fun gif

![Bouncer](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeG5oZ3FqZ3V4Y3V0eHZwcHJvbW5oZ3F4ZGZ0d2Z6cXo4ZzR5ZzR5ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0MYt5jPR6QX5pnqM/giphy.gif)