### PR TITLE
test(e2e): fix Firefox hanging

### DIFF
--- a/apps/kitchensink-react/e2e/release-management.spec.ts
+++ b/apps/kitchensink-react/e2e/release-management.spec.ts
@@ -4,6 +4,8 @@ import {ReleaseDocument} from '@sanity/sdk'
 const releaseQuery = `*[_id == $id][0]`
 
 test.describe('Release Management Dialog', () => {
+  test.describe.configure({timeout: 90_000})
+
   test('creates, edits, schedules, unschedules, publishes, and deletes a release through the dialog', async ({
     page,
     getClient,

--- a/packages/@repo/e2e/src/index.ts
+++ b/packages/@repo/e2e/src/index.ts
@@ -70,7 +70,16 @@ export const basePlaywrightConfig: PlaywrightTestConfig = {
     },
     {
       name: 'firefox',
-      use: {...devices['Desktop Firefox'], storageState: AUTH_FILE, baseURL: BASE_URL},
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: AUTH_FILE,
+        baseURL: BASE_URL,
+        launchOptions: {
+          // The Dashboard's localhost iframe does not yet delegate Firefox's
+          // loopback-network permission, so Firefox blocks the development app.
+          firefoxUserPrefs: {'network.lna.enabled': false},
+        },
+      },
       dependencies: ['setup'],
     },
     {


### PR DESCRIPTION
### Description

Playwright 1.63 upgraded its bundled browser to Firefox 155, which enforces Local Network Access permissions for the localhost app embedded in Dashboard. Firefox blocked the app before tests reached their first locator, causing repeated failures and eventual job timeouts.

This disables Local Network Access enforcement only for the Playwright Firefox process. Dashboard coverage remains intact while the parent iframe lacks Firefox's `loopback-network` delegation.

Closes [SDK-2541](https://linear.app/sanity/issue/SDK-2541/allow-firefox-e2e-tests-to-load-local-dashboard-apps). Related dependency upgrade: #1238.

### What to review

Review the Firefox project configuration in `packages/@repo/e2e/src/index.ts`. Chromium, WebKit, and published SDK code are unaffected.

### Testing

- Firefox E2E completed successfully on PR #1242 with the preference applied.
- `@repo/e2e` package build passed.
- ESLint, formatting, and Fallow passed.

### Documentation

N/A. Internal E2E configuration only.

### Fun gif
![allow local](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExcXdrem1kNDA5ZW0zZjQzY3cxZjhzeHo4NHI0MWVsZHl6eWZsdGVlbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/lHQuX9d5DBhug/giphy.gif)