### PR TITLE
chore(deps): exempt get-it from pnpm minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ minimumReleaseAgeExclude:
   - '@portabletext/*'
   - '@sanity/*'
   - '@types/*'
+  - 'get-it'
   - 'groq-js'
   - 'groq'
   - 'lodash-es'


### PR DESCRIPTION
### Description

Self-hosted Renovate has aborted every run since 2026-09-08 17:25 UTC with `result: lockfile-error`. Building the `renovate/sanity` branch fails:

```
ERR_PNPM_NO_MATURE_MATCHING_VERSION  Version 9.5.4 (released 8 hours ago) of
get-it does not meet the minimumReleaseAge constraint
This error happened while installing the dependencies of @sanity/client@8.6.1
```

`minimumReleaseAge: 1440` applies to every package pnpm resolves, transitive ones included. `@sanity/client` is already exempt via the `@sanity/*` pattern, but `get-it` — its HTTP layer, also a sanity-io package — is not. So any `@sanity/client` release landing within 24h of a `get-it` release blocks the install.

The blast radius is wider than the one update: Renovate aborts the whole repository run before it rewrites the Dependency Dashboard, so ticked checkboxes are never cleared and the abort repeats on every subsequent run.

Adds `get-it` to `minimumReleaseAgeExclude`.

### What to review

- One entry in `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`.
- No lockfile change here on purpose — the `@sanity/client` bump is Renovate's PR to make.

### Testing

Reproduced Renovate's own command locally, both ways:

- Without this change, `pnpm update @sanity/client --lockfile-only --recursive` fails with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`.
- With it, the same command exits 0 and resolves `@sanity/client@8.6.1` alongside `get-it@9.5.4`.
- `pnpm install --lockfile-only --recursive --ignore-scripts` against current deps stays a no-op; `pnpm-lock.yaml` is untouched.

### Documentation

No user-facing change.