### PR TITLE
feat(react): add message bus topic ownership

### DIFF
--- a/packages/react/src/dashboard/messageBus/bus.test.ts
+++ b/packages/react/src/dashboard/messageBus/bus.test.ts
@@ -93,6 +93,9 @@ describe('dashboard connection', () => {
     dashboard.emit('auth.token', 'token')
 
     expect(application.subscribe('auth.token').getCurrent()).toBe('token')
+    expect(() => application.emit('auth.token', 'spoofed')).toThrowError(
+      expect.objectContaining({code: 'OWNERSHIP_MISMATCH'}),
+    )
   })
 
   it('reports request failures as MessageBusError values', async () => {
@@ -215,6 +218,24 @@ describe('state topics', () => {
     expect(messageBus.subscribe('test.count').getCurrent()).toBe(2)
   })
 
+  it('preserves ownership when seeding a manifest topic', async () => {
+    const messageBus = createMessageBus()
+
+    registerStateTopics(messageBus, {'users.current': null})
+
+    await expect(messageBus.query('users.current')).resolves.toBeNull()
+  })
+
+  it('assigns augmented state topics to the installing application', () => {
+    const messageBus = createMessageBus()
+    registerStateTopics(messageBus, {'test.count': 0}, {ownership: 'same_app'})
+    const application = connectApplicationToMessageBus(messageBus, {appId: 'favorites'})
+
+    expect(() => application.emit('test.count', 1)).toThrowError(
+      expect.objectContaining({code: 'OWNERSHIP_MISMATCH'}),
+    )
+  })
+
   it('rejects an event registered as state', () => {
     const messageBus = createMessageBus()
 
@@ -333,6 +354,20 @@ describe('application connections', () => {
     await application.emit('test.echo', {n: 1})
 
     expect(applicationId).toBe('favorites')
+  })
+
+  it('enforces state and responder ownership', () => {
+    const installedMessageBus = createMessageBus('dashboard')
+    const application = connectApplicationToMessageBus(installedMessageBus, {appId: 'favorites'})
+    installedMessageBus.emit('auth.token', 'trusted')
+
+    expect(() => application.emit('auth.token', 'spoofed')).toThrowError(
+      expect.objectContaining({code: 'OWNERSHIP_MISMATCH'}),
+    )
+    expect(() =>
+      application.subscribe('auth.token.refresh', (message) => message.reply('spoofed')),
+    ).toThrowError(expect.objectContaining({code: 'OWNERSHIP_MISMATCH'}))
+    expect(application.subscribe('auth.token').getCurrent()).toBe('trusted')
   })
 
   it('allows applications to publish shared state topics', () => {

--- a/packages/react/src/dashboard/messageBus/bus.ts
+++ b/packages/react/src/dashboard/messageBus/bus.ts
@@ -31,6 +31,7 @@ export type MessageBusErrorCode =
   | 'ABORTED'
   | 'HANDLER_THREW'
   | 'PROTOCOL_MISMATCH'
+  | 'OWNERSHIP_MISMATCH'
   | 'MISSING_APP_ID'
 
 /**
@@ -248,6 +249,9 @@ function assertCompatibleTopicManifest(
         `topic "${type}" is declared "${entry.kind}" but the installed bus knows it as "${existing.kind}"`,
       )
     }
+    if (existing && existing.ownership.type !== entry.ownership.type) {
+      throw new MessageBusError('OWNERSHIP_MISMATCH', `topic "${type}" has conflicting ownership`)
+    }
   }
 }
 
@@ -404,6 +408,12 @@ function emitEvent(
 const isStateTopic = (registry: MessageBusRegistry, type: string): boolean =>
   registry.topics.get(type)?.kind === 'state'
 
+const canPublishOrRespond = (
+  registry: MessageBusRegistry,
+  ownership: TopicManifest[string]['ownership'],
+  appId: string,
+): boolean => ownership.type === 'any_app' || appId === registry.appId
+
 function emit(
   registry: MessageBusRegistry,
   type: string,
@@ -413,6 +423,12 @@ function emit(
 ): MessageBusEmitResult<unknown> | undefined {
   const topic = registry.topics.get(type)
   if (topic?.kind === 'state') {
+    if (!canPublishOrRespond(registry, topic.ownership, appId)) {
+      throw new MessageBusError(
+        'OWNERSHIP_MISMATCH',
+        `Cannot emit state topic "${type}" from app "${appId}". Only the app that owns this topic can publish it. Other apps can read it with query() or subscribe().`,
+      )
+    }
     const subject = resolveStateSubject(registry, type)
     if (!Object.is(subject.getValue(), payload)) subject.next(payload)
     return undefined
@@ -510,6 +526,7 @@ function subscribe(
   type: string,
   handler: ((arg: never) => void) | undefined,
   options: MessageBusAbortOptions | undefined,
+  appId: string,
 ): MessageBusStateSource<unknown> | Observable<unknown> | void {
   const isState = isStateTopic(registry, type)
 
@@ -525,6 +542,14 @@ function subscribe(
     )
     unsubscribeOnAbort(subscription, scopeSignal(options?.signal, registry.resetAbort.signal))
     return
+  }
+
+  const topic = registry.topics.get(type)
+  if (topic && !canPublishOrRespond(registry, topic.ownership, appId)) {
+    throw new MessageBusError(
+      'OWNERSHIP_MISMATCH',
+      `Cannot register a handler for event topic "${type}" from app "${appId}". Only the app that owns this topic can respond to it. Other apps can send it with emit().`,
+    )
   }
 
   registry.responderCounts.set(type, (registry.responderCounts.get(type) ?? 0) + 1)
@@ -563,7 +588,7 @@ export function createIsolatedMessageBus(appId: string): MessageBus {
       emit(registry, type, payload, options, registry.appId),
     query: (type: string, options?: MessageBusAbortOptions) => query(registry, type, options),
     subscribe: (type: string, handler?: (arg: never) => void, options?: MessageBusAbortOptions) =>
-      subscribe(registry, type, handler, options),
+      subscribe(registry, type, handler, options, registry.appId),
   }
 
   const instance = messageBus as unknown as InternalMessageBus
@@ -612,14 +637,14 @@ export function connectApplicationToMessageBus(
         }
         let stream = applicationStreams.get(type)
         if (!stream) {
-          stream = subscribe(registry, type, undefined, options) as
+          stream = subscribe(registry, type, undefined, options, appId) as
             | MessageBusStateSource<unknown>
             | Observable<unknown>
           applicationStreams.set(type, stream)
         }
         return stream
       }
-      return subscribe(registry, type, handler, options)
+      return subscribe(registry, type, handler, options, appId)
     },
   }
 
@@ -728,16 +753,26 @@ export function installMessageBus(options: ConnectMessageBusOptions = {}): Messa
 }
 
 /**
- * Registers or reseeds state topics.
+ * Registers or reseeds state topics, preserving existing ownership and sharing new topics by default.
  * @internal
  */
 export function registerStateTopics(
   target: MessageBus,
   topics: Partial<{[K in StateTopic]: ValueOf<K> | undefined}>,
+  options: {ownership?: 'same_app' | 'any_app'} = {},
 ): void {
   const registry = (target as InternalMessageBus)[MESSAGE_BUS_REGISTRY_KEY]
   const manifest: TopicManifest = Object.fromEntries(
-    Object.entries(topics).map(([name, seed]) => [name, {kind: 'state', seed}]),
+    Object.entries(topics).map(([name, seed]) => [
+      name,
+      {
+        kind: 'state',
+        ownership: registry.topics.get(name)?.ownership ?? {
+          type: options.ownership ?? 'any_app',
+        },
+        seed,
+      },
+    ]),
   )
   mergeTopicManifest(registry, manifest, {reseed: true})
 }

--- a/packages/react/src/dashboard/messageBus/topics.ts
+++ b/packages/react/src/dashboard/messageBus/topics.ts
@@ -152,33 +152,56 @@ type StateTopicsOf<T> = {
  */
 export type StateTopic = StateTopicsOf<Topics>
 
+type TopicOwnership = {readonly type: 'same_app'} | {readonly type: 'any_app'}
+
 type TopicManifestEntry<T> = T extends {kind: 'state'; value: infer V}
   ? {
       readonly kind: 'state'
+      readonly ownership: TopicOwnership
       readonly seed: V | undefined
     }
-  : {readonly kind: 'event'}
+  : {readonly kind: 'event'; readonly ownership: TopicOwnership}
+
+const withOwnership =
+  <const Ownership extends TopicOwnership>(ownership: Ownership) =>
+  <const Topic extends {readonly kind: 'state'; readonly seed: unknown} | {readonly kind: 'event'}>(
+    topic: Topic,
+  ) => ({...topic, ownership})
+
+// `same_app` restricts publishing and responding to the application that installed the bus.
+const dashboardTopic = withOwnership({type: 'same_app'})
+// `any_app` allows every connected application to publish and respond.
+const sharedTopic = withOwnership({type: 'any_app'})
 
 /**
- * Defines the runtime kind and initial value of dashboard topics.
+ * Defines the runtime kind, ownership, and initial value of dashboard topics.
  * @internal
  */
 export const DASHBOARD_TOPIC_MANIFEST: {
   readonly [K in keyof DashboardTopics]: TopicManifestEntry<DashboardTopics[K]>
 } = {
-  'applications.config': {kind: 'state', seed: undefined},
-  'applications.foreground': {kind: 'state', seed: null},
-  'applications.list': {kind: 'state', seed: undefined},
-  'auth.token': {kind: 'state', seed: undefined},
-  'auth.token.refresh': {kind: 'event'},
-  'navigation.location': {kind: 'state', seed: undefined},
-  'navigation.location.update': {kind: 'event'},
-  'organizations.current': {kind: 'state', seed: undefined},
-  'panels.mode': {kind: 'state', seed: {ok: true, value: null}},
-  'panels.mode.set': {kind: 'event'},
-  'preferences.color-scheme': {kind: 'state', seed: undefined},
-  'preferences.dock-locked': {kind: 'state', seed: undefined},
-  'users.current': {kind: 'state', seed: undefined},
+  'applications.config': dashboardTopic({kind: 'state', seed: undefined}),
+  'applications.foreground': dashboardTopic({kind: 'state', seed: null}),
+  'applications.list': dashboardTopic({kind: 'state', seed: undefined}),
+  'auth.token': dashboardTopic({kind: 'state', seed: undefined}),
+  'auth.token.refresh': dashboardTopic({kind: 'event'}),
+  'navigation.location': dashboardTopic({kind: 'state', seed: undefined}),
+  'navigation.location.update': dashboardTopic({kind: 'event'}),
+  'organizations.current': dashboardTopic({kind: 'state', seed: undefined}),
+  'panels.mode': sharedTopic({
+    kind: 'state',
+    seed: {ok: true, value: null},
+  }),
+  'panels.mode.set': dashboardTopic({kind: 'event'}),
+  'preferences.color-scheme': sharedTopic({
+    kind: 'state',
+    seed: undefined,
+  }),
+  'preferences.dock-locked': sharedTopic({
+    kind: 'state',
+    seed: undefined,
+  }),
+  'users.current': dashboardTopic({kind: 'state', seed: undefined}),
 }
 
 /**
@@ -190,9 +213,10 @@ export type TopicManifest = Readonly<
     string,
     | {
         readonly kind: 'state'
+        readonly ownership: TopicOwnership
         readonly seed: unknown
       }
-    | {readonly kind: 'event'}
+    | {readonly kind: 'event'; readonly ownership: TopicOwnership}
   >
 >
 


### PR DESCRIPTION
Adds ownership to dashboard topics so publishing state and responding to events is restricted by contract.

`same_app` limits publishing and responding to the application that installed the bus; `any_app` lets any connected application publish or respond. Every connected application can still send an event regardless of ownership. Emitting a state topic or registering an event responder without the required ownership raises `OWNERSHIP_MISMATCH`.
