### PR TITLE
feat(react): migrate message bus topics across versions

### DIFF
--- a/packages/react/src/dashboard/messageBus/bus.test.ts
+++ b/packages/react/src/dashboard/messageBus/bus.test.ts
@@ -7,14 +7,17 @@ import {
   connectMessageBus,
   createIsolatedMessageBus as createRuntimeMessageBus,
   installMessageBus,
+  type MessageBus,
   MessageBusError,
   registerStateTopics,
   resetMessageBus,
 } from './bus'
+import {type TopicManifest, type TopicMigration} from './topics'
 
 const createMessageBus = (appId = 'dashboard') => createRuntimeMessageBus(appId)
 
 const MESSAGE_BUS_KEY = Symbol.for('sanity.os.bus')
+const MESSAGE_BUS_REGISTRY_KEY = Symbol.for('sanity.os.registry')
 const globals = globalThis as Record<symbol, unknown>
 let previousMessageBus: unknown
 
@@ -26,6 +29,65 @@ const preserveMessageBusInstallation = () => {
 const restoreMessageBusInstallation = () => {
   globals[MESSAGE_BUS_KEY] = previousMessageBus
 }
+
+const getRegistry = (messageBus: MessageBus) =>
+  (
+    messageBus as unknown as Record<
+      symbol,
+      {
+        topics: Map<string, TopicManifest[string]>
+        stateSubjects: Map<string, unknown>
+      }
+    >
+  )[MESSAGE_BUS_REGISTRY_KEY]
+
+type ProfileV1 = {name: string}
+type ProfileV2 = {name: string; tags: readonly string[]}
+type ProfileV3 = {fullName: string; tags: readonly string[]}
+
+const profileMigrations: readonly TopicMigration[] = [
+  {
+    from: 1,
+    to: 2,
+    up: (value) => ({name: (value as ProfileV1).name, tags: []}),
+    down: (value) => ({name: (value as ProfileV2).name}),
+  },
+  {
+    from: 2,
+    to: 3,
+    up: (value) => ({
+      fullName: (value as ProfileV2).name,
+      tags: (value as ProfileV2).tags,
+    }),
+    down: (value) => ({
+      name: (value as ProfileV3).fullName,
+      tags: (value as ProfileV3).tags,
+    }),
+  },
+]
+
+const greetMigrations: readonly TopicMigration[] = [
+  {
+    from: 1,
+    to: 2,
+    up: (value) => ({fullName: (value as {name: string}).name}),
+    down: (value) => ({name: (value as {fullName: string}).fullName}),
+    reply: {
+      up: (value) => ({
+        salutation: (value as {greeting: string}).greeting,
+        language: 'en',
+      }),
+      down: (value) => ({
+        greeting: (value as {salutation: string}).salutation,
+      }),
+    },
+  },
+]
+
+const latestMigrations = new Map([
+  ['test.profile', profileMigrations],
+  ['test.greet', greetMigrations],
+])
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -117,6 +179,16 @@ describe('dashboard connection', () => {
     expect(warn).toHaveBeenCalledWith(
       '[sanity-sdk:message-bus] cannot connect without an app ID; build with the Sanity CLI or pass appId',
     )
+  })
+
+  it('returns undefined when the installed protocol is incompatible', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    installMessageBus({appId: 'dashboard'})
+    const protocolKey = Symbol.for('sanity.os.protocol')
+    const installedMessageBus = globals[MESSAGE_BUS_KEY] as Record<symbol, unknown>
+    installedMessageBus[protocolKey] = 2
+
+    expect(connectMessageBus({appId: 'favorites'})).toBeUndefined()
   })
 })
 
@@ -429,5 +501,185 @@ describe('reset', () => {
     }
     application.emit('panels.mode', panel)
     expect(seen).toEqual([{ok: true, value: null}, panel])
+  })
+})
+
+describe('compatibility', () => {
+  beforeEach(preserveMessageBusInstallation)
+  afterEach(() => {
+    restoreMessageBusInstallation()
+    vi.resetModules()
+  })
+
+  it('connects independently loaded SDK copies through the shared symbol', async () => {
+    const installer = await import('./bus')
+    const dashboard = installer.installMessageBus({appId: 'dashboard'})
+    vi.resetModules()
+    const consumer = await import('./bus')
+    const application = consumer.connectMessageBus({appId: 'favorites'})
+    if (!application) throw new Error('Expected a dashboard message bus')
+
+    dashboard.subscribe('test.echo', (message) => message.reply({n: message.payload.n + 1}))
+
+    await expect(application.emit('test.echo', {n: 1})).resolves.toEqual({n: 2})
+  })
+
+  it('rejects incompatible message bus protocol semantics', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dashboard = createMessageBus('dashboard')
+    const protocolKey = Symbol.for('sanity.os.protocol')
+    const internalDashboard = dashboard as unknown as Record<symbol, unknown>
+    internalDashboard[protocolKey] = 2
+    const application = connectApplicationToMessageBus(dashboard, {appId: 'favorites'})
+
+    expect(() => application.query('applications.foreground')).toThrowError(
+      expect.objectContaining({code: 'PROTOCOL_MISMATCH'}),
+    )
+  })
+
+  it('adapts state across the full migration chain', async () => {
+    const dashboard = createRuntimeMessageBus('dashboard', {migrations: latestMigrations})
+    registerStateTopics(dashboard, {
+      'test.profile': {fullName: 'Initial', tags: ['one']},
+    })
+    const application = connectApplicationToMessageBus(dashboard, {
+      appId: 'favorites',
+      migrations: new Map(),
+    })
+    const source = application.subscribe('test.profile')
+
+    expect(source.getCurrent() as unknown).toEqual({name: 'Initial'})
+    await expect(source.firstValue as Promise<unknown>).resolves.toEqual({name: 'Initial'})
+    expect(source.getCurrent()).toBe(source.getCurrent())
+
+    application.emit('test.profile', {name: 'Ada'} as never)
+
+    await expect(dashboard.query('test.profile')).resolves.toEqual({fullName: 'Ada', tags: []})
+    expect((await application.query('test.profile')) as unknown).toEqual({name: 'Ada'})
+  })
+
+  it('adapts an application newer than the installed message bus', async () => {
+    const dashboard = createMessageBus()
+    registerStateTopics(dashboard, {'test.profile': undefined})
+    const application = connectApplicationToMessageBus(dashboard, {
+      appId: 'favorites',
+      migrations: new Map([['test.profile', [profileMigrations[1]]]]),
+    })
+
+    application.emit('test.profile', {fullName: 'Ada', tags: []})
+
+    expect((await dashboard.query('test.profile')) as unknown).toEqual({
+      name: 'Ada',
+      tags: [],
+    })
+    await expect(application.query('test.profile')).resolves.toEqual({fullName: 'Ada', tags: []})
+  })
+
+  it('adapts event payloads in both directions', () => {
+    const dashboard = createRuntimeMessageBus('dashboard', {migrations: latestMigrations})
+    const application = connectApplicationToMessageBus(dashboard, {
+      appId: 'favorites',
+      migrations: new Map(),
+    })
+    const dashboardPayloads: unknown[] = []
+    dashboard.subscribe('test.greet', (message) => dashboardPayloads.push(message.payload))
+
+    application.emit('test.greet', {name: 'Ada'} as never)
+
+    const applicationPayloads: unknown[] = []
+    application.subscribe('test.greet', (message) => applicationPayloads.push(message.payload))
+    dashboard.emit('test.greet', {fullName: 'Grace'})
+
+    expect(dashboardPayloads).toEqual([{fullName: 'Ada'}, {fullName: 'Grace'}])
+    expect(applicationPayloads).toEqual([{name: 'Grace'}])
+  })
+
+  it('adapts event replies for an older emitter', async () => {
+    const dashboard = createRuntimeMessageBus('dashboard', {migrations: latestMigrations})
+    const application = connectApplicationToMessageBus(dashboard, {
+      appId: 'favorites',
+      migrations: new Map(),
+    })
+    dashboard.subscribe('test.greet', (message) =>
+      message.reply({salutation: `Hello ${message.payload.fullName}`, language: 'en'}),
+    )
+
+    await expect(application.emit('test.greet', {name: 'Ada'} as never)).resolves.toEqual({
+      greeting: 'Hello Ada',
+    })
+  })
+
+  it('adapts event replies from an older responder', async () => {
+    const dashboard = createRuntimeMessageBus('dashboard', {migrations: latestMigrations})
+    const application = connectApplicationToMessageBus(dashboard, {
+      appId: 'favorites',
+      migrations: new Map(),
+    })
+    application.subscribe('test.greet', (message) =>
+      message.reply({
+        greeting: `Hello ${(message.payload as unknown as {name: string}).name}`,
+      } as never),
+    )
+
+    await expect(dashboard.emit('test.greet', {fullName: 'Ada'})).resolves.toEqual({
+      salutation: 'Hello Ada',
+      language: 'en',
+    })
+  })
+
+  it('keeps migrated fire-and-forget replies lazy', () => {
+    vi.useFakeTimers()
+    const dashboard = createRuntimeMessageBus('dashboard', {migrations: latestMigrations})
+    const application = connectApplicationToMessageBus(dashboard, {
+      appId: 'favorites',
+      migrations: new Map(),
+    })
+    let responderSignal: AbortSignal | undefined
+    dashboard.subscribe('test.greet', (message) => {
+      responderSignal = message.signal
+    })
+
+    application.emit('test.greet', {name: 'Ada'} as never, {timeout: 1})
+    vi.advanceTimersByTime(1)
+
+    expect(responderSignal?.aborted).toBe(false)
+  })
+
+  it('returns a failed connection without replacing a conflicting manifest', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const dashboard = createMessageBus()
+    const registry = getRegistry(dashboard)
+    registry.topics.set('panels.mode', {
+      kind: 'event',
+      ownership: {type: 'any_app'},
+    })
+    registry.topics.delete('auth.token')
+    registry.stateSubjects.delete('auth.token')
+
+    const application = connectApplicationToMessageBus(dashboard, {appId: 'favorites'})
+
+    expect(() => application.subscribe('panels.mode')).toThrowError(
+      expect.objectContaining({code: 'PROTOCOL_MISMATCH'}),
+    )
+    expect(registry.topics.get('panels.mode')).toEqual({
+      kind: 'event',
+      ownership: {type: 'any_app'},
+    })
+    expect(registry.topics.has('auth.token')).toBe(false)
+  })
+
+  it('returns a failed connection for an incompatible message bus', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const foreignMessageBus = {
+      emit() {},
+      query() {},
+      subscribe() {},
+    } as unknown as MessageBus
+
+    const application = connectApplicationToMessageBus(foreignMessageBus, {appId: 'stale'})
+
+    expect(() => application.subscribe('panels.mode')).toThrowError(
+      expect.objectContaining({code: 'PROTOCOL_MISMATCH'}),
+    )
   })
 })

--- a/packages/react/src/dashboard/messageBus/bus.ts
+++ b/packages/react/src/dashboard/messageBus/bus.ts
@@ -17,6 +17,8 @@ import {
   type ReplyOf,
   type StateTopic,
   type TopicManifest,
+  type TopicMigration,
+  topicMigrations,
   type TopicName,
   type ValueOf,
 } from './topics'
@@ -185,6 +187,7 @@ interface MessageBusRegistry {
   readonly stateSources: Map<string, MessageBusStateSource<unknown>>
   readonly eventSubjects: Map<string, Subject<MessageBusMessage<unknown, unknown>>>
   readonly responderCounts: Map<string, number>
+  readonly migrations: ReadonlyMap<string, readonly TopicMigration[]>
   resetAbort: AbortController
   generation: number
 }
@@ -563,11 +566,18 @@ function subscribe(
   unsubscribeOnAbort(subscription, scopeSignal(options?.signal, registry.resetAbort.signal))
 }
 
+const bundledMigrations = () => new Map(Object.entries(topicMigrations))
+
 /**
  * Creates an isolated message bus without installing it globally.
  * @internal
  */
-export function createIsolatedMessageBus(appId: string): MessageBus {
+export function createIsolatedMessageBus(
+  appId: string,
+  config: {
+    migrations?: ReadonlyMap<string, readonly TopicMigration[]>
+  } = {},
+): MessageBus {
   if (!appId) throwMissingAppId()
 
   const registry: MessageBusRegistry = {
@@ -577,6 +587,7 @@ export function createIsolatedMessageBus(appId: string): MessageBus {
     stateSources: new Map(),
     eventSubjects: new Map(),
     responderCounts: new Map(),
+    migrations: config.migrations ?? bundledMigrations(),
     resetAbort: new AbortController(),
     generation: 0,
   }
@@ -597,6 +608,171 @@ export function createIsolatedMessageBus(appId: string): MessageBus {
   return instance
 }
 
+type TopicVersionAdapter = {
+  toInstalled: (type: string, value: unknown) => unknown
+  toApplication: (type: string, value: unknown) => unknown
+}
+
+type TopicCompatibility = {
+  toInstalledEmission: TopicVersionAdapter['toInstalled']
+  toApplicationStateValue: TopicVersionAdapter['toApplication']
+  toApplicationEventPayload: TopicVersionAdapter['toApplication']
+  toInstalledEventReply: TopicVersionAdapter['toInstalled']
+  toApplicationEventReply: TopicVersionAdapter['toApplication']
+}
+
+type TopicMigrationTransform = Pick<TopicMigration, 'up' | 'down'>
+
+const identityMigration: TopicMigrationTransform = {
+  up: (value) => value,
+  down: (value) => value,
+}
+
+function effectiveTopicVersions(
+  migrations: ReadonlyMap<string, readonly TopicMigration[]>,
+): Map<string, number> {
+  const versions = new Map<string, number>()
+  for (const [topic, steps] of migrations) {
+    let version = 1
+    for (const step of steps) if (step.to > version) version = step.to
+    versions.set(topic, version)
+  }
+  return versions
+}
+
+function migrationTransformAt(
+  steps: readonly TopicMigration[] | undefined,
+  version: number,
+  select: (step: TopicMigration) => TopicMigrationTransform | undefined,
+): TopicMigrationTransform {
+  const step = steps?.find((candidate) => candidate.from === version)
+  return (step ? select(step) : undefined) ?? identityMigration
+}
+
+function migrateVersionedValue(
+  steps: readonly TopicMigration[] | undefined,
+  value: unknown,
+  from: number,
+  to: number,
+  select: (step: TopicMigration) => TopicMigrationTransform | undefined,
+): unknown {
+  if (from === to) return value
+
+  let current = value
+  if (from < to) {
+    for (let version = from; version < to; version++) {
+      current = migrationTransformAt(steps, version, select).up(current)
+    }
+  } else {
+    for (let version = from; version > to; version--) {
+      current = migrationTransformAt(steps, version - 1, select).down(current)
+    }
+  }
+  return current
+}
+
+function createTopicCompatibility(
+  installedMigrations: ReadonlyMap<string, readonly TopicMigration[]>,
+  applicationMigrations: ReadonlyMap<string, readonly TopicMigration[]>,
+): TopicCompatibility {
+  const installedVersions = effectiveTopicVersions(installedMigrations)
+  const applicationVersions = effectiveTopicVersions(applicationMigrations)
+  const applicationVersion = (type: string) => applicationVersions.get(type) ?? 1
+  const installedVersion = (type: string) => installedVersions.get(type) ?? 1
+  const migrationChainFor = (type: string) =>
+    (applicationVersion(type) > installedVersion(type)
+      ? applicationMigrations
+      : installedMigrations
+    ).get(type)
+  const createVersionAdapter = (
+    select: (step: TopicMigration) => TopicMigrationTransform | undefined,
+  ): TopicVersionAdapter => ({
+    toInstalled: (type, value) =>
+      migrateVersionedValue(
+        migrationChainFor(type),
+        value,
+        applicationVersion(type),
+        installedVersion(type),
+        select,
+      ),
+    toApplication: (type, value) =>
+      migrateVersionedValue(
+        migrationChainFor(type),
+        value,
+        installedVersion(type),
+        applicationVersion(type),
+        select,
+      ),
+  })
+
+  const stateValueAndEventPayload = createVersionAdapter((step) => step)
+  const eventReply = createVersionAdapter((step) => step.reply)
+  return {
+    toInstalledEmission: stateValueAndEventPayload.toInstalled,
+    toApplicationStateValue: stateValueAndEventPayload.toApplication,
+    toApplicationEventPayload: stateValueAndEventPayload.toApplication,
+    toInstalledEventReply: eventReply.toInstalled,
+    toApplicationEventReply: eventReply.toApplication,
+  }
+}
+
+// Cache projections by input reference to keep state snapshots stable.
+function projectCurrent(input: () => unknown, project: (value: unknown) => unknown): () => unknown {
+  let lastInput: unknown
+  let lastOutput: unknown
+  let cached = false
+  return () => {
+    const current = input()
+    if (current === undefined) return undefined
+    if (!cached || current !== lastInput) {
+      lastInput = current
+      lastOutput = project(current)
+      cached = true
+    }
+    return lastOutput
+  }
+}
+
+function mapStateSource(
+  source: MessageBusStateSource<unknown>,
+  project: (value: unknown) => unknown,
+): MessageBusStateSource<unknown> {
+  return toStateSource(source.pipe(map(project)), projectCurrent(source.getCurrent, project))
+}
+
+function migrateEventMessage(
+  message: MessageBusMessage<unknown, unknown>,
+  payload: (value: unknown) => unknown,
+  reply: (value: unknown) => unknown,
+): MessageBusMessage<unknown, unknown> {
+  return {
+    type: message.type,
+    payload: payload(message.payload),
+    meta: message.meta,
+    reply: (value) => message.reply(reply(value)),
+    get signal() {
+      return message.signal
+    },
+  }
+}
+
+function migrateEventReply(
+  result: MessageBusEmitResult<unknown> | undefined,
+  project: (value: unknown) => unknown,
+): MessageBusEmitResult<unknown> | undefined {
+  if (!result) return undefined
+  let projected: Promise<unknown> | undefined
+  return createLazyReply(() => (projected ??= Promise.resolve(result).then(project)))
+}
+
+function createRejectedConnection(throwConnectionError: () => never): MessageBus {
+  return {
+    emit: throwConnectionError,
+    query: throwConnectionError,
+    subscribe: throwConnectionError,
+  } as unknown as MessageBus
+}
+
 /**
  * Options for connecting an application to an isolated message bus.
  * @internal
@@ -604,6 +780,8 @@ export function createIsolatedMessageBus(appId: string): MessageBus {
 export interface ConnectApplicationToMessageBusOptions {
   /** The application ID stamped on emitted messages. */
   appId: string
+  /** The topic migrations supported by the application. */
+  migrations?: ReadonlyMap<string, readonly TopicMigration[]>
 }
 
 /**
@@ -617,9 +795,44 @@ export function connectApplicationToMessageBus(
   if (!config.appId) throwMissingAppId()
 
   const {appId} = config
-  const registry = (installedMessageBus as InternalMessageBus)[MESSAGE_BUS_REGISTRY_KEY]
+  const installedProtocol = (installedMessageBus as Partial<InternalMessageBus>)[
+    MESSAGE_BUS_PROTOCOL_KEY
+  ]
+  if (installedProtocol !== MESSAGE_BUS_PROTOCOL) {
+    console.error(
+      `[sanity-sdk:message-bus] protocol mismatch for "${appId}": installed ${String(installedProtocol)}, this copy speaks ${MESSAGE_BUS_PROTOCOL}`,
+    )
+    return createRejectedConnection(() => {
+      throw new MessageBusError(
+        'PROTOCOL_MISMATCH',
+        `installed message bus speaks protocol ${String(installedProtocol)}, this copy speaks ${MESSAGE_BUS_PROTOCOL}`,
+      )
+    })
+  }
 
-  mergeTopicManifest(registry, DASHBOARD_TOPIC_MANIFEST)
+  const registry = (installedMessageBus as Partial<InternalMessageBus>)[MESSAGE_BUS_REGISTRY_KEY]
+  if (!registry) {
+    console.error(`[sanity-sdk:message-bus] incompatible message bus for "${appId}"`)
+    return createRejectedConnection(() => {
+      throw new MessageBusError(
+        'PROTOCOL_MISMATCH',
+        'installed message bus does not expose a compatible registry',
+      )
+    })
+  }
+
+  const applicationMigrations = config.migrations ?? bundledMigrations()
+
+  try {
+    mergeTopicManifest(registry, DASHBOARD_TOPIC_MANIFEST)
+  } catch (error) {
+    console.error(`[sanity-sdk:message-bus] topic manifest conflict for "${appId}"`, {error})
+    return createRejectedConnection(() => {
+      throw error
+    })
+  }
+  const compatibility = createTopicCompatibility(registry.migrations, applicationMigrations)
+  const isState = (type: string) => isStateTopic(registry, type)
 
   // Reuse topic streams because React external-store snapshots require stable references.
   const applicationStreams = new Map<string, MessageBusStateSource<unknown> | Observable<unknown>>()
@@ -627,8 +840,14 @@ export function connectApplicationToMessageBus(
 
   const connection = {
     emit: (type: string, payload: unknown, options?: MessageBusEmitOptions) =>
-      emit(registry, type, payload, options, appId),
-    query: (type: string, options?: MessageBusAbortOptions) => query(registry, type, options),
+      migrateEventReply(
+        emit(registry, type, compatibility.toInstalledEmission(type, payload), options, appId),
+        (value) => compatibility.toApplicationEventReply(type, value),
+      ),
+    query: (type: string, options?: MessageBusAbortOptions) =>
+      query(registry, type, options).then((value) =>
+        compatibility.toApplicationStateValue(type, value),
+      ),
     subscribe: (type: string, handler?: (arg: never) => void, options?: MessageBusAbortOptions) => {
       if (!handler) {
         if (streamGeneration !== registry.generation) {
@@ -637,14 +856,32 @@ export function connectApplicationToMessageBus(
         }
         let stream = applicationStreams.get(type)
         if (!stream) {
-          stream = subscribe(registry, type, undefined, options, appId) as
-            | MessageBusStateSource<unknown>
-            | Observable<unknown>
+          const installedSource = subscribe(registry, type, undefined, options, appId)
+          stream = isState(type)
+            ? mapStateSource(installedSource as MessageBusStateSource<unknown>, (value) =>
+                compatibility.toApplicationStateValue(type, value),
+              )
+            : (installedSource as Observable<unknown>).pipe(
+                map((payload) => compatibility.toApplicationEventPayload(type, payload)),
+              )
           applicationStreams.set(type, stream)
         }
         return stream
       }
-      return subscribe(registry, type, handler, options, appId)
+      const applicationHandler = isState(type)
+        ? (value: unknown) =>
+            (handler as (value: unknown) => void)(
+              compatibility.toApplicationStateValue(type, value),
+            )
+        : (message: MessageBusMessage<unknown, unknown>) =>
+            (handler as (message: MessageBusMessage<unknown, unknown>) => void)(
+              migrateEventMessage(
+                message,
+                (value) => compatibility.toApplicationEventPayload(type, value),
+                (value) => compatibility.toInstalledEventReply(type, value),
+              ),
+            )
+      return subscribe(registry, type, applicationHandler as (arg: never) => void, options, appId)
     },
   }
 

--- a/packages/react/src/dashboard/messageBus/topics.ts
+++ b/packages/react/src/dashboard/messageBus/topics.ts
@@ -247,3 +247,31 @@ export type PayloadOf<K extends EventTopic> =
  */
 export type ReplyOf<K extends EventTopic> =
   Topics[K] extends EventTopicDef<infer _P, infer R> ? R : never
+
+/**
+ * Converts a topic value between 2 adjacent versions.
+ * @internal
+ */
+export interface TopicMigration {
+  /** The older version. */
+  readonly from: number
+  /** The newer version. */
+  readonly to: number
+  /** Converts an older state value or event payload to the newer version. */
+  up(older: unknown): unknown
+  /** Converts a newer state value or event payload to the older version. */
+  down(newer: unknown): unknown
+  /** Converts event replies between these versions. */
+  readonly reply?: {
+    /** Converts an older reply to the newer version. */
+    up(older: unknown): unknown
+    /** Converts a newer reply to the older version. */
+    down(newer: unknown): unknown
+  }
+}
+
+/**
+ * Defines the bundled migration chain for each topic.
+ * @internal
+ */
+export const topicMigrations: Partial<Record<TopicName, readonly TopicMigration[]>> = {}


### PR DESCRIPTION
Lets an application and Workbench remote bundle different SDK versions.

The message bus protocol version covers the semantics of `emit`, `query`, `subscribe`, replies, timeouts, and cancellation. Clients speaking different protocols are rejected rather than left attached to a contract they cannot interpret.

Topics evolve independently through adjacent bidirectional migrations. The newer SDK copy supplies the migration chain, and state values, event payloads, and event replies are converted between the installed and connected versions.
