### PR TITLE
fix(core): escape backslashes in GROQ search filter

### DIFF
--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   fallow:
     runs-on: ubuntu-latest

--- a/packages/core/src/utils/createGroqSearchFilter.test.ts
+++ b/packages/core/src/utils/createGroqSearchFilter.test.ts
@@ -31,6 +31,14 @@ describe('createGroqSearchFilter', () => {
     )
   })
 
+  test('should escape backslashes so they cannot escape the closing quote', () => {
+    expect(createGroqSearchFilter('hello\\')).toBe('[@] match text::query("hello\\\\*")')
+  })
+
+  test('should escape backslashes inside an exact match phrase', () => {
+    expect(createGroqSearchFilter('"a\\b"')).toBe('[@] match text::query("\\"a\\\\b\\"")')
+  })
+
   test('should return empty string for empty input', () => {
     expect(createGroqSearchFilter('')).toBe('')
   })

--- a/packages/core/src/utils/createGroqSearchFilter.ts
+++ b/packages/core/src/utils/createGroqSearchFilter.ts
@@ -34,7 +34,7 @@ function isExactMatchToken(token: string | undefined): boolean {
  * from a raw search query string.
  *
  * It applies wildcard ('*') logic to the last eligible token and escapes
- * double quotes within the search term.
+ * backslashes and double quotes within the search term.
  *
  * If the input query is empty or only whitespace, it returns an empty string.
  *
@@ -77,8 +77,11 @@ export function createGroqSearchFilter(query: string): string {
   // Join the tokens back into a space-separated string
   const wildcardSearch = processedTokens.join(' ')
 
-  // Escape double quotes within the final search term for the GROQ query
-  const escapedSearch = wildcardSearch.replace(/"/g, '\\"')
+  // Escape backslashes and double quotes within the final search term for the
+  // GROQ query. Backslashes go first, so the escapes added for quotes are not
+  // themselves escaped. Without this a trailing backslash would escape the
+  // closing quote and let the input break out of the string literal.
+  const escapedSearch = wildcardSearch.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 
   // Construct the final GROQ filter clause
   return `[@] match text::query("${escapedSearch}")`


### PR DESCRIPTION
### Description

Fixes the two CodeQL alerts left open after code scanning default setup was re-enabled on the repo.

- **`js/incomplete-sanitization`** (high) — `createGroqSearchFilter` escaped `"` but not `\`, so a trailing backslash could escape the closing quote of the interpolated GROQ string. Backslashes are now escaped first.
- **`actions/missing-workflow-permissions`** (medium) — `fallow.yml` had no `permissions` block. #1185 covered the other seven workflows but missed this one.

Context: CodeQL had not scanned `main` since 2026-03-06, six months and ~340 commits earlier. Re-enabling default setup closed 8 stale alerts as fixed and surfaced these two.

### What to review

- The replace order in `createGroqSearchFilter.ts` — backslashes must be escaped **before** quotes, so the escapes added for quotes are not themselves escaped.
- `contents: read` is sufficient for `fallow.yml`: the job only checks out code and writes to `$GITHUB_STEP_SUMMARY`. Value and placement match the other seven workflows.

### Testing

- Two tests added to `createGroqSearchFilter.test.ts`; 16/16 pass.
- `pnpm ts:check`, `pnpm lint`, and `pnpm fallow audit` are all clean.
- Worth knowing: the tokenizer regex silently drops unbalanced quotes (`a"b` → `a b*`), which limited how far the original bug could reach in practice. The added tests use a backslash inside a quoted phrase, where both the backslash and the quotes survive to the escaping step.

### Fun gif

![Cute kittens](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExazk1dTB5ZDhlZTJxbGNqMHZrNndlc2c4c2FrOXo1cmFmbXJqbTliaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Vuw9m5wXviFIQ/giphy.gif)